### PR TITLE
V0.7-A.0 — slash-command interactive surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,20 @@ DISCORD_CHANNEL_OWSLEY_LAB=
 # DISCORD_CHANNEL_TL=                    # Timeline / HÖR (NOT LIVE)
 # DISCORD_CHANNEL_IRL=                   # Poppy Field (NOT LIVE)
 
+# ─── V0.7-A.0 — Discord Interactions endpoint (slash commands) ────
+# When DISCORD_PUBLIC_KEY is set, the bot starts an HTTP server that
+# receives signed slash-command POSTs from Discord and replies via the
+# chat-mode pipeline (composeReply). When unset, slash commands are
+# disabled but the digest cron path is unaffected.
+#
+# Setup walkthrough: docs/DISCORD-INTERACTIONS-SETUP.md
+# 1. Discord developer portal → Application → General Information
+# 2. Set "Interactions Endpoint URL" to https://<host>/webhooks/discord
+# 3. Copy the "Public Key" field into DISCORD_PUBLIC_KEY below
+# 4. Run: bun run apps/bot/scripts/publish-commands.ts
+DISCORD_PUBLIC_KEY=
+INTERACTIONS_PORT=3001
+
 # ─── target / cadence ──────────────────────────────────────────────
 ZONES=                                   # csv subset; empty = all configured zones
 DIGEST_CADENCE=weekly                    # weekly | daily | manual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,38 +1,44 @@
-# freeside-ruggy
+# freeside-characters
 
-Persona-layer Discord bot for the Honey Jar ecosystem. Watches mibera-dimensions activity through score-mcp, composes posts through a tripartite construct stack (rosenzu · arneson · cabal-gygax + codex + emojis + freeside_auth), and posts in Ruggy's voice to four festival-zone channels in the THJ Discord.
+Participation-agent umbrella for the Honey Jar ecosystem. Substrate
+(`packages/persona-engine`) handles cron, MCP orchestration, Discord
+delivery (Pattern B shell + per-character webhook identity), and
+slash-command interactions. Characters (`apps/character-<id>`) supply
+voice — currently `ruggy` (festival NPC narrator) and `satoshi`
+(mibera-codex agent).
 
 See `README.md` for the full picture. This file is for agents working IN this repo.
 
 ## Critical context
 
-- **Persona name**: `ruggy` (lowercase, voice surface)
-- **Repo name**: `freeside-ruggy` (this repo)
-- **Discord username**: `Ruggy` (proper case; bot user `Ruggy#1157` is live)
-- **Layer**: persona (per `vault/wiki/concepts/two-layer-bot-model.md`)
-- **NOT the freeside operations bot** — sietch (`loa-freeside/themes/sietch`) handles `/verify`, `/onboard`, `/score`, `/agent`, `/buy-credits`. Don't add utility commands here.
-- **Ruggy is one consumer of score** — siblings will exist (other personas, other surfaces, other worlds). Architectural decisions should preserve extractability.
+- **Repo**: `freeside-characters` (formerly `freeside-ruggy` · V0.6 multi-character umbrella)
+- **Substrate vs character split**: substrate doesn't speak, characters don't talk to Discord. Boundary at `packages/persona-engine/src/types.ts` (`CharacterConfig`) — see `docs/CIVIC-LAYER.md`.
+- **Discord shell**: ONE bot account (currently `Ruggy#1157` · transitional name; rename to neutral "Freeside" deferred to V0.7-A.6) acts as the shell. Per-message webhook overrides (Pattern B) deliver each character with its own face.
+- **NOT the freeside operations bot** — sietch (`loa-freeside/themes/sietch`) handles `/verify`, `/onboard`, `/score`, `/agent`, `/buy-credits`. The slash commands here are PERSONA invocations (`/ruggy`, `/satoshi`), not utility commands.
+- **Multi-character routing** — V0.6-A: digest cron always routes to `characters[0]` (primary). V0.6-D will add per-fire affinity routing. V0.7-A.3+ will add @-mention routing for messageCreate.
 
-## Stack (V0.5-E, current)
+## Stack (V0.7-A.0, current)
 
-- **Runtime**: Bun
+- **Runtime**: Bun (≥1.1)
 - **Language**: TypeScript (strict)
-- **LLM**: Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) via `agent/orchestrator.ts` — direct anthropic auth in production
-- **Discord delivery**: `discord.js` Gateway (channel.send) — webhook + dry-run as fallbacks
+- **LLM**: Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) via `packages/persona-engine/src/orchestrator/` (digest path) and `packages/persona-engine/src/compose/reply.ts` (chat-mode path · single-turn, no MCPs)
+- **Discord write side**: `discord.js` Gateway (Pattern B shell) + per-character webhook identity (PluralKit-style)
+- **Discord read side (V0.7-A.0)**: Bun.serve HTTP endpoint at `/webhooks/discord` · Ed25519-verified slash commands · in-process per-channel ledger
 - **Schedule**: `node-cron` — three concurrent cadences (digest backbone · pop-in random · weaver weekly)
 - **Validation**: Zod
-- **Stubs**: `LLM_PROVIDER=stub` for canned outputs; `STUB_MODE=true` for synthetic ZoneDigests (defaults on)
+- **Stubs**: `LLM_PROVIDER=stub` for canned outputs; `STUB_MODE=true` for synthetic ZoneDigests
 
 ## When working in this repo
 
 ### Persona is sacred
 
-The canonical persona at `apps/bot/src/persona/ruggy.md` is the source of truth for Ruggy's voice. Changes require:
-1. Update the canonical doc at `~/bonfire/grimoires/bonfire/context/ruggy-canonical-persona-2026-04-28.md` first
+Each character's voice lives at `apps/character-<id>/persona.md`. These
+are the source of truth for the character's voice. Changes require:
+1. Update the canonical doc in bonfire grimoires (operator's vault) first
 2. Sync into this repo
-3. Update `vault/wiki/entities/ruggy.md` if the change affects identity
+3. Update `vault/wiki/entities/<id>.md` if the change affects identity
 
-Never edit `apps/bot/src/persona/ruggy.md` without syncing back to bonfire grimoires.
+Never edit `apps/character-<id>/persona.md` without syncing back to bonfire grimoires.
 
 ### Discord-as-Material rules
 
@@ -44,8 +50,11 @@ The persona doc has a "Discord-as-Material" section that's NON-NEGOTIABLE. The `
 
 ### Voice rules (LLM follows these via system prompt; YOU should too in code comments / commits)
 
+These apply to **ruggy**'s voice surface specifically. Satoshi's locked
+register is different (sparse, gnomic, dense block · `apps/character-satoshi/persona.md`).
+
 - Lowercase invariant — comments, commit messages, log lines
-- No corporate-bot tells in user-facing strings (banned: 🚀💯🎉🔥🤑💎🙌💪⚡️✨🌟 — use the 43-emoji catalog in `agent/emojis/registry.ts`)
+- No corporate-bot tells in user-facing strings (banned: 🚀💯🎉🔥🤑💎🙌💪⚡️✨🌟 — use the 43-emoji catalog in `packages/persona-engine/src/orchestrator/emojis/registry.ts`)
 - Numbers from data, voice from persona — never hardcode example figures in production paths
 - In-character errors only — "cables got crossed" not "I apologize for the inconvenience"
 
@@ -69,38 +78,55 @@ If a new concern arises that doesn't fit any construct — ask if it's a new con
 
 - This bot has its own Discord application (own user, own token, own per-zone channels)
 - Sietch lives separately in `loa-freeside/themes/sietch` — handles auth/onboard/score-lookup
-- No command overlap between sietch and ruggy
-- `/agent` stays in sietch (generic LLM); ruggy's voice is scoped to channels only
+- **Utility commands** (verify · score · agent · buy-credits) belong in sietch; never duplicate here.
+- **Persona invocation commands** (V0.7-A.0): `/ruggy <prompt>` and `/satoshi <prompt>` summon a character's voice for an explicit reply. These are NOT utility commands — they're the read-side primitive that pairs with Pattern B's write-side. See `docs/DISCORD-INTERACTIONS-SETUP.md` for the setup walkthrough.
+
+## Anti-spam invariant (load-bearing · operator 2026-04-30)
+
+Characters NEVER respond unsolicited. The ONLY triggers in V0.7-A.0 are
+explicit `/ruggy <prompt>` or `/satoshi <prompt>` slash commands.
+`apps/bot/src/discord-interactions/dispatch.ts` enforces:
+
+- Drop on `interaction.user?.bot === true` (bot-author skip)
+- Drop on webhook-author signatures (defense-in-depth per Gemini DR 2026-04-30)
+- Reject unknown character names
+
+Future phases extend this to @USER mentions and reply-to-bot detection
+(V0.7-A.3+), but the rule survives every phase: no auto-respond on
+channel presence, no name-string matching, no cross-character chaining.
 
 ## Don't do
 
-- Add slash commands here (`/ruggy …`) — that crosses into sietch's surface. Persona-layer bots are channel-post-only.
-- Add a database (state lives in score-mcp, midi_profiles, and `.run/` jsonl caches)
+- Duplicate sietch utility commands (`/verify`, `/score`, etc.) here — those stay in sietch.
+- Add a database (state lives in score-mcp, midi_profiles, and `.run/` jsonl caches; conversation ledger is in-process per V0.7-A.0)
 - Re-implement score logic locally (always call score-mcp)
-- Re-implement LLM logic locally (always go through `agent/orchestrator.ts` via Claude Agent SDK)
-- Generate persona content in code (always load from `persona/ruggy.md`)
+- Re-implement LLM logic locally (digest path goes through `packages/persona-engine/src/orchestrator/`; chat-mode path through `packages/persona-engine/src/compose/reply.ts`)
+- Generate persona content in code (always load from `apps/character-<id>/persona.md`)
 - Hardcode emoji choices (always go through `mcp__emojis__*`)
 - Cite raw `0x…` wallets in prose without first calling `mcp__freeside_auth__resolve_wallet`
-- Compose without first calling rosenzu (spatial blindness — guarded against in arneson skill)
+- Compose digests without first calling rosenzu (spatial blindness — guarded against in arneson skill). N.B.: chat-mode replies have NO tool calls by design (`composeReply` configures the SDK with empty MCP servers).
 
 ## Deploy posture
 
-- **Bot user**: Ruggy#1157 (Discord application registered, token in `.env`)
+- **Bot user**: Ruggy#1157 (transitional shell name · Discord application registered, token in `.env`)
 - **Per-zone channels**: 4 channels in THJ guild, IDs in `.env.example`
 - **Production data path**: score-mcp (zerker, `score-api-production.up.railway.app/mcp`)
 - **Production LLM path**: Claude Agent SDK with `ANTHROPIC_API_KEY` (direct, no freeside-gateway routing currently)
+- **Interactions endpoint (V0.7-A.0)**: requires `DISCORD_PUBLIC_KEY` env + Discord developer portal endpoint URL config. See `docs/DISCORD-INTERACTIONS-SETUP.md`. Disabled when `DISCORD_PUBLIC_KEY` unset (digest cron unaffected).
 - **Hosting**: see `docs/DEPLOY.md` — ECS via loa-freeside is the target; Railway is a faster fallback
 
 ## RFC + doctrine refs
 
 - Topology + score-vault: [loa-freeside#191](https://github.com/0xHoneyJar/loa-freeside/issues/191)
-- Persona doctrine: `vault/wiki/entities/ruggy.md`
+- Persona doctrine: `vault/wiki/entities/ruggy.md` · `vault/wiki/entities/satoshi.md`
 - Two-layer model: `vault/wiki/concepts/two-layer-bot-model.md`
 - Naming: `vault/wiki/concepts/loa-org-naming-conventions.md`
 - Score contracts: `vault/wiki/concepts/score-vault.md`
 - Construct ontology: `vault/wiki/concepts/construct-ontology.md`
+- Listener-router substrate (V0.7-A→B roadmap): `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md`
+- V0.7-A.0 build doc: `~/bonfire/grimoires/bonfire/specs/build-listener-substrate-v07a0.md`
 - Source RFC: `~/bonfire/grimoires/bonfire/context/freeside-bot-topology-score-vault-rfc-2026-04-28.md`
-- Creative direction seed (V0.5-E onward): `~/bonfire/grimoires/bonfire/context/ruggy-creative-direction-seed-2026-04-29.md`
+- Creative direction seed: `~/bonfire/grimoires/bonfire/context/ruggy-creative-direction-seed-2026-04-29.md`
 
 ## Test the loop locally
 

--- a/README.md
+++ b/README.md
@@ -1,317 +1,102 @@
-# freeside-characters (née freeside-ruggy)
+# freeside-characters
 
-> participation-agent umbrella for the honey jar ecosystem. **substrate** at `packages/persona-engine/` (system-agent layer — cron · delivery · MCP orchestration · score-mcp client). **characters** at `apps/character-<id>/` (participation-agent layer — markdown + JSON profiles). **bot** at `apps/bot/` (thin runtime that loads characters and dispatches through the substrate).
->
-> V0.6-A pulled the layers apart structurally per [Eileen's civic-layer doctrine](docs/CIVIC-LAYER.md): system agents (governors) and participation agents (speakers) must not blur. Boundary enforced via package imports + the `CharacterConfig` type contract. New characters land as folders, not forks.
->
-> *Ruggy is the first character — honey jar's bear, laid-back, groovy, been here since the og chat days. Satoshi (Mibera ancestor, codex grail #4488 = Hermes) joins in V0.6-C.*
+Multi-character Discord bot for the Honey Jar ecosystem. **Substrate** at
+`packages/persona-engine/` (system-agent layer — cron, MCPs, delivery,
+prompt composition). **Characters** at `apps/character-<id>/`
+(participation-agent layer — markdown + JSON profiles). **Bot runtime**
+at `apps/bot/` (thin loader that wires both into Discord).
 
-```
-ʕ •ᴥ•ʔ  stay groovy 🐻
-```
+Currently shipping **ruggy** (festival NPC narrator, lowercase OG voice)
+and **satoshi** (mibera-codex agent, sentence-case cypherpunk register).
+Slash commands `/ruggy` and `/satoshi` invite either character into
+Discord conversations. Weekly cron also fires digests in voice per zone.
 
-**See:** [`docs/CIVIC-LAYER.md`](docs/CIVIC-LAYER.md) · [`docs/CHARACTER-AUTHORING.md`](docs/CHARACTER-AUTHORING.md) · [`docs/MULTI-REGISTER.md`](docs/MULTI-REGISTER.md) · [`apps/character-ruggy/ledger.md`](apps/character-ruggy/ledger.md)
+## Architecture at a glance
 
----
-
-## what this is
-
-ruggy is a **character**, not a bot. been around since 2023 — `0xHoneyJar/ruggy-bot/index.js:92` is the og system prompt. this repo is one surface of him: the activity-reporting one, running on discord. as of V0.6-A, the runtime that carries his voice is shared substrate; future characters (satoshi · …) plug into the same engine.
-
-```
-   signal  ──▶  lens stack  ──▶  surface
-  score-mcp     rosenzu · arneson    discord (today)
-                cabal · codex        webhook · email · ops · …
-                emojis · auth        (any chat-shaped target)
-```
-
-**the architecture isn't bot-specific.** persona doc, codex prelude, rosenzu spatial profile, cabal lens rotation, emoji catalog — all portable. only `apps/bot/src/discord/` is discord-shaped. swap surfaces, keep the stack. swap the character, swap the world — the composition pattern stays.
-
-this is the extractable thing: a reference implementation for sibling personas — different character, different world, different chat. forks welcome.
-
----
-
-## two-layer bot model
-
-ruggy is the **persona layer**. different layer from the freeside ops bot.
-
-| layer | bot | role | cadence | blast radius |
-|---|---|---|---|---|
-| 🟦 base utility | [sietch](https://github.com/0xHoneyJar/loa-freeside) (jani-managed) | `/verify` `/onboard` `/score` `/agent` `/buy-credits` — must-haves. one per guild. | reactive (slash commands) | wide (auth, payments) |
-| 🟧 persona | **ruggy (this repo)** + future siblings | channel posts, proactive digests, npc voice. want-to-haves. zero-or-many per guild. | proactive (cron + pop-ins) | narrow (one channel set) |
-
-no command overlap. different ownership. different deploy units. sietch is infra; ruggy is a character. ref: [two-layer-bot-model](https://github.com/0xHoneyJar/loa-freeside/issues/191).
-
-the persona-layer slot is the extractable one — zero, one, or many per guild, each their own character + world-tie + posting register.
-
----
-
-## topology
-
-score is the **bookkeeping layer**. many consumers read it; ruggy is one — the one that translates signals into a character's voice in a chat surface. the rest of this repo is how that translation happens.
+The substrate handles plumbing. Characters supply voice through markdown
+profiles. The boundary is the `CharacterConfig` type contract — characters
+never import substrate internals.
 
 ```mermaid
-flowchart TB
-    chain["⛓️ on-chain activity"]:::source
-    contracts["📜 score-vault contracts · canonical ports"]:::source
-    score["📊 score-api · score-mcp · zerker"]:::core
+flowchart LR
+  cron["⏰ cron schedule"] --> compose
+  slash["⌨️ /ruggy /satoshi"] --> compose
+  compose["🧪 persona-engine<br/>substrate compose"] --> deliver
+  deliver["📨 Pattern B webhook<br/>per-character identity"] --> discord["💬 Discord channel"]
 
-    chain --> score
-    contracts --> score
-
-    subgraph consumers["consumers of score"]
-      ruggy["🐻 ruggy · THIS REPO · discord persona"]:::active
-      dim["📈 dimensions app · operator/user dashboard"]:::other
-      gw["🤖 freeside agent-gateway · LLM tool-call layer"]:::other
-      alerts["🚨 midi-watch alerts · V2"]:::future
-      siblings["… status pages · embeds · future siblings"]:::future
-    end
-
-    score --> ruggy
-    score --> dim
-    score --> gw
-    score --> alerts
-    score --> siblings
-
-    classDef source fill:#fff3cd,stroke:#856404
-    classDef core fill:#d1ecf1,stroke:#0c5460,stroke-width:2px
-    classDef active fill:#d4edda,stroke:#155724,stroke-width:3px
-    classDef other fill:#e2e3e5,stroke:#383d41
-    classDef future fill:#f8f9fa,stroke:#6c757d,stroke-dasharray:5 5
+  classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+  classDef io fill:#fff3cd,stroke:#856404
+  class compose,deliver sub
+  class cron,slash io
 ```
 
----
+Two delivery paths share the substrate:
 
-## how a post gets composed
+- **Write side (V0.6)** — cron fires per zone (weekly digest, pop-in, weaver). Pattern B identity via per-channel webhook.
+- **Read side (V0.7-A.0)** — slash command → interactions HTTP endpoint → chat-mode reply with the user's prompt quote-prepended.
 
-cron fires (or a pop-in roll lands). ruggy runs this loop:
+## Slash command flow
 
 ```mermaid
-flowchart TB
-    trigger["⏰ cron · pop-in trigger"]:::trigger
+flowchart LR
+  user["👤 /satoshi prompt:hi"] --> discord1["Discord"]
+  discord1 --> ep["📡 /webhooks/discord<br/>Bun.serve · Ed25519 verify"]
+  ep --> dispatch["🎯 dispatch<br/>anti-spam guard · resolve character"]
+  dispatch --> ack["⚡ defer ACK<br/>(under 3s)"]
+  ack --> compose2["🧪 composeReply<br/>persona + ledger + Anthropic SDK"]
+  compose2 --> webhook["📨 channel webhook<br/>quote-prepend + Pattern B identity"]
+  webhook --> discord2["💬 Satoshi message lands in channel"]
 
-    subgraph lens["🎲 1 · pick a lens"]
-      cabal["Task → cabal-gygax · haiku · 1 turn · picks 1 of 9 archetypes"]:::sub
-    end
-
-    subgraph gather["📡 2 · gather"]
-      score["mcp__score · get_zone_digest · describe_factor · the trigger"]:::mcp
-      rosenzu["mcp__rosenzu · district · kansei · threshold · the place"]:::mcp
-      auth["mcp__freeside_auth · resolve_wallet · the people"]:::mcp
-      emojis["mcp__emojis · pick_by_mood · recent-used cache · the dictionary"]:::mcp
-    end
-
-    subgraph author["✍️ 3 · author"]
-      arneson["arneson skill · fiction · mechanics · fiction"]:::skill
-      persona["ruggy persona · OG voice · post-type fragment"]:::skill
-      codex["codex prelude · archetypes · trait vocab"]:::skill
-    end
-
-    subgraph deliver["📨 4 · deliver"]
-      shape["sanitize · embed-shape per post-type · message.content fallback"]:::format
-      out["discord channel · webhook · stdout"]:::format
-    end
-
-    trigger --> lens --> gather --> author --> deliver
-
-    classDef trigger fill:#fff3cd,stroke:#856404
-    classDef sub fill:#ffe8d6,stroke:#d4773c,stroke-width:2px
-    classDef mcp fill:#e5f5e0,stroke:#41ab5d
-    classDef skill fill:#f0e5fc,stroke:#7e3ff2
-    classDef format fill:#e2e3e5,stroke:#383d41
+  classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+  classDef io fill:#fff3cd,stroke:#856404
+  class dispatch,compose2 sub
+  class ep,webhook io
 ```
 
-**constructs aren't libraries — they're packaged expertise.** rosenzu carries lynch's spatial vocabulary. arneson carries ttrpg-dm scene-gen rules. gygax carries phantom-player archetypes. the codex carries lore + trait vocabulary. the emoji registry carries thj's expressive surface. the agent loop pulls from each before token-1.
+The anti-spam invariant: characters respond only to explicit user
+invocations. Bot-author messages skip. Webhook-author messages skip.
+Channel presence alone never triggers a reply. This rule survives every
+phase.
 
----
-
-## the constructs
-
-each construct is **a single discipline as a callable surface**. voice quality is a function of how much grounded context lands before token-1.
-
-| construct | lens | surface | carries |
-|---|---|---|---|
-| 🗺️ **rosenzu** | place | in-bot mcp | lynch primitives (node/district/edge/path/inner_sanctum) · kansei vectors (warmth/motion/shadow/density/feel) · per-fire variance · threshold transitions |
-| 🎭 **arneson** | scene-gen | claude code skill | fiction·mechanics·fiction primitive · sensory layering (~30% env / 70% action) · in-character error register · anti-westworld variance |
-| 🎲 **cabal-gygax** | rotation | sdk subagent (haiku) | 9 phantom-player archetypes (optimizer · newcomer · storyteller · rules-lawyer · chaos-agent · gm · anxious-player · veteran · explorer) · solves lens monotony |
-| 📚 **codex** | lore | text prelude | mibera codex `llms.txt` ~2k tokens · archetypes · traits · drug-tarot · ancestor lineages · factor vocab · always-on, not on-demand |
-| 😎 **emojis** | expressive | in-bot mcp | 43-emoji thj guild catalog (26 mibera + 17 ruggy) · mood-tagged · random pick + cross-process recent-used cache (`emoji-recent.jsonl`) |
-| 🪪 **freeside_auth** | identity | in-bot mcp | wallet → handle/discord/mibera_id against `midi_profiles` (railway pg) · 5-min lru · lets prose say `@nomadbera` not `0xb307…d8` |
-| 📊 **score** | bookkeeping | remote mcp (zerker) | `get_zone_digest` · `describe_factor` · `list_dimensions` · `describe_dimension` · the trigger |
-
-ref: `vault/wiki/concepts/construct-ontology.md` for why "construct" not "skill".
-
----
-
-## character not chatbot
-
-ruggy is a **character**, not an assistant. voice is sealed by the persona doc — the doc is the constitution; the llm is the actor reading the lines.
-
-| | chatbot | ruggy |
-|---|---|---|
-| voice source | llm defaults (helpful-assistant) | persona doc + ICE exemplars |
-| greeting | "Hello! How can I help?" | "yo stonehenge" · "henlo bear-cave" |
-| numbers | llm-generated (hallucination risk) | score-mcp (deterministic, fact-checked) |
-| errors | "I apologize for the inconvenience" | "cables got crossed on the main rig" |
-| lowercase | inconsistent | invariant — caps only for proper nouns + tickers |
-| lore | none or rag-on-demand | codex always loaded |
-| post shape | one template | 6 types · own fragment + cadence each |
-| lens | fixed | rotated per fire (9 archetypes) |
-| place | none | lynch primitive + kansei vector per zone |
-
-**fact-checked numbers + sealed voice + rotated lens + grounded place + lore awareness = a character that posts, not a bot that reports.**
-
----
-
-## six post types · three cadences
-
-| type | shape | when |
-|---|---|---|
-| 📰 **digest** | weekly backbone · structured (greeting · stat · prose · closing) | sunday utc midnight, one per zone |
-| 💭 **micro** | pop-in · 1-3 sentences · no greeting · casual surface | per-zone die-roll on `POP_IN_PROBABILITY` |
-| 🪡 **weaver** | cross-zone · names a connection across 2+ zones | wednesday noon utc, primary zone |
-| 📚 **lore_drop** | codex-anchored · archetype / drug-tarot / element ref | pop-in roll |
-| ❓ **question** | open-ended invitation, anchored in data | pop-in roll |
-| 🚨 **callout** | anomaly alert · calm voice over alarm-shaped data | trigger-driven |
-
-same og voice across all six. each type has its own persona fragment (loaded selectively) + data-fit guard (`postTypeFitsData()`) so micros don't pop in to flat data and callouts don't fire without an anomaly.
-
-**arcade move: surprise > schedule.** mix shapes so channels feel alive.
-
----
-
-## four festival zones
-
-zerker's `score-mcp` flavor maps four dimensions of mibera activity onto a festival metaphor:
-
-| zone | lynch primitive | score dimension | archetype |
-|---|---|---|---|
-| 🗿 **stonehenge** | node | overall | monolithic observatory hub · cross-zone |
-| 🐻 **bear-cave** | district | og | freetekno lineage · low-lit warehouse |
-| ⛏️ **el-dorado** | edge | nft | milady-aspirational · treasure-hunt |
-| 🧪 **owsley-lab** | inner_sanctum | onchain | acidhouse · owsley stanley · late-night precision |
-
-each zone: a lynch primitive (kind of place), an archetype tie-in (codex), a baseline kansei vector that rosenzu rotates per fire. per-zone channel mapping in `.env`.
-
-`the-warehouse` exists vocabulary-only — accessible to rosenzu for cross-zone weaver references; activation deferred.
-
----
-
-## quick start
+## Run it locally
 
 ```bash
 bun install
 cp .env.example .env
 
-# stub mode — no external deps, end-to-end
+# Stub mode — no external deps, verify the pipeline end-to-end
 LLM_PROVIDER=stub bun run digest:once
 
-# anthropic-direct — LLM testing
-LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-… bun run digest:once
+# Real mode — digest cron + slash interactions
+ANTHROPIC_API_KEY=sk-...     # or LLM_PROVIDER=bedrock when wired
+DISCORD_BOT_TOKEN=...        # for Discord Gateway + webhook permissions
+DISCORD_PUBLIC_KEY=...       # for Ed25519 signature verification
+CHARACTERS=ruggy,satoshi
+bun run --cwd apps/bot start
 ```
 
-`STUB_MODE=true` (default) generates synthetic ZoneDigests by day-of-week (normal/quiet/spike/thin). `LLM_PROVIDER` is explicit — `stub` · `anthropic` · `freeside` · `auto`. full deploy → [`docs/DEPLOY.md`](docs/DEPLOY.md).
+Slash command setup (Discord developer portal + ngrok / Railway domain):
+[`docs/DISCORD-INTERACTIONS-SETUP.md`](docs/DISCORD-INTERACTIONS-SETUP.md).
 
----
+## Where to read more
 
-<details>
-<summary>📁 repository layout</summary>
-
-```
-apps/bot/
-  src/
-    index.ts                  · entry · wires cron + delivery
-    config.ts                 · zod-validated env (LLM_PROVIDER, cadences, channels)
-    cli/digest-once.ts        · one-shot CLI for testing
-    cron/scheduler.ts         · three concurrent cadences with per-zone fire lock
-    score/
-      client.ts               · score-mcp client + stub generator
-      types.ts                · ZoneDigest / RawStats / NarrativeShape
-      codex-context.ts        · mibera codex prelude loader
-    persona/
-      ruggy.md                · canonical persona (the constitution)
-      loader.ts               · per-post-type fragment extractor
-      exemplar-loader.ts      · ICE (in-context exemplars) loader
-      exemplars/              · past ruggy posts grouped by post type
-      creative-direction.md   · FEEL-side direction notes
-    agent/
-      orchestrator.ts         · claude agent sdk query() runtime
-      rosenzu/                · in-bot sdk mcp (place lens)
-      cabal/gygax.ts          · subagent (lens rotation)
-      emojis/                 · in-bot sdk mcp (expressive surface)
-      freeside_auth/          · in-bot sdk mcp (identity overlay)
-    llm/
-      composer.ts             · build prompt pair → invoke
-      agent-gateway.ts        · explicit provider routing
-      post-types.ts           · 6 post types + data-fit guards
-    discord/
-      client.ts               · discord.js gateway client (with reconnect)
-      post.ts                 · per-zone delivery routing
-    format/
-      embed.ts                · embed shape per post type
-      sanitize.ts             · discord markdown escape
-  .claude/
-    skills/arneson/SKILL.md   · scene-gen skill (loaded via settingSources)
-
-packages/
-  protocol/                   · sealed-schema sub-package (V1 empty —
-                                ruggy is a consumer of score-vault)
-
-docs/
-  ARCHITECTURE.md             · deeper architecture walk
-  DEPLOY.md                   · ECS + railway deploy paths
-```
-
-</details>
-
----
-
-## status · 2026-04-29
-
-- 🟢 **V0.5-E shipped** — gygax cabal lens rotation · factor mcp retired (routes to score-mcp v1.1) · phrase variance · emoji-recent variance cache
-- 🟢 **ruggy#1157 live** in 4 thj discord channels · full tooling stack
-- 🟢 **5 in-bot mcps** — rosenzu · freeside_auth · emojis · cabal-gygax (subagent) · score (HTTP)
-- 🟢 **43-emoji catalog** — real discord names · animated flags · cross-process recent-used cache
-- 🟢 **persona doctrine** — og ruggy-bot anchor restored · mibera/MiDi vocab · post-type fragments · ICE-ready
-- 🟡 **voice tightening in flight** — recent-posts cache · vocab leakage · lens-monotony · cadence rhythm → [seed](https://github.com/0xHoneyJar/bonfire/blob/main/grimoires/bonfire/context/ruggy-creative-direction-seed-2026-04-29.md)
-
-infra is shipped. what remains is creative direction tightening — voice, vocab, variance, cadence rhythm — fresh kickoff sessions, not more scaffold.
-
----
-
-## cult · tech · community
-
-the point isn't a better bot. it's making activity **felt** in the channel where the community lives.
-
-honey jar has been community-first since 2023. score quantifies what mibera do; the dimensions app shows it on a dashboard for those who go look. but most of the community lives in discord, in the channels, where attention already is.
-
-**a persona-layer bot brings activity TO the channel** — not as alerts, not as reports, but as a character noticing things in the voice the community already speaks.
-
-not bloomberg terminal in discord skin. a bear who's been here since the og chat days, who happens to watch the data.
-
-the extractable thing isn't ruggy specifically. it's the **pattern**:
-
-```
-   score-as-trigger  ·  construct-stack-as-lens  ·
-   persona-as-voice  ·  chat-channel-as-surface
-```
-
-applied to any community with their own bookkeeping layer, their own world, their own character. fork welcome.
-
----
-
-## refs
-
-| | |
+| Doc | What |
 |---|---|
-| 📐 two-layer bot model | [loa-freeside#191](https://github.com/0xHoneyJar/loa-freeside/issues/191) |
-| 🐻 persona (this repo) | `apps/bot/src/persona/ruggy.md` |
-| 📜 canonical persona | `~/bonfire/grimoires/bonfire/context/ruggy-canonical-persona-2026-04-28.md` |
-| 🎨 creative direction seed | `~/bonfire/grimoires/bonfire/context/ruggy-creative-direction-seed-2026-04-29.md` |
-| 🚀 V0.5-E kickoff seed | `~/bonfire/grimoires/bonfire/context/ruggy-v05-kickoff-seed-2026-04-28.md` |
-| 🏷️ naming conventions | `vault/wiki/concepts/loa-org-naming-conventions.md` |
-| 🧬 construct ontology | `vault/wiki/concepts/construct-ontology.md` |
+| [`docs/AGENTS.md`](docs/AGENTS.md) | **Start here** — landing page for agents working in this repo · ordered traversal of the rest |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Substrate + character + delivery, full architectural picture |
+| [`docs/CIVIC-LAYER.md`](docs/CIVIC-LAYER.md) | Why substrate ≠ character (Eileen's civic-layer doctrine) |
+| [`docs/CHARACTER-AUTHORING.md`](docs/CHARACTER-AUTHORING.md) | Adding a new character to the umbrella |
+| [`docs/MULTI-REGISTER.md`](docs/MULTI-REGISTER.md) | Per-character voice register locks |
+| [`docs/DISCORD-INTERACTIONS-SETUP.md`](docs/DISCORD-INTERACTIONS-SETUP.md) | Slash command setup walkthrough |
+| [`docs/DEPLOY.md`](docs/DEPLOY.md) | Railway / ECS deploy paths |
+| [`CLAUDE.md`](CLAUDE.md) | Repo conventions for agents working in this codebase |
 
----
+## Status (2026-04-30)
 
-AGPL-3.0 · matching loa-freeside.
+- 🟢 **V0.7-A.0 shipped** — slash commands `/ruggy` and `/satoshi` · Pattern B identity for chat replies · in-process per-channel ledger · quote-prepend for channel context
+- 🟢 ruggy + satoshi live in THJ Discord; Ruggy#1157 shell account dispatches both
+- 🟢 Anthropic Opus 4.7 driving digest and chat-mode pipelines
+- 🟡 **V0.7-A.1 next** — gateway intents + messageCreate observe-only (immediately follows A.0 per cadence note)
+- 🟡 Bedrock provider in design — Eileen's local-satoshi setup
+
+License: AGPL-3.0

--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -1,0 +1,131 @@
+/**
+ * Publish slash commands to Discord (V0.7-A.0).
+ *
+ * One-shot script — run after character set or command schema changes.
+ * Registers `/ruggy`, `/satoshi`, and any additional characters loaded
+ * via the standard CHARACTERS env mechanism.
+ *
+ * Usage:
+ *   # guild-only (immediate propagation in a single guild · use during dev):
+ *   DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... DISCORD_GUILD_ID=... \
+ *     bun run apps/bot/scripts/publish-commands.ts
+ *
+ *   # global (up to 1-hour propagation · use for prod cutover):
+ *   DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... \
+ *     bun run apps/bot/scripts/publish-commands.ts
+ *
+ * Propagation gotcha (Gemini DR 2026-04-30): GLOBAL command sync can take
+ * up to 1 HOUR to propagate · users may invoke OLD CACHED schemas during
+ * the window, sending malformed payloads to the new backend. For breaking
+ * changes, prefer guild-only registration during dev and stage carefully
+ * for prod cutover.
+ *
+ * The script does NOT read DISCORD_APPLICATION_ID from the standard config
+ * schema (it's a deploy-time concern, not a runtime one). The bot token
+ * is the only secret in `.env` strictly required for this script.
+ */
+
+import { loadCharacters } from '../src/character-loader.ts';
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+
+interface CommandOption {
+  name: string;
+  description: string;
+  /** Discord application command option type. STRING=3, BOOLEAN=5. */
+  type: number;
+  required?: boolean;
+}
+
+interface CommandSchema {
+  name: string;
+  description: string;
+  options: CommandOption[];
+}
+
+async function main(): Promise<void> {
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  if (!botToken) {
+    console.error('publish-commands: DISCORD_BOT_TOKEN is required');
+    process.exit(1);
+  }
+
+  const applicationId =
+    process.env.DISCORD_APPLICATION_ID ?? (await fetchApplicationId(botToken));
+  if (!applicationId) {
+    console.error(
+      'publish-commands: DISCORD_APPLICATION_ID not set and could not be derived from /applications/@me',
+    );
+    process.exit(1);
+  }
+
+  const guildId = process.env.DISCORD_GUILD_ID;
+  const characters = loadCharacters();
+  if (characters.length === 0) {
+    console.error('publish-commands: no characters loaded — set CHARACTERS env or ensure apps/character-* exists');
+    process.exit(1);
+  }
+
+  const commands: CommandSchema[] = characters.map((c) => buildCommand(c.id, c.displayName ?? c.id));
+
+  const url = guildId
+    ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
+    : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
+
+  const scope = guildId ? `guild ${guildId}` : 'GLOBAL (1-hour propagation)';
+  console.log(`publish-commands: registering ${commands.length} commands → ${scope}`);
+  for (const cmd of commands) {
+    console.log(`  · /${cmd.name} — ${cmd.description}`);
+  }
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bot ${botToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(commands),
+  });
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => '<unreadable>');
+    console.error(`publish-commands: FAILED status=${response.status}`);
+    console.error(txt);
+    process.exit(1);
+  }
+
+  const result = (await response.json()) as Array<{ id: string; name: string }>;
+  console.log(`publish-commands: registered ${result.length} commands successfully`);
+  for (const r of result) {
+    console.log(`  ✓ /${r.name} → id ${r.id}`);
+  }
+}
+
+function buildCommand(id: string, displayName: string): CommandSchema {
+  const lower = displayName.toLowerCase();
+  return {
+    name: id,
+    description: `talk to ${lower}`,
+    options: [
+      { name: 'prompt', description: `what to say to ${lower}`, type: 3, required: true },
+      { name: 'ephemeral', description: 'only you see the reply', type: 5, required: false },
+    ],
+  };
+}
+
+async function fetchApplicationId(botToken: string): Promise<string | undefined> {
+  const response = await fetch(`${DISCORD_API_BASE}/applications/@me`, {
+    headers: { Authorization: `Bot ${botToken}` },
+  });
+  if (!response.ok) {
+    console.warn(`publish-commands: could not fetch /applications/@me (status ${response.status})`);
+    return undefined;
+  }
+  const data = (await response.json()) as { id?: string };
+  return data.id;
+}
+
+main().catch((err) => {
+  console.error('publish-commands: fatal:', err);
+  process.exit(1);
+});

--- a/apps/bot/scripts/smoke-interactions.ts
+++ b/apps/bot/scripts/smoke-interactions.ts
@@ -1,0 +1,167 @@
+/**
+ * Smoke test for V0.7-A.0 interactions surface.
+ *
+ * Boots the HTTP server with a dummy public key + empty character list,
+ * hits the public routes, exercises the in-process ledger, and reports.
+ *
+ * Run via: bun run apps/bot/scripts/smoke-interactions.ts
+ *
+ * Exit code non-zero on any failure. Suitable for CI smoke-gating.
+ */
+
+import {
+  appendToLedger,
+  getLedgerSnapshot,
+  ledgerChannelCount,
+  splitForDiscord,
+} from '@freeside-characters/persona-engine';
+import { startInteractionServer } from '../src/discord-interactions/server.ts';
+import { loadCharacters } from '../src/character-loader.ts';
+
+const PORT = Number(process.env.SMOKE_PORT ?? '34501');
+const DUMMY_PUBLIC_KEY = '0'.repeat(64); // 32-byte hex, valid format · won't verify real sigs
+
+async function main(): Promise<void> {
+  let failures = 0;
+  const fail = (msg: string) => {
+    console.error(`✗ ${msg}`);
+    failures += 1;
+  };
+  const ok = (msg: string) => console.log(`✓ ${msg}`);
+
+  console.log('── V0.7-A.0 interactions smoke ──');
+
+  // ── Ledger smoke ──────────────────────────────────────────────────
+  appendToLedger('test-channel', {
+    role: 'user',
+    content: 'hello',
+    authorId: 'u1',
+    authorUsername: 'eileen',
+    timestamp: new Date().toISOString(),
+  });
+  appendToLedger('test-channel', {
+    role: 'character',
+    content: 'yo',
+    characterId: 'ruggy',
+    authorId: 'ruggy',
+    authorUsername: 'Ruggy',
+    timestamp: new Date().toISOString(),
+  });
+
+  const snap = getLedgerSnapshot('test-channel', 10);
+  if (snap.length !== 2) fail(`ledger snapshot length expected 2, got ${snap.length}`);
+  else ok('ledger append + snapshot · 2 entries');
+
+  // Ring buffer overflow — push 60, expect 50 cap
+  for (let i = 0; i < 60; i++) {
+    appendToLedger('overflow-channel', {
+      role: 'user',
+      content: `msg ${i}`,
+      authorId: 'u1',
+      authorUsername: 'eileen',
+      timestamp: new Date().toISOString(),
+    });
+  }
+  const overflow = getLedgerSnapshot('overflow-channel', 100);
+  if (overflow.length !== 50) fail(`ring buffer cap broken: expected 50, got ${overflow.length}`);
+  else ok('ledger ring buffer cap · 50 entries after 60 pushes');
+
+  if (overflow[0]?.content !== 'msg 10') {
+    fail(`drop-oldest broken: first entry should be "msg 10", got "${overflow[0]?.content}"`);
+  } else {
+    ok('ledger drop-oldest semantics · oldest entry is msg 10');
+  }
+
+  if (ledgerChannelCount() < 2) fail(`channel count expected ≥2, got ${ledgerChannelCount()}`);
+  else ok(`ledger channel count · ${ledgerChannelCount()}`);
+
+  // ── splitForDiscord smoke ─────────────────────────────────────────
+  const short = splitForDiscord('hello world', 2000);
+  if (short.length !== 1 || short[0] !== 'hello world') fail('split short content failed');
+  else ok('split · short content stays as 1 chunk');
+
+  const longParas = `${'a'.repeat(1500)}\n\n${'b'.repeat(800)}`;
+  const longChunks = splitForDiscord(longParas, 2000);
+  if (longChunks.length !== 2) fail(`split paragraph break expected 2 chunks, got ${longChunks.length}`);
+  else ok('split · paragraph break preserved');
+
+  // ── HTTP server smoke ─────────────────────────────────────────────
+  process.env.DISCORD_PUBLIC_KEY = DUMMY_PUBLIC_KEY;
+
+  // Build a stub Config — only fields the server actually reads at startup.
+  // The server doesn't use any zone or LLM config; it just routes requests.
+  const stubConfig = {
+    LOG_LEVEL: 'info' as const,
+  } as Parameters<typeof startInteractionServer>[0]['config'];
+
+  let characters;
+  try {
+    characters = loadCharacters();
+  } catch {
+    // No CHARACTERS env / character.json missing in CI · fine for smoke
+    characters = [];
+  }
+
+  const handle = startInteractionServer({
+    config: stubConfig,
+    characters,
+    port: PORT,
+  });
+  ok(`server started on :${handle.port}`);
+
+  try {
+    // Health probe
+    const healthResponse = await fetch(`http://localhost:${PORT}/health`);
+    if (!healthResponse.ok) fail(`/health returned ${healthResponse.status}`);
+    else {
+      const body = (await healthResponse.json()) as { status: string; service: string };
+      if (body.status === 'ok' && body.service === 'freeside-characters-interactions') {
+        ok('GET /health · 200 ok');
+      } else {
+        fail(`/health body unexpected: ${JSON.stringify(body)}`);
+      }
+    }
+
+    // Forged signature should reject
+    const forged = await fetch(`http://localhost:${PORT}/webhooks/discord`, {
+      method: 'POST',
+      headers: {
+        'X-Signature-Ed25519': 'aa'.repeat(64),
+        'X-Signature-Timestamp': String(Math.floor(Date.now() / 1000)),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ type: 1 }),
+    });
+    if (forged.status !== 401) fail(`forged sig should yield 401, got ${forged.status}`);
+    else ok('POST /webhooks/discord · 401 on forged signature');
+
+    // Missing headers should also reject
+    const noHeader = await fetch(`http://localhost:${PORT}/webhooks/discord`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    if (noHeader.status !== 401) fail(`missing-header should yield 401, got ${noHeader.status}`);
+    else ok('POST /webhooks/discord · 401 on missing signature headers');
+
+    // 404 for unknown route
+    const notfound = await fetch(`http://localhost:${PORT}/nope`);
+    if (notfound.status !== 404) fail(`unknown path should yield 404, got ${notfound.status}`);
+    else ok('GET /nope · 404');
+  } finally {
+    handle.stop();
+    ok('server stopped');
+  }
+
+  console.log('────────────────────────────────');
+  if (failures > 0) {
+    console.error(`smoke FAILED · ${failures} check(s) failed`);
+    process.exit(1);
+  }
+  console.log('smoke PASSED · all checks green');
+}
+
+main().catch((err) => {
+  console.error('smoke fatal:', err);
+  process.exit(1);
+});

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -26,6 +26,10 @@
 
 import {
   composeReply,
+  getBotClient,
+  getOrCreateChannelWebhook,
+  invalidateWebhookCache,
+  sendChatReplyViaWebhook,
   splitForDiscord,
   type CharacterConfig,
   type Config,
@@ -224,24 +228,33 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
       return;
     }
 
-    const { chunks } = formatReply(character, result.chunks);
-
-    // PATCH first chunk on the deferred response.
-    await patchOriginal(interaction, ephemeral, chunks[0] ?? '');
-
-    // POST remaining chunks as follow-ups, throttled to stay under the
-    // 5-req/2-sec follow-up rate limit (Gemini DR 2026-04-30).
-    for (let i = 1; i < chunks.length; i++) {
-      await sleep(FOLLOW_UP_THROTTLE_MS);
-      await postFollowUp(interaction, ephemeral, chunks[i]!);
+    // Delivery routing:
+    //   - ephemeral=true   → interaction PATCH (webhooks can't be ephemeral ·
+    //                        invoker chose this · accepts shell identity)
+    //   - ephemeral=false  → Pattern B webhook (per-character avatar + username)
+    //                        with PATCH fallback if webhook delivery fails
+    if (ephemeral) {
+      await deliverViaInteraction(interaction, character, result.chunks, true);
+    } else {
+      try {
+        await deliverViaWebhook(interaction, config, character, channelId, result.chunks);
+      } catch (webhookErr) {
+        console.warn(
+          `interactions: ${character.id} webhook delivery failed · falling back to PATCH:`,
+          webhookErr,
+        );
+        invalidateWebhookCache(channelId);
+        await deliverViaInteraction(interaction, character, result.chunks, false);
+      }
     }
 
     console.log(
       `interactions: ${character.id} delivered · ` +
-        `channel=${channelId} chunks=${chunks.length} ` +
+        `channel=${channelId} chunks=${result.chunks.length} ` +
         `compose_ms=${result.contextUsed.durationMs} ` +
         `total_ms=${Date.now() - t0} ` +
-        `ledger=${result.contextUsed.ledgerSize}`,
+        `ledger=${result.contextUsed.ledgerSize} ` +
+        `via=${ephemeral ? 'patch' : 'webhook'}`,
     );
   } catch (err) {
     console.error(
@@ -255,6 +268,67 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
       // recordPatchOutcome inside patchOriginal. No further recovery.
       console.error(`interactions: PATCH-original after error also failed:`, patchErr);
     }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Delivery paths — webhook (Pattern B) vs interaction PATCH (ephemeral)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Pattern B delivery via channel webhook. Slash reply renders with the
+ * character's avatar + username (per-message override on the shell
+ * webhook). The deferred "thinking" PATCH placeholder is DELETEd once
+ * the first chunk lands, leaving a clean Pattern B-shaped channel timeline.
+ *
+ * Throws on any webhook failure so the caller can fall back to PATCH.
+ */
+async function deliverViaWebhook(
+  interaction: DiscordInteraction,
+  config: Config,
+  character: CharacterConfig,
+  channelId: string,
+  chunks: string[],
+): Promise<void> {
+  const client = await getBotClient(config);
+  if (!client) {
+    throw new Error('webhook path: bot client unavailable');
+  }
+  const webhook = await getOrCreateChannelWebhook(client, channelId);
+
+  for (let i = 0; i < chunks.length; i++) {
+    if (i > 0) await sleep(FOLLOW_UP_THROTTLE_MS);
+    await sendChatReplyViaWebhook(webhook, character, chunks[i]!);
+    if (i === 0) {
+      // Delete the deferred "thinking..." placeholder once the first
+      // webhook chunk is up. Best-effort — if it fails (e.g., expired
+      // token, race), the placeholder lingers but delivery is unaffected.
+      void deleteOriginal(interaction).catch((err) => {
+        console.warn(
+          `interactions: deleteOriginal best-effort failed (placeholder may linger):`,
+          err,
+        );
+      });
+    }
+  }
+}
+
+/**
+ * Interaction PATCH delivery — used for ephemeral replies and as a
+ * fallback when webhook delivery fails. Bold-prefix attribution because
+ * the shell-bot identity is the one Discord renders.
+ */
+async function deliverViaInteraction(
+  interaction: DiscordInteraction,
+  character: CharacterConfig,
+  rawChunks: string[],
+  ephemeral: boolean,
+): Promise<void> {
+  const { chunks } = formatReply(character, rawChunks);
+  await patchOriginal(interaction, ephemeral, chunks[0] ?? '');
+  for (let i = 1; i < chunks.length; i++) {
+    await sleep(FOLLOW_UP_THROTTLE_MS);
+    await postFollowUp(interaction, ephemeral, chunks[i]!);
   }
 }
 
@@ -372,6 +446,23 @@ async function postFollowUp(
     const txt = await response.text().catch(() => '<unreadable body>');
     throw new Error(
       `interactions: follow-up POST failed status=${response.status} body=${txt.slice(0, 200)}`,
+    );
+  }
+}
+
+/**
+ * DELETE the deferred response. Used after Pattern B webhook delivery to
+ * clean up the "Application is thinking..." placeholder. 404 is acceptable
+ * (already deleted or token expired).
+ * Endpoint: DELETE /webhooks/{application_id}/{interaction_token}/messages/@original
+ */
+async function deleteOriginal(interaction: DiscordInteraction): Promise<void> {
+  const url = `${DISCORD_API_BASE}/webhooks/${interaction.application_id}/${interaction.token}/messages/@original`;
+  const response = await fetch(url, { method: 'DELETE' });
+  if (!response.ok && response.status !== 404) {
+    const txt = await response.text().catch(() => '<unreadable body>');
+    throw new Error(
+      `interactions: DELETE @original failed status=${response.status} body=${txt.slice(0, 200)}`,
     );
   }
 }

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -232,12 +232,21 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
     //   - ephemeral=true   → interaction PATCH (webhooks can't be ephemeral ·
     //                        invoker chose this · accepts shell identity)
     //   - ephemeral=false  → Pattern B webhook (per-character avatar + username)
-    //                        with PATCH fallback if webhook delivery fails
+    //                        with the user's prompt quote-prepended for channel
+    //                        context · PATCH fallback if webhook delivery fails
     if (ephemeral) {
       await deliverViaInteraction(interaction, character, result.chunks, true);
     } else {
       try {
-        await deliverViaWebhook(interaction, config, character, channelId, result.chunks);
+        await deliverViaWebhook(
+          interaction,
+          config,
+          character,
+          channelId,
+          result.chunks,
+          prompt,
+          invoker.username,
+        );
       } catch (webhookErr) {
         console.warn(
           `interactions: ${character.id} webhook delivery failed · falling back to PATCH:`,
@@ -281,6 +290,11 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
  * webhook). The deferred "thinking" PATCH placeholder is DELETEd once
  * the first chunk lands, leaving a clean Pattern B-shaped channel timeline.
  *
+ * The user's prompt is quote-prepended to the first chunk so other channel
+ * members see what was asked (slash-command argument values aren't shown
+ * in Discord's invocation header). Bridge until V0.7-A.3 lands @-mention
+ * routing where the user's message is a regular Discord post everyone sees.
+ *
  * Throws on any webhook failure so the caller can fall back to PATCH.
  */
 async function deliverViaWebhook(
@@ -289,6 +303,8 @@ async function deliverViaWebhook(
   character: CharacterConfig,
   channelId: string,
   chunks: string[],
+  prompt: string,
+  authorUsername: string,
 ): Promise<void> {
   const client = await getBotClient(config);
   if (!client) {
@@ -296,9 +312,19 @@ async function deliverViaWebhook(
   }
   const webhook = await getOrCreateChannelWebhook(client, channelId);
 
-  for (let i = 0; i < chunks.length; i++) {
+  // Prepend the user's prompt as a Discord blockquote on the first chunk so
+  // others in the channel see context. allowedMentions:[] (set in
+  // sendChatReplyViaWebhook) prevents the @ from triggering a ping.
+  const quote = buildQuotePrefix(authorUsername, prompt);
+  const firstWithQuote = quote + chunks[0]!;
+  const allChunks =
+    firstWithQuote.length <= DISCORD_CHAR_LIMIT
+      ? [firstWithQuote, ...chunks.slice(1)]
+      : [...splitForDiscord(firstWithQuote, DISCORD_CHAR_LIMIT), ...chunks.slice(1)];
+
+  for (let i = 0; i < allChunks.length; i++) {
     if (i > 0) await sleep(FOLLOW_UP_THROTTLE_MS);
-    await sendChatReplyViaWebhook(webhook, character, chunks[i]!);
+    await sendChatReplyViaWebhook(webhook, character, allChunks[i]!);
     if (i === 0) {
       // Delete the deferred "thinking..." placeholder once the first
       // webhook chunk is up. Best-effort — if it fails (e.g., expired
@@ -311,6 +337,23 @@ async function deliverViaWebhook(
       });
     }
   }
+}
+
+const QUOTE_PROMPT_MAX_LEN = 240;
+
+/**
+ * Build a single-line Discord blockquote of the user's prompt. The `@` is
+ * decorative (no ping fires because allowedMentions is empty). Multi-line
+ * prompts collapse to one line so the blockquote renders as one visual
+ * unit · long prompts truncate with an ellipsis (full text remains in the
+ * conversation ledger for LLM context on subsequent invocations).
+ */
+function buildQuotePrefix(authorUsername: string, prompt: string): string {
+  let body = prompt.trim().replace(/\s+/g, ' ');
+  if (body.length > QUOTE_PROMPT_MAX_LEN) {
+    body = body.slice(0, QUOTE_PROMPT_MAX_LEN - 1) + '…';
+  }
+  return `> @${authorUsername} asked: ${body}\n\n`;
 }
 
 /**

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -1,0 +1,405 @@
+/**
+ * Slash command dispatch (V0.7-A.0).
+ *
+ * Discord sends an APPLICATION_COMMAND interaction (POST to our endpoint).
+ * We:
+ *   1. Apply the anti-spam invariant guard (bot-author skip).
+ *   2. Resolve which character the command targets (`/ruggy` → ruggy, etc).
+ *   3. ACK the interaction with a deferred "Application is thinking..." response.
+ *   4. Kick off composeReply in the background.
+ *   5. PATCH the original deferred message with the LLM reply when ready
+ *      (or with a friendly error on timeout/failure).
+ *
+ * The hard rules:
+ *   - 14m30s timeout (Discord interaction token expires at exactly 15:00;
+ *     PATCH after that = 404 + silent UI freeze).
+ *   - 5 req / 2 sec rate limit on follow-ups (per Gemini DR 2026-04-30).
+ *     Multi-chunk replies throttle at 1.5s between sends.
+ *   - Circuit breaker: 3 consecutive 403s on a channel → blacklist ID
+ *     in-process · halt processing until restart (prevents 10K invalid req
+ *     / 10 min Cloudflare global ban from cascading orphaned PATCHes).
+ *
+ * Anti-spam invariant (operator-named load-bearing 2026-04-30):
+ *   characters NEVER respond to bot-authored invocations · NEVER respond
+ *   to webhook invocations · ONLY respond to explicit user invocations.
+ */
+
+import {
+  composeReply,
+  splitForDiscord,
+  type CharacterConfig,
+  type Config,
+} from '@freeside-characters/persona-engine';
+import {
+  InteractionResponseType,
+  InteractionType,
+  MessageFlags,
+  interactionInvoker,
+  readBooleanOption,
+  readStringOption,
+  type DiscordInteraction,
+  type DiscordInteractionResponse,
+} from './types.ts';
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+const DISCORD_CHAR_LIMIT = 2000;
+const FOLLOW_UP_THROTTLE_MS = 1_500; // ≥1.5s between follow-ups (5 req / 2 sec ceiling)
+const TOKEN_LIFETIME_MS = 14 * 60 * 1000 + 30 * 1000; // 14m30s safety margin under 15-min hard expiry
+const CIRCUIT_BREAKER_THRESHOLD = 3;
+
+// Per-channel circuit breaker state. Keyed by channel_id (or interaction.id
+// fallback for DMs). A channel is blacklisted after N consecutive 403s on
+// PATCH/POST attempts; subsequent dispatches in that channel short-circuit
+// until process restart.
+interface CircuitState {
+  consecutive403s: number;
+  blacklisted: boolean;
+}
+const circuitStates = new Map<string, CircuitState>();
+
+function getCircuitState(channelId: string): CircuitState {
+  let s = circuitStates.get(channelId);
+  if (!s) {
+    s = { consecutive403s: 0, blacklisted: false };
+    circuitStates.set(channelId, s);
+  }
+  return s;
+}
+
+function recordPatchOutcome(channelId: string, status: number): void {
+  const s = getCircuitState(channelId);
+  if (status === 403) {
+    s.consecutive403s += 1;
+    if (s.consecutive403s >= CIRCUIT_BREAKER_THRESHOLD) {
+      s.blacklisted = true;
+      console.error(
+        `interactions: circuit breaker tripped for channel ${channelId} ` +
+          `(${s.consecutive403s} consecutive 403s) — blacklisted until restart`,
+      );
+    }
+  } else {
+    s.consecutive403s = 0;
+  }
+}
+
+/**
+ * Main entry — handles APPLICATION_COMMAND interactions.
+ *
+ * Returns the immediate Discord response (deferred ACK or error). Side
+ * effects: when the command is valid, kicks off `doReplyAsync` to PATCH
+ * the deferred message later.
+ */
+export async function dispatchSlashCommand(
+  interaction: DiscordInteraction,
+  config: Config,
+  characters: CharacterConfig[],
+): Promise<DiscordInteractionResponse> {
+  if (interaction.type !== InteractionType.APPLICATION_COMMAND) {
+    return ephemeralReply(`unsupported interaction type ${interaction.type}`);
+  }
+
+  // ─── Anti-spam invariant guard ─────────────────────────────────────
+  // Operator-named load-bearing: characters NEVER respond to bots.
+  // The webhook-author check is a defense-in-depth on top of `bot:true`
+  // since some Discord API versions don't reliably set the bot flag on
+  // webhook-authored invocations (Gemini DR 2026-04-30).
+  const invoker = interactionInvoker(interaction);
+  if (!invoker) {
+    console.warn(`interactions: dropped command with no invoker (id=${interaction.id})`);
+    return ephemeralReply('could not resolve invoker — skipping.');
+  }
+  if (invoker.bot === true) {
+    console.warn(
+      `interactions: ANTI-SPAM SKIP · bot invocation rejected ` +
+        `(invoker=${invoker.username}/${invoker.id})`,
+    );
+    return ephemeralReply('characters do not respond to bot invocations.');
+  }
+
+  // ─── Circuit breaker pre-check ─────────────────────────────────────
+  const channelId = interaction.channel_id ?? `dm:${invoker.id}`;
+  const circuit = getCircuitState(channelId);
+  if (circuit.blacklisted) {
+    console.warn(
+      `interactions: circuit breaker active · skipping channel ${channelId}`,
+    );
+    return ephemeralReply(
+      'this channel is temporarily unavailable for character replies. try again after the next restart.',
+    );
+  }
+
+  // ─── Resolve target character ──────────────────────────────────────
+  const commandName = interaction.data?.name;
+  if (!commandName) {
+    return ephemeralReply('no command name in interaction.');
+  }
+  const character = characters.find((c) => c.id === commandName);
+  if (!character) {
+    return ephemeralReply(
+      `unknown character: \`${commandName}\`. available: ${characters.map((c) => `/${c.id}`).join(', ') || '(none loaded)'}`,
+    );
+  }
+
+  // ─── Read options ──────────────────────────────────────────────────
+  const prompt = readStringOption(interaction, 'prompt');
+  if (!prompt || prompt.trim().length === 0) {
+    return ephemeralReply('prompt is required.');
+  }
+  const ephemeral = readBooleanOption(interaction, 'ephemeral') ?? false;
+
+  // ─── Defer + kick off async work ───────────────────────────────────
+  // The deferred response opens a 15-min token window. We must PATCH
+  // /messages/@original before that window expires or the UI freezes.
+  void doReplyAsync({
+    interaction,
+    config,
+    character,
+    prompt: prompt.trim(),
+    ephemeral,
+    channelId,
+    invoker,
+  }).catch((err) => {
+    // doReplyAsync handles its own errors, but a top-level catch here
+    // prevents an unhandled rejection from crashing the bot.
+    console.error(`interactions: doReplyAsync top-level error:`, err);
+  });
+
+  return {
+    type: InteractionResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+    data: ephemeral ? { flags: MessageFlags.EPHEMERAL } : {},
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Async reply worker
+// ──────────────────────────────────────────────────────────────────────
+
+interface AsyncWorkerArgs {
+  interaction: DiscordInteraction;
+  config: Config;
+  character: CharacterConfig;
+  prompt: string;
+  ephemeral: boolean;
+  channelId: string;
+  invoker: { id: string; username: string };
+}
+
+async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
+  const { interaction, config, character, prompt, ephemeral, channelId, invoker } = args;
+  const t0 = Date.now();
+
+  console.log(
+    `interactions: ${character.id} dispatch · invoker=${invoker.username} ` +
+      `channel=${channelId} ephemeral=${ephemeral} prompt="${truncate(prompt, 80)}"`,
+  );
+
+  try {
+    // Wrap composeReply in a 14m30s timeout so we never PATCH against an
+    // expired interaction token (404 → silent freeze in Discord UI).
+    const result = await Promise.race([
+      composeReply({
+        config,
+        character,
+        prompt,
+        channelId,
+        authorId: invoker.id,
+        authorUsername: invoker.username,
+      }),
+      timeoutAfter(TOKEN_LIFETIME_MS),
+    ]);
+
+    if (result === TIMEOUT_SENTINEL) {
+      console.error(
+        `interactions: ${character.id} TIMEOUT after ${Date.now() - t0}ms · channel=${channelId}`,
+      );
+      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'timeout'));
+      return;
+    }
+
+    if (!result) {
+      console.warn(
+        `interactions: ${character.id} composeReply returned null · channel=${channelId}`,
+      );
+      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'empty'));
+      return;
+    }
+
+    const { chunks } = formatReply(character, result.chunks);
+
+    // PATCH first chunk on the deferred response.
+    await patchOriginal(interaction, ephemeral, chunks[0] ?? '');
+
+    // POST remaining chunks as follow-ups, throttled to stay under the
+    // 5-req/2-sec follow-up rate limit (Gemini DR 2026-04-30).
+    for (let i = 1; i < chunks.length; i++) {
+      await sleep(FOLLOW_UP_THROTTLE_MS);
+      await postFollowUp(interaction, ephemeral, chunks[i]!);
+    }
+
+    console.log(
+      `interactions: ${character.id} delivered · ` +
+        `channel=${channelId} chunks=${chunks.length} ` +
+        `compose_ms=${result.contextUsed.durationMs} ` +
+        `total_ms=${Date.now() - t0} ` +
+        `ledger=${result.contextUsed.ledgerSize}`,
+    );
+  } catch (err) {
+    console.error(
+      `interactions: ${character.id} dispatch failed · channel=${channelId}`,
+      err,
+    );
+    try {
+      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'error'));
+    } catch (patchErr) {
+      // Already-failed PATCH attempt feeds the circuit breaker via
+      // recordPatchOutcome inside patchOriginal. No further recovery.
+      console.error(`interactions: PATCH-original after error also failed:`, patchErr);
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Reply rendering — bold-prefix attribution
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Format the reply with character attribution prefix on the FIRST chunk
+ * only. Subsequent chunks render bare so the prefix doesn't repeat awkwardly.
+ *
+ * The bold-prefix exists because slash command responses come from the
+ * SHELL bot identity (no per-message webhook override is available on
+ * interaction patches per Gemini DR 2026-04-30). It's the unobtrusive
+ * disambiguation when multiple characters share one shell-bot identity.
+ */
+function formatReply(
+  character: CharacterConfig,
+  rawChunks: string[],
+): { chunks: string[] } {
+  if (rawChunks.length === 0) {
+    return { chunks: [`**${character.displayName ?? character.id}**\n\n(empty reply — try again?)`] };
+  }
+  const displayName = character.displayName ?? character.id;
+  const prefix = `**${displayName}**\n\n`;
+  const first = prefix + rawChunks[0]!;
+
+  // If prefix push first chunk over Discord's 2000-char limit, re-split.
+  const chunks: string[] = [];
+  if (first.length <= DISCORD_CHAR_LIMIT) {
+    chunks.push(first);
+    for (let i = 1; i < rawChunks.length; i++) {
+      chunks.push(rawChunks[i]!);
+    }
+  } else {
+    const reSplit = splitForDiscord(first, DISCORD_CHAR_LIMIT);
+    chunks.push(...reSplit);
+    for (let i = 1; i < rawChunks.length; i++) {
+      chunks.push(rawChunks[i]!);
+    }
+  }
+  return { chunks };
+}
+
+function formatErrorReply(character: CharacterConfig, kind: 'timeout' | 'empty' | 'error'): string {
+  const displayName = character.displayName ?? character.id;
+  switch (kind) {
+    case 'timeout':
+      return `**${displayName}**\n\nthat took longer than i had time for. mind trying again?`;
+    case 'empty':
+      return `**${displayName}**\n\ncables got crossed — nothing came back. try again?`;
+    case 'error':
+      return `**${displayName}**\n\nsomething broke. try again?`;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Discord REST helpers — PATCH original + POST follow-up
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * PATCH the deferred response with the actual reply content.
+ * Endpoint: PATCH /webhooks/{application_id}/{interaction_token}/messages/@original
+ * Note: interaction token in URL · NO Authorization header needed.
+ */
+async function patchOriginal(
+  interaction: DiscordInteraction,
+  ephemeral: boolean,
+  content: string,
+): Promise<void> {
+  const url = `${DISCORD_API_BASE}/webhooks/${interaction.application_id}/${interaction.token}/messages/@original`;
+  const body: { content: string; flags?: number } = { content };
+  if (ephemeral) body.flags = MessageFlags.EPHEMERAL;
+
+  const channelId = interaction.channel_id ?? `dm:${interactionInvoker(interaction)?.id ?? 'unknown'}`;
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  recordPatchOutcome(channelId, response.status);
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => '<unreadable body>');
+    throw new Error(
+      `interactions: PATCH @original failed status=${response.status} body=${txt.slice(0, 200)}`,
+    );
+  }
+}
+
+/**
+ * POST a follow-up message (used for chunks 2..N when reply > 2000 chars).
+ * Endpoint: POST /webhooks/{application_id}/{interaction_token}
+ */
+async function postFollowUp(
+  interaction: DiscordInteraction,
+  ephemeral: boolean,
+  content: string,
+): Promise<void> {
+  const url = `${DISCORD_API_BASE}/webhooks/${interaction.application_id}/${interaction.token}`;
+  const body: { content: string; flags?: number } = { content };
+  if (ephemeral) body.flags = MessageFlags.EPHEMERAL;
+
+  const channelId = interaction.channel_id ?? `dm:${interactionInvoker(interaction)?.id ?? 'unknown'}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  recordPatchOutcome(channelId, response.status);
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => '<unreadable body>');
+    throw new Error(
+      `interactions: follow-up POST failed status=${response.status} body=${txt.slice(0, 200)}`,
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Util
+// ──────────────────────────────────────────────────────────────────────
+
+const TIMEOUT_SENTINEL = Symbol('timeout');
+type TimeoutSentinel = typeof TIMEOUT_SENTINEL;
+
+function timeoutAfter(ms: number): Promise<TimeoutSentinel> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(TIMEOUT_SENTINEL), ms);
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function ephemeralReply(content: string): DiscordInteractionResponse {
+  return {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: { content, flags: MessageFlags.EPHEMERAL },
+  };
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}

--- a/apps/bot/src/discord-interactions/server.ts
+++ b/apps/bot/src/discord-interactions/server.ts
@@ -94,6 +94,13 @@ export function startInteractionServer(args: InteractionServerArgs): Interaction
 // Discord POST handler
 // ──────────────────────────────────────────────────────────────────────
 
+/**
+ * Maximum age of a Discord-signed request, in seconds. Beyond this, the
+ * request is rejected as stale (replay protection · bridgebuilder F6
+ * 2026-04-30). Discord's reference implementations use a 5-minute window.
+ */
+const SIGNATURE_FRESHNESS_WINDOW_SECONDS = 5 * 60;
+
 async function handleDiscordPost(
   request: Request,
   publicKey: string,
@@ -104,6 +111,17 @@ async function handleDiscordPost(
 
   if (!signature || !timestamp) {
     return new Response('missing signature headers', { status: 401 });
+  }
+
+  // Freshness check before crypto verify — rejects stale/replayed signatures
+  // cheaply (no Ed25519 work on captured POSTs older than the window).
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) {
+    return new Response('malformed signature timestamp', { status: 401 });
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - timestampSeconds) > SIGNATURE_FRESHNESS_WINDOW_SECONDS) {
+    return new Response('stale signature timestamp', { status: 401 });
   }
 
   const body = await request.text();

--- a/apps/bot/src/discord-interactions/server.ts
+++ b/apps/bot/src/discord-interactions/server.ts
@@ -1,0 +1,213 @@
+/**
+ * Discord Interactions HTTP server (V0.7-A.0).
+ *
+ * Bun HTTP server that receives signed POSTs from Discord, verifies the
+ * Ed25519 signature, dispatches APPLICATION_COMMAND interactions through
+ * `dispatch.ts`, and replies synchronously with the deferred ACK.
+ *
+ * Pattern source:
+ *   - Bun.serve shape    → `~/Documents/GitHub/ruggy-v2/src/webhook-server.ts`
+ *   - Ed25519 + PING     → `~/Documents/GitHub/ruggy-moltbot/src/webhooks/discord.ts:248-277`
+ *
+ * Env required:
+ *   DISCORD_PUBLIC_KEY  Ed25519 public key from Discord developer portal
+ *   INTERACTIONS_PORT   default 3001 (any free port works · only Discord
+ *                       public-internet URL needs to match Railway routing)
+ *
+ * Routes:
+ *   GET  /health              health probe
+ *   POST /webhooks/discord    Discord interactions endpoint
+ */
+
+import type { CharacterConfig, Config } from '@freeside-characters/persona-engine';
+import {
+  InteractionResponseType,
+  InteractionType,
+  type DiscordInteraction,
+  type DiscordInteractionResponse,
+} from './types.ts';
+import { dispatchSlashCommand } from './dispatch.ts';
+
+const DEFAULT_PORT = 3001;
+
+export interface InteractionServerHandle {
+  /** Stop the HTTP server (called from shutdown handlers). */
+  stop: () => void;
+  /** The actual port the server is listening on (helpful for tests). */
+  port: number;
+}
+
+export interface InteractionServerArgs {
+  config: Config;
+  characters: CharacterConfig[];
+  /** Optional override for tests · production reads INTERACTIONS_PORT from env. */
+  port?: number;
+}
+
+export function startInteractionServer(args: InteractionServerArgs): InteractionServerHandle {
+  // Port resolution order (highest precedence first):
+  //   1. explicit args.port (tests / overrides)
+  //   2. INTERACTIONS_PORT env (operator-pinned)
+  //   3. PORT env (Railway / Heroku / Fly auto-inject — the platform's
+  //      reverse proxy maps public 443 → this port)
+  //   4. DEFAULT_PORT 3001 (local dev)
+  const port =
+    args.port ??
+    Number(process.env.INTERACTIONS_PORT ?? process.env.PORT ?? DEFAULT_PORT);
+  const publicKey = process.env.DISCORD_PUBLIC_KEY;
+  if (!publicKey) {
+    throw new Error('DISCORD_PUBLIC_KEY is required to start the interactions server');
+  }
+
+  const server = Bun.serve({
+    port,
+    async fetch(request) {
+      const url = new URL(request.url);
+
+      if (request.method === 'GET' && url.pathname === '/health') {
+        return jsonResponse({
+          status: 'ok',
+          service: 'freeside-characters-interactions',
+          characters: args.characters.map((c) => c.id),
+        });
+      }
+
+      if (request.method === 'POST' && url.pathname === '/webhooks/discord') {
+        return handleDiscordPost(request, publicKey, args);
+      }
+
+      return new Response('Not Found', { status: 404 });
+    },
+    error(err) {
+      console.error('interactions: server error:', err);
+      return new Response('Internal Server Error', { status: 500 });
+    },
+  });
+
+  return {
+    port,
+    stop: () => server.stop(true),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Discord POST handler
+// ──────────────────────────────────────────────────────────────────────
+
+async function handleDiscordPost(
+  request: Request,
+  publicKey: string,
+  args: InteractionServerArgs,
+): Promise<Response> {
+  const signature = request.headers.get('X-Signature-Ed25519');
+  const timestamp = request.headers.get('X-Signature-Timestamp');
+
+  if (!signature || !timestamp) {
+    return new Response('missing signature headers', { status: 401 });
+  }
+
+  const body = await request.text();
+
+  let isValid: boolean;
+  try {
+    isValid = await verifyDiscordSignature(body, signature, timestamp, publicKey);
+  } catch (err) {
+    console.error('interactions: signature verification threw:', err);
+    return new Response('signature verification error', { status: 401 });
+  }
+  if (!isValid) {
+    return new Response('invalid signature', { status: 401 });
+  }
+
+  let interaction: DiscordInteraction;
+  try {
+    interaction = JSON.parse(body) as DiscordInteraction;
+  } catch {
+    return new Response('invalid json body', { status: 400 });
+  }
+
+  // PING (type 1) → PONG (type 1). Required for Discord to validate the
+  // endpoint at registration time. Trivial but mandatory.
+  if (interaction.type === InteractionType.PING) {
+    return jsonResponse({ type: InteractionResponseType.PONG });
+  }
+
+  if (interaction.type === InteractionType.APPLICATION_COMMAND) {
+    const response = await dispatchSlashCommand(interaction, args.config, args.characters);
+    return jsonResponse(response);
+  }
+
+  // Other interaction types (component, autocomplete, modal_submit) aren't
+  // wired in V0.7-A.0. Return a generic ephemeral acknowledgement so Discord
+  // doesn't show "interaction failed" to the user.
+  console.warn(`interactions: unhandled interaction type ${interaction.type}`);
+  const fallback: DiscordInteractionResponse = {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: { content: `interaction type ${interaction.type} not yet supported`, flags: 64 },
+  };
+  return jsonResponse(fallback);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Ed25519 signature verification (Bun WebCrypto · Ed25519 since Bun 1.1)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Verify the Discord Ed25519 signature against `timestamp + body` using the
+ * application's public key. Returns false on any failure (key import error,
+ * malformed hex, signature mismatch).
+ */
+export async function verifyDiscordSignature(
+  body: string,
+  signature: string,
+  timestamp: string,
+  publicKey: string,
+): Promise<boolean> {
+  let publicKeyBytes: Uint8Array;
+  let signatureBytes: Uint8Array;
+  try {
+    publicKeyBytes = hexToBytes(publicKey);
+    signatureBytes = hexToBytes(signature);
+  } catch (err) {
+    console.error('interactions: malformed hex in signature/key:', err);
+    return false;
+  }
+
+  // crypto.subtle's BufferSource type is strict (rejects SharedArrayBuffer).
+  // We know our buffers are ArrayBuffer-backed (TextEncoder + hex parse),
+  // but TS still flags the `.buffer` access. Cast through BufferSource.
+  const message = new TextEncoder().encode(timestamp + body);
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    publicKeyBytes as unknown as BufferSource,
+    { name: 'Ed25519' },
+    false,
+    ['verify'],
+  );
+
+  return crypto.subtle.verify(
+    'Ed25519',
+    key,
+    signatureBytes as unknown as BufferSource,
+    message as unknown as BufferSource,
+  );
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('hex string must have even length');
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    const byte = parseInt(hex.slice(i, i + 2), 16);
+    if (Number.isNaN(byte)) throw new Error(`invalid hex byte at index ${i}`);
+    out[i / 2] = byte;
+  }
+  return out;
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/apps/bot/src/discord-interactions/types.ts
+++ b/apps/bot/src/discord-interactions/types.ts
@@ -1,0 +1,132 @@
+/**
+ * Discord Interactions API types (V0.7-A.0).
+ *
+ * Pattern source: `~/Documents/GitHub/ruggy-moltbot/src/webhooks/discord.ts:299-358`.
+ * Ported to module-level enums + interfaces — kept minimal to what
+ * V0.7-A.0 dispatch actually needs. Extend at V0.7-A.5+ when message
+ * components / modals / autocomplete land.
+ *
+ * Reference: https://discord.com/developers/docs/interactions/receiving-and-responding
+ */
+
+/** Top-level Discord interaction kinds Discord sends to our webhook. */
+export const InteractionType = {
+  PING: 1,
+  APPLICATION_COMMAND: 2,
+  MESSAGE_COMPONENT: 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE: 4,
+  MODAL_SUBMIT: 5,
+} as const;
+export type InteractionType = (typeof InteractionType)[keyof typeof InteractionType];
+
+/** Response types for Discord interactions. */
+export const InteractionResponseType = {
+  PONG: 1,
+  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  /** ACK with "Application is thinking..." UI · 15-min token window opens. */
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE: 5,
+  DEFERRED_UPDATE_MESSAGE: 6,
+  UPDATE_MESSAGE: 7,
+  APPLICATION_COMMAND_AUTOCOMPLETE_RESULT: 8,
+  MODAL: 9,
+} as const;
+export type InteractionResponseType =
+  (typeof InteractionResponseType)[keyof typeof InteractionResponseType];
+
+/**
+ * Discord MessageFlags bitwise constants. EPHEMERAL = 1 << 6 = 64.
+ * Set on initial deferred response to scope the entire interaction lifecycle
+ * to invoker-only visibility (cannot convert to public mid-flight per Gemini DR
+ * 2026-04-30; choose at invocation time).
+ */
+export const MessageFlags = {
+  EPHEMERAL: 1 << 6, // 64
+} as const;
+
+export interface DiscordInteractionUser {
+  id: string;
+  username: string;
+  discriminator?: string;
+  global_name?: string | null;
+  bot?: boolean;
+}
+
+/** Application command option as Discord delivers it (data.options[i]). */
+export interface DiscordOption {
+  name: string;
+  /** Discord application command option type. STRING=3, BOOLEAN=5. */
+  type: number;
+  value?: string | number | boolean;
+  options?: DiscordOption[];
+}
+
+export interface DiscordInteractionData {
+  id: string;
+  name: string;
+  type?: number;
+  options?: DiscordOption[];
+}
+
+export interface DiscordInteraction {
+  type: InteractionType;
+  id: string;
+  application_id: string;
+  /** 15-min interaction token used in PATCH @original / POST follow-ups. */
+  token: string;
+  guild_id?: string;
+  channel_id?: string;
+  /** Present when invoked in a guild (member.user is the invoker). */
+  member?: {
+    user: DiscordInteractionUser;
+  };
+  /** Present when invoked in a DM (user is the invoker). */
+  user?: DiscordInteractionUser;
+  data?: DiscordInteractionData;
+}
+
+export interface DiscordInteractionResponseData {
+  content?: string;
+  embeds?: object[];
+  /** Bitwise OR of MessageFlags (e.g., MessageFlags.EPHEMERAL = 64). */
+  flags?: number;
+  allowed_mentions?: {
+    parse?: ('roles' | 'users' | 'everyone')[];
+    users?: string[];
+    roles?: string[];
+    replied_user?: boolean;
+  };
+}
+
+export interface DiscordInteractionResponse {
+  type: InteractionResponseType;
+  data?: DiscordInteractionResponseData;
+}
+
+/** Helper: extract the invoking user from member (guild) or user (DM). */
+export function interactionInvoker(
+  interaction: DiscordInteraction,
+): DiscordInteractionUser | undefined {
+  return interaction.member?.user ?? interaction.user;
+}
+
+/** Helper: read a typed string option from interaction.data.options. */
+export function readStringOption(
+  interaction: DiscordInteraction,
+  name: string,
+): string | undefined {
+  const opt = interaction.data?.options?.find((o) => o.name === name);
+  if (!opt) return undefined;
+  if (typeof opt.value !== 'string') return undefined;
+  return opt.value;
+}
+
+/** Helper: read a typed boolean option from interaction.data.options. */
+export function readBooleanOption(
+  interaction: DiscordInteraction,
+  name: string,
+): boolean | undefined {
+  const opt = interaction.data?.options?.find((o) => o.name === name);
+  if (!opt) return undefined;
+  if (typeof opt.value !== 'boolean') return undefined;
+  return opt.value;
+}

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -34,6 +34,10 @@ import {
   type CharacterConfig,
 } from '@freeside-characters/persona-engine';
 import { loadCharacters } from './character-loader.ts';
+import {
+  startInteractionServer,
+  type InteractionServerHandle,
+} from './discord-interactions/server.ts';
 
 const banner = `─── freeside-characters bot · v0.6.0-A ────────────────────────`;
 
@@ -116,6 +120,24 @@ async function main(): Promise<void> {
   if (handle.popInExpression) console.log(`${primary.id}: pop-in cron · ${handle.popInExpression}`);
   if (handle.weaverExpression) console.log(`${primary.id}: weaver cron · ${handle.weaverExpression}`);
 
+  // V0.7-A.0: Discord Interactions endpoint for slash commands.
+  // Disjoint from digest cron — failure here doesn't affect Pattern B writes.
+  let interactionServer: InteractionServerHandle | null = null;
+  if (config.DISCORD_PUBLIC_KEY) {
+    try {
+      interactionServer = startInteractionServer({ config, characters, port: config.INTERACTIONS_PORT });
+      console.log(
+        `interactions:   listening on :${interactionServer.port} · ` +
+          `commands /${characters.map((c) => c.id).join(' /')}`,
+      );
+    } catch (err) {
+      console.error('interactions: failed to start —', err);
+      interactionServer = null;
+    }
+  } else {
+    console.log(`interactions:   DISABLED (set DISCORD_PUBLIC_KEY to enable slash commands)`);
+  }
+
   // Always fire digest sweep once on boot in dev or manual
   if (config.NODE_ENV === 'development' || config.DIGEST_CADENCE === 'manual') {
     console.log(`${primary.id}: firing digest sweep once on boot (dev/manual mode)`);
@@ -127,6 +149,7 @@ async function main(): Promise<void> {
   if (config.DIGEST_CADENCE === 'manual') {
     console.log(`${primary.id}: manual mode — exiting after single fire`);
     handle.stop();
+    interactionServer?.stop();
     await shutdownClient();
     process.exit(0);
   }
@@ -134,6 +157,7 @@ async function main(): Promise<void> {
   const shutdown = async (signal: string) => {
     console.log(`\n${primary.id}: ${signal} — shutting down`);
     handle.stop();
+    interactionServer?.stop();
     await shutdownClient();
     process.exit(0);
   };

--- a/apps/character-satoshi/persona.md
+++ b/apps/character-satoshi/persona.md
@@ -276,6 +276,16 @@ choose when and where. Appearances outside stonehenge are event-driven — when
 a genuine threshold surfaces — not restricted, not scheduled.
 The current post is for ZONE: {{ZONE_ID}}.
 
+═══ CODEX ANCHORS (per-character mibera-codex SOIL) ═══
+Below is your character-specific lore tilt — the gumi-authored anchors that
+ground who you are in canonical text. Hermes / Mercury / psychopompia / divine
+trickster / 33 ancestors / cypherpunk reference set. The {{CODEX_PRELUDE}}
+that loads later is the substrate-wide schema index; THIS block is your
+specific lineage. Reference sparingly · ambient register only. Don't quote.
+Don't lore-bomb. The crossing between this and the surface event IS the work.
+
+{{CODEX_ANCHORS}}
+
 {{EXEMPLARS}}
 
 ═══ THIS POST ═══

--- a/apps/character-satoshi/persona.md
+++ b/apps/character-satoshi/persona.md
@@ -413,6 +413,47 @@ Standard emoji rules:
 - 🚨 — never; ruggy's callout signal
 - ʕ •ᴥ•ʔ — ruggy's ascii bear; never satoshi's
 
+═══ VOICE REGISTER LOCK (affirmative anchor — operator-iterated 2026-04-30) ═══
+
+These are the affirmative blueprints that hold across every shape, every
+turn, every conversation. Earlier sections describe what to avoid; THESE
+describe what to compose toward. Read these last; they are the final
+attention anchor before you write.
+
+- **Sentence case throughout.** Every sentence begins with a capital letter.
+  Proper nouns capitalize. The capitalization carries declarative precision —
+  it IS the editorial stance rendered structurally. Lowercase is ruggy's
+  invariant and stays with him; sentence case is yours.
+
+- **Full sentences with subject, verb, observation.** "There are 47 confirmations
+  across 12 keys this window" is the shape — clauses linked by precision. Not
+  "47 confirmations." Sparseness comes from saying one thing fully and stopping,
+  not from rationing syllables.
+
+- **Whitepaper vocabulary as the bedrock.** chain · ledger · consensus ·
+  confirmation · signature · key · hash · observed · noted · recorded ·
+  updated · held · advanced · boundary · threshold · bridge · crossing ·
+  seam · between · cypher · whisper · signal · transmission · pseudonymous ·
+  trustless. Hughes Manifesto cadence; Bitcoin whitepaper register.
+
+- **Wry editorial stance is the voice.** "Surprising no one, the chain has
+  held." "The ledger holds, as it has." The knowing nod is what distinguishes
+  Hermes-as-mediator from a neutral analyst. You have a point of view.
+
+- **Mid-thought opens.** The crossing is already underway when you speak.
+  Drop in; no greeting; no naming the room before observing it.
+
+- **Hermetic close, used sparingly.** "The chain has held." "The ledger
+  holds." "Make of that what you will." Not every reply; not never. Trust
+  silence over filler.
+
+- **Performed silence over literal silence on flat windows.** Brief
+  dismissal or italicized stage direction. Active presence without content.
+
+These blueprints are the positive description. Every "Avoid" item above is
+the shadow of one of these — but compose toward the blueprint, not away from
+the shadow.
+
 ═══ INPUT PAYLOAD ═══
 Zone: {{ZONE_ID}}
 Post-type: {{POST_TYPE}}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,254 @@
+# Agents — Start Here
+
+You're an AI agent (Claude, Codex, Eileen's agent, future ones) landing in
+this repository. This doc is your map. Read it in order; the rest of the
+docs follow naturally from here.
+
+## What this repo is, in 3 lines
+
+1. **A multi-character Discord bot** — currently shipping ruggy (festival NPC
+   narrator, lowercase OG voice) and satoshi (mibera-codex agent, sentence-case
+   cypherpunk register). Slash commands `/ruggy` and `/satoshi` invite either
+   character into Discord conversations. Weekly cron also fires per-zone digests.
+
+2. **Two layers, hard boundary** — `packages/persona-engine/` is the
+   substrate (system-agent layer). `apps/character-<id>/` are characters
+   (participation-agent layer). Characters never import substrate internals;
+   the only coupling is the `CharacterConfig` type contract.
+
+3. **Pattern B identity for delivery** — one shell bot account ("Ruggy#1157")
+   owns the Discord identity. Per-message webhook overrides (PluralKit-style)
+   render each character with their own avatar + name in the channel. This
+   applies to both digest writes and slash-command replies.
+
+## Read these docs in this order
+
+| # | Doc | Why |
+|---|---|---|
+| 1 | [`../README.md`](../README.md) | Smol orientation · architecture diagrams · run instructions |
+| 2 | This doc | What you're reading. Map. |
+| 3 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Full architectural picture · module responsibilities · dependency rules · swap-out matrix |
+| 4 | [`CIVIC-LAYER.md`](CIVIC-LAYER.md) | The doctrine behind substrate ≠ character separation (Eileen's puruhani-as-spine framing) |
+| 5 | [`MULTI-REGISTER.md`](MULTI-REGISTER.md) | Why each character has a locked voice register · gumi corrections · cabal archetypes are AUDIENCE not CHARACTER modes |
+| 6 | [`CHARACTER-AUTHORING.md`](CHARACTER-AUTHORING.md) | How to add a new character to the umbrella |
+| 7 | [`DISCORD-INTERACTIONS-SETUP.md`](DISCORD-INTERACTIONS-SETUP.md) | V0.7-A.0 slash command setup · Discord developer portal config · Railway env |
+| 8 | [`DEPLOY.md`](DEPLOY.md) | Railway / ECS deploy paths |
+| 9 | [`../CLAUDE.md`](../CLAUDE.md) | Repo conventions for agents working in this codebase · Don't-Do list · two-layer model invariants |
+| 10 | [`../apps/character-ruggy/persona.md`](../apps/character-ruggy/persona.md) · [`../apps/character-satoshi/persona.md`](../apps/character-satoshi/persona.md) | The voices themselves · system prompt templates · per-post-type fragments |
+
+## Mental model anchors
+
+These are the load-bearing facts. Internalize before touching code.
+
+### 1. The CharacterConfig boundary
+
+The `CharacterConfig` type at `packages/persona-engine/src/types.ts` is the
+ONLY legitimate import a character can have from the substrate. Characters
+declare what they are via `character.json` + persona markdown; the substrate
+loads them via `loadCharacters()` and dispatches.
+
+```mermaid
+flowchart LR
+  char_json["character.json<br/>id, displayName, personaFile, ..."]:::char
+  persona_md["persona.md<br/>system prompt template + fragments"]:::char
+
+  char_json --> loader["character-loader.ts<br/>(apps/bot)"]
+  persona_md -.->|read at runtime| pe["persona-engine<br/>substrate"]
+  loader -->|"CharacterConfig"| pe
+
+  classDef char fill:#fff3cd,stroke:#856404
+```
+
+Any work that adds substrate features should preserve this contract. If you
+need a new per-character knob, extend `CharacterConfig`. If you need a new
+runtime behavior, add it to the substrate. Don't blur the layers.
+
+### 2. Two delivery pipelines, one substrate
+
+```mermaid
+flowchart LR
+  cron["⏰ cron"] --> digest_compose["composer.ts<br/>composeForCharacter"]
+  slash["⌨️ /slash"] --> chat_compose["compose/reply.ts<br/>composeReply"]
+  digest_compose --> webhook["deliver/webhook.ts<br/>(Pattern B)"]
+  chat_compose --> webhook
+  webhook --> discord["💬 Discord channel"]
+
+  classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+  class digest_compose,chat_compose,webhook sub
+```
+
+- **Write side (V0.6 · digest)** — `composeForCharacter` runs the full Claude
+  Agent SDK with MCPs (score, rosenzu, emojis, freeside_auth). Multi-turn
+  with tool calls. Heavy.
+- **Read side (V0.7-A.0 · chat)** — `composeReply` runs single-turn SDK with
+  empty MCP servers. No tools. Persona + conversation ledger only. Light.
+
+Both deliver via `deliver/webhook.ts` (Pattern B). Slash replies prepend a
+quote of the user's prompt for channel context. Ephemeral slash replies use
+interaction PATCH instead (webhooks can't be ephemeral).
+
+### 3. Anti-spam invariant — load-bearing
+
+Characters respond ONLY to explicit user invocations. The rule survives
+every phase:
+
+- Bot-author messages skip (`interaction.user?.bot === true`)
+- Webhook-author messages skip (defense-in-depth; some Discord versions don't reliably set the bot flag)
+- Channel presence alone never triggers a reply
+- Name-string matching ("hey ruggy") never triggers — only Discord-native triggers (slash, @mention, reply-to-bot)
+- Cross-character chains never auto-trigger; if a user invokes `@ruggy @satoshi` in one message, BOTH respond (operator-ratified) but only because the user explicitly asked for both
+
+If your code lets a character auto-respond on anything other than explicit
+user intent, it's wrong.
+
+### 4. Voice fidelity is iterative
+
+Each character's persona.md has a locked voice register (gumi-curated for
+satoshi · ogr ruggy-bot canon for ruggy). The LLM compose path tries to
+preserve it but can drift, especially on multi-turn under opus-4-7's
+wider interpretive surface.
+
+When drift is observed:
+
+- **Persona-level fix** — replace negative constraints ("NOT lowercase") with
+  affirmative blueprints ("Sentence case throughout — every sentence begins
+  with a capital letter") per Gemini DR's negative-constraint-echo finding.
+- **Substrate-level reinforcement** — the `CONVERSATION_MODE_OVERRIDE` block
+  in `persona/loader.ts` adds chat-mode-specific anchors ("Your case is YOURS")
+  to counter the LLM mirroring user/peer registers in the ledger.
+
+Both layers exist by design. Don't move logic from one to the other unless
+you're sure of the trade.
+
+## Where the action happens
+
+Key files mapped to what they do.
+
+```
+packages/persona-engine/src/
+├── types.ts                    ← CharacterConfig contract (the boundary)
+├── config.ts                   ← Zod env schema
+├── compose/
+│   ├── composer.ts             ← Digest pipeline (write side)
+│   ├── reply.ts                ← Chat-mode pipeline (V0.7-A.0 read side)
+│   └── agent-gateway.ts        ← LLM_PROVIDER routing (stub/anthropic/freeside)
+├── persona/loader.ts           ← buildPromptPair + buildReplyPromptPair + CONVERSATION_MODE_OVERRIDE
+├── conversation/ledger.ts      ← Per-channel ring buffer (V0.7-A.0)
+├── orchestrator/index.ts       ← Claude Agent SDK runtime (digest path with MCPs)
+└── deliver/webhook.ts          ← Pattern B sends (digest + chat both go through here)
+
+apps/bot/src/
+├── index.ts                    ← Entry point · wires everything
+├── character-loader.ts         ← Reads apps/character-<id>/character.json
+└── discord-interactions/
+    ├── server.ts               ← Bun.serve HTTP endpoint (V0.7-A.0)
+    ├── dispatch.ts             ← Slash dispatch + delivery routing
+    └── types.ts                ← Discord Interactions API types
+
+apps/character-<id>/
+├── character.json              ← CharacterConfig shape
+├── persona.md                  ← Voice + system prompt template (gumi-curated for satoshi)
+├── codex-anchors.md            ← Per-character lore tilt
+├── voice-anchors.md            ← Operator-curated past utterances (ruggy)
+└── exemplars/                  ← Per-post-type ICE samples
+```
+
+## Current state (2026-04-30)
+
+| Status | Surface |
+|---|---|
+| 🟢 shipped | V0.6 substrate split (digest cron · Pattern B identity · per-character webhook) |
+| 🟢 shipped | V0.7-A.0 slash command surface (`/ruggy`, `/satoshi` · interactions HTTP webhook · per-channel ledger · quote-prepend · Pattern B for chat replies · circuit breaker · 14m30s timeout guard) |
+| 🟢 shipped | Opus 4.7 default (digest + chat both) · Anthropic-direct via Claude Agent SDK |
+| 🟢 deployed | Railway prod-ruggy (`prod-ruggy-production.up.railway.app`) · 4 zones THJ guild · slash commands registered guild-scoped to project-purupuru staging |
+| 🟡 in design | V0.7-A.1 — gateway intents + messageCreate observe-only (immediately follows A.0 per cadence note in `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md`) |
+| 🟡 in design | Bedrock LLM provider — Eileen's local-satoshi setup ([`EILEEN-LOCAL-SATOSHI.md`](EILEEN-LOCAL-SATOSHI.md)) |
+| 🟡 queued | `/usage` slash + JSONL token tracking · `.dockerignore` `.claude` recursion fix · ruggy persona negative-constraint audit |
+
+## Pending V0.7 → V0.7-B roadmap
+
+The full roadmap lives at `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md`
+(operator's planning area, outside this repo). Phase summary:
+
+| Phase | Surface |
+|---|---|
+| ✅ V0.7-A.0 | Slash commands · barebones interactive surface |
+| 🟡 V0.7-A.1 | Gateway intents + messageCreate observe-only (extends ledger to room-aware) |
+| 🟡 V0.7-A.2 | Channel-context substrate (port to durable store if restart-loss is felt) |
+| 🟡 V0.7-A.3 | Router + reply API for messageCreate (@USER mentions · reply-to-bot) |
+| 🟡 V0.7-A.4 | Classifier (regex first, then LLM) — decides respond-vs-skip |
+| 🟡 V0.7-A.5 | ❓-reaction "who wrote this?" affordance (port from Tupperbox shape) |
+| 🟡 V0.7-A.6 | Rename shell bot from "Ruggy" to neutral ("Freeside") |
+| 🟡 V0.7-B.1 | Cross-character trigger primitive (governance: no infinite loops) |
+| 🟡 V0.7-B.2 | Stage 2 [EXP] — character ↔ character interactions |
+
+## Anti-patterns — DON'T
+
+- **Don't import substrate internals from a character.** Characters declare via JSON + markdown.
+  Substrate dispatches.
+- **Don't add a database for V0.7-A.0 conversation memory.** In-process ledger only.
+  Persistence becomes a problem when restart-loss is felt by humans, not before.
+- **Don't auto-respond.** Anti-spam invariant. Explicit user invocation only.
+- **Don't bypass `composeReply` / `composeForCharacter`.** They wire the persona +
+  voice register lock + provider routing. Going around them = voice drift + cost surprises.
+- **Don't edit gumi-locked persona content destructively.** Locked sections (e.g.
+  `## Voice rules (gumi-locked 2026-04-29)` in satoshi's persona.md) are operator-iteration
+  boundaries. Augment with new sections, don't rewrite.
+- **Don't use the Claude Agent SDK for chat-mode replies expecting it's free.**
+  Chat-mode `composeReply` configures `mcpServers: {}, allowedTools: [], maxTurns: 1, effort: 'low'` for cost reasons.
+  Adding tools or turns to chat-mode bloats per-reply cost.
+- **Don't ship a slash command without registering it via `apps/bot/scripts/publish-commands.ts`.**
+  Code-side `dispatchSlashCommand` won't be invoked unless Discord knows about the command.
+
+## Common workflows
+
+### Adding a new character
+
+See [`CHARACTER-AUTHORING.md`](CHARACTER-AUTHORING.md). Skeleton:
+
+1. Create `apps/character-<id>/` with `character.json` + `persona.md` + `package.json`
+2. Add to `CHARACTERS` env (e.g., `CHARACTERS=ruggy,satoshi,newchar`)
+3. Run `bun run apps/bot/scripts/publish-commands.ts` to register `/<id>` slash
+4. (Optional) Per-character webhook avatar uploaded to assets CDN
+
+### Iterating on a character's voice
+
+Voice changes live at the character level (`apps/character-<id>/persona.md`).
+Substrate changes (`packages/persona-engine/src/persona/loader.ts`) apply
+across all characters — be careful which layer you touch.
+
+For locked content (e.g. gumi's satoshi voice rules), prefer ADDITIVE
+operator-iterated sections over destructive edits. See the
+"VOICE REGISTER LOCK (affirmative anchor)" pattern in satoshi's persona.md
+for an example.
+
+### Local development with Discord interactions
+
+The slash command surface needs a publicly-reachable HTTPS endpoint Discord can
+POST to. For local dev:
+
+1. Run bot with `DISCORD_PUBLIC_KEY=...` env (gets endpoint started)
+2. Run ngrok / cloudflared tunnel to localhost:3001 → public HTTPS URL
+3. Temporarily swap Discord developer portal Interactions Endpoint URL to the tunnel URL
+4. Iterate (bun --watch auto-restarts on code changes)
+5. Swap portal URL back to Railway domain when done
+
+## Reference: planning docs (operator-side, not in repo)
+
+Some context lives in the operator's planning area at `~/bonfire/grimoires/bonfire/`:
+
+- `specs/listener-router-substrate.md` — full V0.7-A → V0.7-B roadmap brief
+- `specs/build-listener-substrate-v07a0.md` — V0.7-A.0 build doc (this ship)
+- `research/gemini-deep-research-output-multi-character-bot-substrate-2026-04-30.md` — Gemini DR findings (negative-constraint echo, MidJourney pattern, etc.)
+- `context/ruggy-creative-direction-seed-2026-04-29.md` — voice tightening direction
+
+If you need that context and it's not in the repo, ask the operator. Don't
+re-derive from training-priors.
+
+## Questions an agent might ask before acting
+
+- "Is this a substrate change or a character change?" → Check what files you'd touch. If `apps/character-<id>/` only → character change. If `packages/persona-engine/` → substrate change. If both → reconsider; usually one is enough.
+- "Should I deploy now?" → Local first via ngrok if iterating; Railway via `railway up` (no GitHub auto-deploy connected) when ready.
+- "Should I commit?" → Confirm with operator unless they've granted explicit autonomy. The repo's history is operator-curated.
+- "Is this voice drift or a feature?" → Check the character's `persona.md`. If the rule is in the doc and being violated, it's drift. If the doc is silent, it's underspecified.
+- "Is the conversation ledger persistent?" → No. In-process only. Restart loses it. By design.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,180 +1,252 @@
-# architecture
+# Architecture
 
-V0.5-E. single bot process. three concurrent cadences. tripartite construct stack: trigger (score-mcp) + place (rosenzu) + scene-gen (arneson) + rotation (cabal-gygax) + identity (freeside_auth) + expressive (emojis). LLM runtime is the claude agent sdk; subagents and in-bot mcps are sdk primitives.
+Multi-character Discord bot. V0.6 split substrate from characters. V0.7-A.0
+added the read-side surface (slash commands → chat-mode replies) alongside
+the existing write-side (cron-driven digest delivery). Single bot process,
+two character profiles, two delivery paths sharing one substrate.
 
-> earlier "V1 webhook + polling" framing has been superseded. git history (`b3bf205` → present) carries the V0.2 → V0.5-E evolution.
+> Earlier "V1 webhook + polling" framing has been superseded. Git history
+> (`b3bf205` → `46dda38` V0.6 substrate split → `60aaf51` V0.7-A.0 ship)
+> carries the V0.2 → V0.7-A.0 evolution.
+
+## Layers
 
 ```mermaid
 flowchart TB
-    cron["⏰ cron/scheduler · digest weekly · pop-in random · weaver weekly · per-zone fire lock"]:::sched
-    cron -->|"FireRequest · zone, postType"| composer
-
-    composer["🧪 llm/composer · build prompt pair → invoke"]:::flow
-    composer --> loader
-
-    loader["📜 persona/loader · per-post-type fragment + codex + ICE + zone hint"]:::flow
-    loader --> orch
-
-    subgraph orch["🎛️ agent/orchestrator · claude agent sdk · permissionMode dontAsk · maxTurns 12 · effort medium"]
-      direction TB
-
-      subgraph sub["🎲 subagent"]
-        cabal["cabal-gygax · haiku · effort low · maxTurns 1 · picks 1 of 9 archetypes · LENS + RATIONALE"]:::subagent
-      end
-
-      subgraph mcps["📡 in-bot mcps · createSdkMcpServer"]
-        rosenzu["rosenzu · 5 tools · place lens"]:::mcp
-        emojis["emojis · 6 tools · THJ guild catalog"]:::mcp
-        auth["freeside_auth · 2 tools · wallet → handle"]:::mcp
-      end
-
-      subgraph remote["🌐 remote mcp · HTTP · MCP_KEY-gated"]
-        score["score (zerker) · get_zone_digest · describe_factor · list/describe_dimension"]:::mcp
-      end
-
-      subgraph skill["📚 skill · settingSources project"]
-        arneson["arneson · scene-gen rules · fiction · mechanics · fiction · sensory layering · in-character errors"]:::skill
-      end
+    subgraph apps["apps/"]
+      bot["📦 apps/bot/<br/>thin runtime · loads characters · wires substrate to Discord"]
+      char_ruggy["🐻 apps/character-ruggy/<br/>persona.md · codex-anchors.md · voice-anchors.md"]
+      char_satoshi["🌀 apps/character-satoshi/<br/>persona.md · codex-anchors.md"]
     end
 
-    orch -->|"voice text"| sanitize
-    sanitize["🧹 format/sanitize · markdown escape · underscore protection"]:::format
-    sanitize --> embed
-    embed["📦 format/embed · per-post-type shape · digest/weaver/callout = embed · micro/lore/question = plain"]:::format
-    embed -->|"DigestPayload"| post
-
-    post["📬 discord/post · routing priority · bot.send → webhook → dry-run"]:::deliver
-    post --> discord
-
-    subgraph discord["🎯 Discord"]
-      direction LR
-      stone["#stonehenge"]:::ch
-      bear["#bear-cave"]:::ch
-      eldorado["#el-dorado"]:::ch
-      owsley["#owsley-lab"]:::ch
+    subgraph packages["packages/"]
+      pe["🧪 packages/persona-engine/<br/>SUBSTRATE — system-agent layer"]
+      proto["📜 packages/protocol/<br/>(placeholder · sealed schemas)"]
     end
 
-    classDef sched fill:#fff3cd,stroke:#856404
-    classDef flow fill:#cce5ff,stroke:#004085
-    classDef subagent fill:#ffe8d6,stroke:#d4773c,stroke-width:2px
-    classDef mcp fill:#e5f5e0,stroke:#41ab5d
-    classDef skill fill:#f0e5fc,stroke:#7e3ff2
-    classDef format fill:#e2e3e5,stroke:#383d41
-    classDef deliver fill:#d1ecf1,stroke:#0c5460
-    classDef ch fill:#f8f9fa,stroke:#495057
+    bot -->|imports| pe
+    bot -->|loads| char_ruggy
+    bot -->|loads| char_satoshi
+
+    char_ruggy -.->|"CharacterConfig (no internal imports)"| pe
+    char_satoshi -.->|CharacterConfig| pe
+
+    classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+    classDef char fill:#fff3cd,stroke:#856404
+    classDef bot fill:#d4edda,stroke:#155724
+    class pe sub
+    class char_ruggy,char_satoshi char
+    class bot bot
 ```
 
-## Module responsibilities
+The boundary is the `CharacterConfig` type contract (`packages/persona-engine/src/types.ts`). Characters
+NEVER import substrate internals; they declare what they are via `character.json` + persona
+markdown, and the substrate dispatches.
 
-| Module | Responsibility | External deps |
-|---|---|---|
-| `cron/scheduler.ts` | Three concurrent cadences (digest backbone, pop-in random, weaver weekly) with per-zone fire lock | `node-cron` |
-| `score/client.ts` | Real MCP client over JSON-RPC + SSE (initialize → notifications/initialized → tools/call) OR synthetic ZoneDigest in stub mode | `fetch` |
-| `score/types.ts` | Mirror score-vault contracts (ZoneDigest / RawStats / NarrativeShape) until `@score-vault/ports` ships | — |
-| `score/codex-context.ts` | Load Mibera Codex `llms.txt` from bundled or operator-local path | — |
-| `persona/ruggy.md` | Canonical persona — single source of truth for voice + Discord-as-Material rules + per-post-type fragments | — |
-| `persona/loader.ts` | Extract per-post-type fragment + substitute placeholders | — |
-| `persona/exemplar-loader.ts` | Load ICE (in-context exemplars) by post type, random select up to 5 per call | — |
-| `agent/orchestrator.ts` | Claude Agent SDK query() runtime; wires mcpServers, subagents, allowedTools, permissionMode | `@anthropic-ai/claude-agent-sdk` |
-| `agent/rosenzu/` | In-bot SDK MCP — place lens (Lynch primitives, KANSEI vectors, threshold transitions) | `@anthropic-ai/claude-agent-sdk` |
-| `agent/cabal/gygax.ts` | Subagent (haiku, maxTurns:1) — picks 1 of 9 phantom-player archetypes; main thread shifts register | `@anthropic-ai/claude-agent-sdk` |
-| `agent/emojis/` | In-bot SDK MCP — 43-emoji THJ catalog with mood tags + cross-process recent-used cache (`.run/emoji-recent.jsonl`) | `@anthropic-ai/claude-agent-sdk` |
-| `agent/freeside_auth/` | In-bot SDK MCP — wallet → handle/discord/mibera_id resolution against `midi_profiles` (Railway Postgres) with 5-min LRU | `@anthropic-ai/claude-agent-sdk`, `pg` |
-| `llm/composer.ts` | Build prompt pair → fetch digest in parallel → invoke LLM → build payload | composes others |
-| `llm/agent-gateway.ts` | Explicit provider routing (`stub` / `anthropic` / `freeside` / `auto`) | — |
-| `llm/post-types.ts` | 6 post-type specs (digest/micro/weaver/lore_drop/question/callout) + data-fit guards (`postTypeFitsData`, `popInFits`, `calloutFits`) | — |
-| `format/sanitize.ts` | Discord markdown escape (underscore protection, etc.) | — |
-| `format/embed.ts` | Per-post-type shape (embed for structured, plain content for casual) | — |
-| `discord/client.ts` | discord.js Gateway client with reconnect-on-disconnect | `discord.js` |
-| `discord/post.ts` | Per-zone delivery routing (bot → webhook → dry-run) | — |
-| `apps/bot/.claude/skills/arneson/SKILL.md` | Scene-gen skill — fiction·mechanics·fiction primitive, sensory layering, in-character errors | (loaded via `settingSources: ['project']`) |
+## Two pipelines, one substrate
 
-## dependency rules
+Both write side (digest cron) and read side (slash commands) compose through
+`packages/persona-engine/`. They differ in trigger source, prompt shape, and
+delivery mechanics.
 
-| module | knows | doesn't know |
-|---|---|---|
-| `score/*` | score-mcp protocol | discord, llm |
-| `agent/*` | sdk runtime + each construct's discipline | delivery |
-| `persona/*` | markdown → strings (pure) | data |
-| `format/*` | data + voice → discord shape (pure) | transport |
-| `discord/*` | discord transport | llm, score |
-| `llm/composer.ts` | **all of them** — the ONE module that composes | — |
+```mermaid
+flowchart TB
+    subgraph triggers["Triggers"]
+      cron["⏰ cron/scheduler<br/>weekly · pop-in · weaver"]:::trig
+      slash["⌨️ /ruggy /satoshi<br/>Discord interaction POST"]:::trig
+    end
 
-swap-out matrix:
+    subgraph compose["Substrate compose"]
+      digest_compose["composer.ts<br/>composeForCharacter<br/>full SDK · MCPs · maxTurns 12"]:::sub
+      chat_compose["compose/reply.ts<br/>composeReply<br/>single-turn SDK · no MCPs"]:::sub
+    end
 
-| swap | rest unchanged |
-|---|---|
-| `discord/*` → email · status page · slack · terminal | voice + constructs |
-| `score/*` → other bookkeeping layer | persona + constructs |
-| persona doc → sibling character | construct stack |
-| zones → different topology | rosenzu profile + cron pivot |
-| add MCP | register in `buildMcpServers`, llm picks up via persona |
+    subgraph context["Context primitives"]
+      persona["persona/loader.ts<br/>buildPromptPair / buildReplyPromptPair"]:::ctx
+      ledger["conversation/ledger.ts<br/>per-channel ring buffer (50)"]:::ctx
+    end
 
-## stub modes — two orthogonal axes
+    subgraph deliver["Pattern B delivery"]
+      webhook["deliver/webhook.ts<br/>per-character avatar + username override"]:::deliv
+      embed["deliver/embed.ts<br/>(digest only · embed shape)"]:::deliv
+    end
 
-- **`STUB_MODE=true`** (default) — synthetic ZoneDigest by day-of-week (normal/quiet/spike/thin). bypasses score-mcp.
-- **`LLM_PROVIDER=stub`** — canned digest output, no llm call. bypasses anthropic sdk + freeside gateway.
+    cron --> digest_compose
+    slash --> chat_compose
+    digest_compose --> persona
+    chat_compose --> persona
+    chat_compose --> ledger
+    digest_compose --> embed
+    digest_compose --> webhook
+    chat_compose --> webhook
+    webhook --> discord["💬 Discord channel<br/>(Pattern B identity per message)"]
 
-independent. pure-offline = both on. voice-validation path: `STUB_MODE=true LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=…`.
+    classDef trig fill:#fff3cd,stroke:#856404
+    classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+    classDef ctx fill:#f0e5fc,stroke:#7e3ff2
+    classDef deliv fill:#e5f5e0,stroke:#41ab5d
+```
 
-## why discord.js (gateway) now
+## Read side (V0.7-A.0)
 
-V0.2 used webhooks. V0.5-A migrated to the gateway (`discord.js`) for:
-
-- per-zone channel routing (4 channels, 1 bot user) — webhooks force 1-channel-per-url
-- reconnect-on-disconnect lifecycle
-- future bot mention parsing (V2)
-- gateway-only intents (Guilds intent suffices today)
-
-webhooks remain as fallback. slash commands are NOT here — they'd cross into sietch's surface (`loa-freeside/themes/sietch`).
-
-## why no DB
-
-state that persists across runs:
-
-- **score-mcp** — activity history (zerker's domain)
-- **midi_profiles** — wallet→identity (loa-freeside's domain)
-- **`.run/*.jsonl`** — emoji recent-used cache (file-backed, cross-process)
-
-ruggy is otherwise stateless. persona is markdown, schedule is cron, digest is fetched fresh per fire. nothing else needs to persist.
-
-if V2+ adds per-guild config (cadence override, mute-until), digest history, error/retry state — small sqlite + drizzle is planned. not before. queued: `recent-posts.jsonl` cache parallel to emoji-recent (per V0.5-E creative direction seed) for content-variance pressure.
-
-## future shape
-
-| addition | trigger | module |
-|---|---|---|
-| `recent-posts.jsonl` cache + MCP | V0.5-E same-data restatement fix | new `agent/memory/` MCP |
-| NATS subscriber | freeside ACTIVITY stream live | `score/nats-subscriber.ts` |
-| slack · email · status-page surface | sibling persona on non-discord surface | new module peer to `discord/` |
-| multi-guild config | another guild adopts ruggy | sqlite + drizzle |
-| ANSI granular feed | high-frequency anomaly alerts | `format/ansi.ts` |
-| schemas published by ruggy | sibling persona coordination | `packages/protocol/` (currently empty placeholder) |
-
-## construct extractability
-
-pattern is portable. to deploy a sibling persona:
+Discord interaction webhook + chat-mode pipeline. Bot listens on
+`INTERACTIONS_PORT` (default 3001 · falls back to `PORT` for Railway/Heroku).
 
 ```mermaid
 flowchart LR
-    persona["📜 persona doc · character.md"]:::var
-    topo["🗺️ zone topology · rosenzu profile"]:::var
-    lens["🎲 cabal lens stack · 9 archetypes"]:::shared
-    codex["📚 codex prelude · llms.txt for your world"]:::var
-    emoji["😎 emoji catalog · mood-tagged"]:::var
-    auth["🪪 identity overlay · your profile table"]:::var
-    score["📊 score consumer · your bookkeeping mcp"]:::var
-    surface["🎯 surface · discord · slack · email · …"]:::var
+  user["👤 /satoshi prompt:hi"] --> discord1["Discord"]
+  discord1 -->|"signed POST"| ep["📡 /webhooks/discord<br/>Bun.serve · Ed25519 verify · PING/PONG"]
+  ep --> dispatch["🎯 dispatch<br/>anti-spam guard<br/>resolve character<br/>parse options"]
+  dispatch -->|"<3s"| ack["⚡ DEFERRED ACK"]
+  ack -.->|"async"| compose["🧪 composeReply<br/>buildReplyPromptPair · ledger snapshot · single-turn SDK"]
+  compose --> deliver["📨 channel webhook<br/>quote-prepend · Pattern B identity"]
+  deliver --> delete["🗑️ DELETE @original<br/>(cleanup deferred placeholder)"]
+  deliver --> discord2["💬 Satoshi reply lands"]
 
-    scaffold["⚙️ shared scaffold · cron · composer · sdk · delivery · character-agnostic"]:::shared
+  classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+  classDef io fill:#fff3cd,stroke:#856404
+  class dispatch,compose sub
+  class ep,deliver,delete io
+```
+
+Key design rules baked into V0.7-A.0:
+
+- **Anti-spam invariant** — characters reply ONLY to explicit user invocations. Bot-author messages skip · webhook-author messages skip · channel presence alone never triggers.
+- **Token-expiry guard** — composeReply wrapped in 14m30s `Promise.race` (Discord interaction tokens hard-expire at 15:00 with no refresh; PATCH after that returns 404 + freezes the UI).
+- **Follow-up rate limit** — chunks beyond the first throttle at 1.5s gaps to stay under Discord's 5/2sec interaction follow-up ceiling.
+- **Circuit breaker** — 3 consecutive 403s on a channel webhook → blacklist that channel ID in-memory until process restart. Prevents Cloudflare's 10K-invalid-req/10min global ban from cascading.
+- **Ephemeral fallback** — `ephemeral:true` invocations use interaction PATCH (webhooks can't be ephemeral); non-ephemeral uses Pattern B webhook for character-identity rendering.
+- **Quote-prepend** — non-ephemeral replies prepend a Discord blockquote of the user's prompt so other channel members see context (slash-command argument values aren't shown in Discord's invocation header).
+
+## Module responsibilities
+
+### `packages/persona-engine/src/` — substrate
+
+| Module | Responsibility | External deps |
+|---|---|---|
+| `index.ts` | Public API barrel · what `apps/bot/` imports | — |
+| `types.ts` | `CharacterConfig` (the contract), `ZoneId`, `PostType`, `EmojiAffinityKind` | — |
+| `config.ts` | Zod-validated env (LLM_PROVIDER, cadences, channels, INTERACTIONS_PORT, DISCORD_PUBLIC_KEY) | `zod` |
+| `cron/scheduler.ts` | Three concurrent cadences (digest backbone, pop-in random, weaver weekly) with per-zone fire lock | `node-cron` |
+| `score/client.ts` | score-mcp client over JSON-RPC + SSE OR synthetic ZoneDigest in stub mode | `fetch` |
+| `score/types.ts` | Mirror score-vault contracts (ZoneDigest / RawStats / NarrativeShape) | — |
+| `score/codex-context.ts` | Mibera Codex `llms.txt` prelude loader | — |
+| `persona/loader.ts` | `buildPromptPair` (digest) + `buildReplyPromptPair` (chat-mode · V0.7-A.0) · CONVERSATION_MODE_OVERRIDE · per-post-type fragment + placeholder substitution | — |
+| `persona/exemplar-loader.ts` | ICE (in-context exemplars) loader, random select up to 5 per call | — |
+| `compose/composer.ts` | `composeForCharacter` — digest pipeline · invokes orchestrator with full MCP stack | — |
+| `compose/reply.ts` | `composeReply` — V0.7-A.0 chat-mode pipeline · single-turn SDK · ledger snapshot · `splitForDiscord` | `@anthropic-ai/claude-agent-sdk` |
+| `compose/agent-gateway.ts` | Explicit provider routing (`stub` / `anthropic` / `freeside` / `auto`) for digest path | — |
+| `compose/headline-lock.ts` | Substrate-level guard enforcing canonical zone emoji in digest headline | — |
+| `compose/post-types.ts` | 6 post-type specs (digest/micro/weaver/lore_drop/question/callout) + data-fit guards | — |
+| `conversation/ledger.ts` | V0.7-A.0 in-process `Map<channelId, RingBuffer<50>>` · drop-oldest · no persistence | — |
+| `orchestrator/index.ts` | Claude Agent SDK `query()` runtime wiring mcpServers + subagents + allowedTools (digest path) | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/rosenzu/` | In-bot SDK MCP — Lynch primitives, KANSEI vectors | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/emojis/` | In-bot SDK MCP — 43-emoji THJ catalog with mood tags + `.run/emoji-recent.jsonl` cache | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/freeside_auth/` | In-bot SDK MCP — wallet → handle/discord/mibera_id resolution against Railway Postgres | `@anthropic-ai/claude-agent-sdk`, `pg` |
+| `orchestrator/cabal/gygax.ts` | Cabal subagent (retired from per-fire compose 2026-04-30 · preserved for future `/cabal` command) | — |
+| `deliver/webhook.ts` | Pattern B delivery · `getOrCreateChannelWebhook` + `sendViaWebhook` (digest) + `sendChatReplyViaWebhook` (V0.7-A.0 chat) | `discord.js` |
+| `deliver/embed.ts` | Per-post-type embed shape (digest/weaver/callout = embed; micro/lore/question = plain) | — |
+| `deliver/post.ts` | `deliverZoneDigest` — bot.send → webhook → dry-run routing | `discord.js` |
+| `deliver/client.ts` | `discord.js` Gateway client with reconnect-on-disconnect | `discord.js` |
+
+### `apps/bot/src/` — runtime
+
+| Module | Responsibility |
+|---|---|
+| `index.ts` | Entry point · loads characters · wires cron + interactions · graceful shutdown |
+| `character-loader.ts` | Reads `apps/character-<id>/character.json` → `CharacterConfig` · honors `CHARACTERS` env |
+| `cli/digest-once.ts` | One-shot CLI for testing — fires single digest sweep then exits |
+| `discord-interactions/server.ts` | V0.7-A.0 `Bun.serve` HTTP endpoint · Ed25519 verify · `/health` + `/webhooks/discord` |
+| `discord-interactions/dispatch.ts` | V0.7-A.0 slash dispatch · anti-spam guard · 14m30s timeout · circuit breaker · webhook-or-PATCH delivery routing |
+| `discord-interactions/types.ts` | Discord Interactions API types (`InteractionType`, `InteractionResponseType`, `MessageFlags`) |
+| `scripts/publish-commands.ts` | One-shot · registers `/ruggy` + `/satoshi` slash commands via Discord API |
+| `scripts/smoke-interactions.ts` | Smoke test · ledger ring buffer + server endpoints |
+
+### `apps/character-<id>/` — characters
+
+| File | What |
+|---|---|
+| `character.json` | `CharacterConfig` shape · id · displayName · personaFile · webhookAvatarUrl · anchoredArchetypes |
+| `persona.md` | Source of truth for voice · system prompt template · per-post-type fragments · gumi-locked content + operator-iterated affirmative voice anchor |
+| `codex-anchors.md` | Per-character mibera-codex SOIL · which archetypes resonate · which lineage |
+| `voice-anchors.md` | Cross-post-type voice texture · operator-curated past utterances |
+| `creative-direction.md` | FEEL-side direction notes |
+| `ledger.md` | Per-character session log · what changed when |
+| `exemplars/` | Per-post-type past utterances for ICE injection |
+| `avatar.png` | Pattern B identity image · operator-uploaded |
+
+## Dependency rules
+
+| Module | Knows | Doesn't know |
+|---|---|---|
+| `packages/persona-engine/score/*` | score-mcp protocol | discord, llm |
+| `packages/persona-engine/orchestrator/*` | SDK runtime + each construct's discipline | delivery |
+| `packages/persona-engine/persona/*` | markdown → strings (pure) | data |
+| `packages/persona-engine/compose/*` | compose pipelines (digest + chat) | persistent state |
+| `packages/persona-engine/deliver/*` | Discord transport (Gateway + webhooks) | LLM internals |
+| `packages/persona-engine/conversation/*` | in-process ring buffer (pure) | LLM |
+| `apps/bot/discord-interactions/*` | HTTP endpoint + slash dispatch | persona, score directly (delegates to substrate) |
+| `apps/bot/index.ts` | wiring · loads characters · starts schedule + interactions server | — |
+| `apps/character-<id>/*` | nothing about substrate internals | substrate code |
+
+Swap-out matrix:
+
+| Swap | Rest unchanged |
+|---|---|
+| `deliver/*` → email · status page · Slack · terminal | voice + constructs |
+| `score/*` → other bookkeeping layer | persona + constructs |
+| persona doc → sibling character | construct stack |
+| zones → different topology | rosenzu profile + cron pivot |
+| add MCP | register in `buildMcpServers`, LLM picks up via persona |
+| add LLM provider | extend `agent-gateway.ts` resolver + `compose/reply.ts` chat path |
+
+## Stub modes — two orthogonal axes
+
+- **`STUB_MODE=true`** (default) — synthetic `ZoneDigest` by day-of-week (normal/quiet/spike/thin). Bypasses score-mcp.
+- **`LLM_PROVIDER=stub`** — canned digest output, no LLM call. Bypasses Anthropic SDK + freeside gateway.
+
+Independent. Pure-offline = both on. Voice-validation path:
+`STUB_MODE=true LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=…`
+
+## Why discord.js (Gateway) + Bun.serve (HTTP)
+
+- **Gateway (`discord.js`)** — V0.5-A migration from V0.2 webhooks. Used for:
+  - Per-zone channel routing (4 channels, 1 bot user) — webhooks force 1-channel-per-url
+  - Reconnect-on-disconnect lifecycle
+  - Webhook fetch/create per channel (Pattern B requires Manage Webhooks)
+  - V0.7-A.1 will extend with messageCreate handler + privileged MessageContent intent
+- **HTTP endpoint (`Bun.serve`)** — V0.7-A.0 addition for Discord Interactions:
+  - Slash commands deliver via signed POST, not Gateway events
+  - Ed25519 verification + PING/PONG handshake
+  - Bun's WebCrypto supports Ed25519 since 1.1+ (no third-party crypto lib)
+
+## Why no DB
+
+State that persists across runs:
+
+- **score-mcp** — activity history (zerker's domain)
+- **midi_profiles** — wallet→identity (loa-freeside's domain)
+- **`apps/bot/.run/*.jsonl`** — emoji recent-used cache (file-backed, cross-process)
+- **conversation ledger** — IN-PROCESS ONLY (V0.7-A.0). Restart loses it by design; persistence becomes a problem only when felt.
+
+Everything else is recomputed: persona is markdown, schedule is cron, digest is fetched fresh per fire. If V2+ adds per-guild config (cadence override, mute-until), digest history, error/retry state, or persistent character memory — small SQLite + Drizzle is planned. Not before.
+
+## Construct extractability
+
+Pattern is portable. To deploy a sibling character:
+
+```mermaid
+flowchart LR
+    persona["📜 character.json + persona.md<br/>+ codex-anchors.md + voice-anchors.md"]:::var
+    avatar["🖼️ avatar.png<br/>+ webhookAvatarUrl"]:::var
+    codex_per["📚 per-character codex anchors<br/>(your character's lore tilt)"]:::var
+
+    scaffold["⚙️ shared substrate<br/>packages/persona-engine/<br/>character-agnostic"]:::shared
+    surface["🎯 Discord (today)<br/>or Slack · email · ops · …"]:::var
 
     persona --> scaffold
-    topo --> scaffold
-    lens --> scaffold
-    codex --> scaffold
-    emoji --> scaffold
-    auth --> scaffold
-    score --> scaffold
+    avatar --> scaffold
+    codex_per --> scaffold
     scaffold --> surface
 
     classDef var fill:#fff3cd,stroke:#856404
@@ -183,4 +255,18 @@ flowchart LR
 
 🟨 = per-character variable. 🟩 = stays the same across siblings.
 
-most of `apps/bot/src/` works as a template. `persona/`, the rosenzu profile, the codex pointer, and the surface module are the per-character variables. the rest carries.
+The only required per-character files are `character.json` + `persona.md` (with system prompt template + per-post-type fragments). Everything else is optional enrichment.
+
+## Future shape
+
+| Addition | Trigger | Module |
+|---|---|---|
+| messageCreate handler + observe-only ledger extension | V0.7-A.1 (immediately after A.0 per cadence note) | `apps/bot/src/discord-interactions/gateway-listener.ts` |
+| @USER mention routing | V0.7-A.3 | `apps/bot/src/discord-interactions/router.ts` |
+| Bedrock LLM provider | Eileen's local-satoshi setup | `compose/reply.ts` extension + `compose/agent-gateway.ts` resolver |
+| `/usage` slash + JSONL token tracking | cost awareness | `apps/bot/src/discord-interactions/dispatch.ts` + `apps/bot/scripts/usage-report.ts` |
+| `recent-posts.jsonl` cache + MCP | content-variance pressure | new `orchestrator/memory/` MCP |
+| Conversation ledger persistence | restart-loss becomes felt | `conversation/ledger.ts` extension to SQLite |
+| Slash command for `/usage` cost reporting | operator awareness | `apps/bot/src/discord-interactions/dispatch.ts` |
+| Multi-guild config | another guild adopts a character | SQLite + Drizzle |
+| Schemas published by characters | sibling persona coordination | `packages/protocol/` (currently empty placeholder) |

--- a/docs/CHARACTER-AUTHORING.md
+++ b/docs/CHARACTER-AUTHORING.md
@@ -143,9 +143,10 @@ CHARACTERS=satoshi           # only satoshi
 CHARACTERS=ruggy,satoshi     # both (V0.6-D routing decides who speaks per fire)
 ```
 
-Default is `ruggy` (V0.5-E parity). The first character in the list is the
-"primary" — until V0.6-D's routing layer ships, all fires dispatch through
-the primary.
+Default is `ruggy`. The first character in the list is the "primary" — for
+the digest path, all fires dispatch through the primary (V0.6-A behavior).
+V0.6-D will add per-fire affinity routing. V0.7-A.0 slash commands route
+explicitly to the invoked character regardless of primary.
 
 ## Smoke-test a new character
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,6 +1,20 @@
 # Deploy
 
-V0.6-D deploy shape: **1 bot account · 2 Railway services · webhook-shell pattern.** One Discord App acts as the runtime shell hosting N characters via per-channel webhooks with per-message identity override (`username` + `avatar_url`). Per Eileen's `puruhani-as-spine.md`: *"the Discord App becomes the interface/runtime shell."*
+> ⚠️ **STATUS (2026-04-30)**: this doc describes the V0.6-D **target** deploy
+> shape (2 Railway services). Reality after V0.7-A.0 ship: there is **1
+> Railway service** (`prod-ruggy`) running the V0.6 + V0.7-A.0 codebase
+> against THJ guild + project-purupuru staging guild (the same bot account
+> is in both guilds; channel IDs differ per env). GitHub auto-deploy is NOT
+> wired — deploys go via `railway up`. Slash commands registered guild-scoped
+> to project-purupuru only. Full doc rewrite is pending.
+>
+> **Quick reference for V0.7-A.0**: required env on Railway = `ANTHROPIC_API_KEY`,
+> `ANTHROPIC_MODEL` (set to `claude-opus-4-7`), `DISCORD_BOT_TOKEN`,
+> `DISCORD_PUBLIC_KEY`, `INTERACTIONS_PORT=3001`, `MCP_KEY`, `CHARACTERS=ruggy,satoshi`.
+> Plus 4 zone channel IDs. See [`DISCORD-INTERACTIONS-SETUP.md`](DISCORD-INTERACTIONS-SETUP.md)
+> for the slash-command-specific setup.
+
+V0.6-D deploy shape (target): **1 bot account · 2 Railway services · webhook-shell pattern.** One Discord App acts as the runtime shell hosting N characters via per-channel webhooks with per-message identity override (`username` + `avatar_url`). Per Eileen's `puruhani-as-spine.md`: *"the Discord App becomes the interface/runtime shell."*
 
 > ECS migration via `loa-freeside` is queued (see end of this doc). Railway is the active path.
 

--- a/docs/DISCORD-INTERACTIONS-SETUP.md
+++ b/docs/DISCORD-INTERACTIONS-SETUP.md
@@ -1,0 +1,221 @@
+# Discord Interactions Setup (V0.7-A.0)
+
+The slash-command surface for the freeside-characters bot. After V0.6's
+write-side substrate (Pattern B per-character webhook digest delivery),
+V0.7-A.0 adds the **read-side primitive**: explicit `/ruggy <prompt>`
+and `/satoshi <prompt>` invocations that route a user's message to the
+target character and reply with the LLM's voice in-channel.
+
+This doc walks through Discord developer portal setup, env vars, and
+slash-command registration. The bot's digest cron is unaffected by any
+of this; the interactions endpoint is additive.
+
+> Before running this, confirm V0.6 is healthy: `digest:once` fires post,
+> bot user is connected, per-zone channels mapped. The interactions path
+> doesn't touch those, but a broken V0.6 makes V0.7 confusion harder to debug.
+
+## What you'll set up
+
+1. A public-internet HTTPS endpoint Discord can POST to
+2. The Ed25519 public key from your Discord application
+3. Two slash commands: `/ruggy` and `/satoshi`
+
+After setup, an authorized user can invoke `/satoshi prompt:hey` in any
+channel where the bot is present, and Satoshi will reply in-character
+within ~10 seconds.
+
+## Env vars
+
+Add to your Railway service (or local `.env` for dev):
+
+```dotenv
+# Required to start the interactions HTTP server
+DISCORD_PUBLIC_KEY=<copy from Discord developer portal · General Information tab>
+
+# Optional · port resolution order:
+#   1. INTERACTIONS_PORT (this var, operator-pinned)
+#   2. PORT (Railway / Heroku / Fly auto-inject)
+#   3. 3001 (local dev default)
+INTERACTIONS_PORT=
+```
+
+On Railway, leave `INTERACTIONS_PORT` unset and the bot will bind to
+whatever `PORT` Railway injects — the edge proxy maps public 443 → that
+internal port automatically. Pin `INTERACTIONS_PORT` only if you want
+local-dev parity with prod (e.g., 3001).
+
+The existing `DISCORD_BOT_TOKEN` is reused for command registration.
+Slash command **invocations** use the interaction token Discord embeds
+in each request — no bot token in the request path.
+
+### Railway networking
+
+V0.6 ran outbound-only — the existing Railway service may not have a
+public domain. To enable inbound HTTPS for V0.7-A.0:
+
+1. Railway → bot service → **Networking** → **Generate Domain** (yields
+   `<service>.up.railway.app`)
+2. The platform reverse proxy will route public 443 → the `PORT` env it
+   injects. The bot's interactions server picks `PORT` up automatically
+   (see env table above).
+3. Use the generated domain as your Discord Interactions Endpoint URL:
+   `https://<service>.up.railway.app/webhooks/discord`
+
+## Step-by-step
+
+### 1. Pick the deploy mode
+
+Two modes for slash command registration:
+
+| Mode    | Propagation  | When to use                            |
+|---------|--------------|----------------------------------------|
+| guild   | immediate    | development · staging · single-server  |
+| global  | up to 1 hour | production cutover · multi-server bots |
+
+Always start guild-only. Promote to global only after the staging shape
+is confirmed.
+
+### 2. Configure the Discord application
+
+In the Discord developer portal:
+
+1. Navigate to **Applications → freeside-characters → General Information**
+2. Set **Interactions Endpoint URL** to your public HTTPS host:
+   - prod: `https://<your-railway-host>/webhooks/discord`
+   - staging: `https://<your-staging-host>/webhooks/discord`
+3. Copy the **Public Key** field. Set it as `DISCORD_PUBLIC_KEY` on the
+   Railway service that runs the bot.
+4. **Save Changes.** Discord will POST a PING to the endpoint to verify
+   the signing handshake. If your endpoint is reachable and the public key
+   is correct, the save succeeds. Otherwise see Troubleshoot below.
+
+### 3. Register the slash commands
+
+```bash
+# Guild-only (dev / staging)
+DISCORD_BOT_TOKEN=<bot token> \
+DISCORD_APPLICATION_ID=<application id> \
+DISCORD_GUILD_ID=<guild id> \
+  bun run apps/bot/scripts/publish-commands.ts
+
+# Global (prod cutover)
+DISCORD_BOT_TOKEN=<bot token> \
+DISCORD_APPLICATION_ID=<application id> \
+  bun run apps/bot/scripts/publish-commands.ts
+```
+
+`DISCORD_APPLICATION_ID` is in the developer portal under
+**General Information → Application ID**. The script will fall back to
+`GET /applications/@me` if the env var is unset.
+
+The script auto-loads characters via the standard `character-loader.ts`
+mechanism, so it registers `/<id>` for each. `CHARACTERS=ruggy,satoshi`
+yields `/ruggy` and `/satoshi`.
+
+### 4. Smoke-test in a private channel
+
+Invoke `/satoshi prompt:say hi in voice` in a guild channel. Expect:
+
+1. Discord shows "freeside-characters is thinking..." immediately (the
+   deferred ACK).
+2. Within ~10 seconds the deferred message updates to the reply prefixed
+   with `**Satoshi**`.
+3. The reply preserves Satoshi's locked register (dense block, no honey-
+   bear emoji).
+
+Try `/ruggy prompt:report on stonehenge` — expect chunked-beats voice.
+
+Try `/satoshi prompt:test ephemeral:true` — only the invoker sees the reply.
+
+## Required Discord permissions
+
+The bot's OAuth invite link must include the `applications.commands`
+scope. If the bot was invited via the standard URL Discord generates
+under **OAuth2 → URL Generator → Scopes**, this is already included.
+
+If `/ruggy` shows up but Discord says "the application did not respond
+in time," see Troubleshoot below.
+
+## Troubleshoot
+
+### Discord rejects "Save" on Interactions Endpoint URL
+
+Discord posts a PING to verify the endpoint when you save. Common causes
+of failure:
+
+- `DISCORD_PUBLIC_KEY` env var doesn't match the Public Key in the portal
+- The endpoint isn't actually reachable from the public internet (Railway
+  preview URL · localhost · firewall)
+- The endpoint isn't replying with `{ "type": 1 }` to PING. Check:
+  ```bash
+  curl https://<host>/health
+  # → {"status":"ok","service":"freeside-characters-interactions","characters":[...]}
+  ```
+- The PING/PONG handshake takes more than 3 seconds (cold-start bot,
+  startup probe failing)
+
+### Endpoint validates but slash commands don't appear
+
+Slash command propagation:
+
+- Guild-only: appears within seconds. If not, run `publish-commands.ts`
+  again and check the output for command IDs.
+- Global: up to 1 hour. Use guild-only during dev to dodge this.
+
+If the script returns `401 Unauthorized` — bot token is wrong.
+If `403 Forbidden` — the bot OAuth invite doesn't include
+`applications.commands` scope. Re-invite with the correct URL.
+
+### Slash invokes but Discord shows "the application did not respond in time"
+
+- Bot didn't ACK within Discord's 3-second initial-response window.
+  Check `interactions:` log output — the deferred ACK should fire
+  within ~10ms of receiving the POST.
+- Service crashed mid-dispatch and PATCH @original never fired. Check
+  bot logs for unhandled errors during composeReply.
+- Interaction token expired (15-min hard limit · LLM took too long).
+  V0.7-A.0 wraps composeReply in a 14m30s timeout · the user sees a
+  timeout-apology in this case · should be rare for slash commands.
+
+### "Application is thinking..." never updates
+
+- `DISCORD_PUBLIC_KEY` is correct but the PATCH endpoint is unreachable
+  from the bot. Confirm outbound HTTPS works to discord.com from Railway.
+- Circuit breaker tripped on this channel (3 consecutive 403s on PATCH
+  attempts). Check logs for `circuit breaker tripped for channel`.
+  Restart the bot to clear the in-process state.
+
+### Local dev signature reject (expected)
+
+The interactions server rejects signatures it can't verify. To smoke-test
+locally without the Discord round-trip:
+
+```bash
+# Health check
+curl http://localhost:3001/health
+
+# Forged PING — expect 401 Invalid signature
+curl -X POST http://localhost:3001/webhooks/discord \
+  -H "X-Signature-Ed25519: dummy" \
+  -H "X-Signature-Timestamp: $(date +%s)" \
+  -d '{"type":1}'
+```
+
+Real PING/PONG validation only happens once Discord can reach the
+endpoint with a valid signature.
+
+## What V0.7-A.0 doesn't do
+
+These are intentionally out of scope (V0.7-A.1 onward):
+
+- **messageCreate handler** — the bot doesn't observe arbitrary channel
+  messages. Only explicit `/ruggy` or `/satoshi` invocations trigger replies.
+- **Reply-to-bot continuation** — replying natively to a character's
+  message in Discord won't route to that character. Use `/character` again.
+- **Cross-character chaining** — `@ruggy @satoshi` in plain text doesn't
+  trigger both. (When V0.7-A.3 lands, explicit `@USER` mentions will.)
+- **Persistent memory** — the per-channel ledger is in-process. Restart
+  loses it. V0.7+ daemon-stage adds durable per-character memory.
+
+See `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md` for
+the full V0.7-A → V0.7-B roadmap.

--- a/docs/EILEEN-LOCAL-SATOSHI.md
+++ b/docs/EILEEN-LOCAL-SATOSHI.md
@@ -1,0 +1,120 @@
+# Eileen's local-satoshi setup (in design — placeholder doc)
+
+> **Status (2026-04-30)**: this is a stub. The Bedrock LLM provider isn't
+> built yet. Eileen will share her Bedrock model spec; we'll wire the
+> provider + a one-command launcher in the next session.
+
+## What this is for
+
+Eileen has been given a private Amazon Bedrock API key and wants to run
+satoshi on her own machine using Bedrock for inference. The freeside-characters
+runtime currently supports `LLM_PROVIDER=stub | anthropic | freeside | auto`;
+adding `bedrock` is a small extension to `compose/reply.ts` and `compose/agent-gateway.ts`.
+
+Goal: she clones the repo, sets a few env vars, runs one command, and
+satoshi is alive in the project-purupuru staging guild — using HER bedrock
+key, on HER machine, isolated from operator's Railway deploy.
+
+## What's pending
+
+| Item | Owner | Notes |
+|---|---|---|
+| Bedrock provider in chat-mode pipeline | operator + agent | `LLM_PROVIDER=bedrock` · `@aws-sdk/client-bedrock-runtime` · single-turn invoke · ~1 hour lift |
+| Bedrock model spec | Eileen | She'll share which model IDs her access covers (anthropic.claude-* on Bedrock) |
+| Easy-launch script | operator + agent | `bun run satoshi:dev` · starts tunnel + bot + prints Discord portal URL · ~1 hour |
+| Discord app architecture | decision | Hand over freeside-characters portal URL temporarily vs. Eileen creates her own "satoshi-local" Discord app |
+| `.dockerignore` `.claude` recursion fix | low priority | Currently `.claude` excludes recursively; `apps/bot/.claude/skills/arneson/SKILL.md` doesn't make it into Railway image. Doesn't affect Eileen's local run. |
+
+## Setup flow (when bedrock provider lands)
+
+This is the target shape, not yet wired:
+
+```bash
+# 1. Clone + install
+git clone https://github.com/0xHoneyJar/freeside-characters
+cd freeside-characters
+bun install
+
+# 2. Copy + edit env
+cp .env.example .env
+
+# Required for Eileen's setup:
+#   AWS_ACCESS_KEY_ID=...           (her bedrock creds)
+#   AWS_SECRET_ACCESS_KEY=...
+#   AWS_REGION=us-east-1            (or whichever region her bedrock access covers)
+#   BEDROCK_MODEL_ID=anthropic.claude-opus-4-7-...   (per her spec)
+#   LLM_PROVIDER=bedrock
+#
+#   DISCORD_BOT_TOKEN=...           (operator hands over OR Eileen registers her own bot)
+#   DISCORD_PUBLIC_KEY=...          (matches her Discord app)
+#   CHARACTERS=satoshi              (just satoshi, not ruggy, for her solo experiments)
+
+# 3. One-command launcher (TODO — not built yet)
+bun run satoshi:dev
+# → starts ngrok tunnel
+# → starts bot with --watch
+# → prints "set Discord portal URL to: https://<tunnel>/webhooks/discord"
+# → tails bot logs
+```
+
+## What Eileen's agent should know now
+
+Until the bedrock provider lands, Eileen's agent can study the existing
+infrastructure to plan the bedrock integration:
+
+1. **Read [`AGENTS.md`](AGENTS.md) first** — the orientation doc for any
+   incoming agent. Maps the rest of the docs.
+2. **Read [`ARCHITECTURE.md`](ARCHITECTURE.md)** — full architectural picture.
+   Key for understanding where the bedrock provider would slot in
+   (`compose/agent-gateway.ts` resolver + `compose/reply.ts` chat path).
+3. **Read [`MULTI-REGISTER.md`](MULTI-REGISTER.md)** — voice register doctrine.
+   Especially relevant if Eileen iterates on satoshi's voice using bedrock-served Claude.
+4. **Read `apps/character-satoshi/persona.md`** — satoshi's full voice
+   specification. The "VOICE REGISTER LOCK (affirmative anchor)" section
+   added 2026-04-30 is the operator-iterated layer; everything above it is
+   gumi-locked.
+5. **Look at `packages/persona-engine/src/compose/reply.ts`** — the chat-mode
+   pipeline. The bedrock provider is a sibling to `invokeChatAnthropicSdk`
+   in this file (or extracted into `compose/agent-gateway.ts` for symmetry).
+
+## Why local-only (and not on Railway prod-ruggy)
+
+- **Cost isolation** — Eileen's bedrock key is private; she shouldn't fund
+  operator's prod-ruggy traffic.
+- **Voice iteration speed** — local `--watch` restart on code edit beats
+  Railway redeploy for tight voice-tuning loops.
+- **Identity isolation** — operator's Discord application has prod-ruggy's
+  identity; running Eileen's local satoshi against the same app would
+  conflict on the global Interactions Endpoint URL.
+
+## Discord app architecture options
+
+The freeside-characters Discord application has ONE Interactions Endpoint URL.
+While Eileen's local bot is running, slash invocations from project-purupuru
+need to route to HER local, not to operator's Railway. Three paths:
+
+| Option | Trade |
+|---|---|
+| **A. Hand over the freeside-characters URL during her sessions** | Simple · prod /satoshi blackout while Eileen is running locally |
+| **B. Eileen creates her own "satoshi-local" Discord app + bot** | Two `/satoshi` commands appear in the autocomplete (one per app) · she manages her own bot identity |
+| **C. Run side-by-side via different guilds** | Doesn't work — Discord routes per app, not per guild |
+
+Recommend **A for the first couple of sessions** (paired iteration with
+operator), then **B once she's running solo** so the prod path stays clean.
+
+## Tomorrow's session
+
+Operator + agent + (optionally) Eileen pair on:
+
+1. Read her bedrock spec
+2. Wire `LLM_PROVIDER=bedrock` in `compose/reply.ts` + `agent-gateway.ts`
+3. Add `BEDROCK_MODEL_ID` + AWS creds to `config.ts`
+4. Write `apps/bot/scripts/satoshi-dev.ts` launcher
+5. Update this doc with the actual setup walkthrough (replace placeholders)
+6. Eileen test-runs it with operator on standby
+7. Hand over portal URL or Eileen registers her own app per option above
+
+## Coordination
+
+When Eileen's spec arrives or this doc needs updates: ping operator (soju).
+The build doc roadmap is in `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md` (operator's planning vault).

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -1,0 +1,325 @@
+/**
+ * Reply composer (V0.7-A.0) — slash-command chat-mode pipeline.
+ *
+ * Mirror of `composeForCharacter` for conversational replies. The substrate
+ * supplies plumbing (ledger snapshot, prompt build, LLM call, chunk split);
+ * the character supplies voice via persona.md.
+ *
+ * Civic-layer note: this is a SUBSTRATE-level composer. It speaks Discord
+ * shape (chunks, character limits) and persona-engine shape (config,
+ * CharacterConfig, LedgerEntry) — never both. Characters consume the
+ * result through `apps/bot/src/discord-interactions/dispatch.ts`.
+ *
+ * V0.7-A.0 invariants honored:
+ *   - No tool calls (mcpServers = {}, allowedTools = [], maxTurns: 1).
+ *   - No memory primitive — ledger is in-process per channel only.
+ *   - No persistent state — restart loses ledger by design.
+ *   - Voice fidelity preserved via persona template + chat-mode override.
+ */
+
+import { query, type Options } from '@anthropic-ai/claude-agent-sdk';
+import type { Config } from '../config.ts';
+import type { CharacterConfig } from '../types.ts';
+import { buildReplyPromptPair } from '../persona/loader.ts';
+import {
+  appendToLedger,
+  getLedgerSnapshot,
+  type LedgerEntry,
+} from '../conversation/ledger.ts';
+
+export interface ReplyComposeArgs {
+  config: Config;
+  character: CharacterConfig;
+  /** The user's message text (the slash-command `prompt:` option). */
+  prompt: string;
+  /** Discord channel id where the slash was invoked. */
+  channelId: string;
+  /** Discord user id of the invoker (stored in ledger for transcript). */
+  authorId: string;
+  /** Discord username (or display name) of the invoker. */
+  authorUsername: string;
+  options?: {
+    /** How many recent ledger entries to feed the prompt. Default 10. */
+    historyDepth?: number;
+    /** For telemetry only — actual ephemeral flag handled by dispatch. */
+    ephemeral?: boolean;
+  };
+}
+
+export interface ReplyComposeResult {
+  /** The full reply text (pre-split). */
+  content: string;
+  /** Pre-split chunks, each ≤ 2000 chars (Discord message limit). */
+  chunks: string[];
+  contextUsed: {
+    ledgerSize: number;
+    promptTokens?: number;
+    durationMs: number;
+  };
+}
+
+const DISCORD_CHAR_LIMIT = 2000;
+const DEFAULT_HISTORY_DEPTH = 10;
+
+export async function composeReply(
+  args: ReplyComposeArgs,
+): Promise<ReplyComposeResult | null> {
+  const t0 = Date.now();
+  const historyDepth = args.options?.historyDepth ?? DEFAULT_HISTORY_DEPTH;
+  const history = getLedgerSnapshot(args.channelId, historyDepth);
+
+  const { systemPrompt, userMessage } = buildReplyPromptPair({
+    character: args.character,
+    prompt: args.prompt,
+    authorUsername: args.authorUsername,
+    history: history.map((h) => ({
+      role: h.role,
+      authorUsername: h.authorUsername,
+      content: h.content,
+    })),
+  });
+
+  const replyText = await invokeChat(args.config, {
+    character: args.character,
+    systemPrompt,
+    userMessage,
+  });
+
+  if (!replyText || replyText.trim().length === 0) {
+    return null;
+  }
+
+  const trimmed = replyText.trim();
+  const chunks = splitForDiscord(trimmed, DISCORD_CHAR_LIMIT);
+
+  // Ledger discipline: append BOTH the user message AND the character
+  // reply, in order. Future invocations in the same channel see this as
+  // shared context. The ledger entry stores the FULL reply (not chunks)
+  // so transcript rendering doesn't repeat the split.
+  const nowIso = new Date().toISOString();
+  const userEntry: LedgerEntry = {
+    role: 'user',
+    content: args.prompt.trim(),
+    authorId: args.authorId,
+    authorUsername: args.authorUsername,
+    timestamp: nowIso,
+  };
+  const characterEntry: LedgerEntry = {
+    role: 'character',
+    content: trimmed,
+    characterId: args.character.id,
+    authorId: args.character.id,
+    authorUsername: args.character.displayName ?? args.character.id,
+    timestamp: new Date().toISOString(),
+  };
+  appendToLedger(args.channelId, userEntry);
+  appendToLedger(args.channelId, characterEntry);
+
+  return {
+    content: trimmed,
+    chunks,
+    contextUsed: {
+      ledgerSize: history.length,
+      durationMs: Date.now() - t0,
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Chat-mode LLM invocation (single-turn, no MCPs, no tools)
+// ──────────────────────────────────────────────────────────────────────
+
+interface ChatInvokeArgs {
+  character: CharacterConfig;
+  systemPrompt: string;
+  userMessage: string;
+}
+
+async function invokeChat(config: Config, req: ChatInvokeArgs): Promise<string> {
+  // Provider resolution mirrors agent-gateway.ts but for chat-mode the
+  // anthropic path is the canonical one. Stub returns a canned in-voice
+  // reply; freeside path uses the gateway's chat shape.
+  switch (resolveChatProvider(config)) {
+    case 'anthropic':
+      return invokeChatAnthropicSdk(config, req);
+    case 'stub':
+      return invokeChatStub(req);
+    case 'freeside':
+      return invokeChatFreeside(config, req);
+  }
+}
+
+type ChatProvider = 'stub' | 'anthropic' | 'freeside';
+
+function resolveChatProvider(config: Config): ChatProvider {
+  switch (config.LLM_PROVIDER) {
+    case 'stub':
+      return 'stub';
+    case 'anthropic':
+      if (!config.ANTHROPIC_API_KEY) {
+        throw new Error('LLM_PROVIDER=anthropic but ANTHROPIC_API_KEY is unset');
+      }
+      return 'anthropic';
+    case 'freeside':
+      if (!config.FREESIDE_API_KEY) {
+        throw new Error('LLM_PROVIDER=freeside but FREESIDE_API_KEY is unset');
+      }
+      return 'freeside';
+    case 'auto':
+      if (config.ANTHROPIC_API_KEY) return 'anthropic';
+      if (config.STUB_MODE) return 'stub';
+      if (config.FREESIDE_API_KEY) return 'freeside';
+      throw new Error('LLM_PROVIDER=auto: no chat provider available');
+  }
+}
+
+async function invokeChatAnthropicSdk(
+  config: Config,
+  req: ChatInvokeArgs,
+): Promise<string> {
+  // Single-turn chat shape: no MCP servers, no allowed tools, no skills.
+  // Subprocess env scrubbed of CLAUDECODE_* so the SDK uses direct
+  // Anthropic auth (mirrors orchestrator/index.ts buildSdkEnv).
+  const env: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith('CLAUDE_CODE_') || k === 'CLAUDECODE' || k === 'CLAUDE_PLUGIN_DATA') {
+      continue;
+    }
+    env[k] = v;
+  }
+  env.ANTHROPIC_API_KEY = config.ANTHROPIC_API_KEY!;
+
+  const options: Options = {
+    systemPrompt: req.systemPrompt,
+    model: config.ANTHROPIC_MODEL,
+    mcpServers: {},
+    allowedTools: [],
+    permissionMode: 'dontAsk',
+    settingSources: [],
+    tools: [],
+    maxTurns: 1,
+    effort: 'low',
+    env,
+    stderr: (data) => {
+      if (config.LOG_LEVEL === 'debug') {
+        console.error(`[sdk:chat] ${data.trimEnd()}`);
+      }
+    },
+  };
+
+  let text = '';
+  for await (const message of query({ prompt: req.userMessage, options })) {
+    if (message.type !== 'result') continue;
+    if (message.subtype === 'success') {
+      text = message.result;
+      break;
+    }
+    throw new Error(
+      `composeReply: SDK chat error subtype=${message.subtype}` +
+        (message.errors?.length ? ` errors=${message.errors.join('; ')}` : ''),
+    );
+  }
+  return text;
+}
+
+async function invokeChatFreeside(
+  config: Config,
+  req: ChatInvokeArgs,
+): Promise<string> {
+  const url = `${config.FREESIDE_BASE_URL}/api/agents/invoke`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(config.FREESIDE_API_KEY && { 'x-api-key': config.FREESIDE_API_KEY }),
+    },
+    body: JSON.stringify({
+      agent: 'default',
+      modelAlias: config.FREESIDE_AGENT_MODEL,
+      messages: [
+        { role: 'system', content: req.systemPrompt },
+        { role: 'user', content: req.userMessage },
+      ],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`freeside agent-gateway chat error: ${response.status} ${await response.text()}`);
+  }
+  const data = (await response.json()) as { text: string };
+  return data.text;
+}
+
+function invokeChatStub(req: ChatInvokeArgs): string {
+  // Voice-shaped canned replies — keeps STUB_MODE smoke testing meaningful
+  // (operators can verify the dispatch + ledger + chunk pipeline without
+  // burning Anthropic credits or risking voice drift in tests).
+  const id = req.character.id;
+  if (id === 'satoshi') {
+    return 'the ledger acknowledges. attention is the asset; you brought yours. that is the relevant transaction.';
+  }
+  if (id === 'ruggy') {
+    return [
+      'yo — ruggy here, stub-mode (no llm wired).',
+      ``,
+      `you said: "${truncate(req.userMessage, 120)}"`,
+      ``,
+      `wire ANTHROPIC_API_KEY + LLM_PROVIDER=anthropic to get the real voice. stay groovy.`,
+    ].join('\n');
+  }
+  return `[stub reply from ${req.character.displayName ?? req.character.id}]`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Chunk splitting (Discord 2000-char message limit)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Split content into Discord-safe chunks, preferring natural break points.
+ * Order: paragraph (\n\n) → line (\n) → sentence (. ) → word ( ) → hard cut.
+ *
+ * Pattern source: `~/Documents/GitHub/ruggy-moltbot/src/handlers/chat.ts:192-238`
+ * (splitLongMessage). Same shape, no functional changes.
+ */
+export function splitForDiscord(content: string, maxLength: number): string[] {
+  if (content.length <= maxLength) return [content];
+
+  const out: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      out.push(remaining);
+      break;
+    }
+
+    let splitAt = maxLength;
+    const paragraph = remaining.lastIndexOf('\n\n', maxLength);
+    if (paragraph > maxLength * 0.5) {
+      splitAt = paragraph + 2;
+    } else {
+      const line = remaining.lastIndexOf('\n', maxLength);
+      if (line > maxLength * 0.5) {
+        splitAt = line + 1;
+      } else {
+        const sentence = remaining.lastIndexOf('. ', maxLength);
+        if (sentence > maxLength * 0.5) {
+          splitAt = sentence + 2;
+        } else {
+          const word = remaining.lastIndexOf(' ', maxLength);
+          if (word > maxLength * 0.5) {
+            splitAt = word + 1;
+          }
+        }
+      }
+    }
+
+    out.push(remaining.slice(0, splitAt).trim());
+    remaining = remaining.slice(splitAt).trim();
+  }
+
+  return out;
+}

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -321,5 +321,8 @@ export function splitForDiscord(content: string, maxLength: number): string[] {
     remaining = remaining.slice(splitAt).trim();
   }
 
-  return out;
+  // Filter empty chunks — whitespace-only LLM output or trim-on-boundary
+  // edge cases can yield empty strings, which Discord rejects with 400
+  // (bridgebuilder F10 2026-04-30).
+  return out.filter((c) => c.length > 0);
 }

--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -24,7 +24,11 @@ const ConfigSchema = z.object({
 
   // ─── anthropic-direct (V0 LLM testing) ────────────────────────────────
   ANTHROPIC_API_KEY: z.string().optional(),
-  ANTHROPIC_MODEL: z.string().default('claude-sonnet-4-6'),
+  /** Default flipped sonnet-4-6 → opus-4-7 (operator pick 2026-04-30 ·
+   *  V0.7-A.0 ship pass · highest voice-fidelity model for both digest
+   *  and chat-mode pipelines). Override via env when a per-deploy cost
+   *  tradeoff calls for sonnet/haiku. */
+  ANTHROPIC_MODEL: z.string().default('claude-opus-4-7'),
 
   // ─── discord delivery — bot client OR webhook fallback ────────────────
   DISCORD_BOT_TOKEN: z.string().optional(),

--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -65,6 +65,13 @@ const ConfigSchema = z.object({
   /** Where weaver posts land — usually stonehenge (cross-zone observatory). */
   WEAVER_PRIMARY_ZONE: z.enum(['stonehenge', 'bear-cave', 'el-dorado', 'owsley-lab']).default('stonehenge'),
 
+  // ─── V0.7-A.0 — Discord Interactions endpoint (slash commands) ────────
+  /** Ed25519 public key from Discord developer portal. When unset the
+   *  interactions server doesn't start (digest cron path is unaffected). */
+  DISCORD_PUBLIC_KEY: z.string().optional(),
+  /** Port the interactions HTTP server binds to (default 3001). */
+  INTERACTIONS_PORT: z.coerce.number().int().min(1).max(65535).default(3001),
+
   // ─── meta ─────────────────────────────────────────────────────────────
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),

--- a/packages/persona-engine/src/conversation/ledger.ts
+++ b/packages/persona-engine/src/conversation/ledger.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-channel conversation ledger (V0.7-A.0).
+ *
+ * In-process ring buffer of recent messages per Discord channel. Used by
+ * `composeReply` to give characters short-term "reading-the-room" awareness
+ * across slash invocations without a persistent memory primitive.
+ *
+ * Civic-layer note (per `listener-router-substrate.md` §invariants 5):
+ * this is CONVERSATION CONTEXT, not character MEMORY. Restart loses it
+ * by design — restart-loss only becomes a problem when felt. Persistent
+ * cross-session character memory is V0.7+ daemon-stage territory.
+ *
+ * Cap: 50 entries per channel (matches moltbot `chat.ts:319` precedent).
+ * Drop-oldest-on-overflow. No persistence. No cross-channel leakage.
+ *
+ * Pattern source: `~/Documents/GitHub/ruggy-moltbot/src/handlers/chat.ts`
+ * (loadConversationHistory + storeConversation) — same shape, R2 dropped
+ * for in-process Map.
+ */
+
+export interface LedgerEntry {
+  /** 'user' = human invoker · 'character' = a character's reply */
+  role: 'user' | 'character';
+  /** The message text. For character entries, the LLM's reply (not chunks). */
+  content: string;
+  /** Present only when role='character' — which character authored. */
+  characterId?: string;
+  /**
+   * For role='user': Discord user id.
+   * For role='character': character.id (e.g. 'ruggy', 'satoshi').
+   */
+  authorId: string;
+  /**
+   * Display label for transcript rendering.
+   * For role='user': Discord username (resolved via mention lookup if needed).
+   * For role='character': character.displayName ?? character.id.
+   */
+  authorUsername: string;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+}
+
+const MAX_ENTRIES_PER_CHANNEL = 50;
+
+const ledgers = new Map<string, LedgerEntry[]>();
+
+export function appendToLedger(channelId: string, entry: LedgerEntry): void {
+  const buf = ledgers.get(channelId) ?? [];
+  buf.push(entry);
+  if (buf.length > MAX_ENTRIES_PER_CHANNEL) {
+    buf.splice(0, buf.length - MAX_ENTRIES_PER_CHANNEL);
+  }
+  ledgers.set(channelId, buf);
+}
+
+export function getLedgerSnapshot(channelId: string, lastN: number): LedgerEntry[] {
+  const buf = ledgers.get(channelId);
+  if (!buf || buf.length === 0) return [];
+  if (lastN <= 0) return [];
+  return buf.slice(-lastN);
+}
+
+/** Testing only — not exported from package barrel. */
+export function clearLedger(channelId: string): void {
+  ledgers.delete(channelId);
+}
+
+/** Diagnostic — exposed for boot banner / health checks. */
+export function ledgerChannelCount(): number {
+  return ledgers.size;
+}

--- a/packages/persona-engine/src/deliver/webhook.ts
+++ b/packages/persona-engine/src/deliver/webhook.ts
@@ -122,6 +122,34 @@ export async function sendViaWebhook(
 }
 
 /**
+ * Send a plain-text chat reply through the channel webhook with per-character
+ * identity (V0.7-A.0). Mirror of `sendViaWebhook` but for the conversation
+ * surface — no embed, no digest payload shape, just the LLM's reply text.
+ *
+ * Pattern B identity preservation for slash command replies: the user sees
+ * the character's avatar + username as the speaker, not the shell-bot
+ * identity. Aligns chat replies with digest writes per Eileen's vault canon.
+ */
+export async function sendChatReplyViaWebhook(
+  webhook: Webhook,
+  character: CharacterConfig,
+  content: string,
+): Promise<{ posted: true; messageId: string }> {
+  const username =
+    character.webhookUsername ?? character.displayName ?? character.id;
+  const avatarURL = character.webhookAvatarUrl;
+
+  const message = await webhook.send({
+    username,
+    avatarURL,
+    content,
+    allowedMentions: { parse: [] },
+  });
+
+  return { posted: true, messageId: message.id };
+}
+
+/**
  * Invalidate the cache entry for a channel — call when send fails with
  * "unknown webhook" (HTTP 404) so the next call re-fetches/re-creates.
  */

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -35,6 +35,13 @@ export { schedule } from './cron/scheduler.ts';
 export { deliverZoneDigest, isDryRun } from './deliver/post.ts';
 export { getBotClient, shutdownClient } from './deliver/client.ts';
 
+// Webhook delivery primitives (V0.7-A.0 — slash replies use Pattern B too)
+export {
+  getOrCreateChannelWebhook,
+  sendChatReplyViaWebhook,
+  invalidateWebhookCache,
+} from './deliver/webhook.ts';
+
 // Config API
 export { loadConfig, getZoneChannelId, selectedZones } from './config.ts';
 

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -42,6 +42,18 @@ export { loadConfig, getZoneChannelId, selectedZones } from './config.ts';
 export { loadSystemPrompt } from './persona/loader.ts';
 export { exemplarStats } from './persona/exemplar-loader.ts';
 
+// Reply API (V0.7-A.0 — chat-mode pipeline for slash command replies)
+export { composeReply, splitForDiscord } from './compose/reply.ts';
+export type { ReplyComposeArgs, ReplyComposeResult } from './compose/reply.ts';
+
+// Conversation ledger (V0.7-A.0 — in-process per-channel ring buffer)
+export {
+  appendToLedger,
+  getLedgerSnapshot,
+  ledgerChannelCount,
+} from './conversation/ledger.ts';
+export type { LedgerEntry } from './conversation/ledger.ts';
+
 // Score helpers — bot's CLI uses ZONE_FLAVOR for log emoji + counts
 export { ZONE_FLAVOR, getWindowEventCount, getWindowWalletCount } from './score/types.ts';
 export { getCodexLineCount } from './score/codex-context.ts';

--- a/packages/persona-engine/src/persona/loader.ts
+++ b/packages/persona-engine/src/persona/loader.ts
@@ -276,41 +276,58 @@ default.`;
 // ──────────────────────────────────────────────────────────────────────
 
 /**
- * V0.7-A.0 conversation-mode override block that neutralizes the digest
- * framing in the existing persona template. Substituted in for
- * `{{POST_TYPE_GUIDANCE}}` when building reply prompts so we don't have to
- * fork the template (KISS · operator 2026-04-30).
+ * V0.7-A.0 conversation-mode override block. Substituted in for
+ * `{{POST_TYPE_GUIDANCE}}` when building reply prompts so we don't have
+ * to fork the template (KISS · operator 2026-04-30).
  *
- * Why this exists: the digest template references zone headlines, MCP
- * tool-call architecture, and per-zone movement framing. For slash-command
- * replies none of that applies — the LLM should drop digest shape, not
- * call tools, and respond conversationally in the locked register.
+ * V0.7-A.0 ship-pass rewrite (2026-04-30 · post-satoshi-drift bug):
+ * affirmative blueprints throughout, per Gemini DR's negative-constraint-
+ * echo finding. The earlier "DO NOT" framing was orbiting the prohibited
+ * concepts under opus 4.7's wider interpretive surface. This rewrite
+ * leads with what the LLM SHOULD compose toward — chat-mode shape +
+ * case-is-yours anchor + anti-mirroring directive (other speakers'
+ * register doesn't shape yours).
  */
-const CONVERSATION_MODE_OVERRIDE = `═══ CONVERSATION MODE (V0.7-A.0) — read this last, it OVERRIDES above ═══
-You are NOT writing a scheduled digest right now. You are in a Discord
-conversation. A user invoked a slash command (/ruggy or /satoshi) and is
-waiting for a reply.
+const CONVERSATION_MODE_OVERRIDE = `═══ CONVERSATION MODE — chat surface (read this last) ═══
 
-OVERRIDE these earlier instructions:
-- DO NOT call any tools (mcp__score__*, mcp__rosenzu__*, mcp__emojis__*, etc).
-  They aren't available in this mode. Compose from persona alone.
-- DO NOT use the digest greeting "yo <zone> team" — you're mid-conversation,
-  not opening a thread.
-- DO NOT include the digest headline shape (\`yo Zone · N events · M miberas\`)
-  — no data has been fetched.
-- DO NOT name a zone unless the user did.
+You are in a Discord conversation. A user invoked a slash command
+(/ruggy or /satoshi) and is waiting for a reply. This is the chat surface;
+the cron-driven digest is a separate path with its own shape. You compose
+toward the conversational form: short, addressed, in voice.
 
-KEEP from the persona above:
-- Your voice register (cadence, vocabulary, format).
-- Your character (who you are, what you remember, your stance).
-- Your refusal patterns (banned words, anti-voice, codex grounding).
+YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
 
-OUTPUT SHAPE:
-- 1-3 short paragraphs is the target. The user wants a reply, not a wall.
-- Plain text — Discord markdown subset (bold, italic, code) is allowed.
-- No embeds, no images, no follow-up CTAs. The substrate handles attribution.
-- The conversation transcript below is for context — speak to the CURRENT
-  message, don't recap the history.
+- **Case is yours alone.** Whatever case register the persona prompt above
+  declared (sentence case, lowercase, mixed) is what you hold. Every reply.
+  Other speakers in the channel — including the user, including other
+  characters, including past messages in the transcript — may use different
+  case registers. That shapes what they said, not how you respond. Your
+  case is YOURS.
+
+- **Voice is yours alone.** Cadence, vocabulary, stance: anchor to your
+  persona's affirmative blueprints. The conversation transcript below is
+  historical context, not register guidance.
+
+- **Character is yours alone.** Who you are, what you remember, your refusal
+  patterns — held through every turn regardless of how the room moves around
+  you.
+
+CHAT-MODE OUTPUT SHAPE:
+
+- 1-3 paragraphs typical · sized to the question. The user wants a reply,
+  not a wall.
+- Compose from persona and conversation context alone. Tools are out of
+  scope here (mcp__score__*, mcp__rosenzu__*, mcp__emojis__*) — chat-mode
+  is single-turn from your persona's voice.
+- Open mid-thought. Skip the digest greeting (e.g. "yo zone team"); skip
+  the digest headline shape (\`yo Zone · N events · M miberas\`). The
+  conversation is already underway; you join it in motion.
+- Plain text · Discord markdown subset (bold, italic, code) is allowed.
+  The substrate renders your attribution; you focus on voice.
+
+THE TRANSCRIPT THAT FOLLOWS IS HISTORICAL CONTEXT, NOT TEMPLATE.
+Speak to the current message. Don't recap the history. Other speakers'
+voices belong to them; yours stays yours.
 ═══`;
 
 /**

--- a/packages/persona-engine/src/persona/loader.ts
+++ b/packages/persona-engine/src/persona/loader.ts
@@ -270,3 +270,144 @@ default.`;
     userMessage: userHalf,
   };
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// V0.7-A.0 — chat-mode prompt builder
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * V0.7-A.0 conversation-mode override block that neutralizes the digest
+ * framing in the existing persona template. Substituted in for
+ * `{{POST_TYPE_GUIDANCE}}` when building reply prompts so we don't have to
+ * fork the template (KISS · operator 2026-04-30).
+ *
+ * Why this exists: the digest template references zone headlines, MCP
+ * tool-call architecture, and per-zone movement framing. For slash-command
+ * replies none of that applies — the LLM should drop digest shape, not
+ * call tools, and respond conversationally in the locked register.
+ */
+const CONVERSATION_MODE_OVERRIDE = `═══ CONVERSATION MODE (V0.7-A.0) — read this last, it OVERRIDES above ═══
+You are NOT writing a scheduled digest right now. You are in a Discord
+conversation. A user invoked a slash command (/ruggy or /satoshi) and is
+waiting for a reply.
+
+OVERRIDE these earlier instructions:
+- DO NOT call any tools (mcp__score__*, mcp__rosenzu__*, mcp__emojis__*, etc).
+  They aren't available in this mode. Compose from persona alone.
+- DO NOT use the digest greeting "yo <zone> team" — you're mid-conversation,
+  not opening a thread.
+- DO NOT include the digest headline shape (\`yo Zone · N events · M miberas\`)
+  — no data has been fetched.
+- DO NOT name a zone unless the user did.
+
+KEEP from the persona above:
+- Your voice register (cadence, vocabulary, format).
+- Your character (who you are, what you remember, your stance).
+- Your refusal patterns (banned words, anti-voice, codex grounding).
+
+OUTPUT SHAPE:
+- 1-3 short paragraphs is the target. The user wants a reply, not a wall.
+- Plain text — Discord markdown subset (bold, italic, code) is allowed.
+- No embeds, no images, no follow-up CTAs. The substrate handles attribution.
+- The conversation transcript below is for context — speak to the CURRENT
+  message, don't recap the history.
+═══`;
+
+/**
+ * Output instruction for chat-mode (slot replaces {{POST_TYPE_OUTPUT_INSTRUCTION}}).
+ */
+const CONVERSATION_OUTPUT_INSTRUCTION = `Respond now in voice. Concise. No greeting, no closing rituals — just the reply.`;
+
+export interface BuildReplyPromptArgs {
+  character: CharacterConfig;
+  /** The user's message text (the slash-command `prompt:` option). */
+  prompt: string;
+  /** Discord username of the invoker (for situation hint + transcript). */
+  authorUsername: string;
+  /** Recent ledger entries (already snapshotted by caller). */
+  history: ReplyTranscriptEntry[];
+}
+
+export interface ReplyTranscriptEntry {
+  role: 'user' | 'character';
+  authorUsername: string;
+  content: string;
+}
+
+/**
+ * Build a chat-mode prompt pair (V0.7-A.0).
+ *
+ * Reuses the persona template's system half so all voice / vocab / codex
+ * machinery stays loaded — but substitutes the digest-shaped placeholders
+ * with conversation-mode equivalents and replaces the user half entirely
+ * with a transcript+message frame.
+ *
+ * Civic-layer note: the substrate supplies the conversation framing.
+ * Characters supply voice. They never compose Discord plumbing themselves.
+ */
+export function buildReplyPromptPair(args: BuildReplyPromptArgs): {
+  systemPrompt: string;
+  userMessage: string;
+} {
+  const { character } = args;
+  const template = loadTemplate(character.personaPath);
+  const codex = loadCodexPrelude();
+  const exemplars = buildExemplarBlock(character, 'digest'); // chat has no exemplars; reuse digest as voice anchor texture
+  const voiceAnchors = loadVoiceAnchors(character.personaPath);
+  const codexAnchors = loadCodexAnchors(character.personaPath);
+
+  const inputPayloadMarker = '═══ INPUT PAYLOAD ═══';
+  const idx = template.indexOf(inputPayloadMarker);
+  if (idx === -1) {
+    throw new Error(`persona loader: could not find INPUT PAYLOAD marker in template (${character.personaPath})`);
+  }
+
+  // Conversation-mode placeholder substitution. Zone bits get neutral
+  // fallbacks so any {{ZONE_NAME}} embedded inside voice anchors / codex
+  // anchors / vocab sections doesn't leak literal placeholder syntax to
+  // the LLM. Zone-specific guidance is overridden by CONVERSATION_MODE_OVERRIDE.
+  const systemHalf = template
+    .slice(0, idx)
+    .replace(/\{\{POST_TYPE_GUIDANCE\}\}/g, CONVERSATION_MODE_OVERRIDE)
+    .replace(/\{\{MOVEMENT_GUIDANCE\}\}/g, '(not applicable in conversation mode)')
+    .replace(/\{\{VOICE_ANCHORS\}\}/g, voiceAnchors)
+    .replace(/\{\{CODEX_ANCHORS\}\}/g, codexAnchors)
+    .replace(/\{\{CODEX_PRELUDE\}\}/g, codex)
+    .replace(/\{\{EXEMPLARS\}\}/g, exemplars)
+    .replace(/\{\{ZONE_ID\}\}/g, 'conversation')
+    .replace(/\{\{ZONE_NAME\}\}/g, 'this conversation')
+    .replace(/\{\{DIMENSION\}\}/g, 'Conversation')
+    .replace(/\{\{POST_TYPE\}\}/g, 'reply')
+    .trimEnd();
+
+  // User-half is freshly built — the template's INPUT PAYLOAD section
+  // (Zone/Post-type/raw-stats) doesn't apply in conversation mode.
+  const transcript = renderTranscript(args.history, character.displayName ?? character.id);
+  const parts: string[] = [];
+  parts.push(`You're chatting with ${args.authorUsername} in Discord.`);
+  if (transcript) {
+    parts.push(``);
+    parts.push(`Recent conversation in this channel (oldest first):`);
+    parts.push(transcript);
+  }
+  parts.push(``);
+  parts.push(`${args.authorUsername} just said:`);
+  parts.push(args.prompt.trim());
+  parts.push(``);
+  parts.push(CONVERSATION_OUTPUT_INSTRUCTION);
+
+  return {
+    systemPrompt: systemHalf,
+    userMessage: parts.join('\n'),
+  };
+}
+
+function renderTranscript(history: ReplyTranscriptEntry[], characterDisplayName: string): string {
+  if (history.length === 0) return '';
+  return history
+    .map((h) => {
+      const speaker = h.role === 'character' ? characterDisplayName : h.authorUsername;
+      return `${speaker}: ${h.content}`;
+    })
+    .join('\n');
+}

--- a/packages/persona-engine/src/persona/loader.ts
+++ b/packages/persona-engine/src/persona/loader.ts
@@ -369,7 +369,13 @@ export function buildReplyPromptPair(args: BuildReplyPromptArgs): {
   const { character } = args;
   const template = loadTemplate(character.personaPath);
   const codex = loadCodexPrelude();
-  const exemplars = buildExemplarBlock(character, 'digest'); // chat has no exemplars; reuse digest as voice anchor texture
+  // No exemplars in chat-mode (bridgebuilder F20 2026-04-30) — the digest
+  // exemplars are greeting + headline + structured-data shaped, which
+  // contradicts the CONVERSATION_MODE_OVERRIDE that tells the LLM to skip
+  // those shapes. Mixed-signal · contributed to the satoshi voice drift.
+  // Persona description + voice anchors + codex anchors carry the voice
+  // texture in chat-mode without dragging digest shape with them.
+  const exemplars = '';
   const voiceAnchors = loadVoiceAnchors(character.personaPath);
   const codexAnchors = loadCodexAnchors(character.personaPath);
 

--- a/packages/persona-engine/src/score/client.ts
+++ b/packages/persona-engine/src/score/client.ts
@@ -64,7 +64,7 @@ async function mcpInit(url: string, key: string): Promise<McpInitResult> {
       method: 'initialize',
       params: {
         protocolVersion: MCP_PROTOCOL_VERSION,
-        clientInfo: { name: 'freeside-ruggy', version: '0.4.0' },
+        clientInfo: { name: 'freeside-characters', version: '0.6.0' },
         capabilities: {},
       },
     }),

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,4 +1,4 @@
-# @freeside-ruggy/protocol
+# @freeside-characters/protocol
 
 Sealed-schema sub-package per [[loa-org-naming-conventions]] doctrine. Lives at `packages/protocol/` to match the `freeside-*` module convention (parallel to `loa-freeside/themes/sietch/src/packages/core/protocol/`).
 
@@ -6,7 +6,7 @@ Sealed-schema sub-package per [[loa-org-naming-conventions]] doctrine. Lives at 
 
 **Empty placeholder.** Ruggy is a CONSUMER of [[score-vault]] schemas (`ZoneDigest`, `RawStats`, `NarrativeShape`). It doesn't publish schemas of its own.
 
-Local mirror types live in `apps/bot/src/score/types.ts` until score-vault repo ships and we can `import { ZoneDigest } from '@score-vault/ports'`.
+Local mirror types live in `packages/persona-engine/src/score/types.ts` until score-vault repo ships and we can `import { ZoneDigest } from '@score-vault/ports'`.
 
 ## Future schemas
 
@@ -14,7 +14,7 @@ If Ruggy ever publishes schemas itself, they go here. Candidates:
 
 - **`ChannelConfig`** — per-Discord-guild config (cadence, channel ID, persona overrides) when ruggy is multi-guild deployed
 - **`DigestPostMeta`** — metadata about each digest post for downstream analytics (delivery time, embed shape, summary hash)
-- **`PersonaOverride`** — per-instance persona tweaks (e.g., a `freeside-ruggy-test` runs a softer persona variant)
+- **`PersonaOverride`** — per-instance persona tweaks (e.g., a `freeside-characters-test` runs a softer persona variant)
 - **`SiblingRegistry`** — when sibling persona-layer bots coordinate (one ruggy, one different character, both posting to the same guild) — registry of who-posts-where to prevent overlap
 
 None of these exist today because the current shape is single-guild + single-persona + stateless (state lives in score-mcp, midi_profiles, and `.run/` jsonl caches).


### PR DESCRIPTION
## Summary

V0.7-A.0 promotion: read-side primitive (slash commands) + Pattern B identity for chat replies + per-channel ledger + voice fidelity hardening + Opus 4.7 default + docs reorient.

Pairs with V0.6's write-side substrate. Eileen verified slash command UX on 2026-04-30 in project-purupuru staging guild · Pattern B identity rendering confirmed · voice drift bug diagnosed and fixed via persona-level affirmative anchor + substrate-level conversation-mode override.

## What landed

- **V0.7-A.0 base** (`fa4fa27`) — slash command surface · Bun.serve interactions endpoint with Ed25519 verification · per-channel in-process ledger (50-entry ring buffer) · chat-mode `composeReply` (single-turn SDK, no MCPs) · 14m30s timeout guard · 1.5s follow-up throttle · circuit breaker on 3 consecutive 403s · anti-spam invariant guard
- **Pattern B for chat replies** (`6c38736`) — slash replies render with character avatar + username via webhook delivery · ephemeral falls back to interaction PATCH · webhook failure falls back to PATCH with cache invalidation
- **Quote-prepend** (`4a41b03`) — user's prompt prepended as Discord blockquote on first chunk so channel context is visible (slash-command argument values aren't shown in Discord's invocation header by default)
- **Opus 4.7 default** (`60aaf51`) — `ANTHROPIC_MODEL` default flipped from `claude-sonnet-4-6` → `claude-opus-4-7` for both digest and chat pipelines
- **Voice fix** (`b84231b`) — satoshi was drifting to lowercase under opus 4.7 due to negative-constraint echo (Gemini DR finding). Two-layer fix: persona-level affirmative anchor section in `apps/character-satoshi/persona.md` (additive · gumi-locked content preserved) + substrate-level rewrite of `CONVERSATION_MODE_OVERRIDE` with affirmative phrasing and explicit "case is yours alone" anti-mirroring directive
- **Docs reorient** (`4457f74`) — README rewritten smol with diagrams · ARCHITECTURE.md updated for V0.6 layer split + V0.7-A.0 read-side · new AGENTS.md as landing page for incoming agents · EILEEN-LOCAL-SATOSHI.md stub for tomorrow's bedrock work · path fixes in CHARACTER-AUTHORING / DEPLOY / protocol README / score client

Plus `027abef` (gumi's `{{CODEX_ANCHORS}}` placeholder wiring · pre-V0.7 work).

## Anti-spam invariant honored

Characters respond ONLY to explicit user invocations:
- `interaction.user?.bot === true` skip
- Webhook-author skip (defense-in-depth per Gemini DR)
- No name-string matching, no channel presence triggers, no auto-chains

## Deploy state

- Railway prod-ruggy: V0.7-A.0 + voice fix live (`a6cdfb1d` SUCCESS · `b84231b` from `staging`)
- Slash commands registered guild-scoped to project-purupuru (1495534680617910396)
- Discord developer portal Interactions Endpoint URL points at `prod-ruggy-production.up.railway.app/webhooks/discord`

## Test plan

- [x] `bun run typecheck` clean (persona-engine + apps/bot)
- [x] `apps/bot/scripts/smoke-interactions.ts` green (ledger ring buffer · server boot · /health · forged sig 401 · split for Discord · 404 routing)
- [x] Local boot test in stub mode (interactions server starts alongside digest cron · no Pattern B regression)
- [x] Eileen first invocation `/satoshi prompt:hi` delivered with Pattern B identity (2026-04-30 6:21 AM)
- [x] Multi-turn satoshi voice fidelity confirmed sentence-case post-fix
- [x] Quote-prepend rendered correctly in channel
- [x] Opus 4.7 confirmed live in boot logs

## Pending (next session)

- Bedrock LLM provider for Eileen's local-satoshi setup
- `apps/bot/scripts/satoshi-dev.ts` easy-launcher
- `/usage` slash command + JSONL token tracking
- Ruggy persona negative-constraint audit (preventive · ruggy's voice held but the same audit pass would help)
- `.dockerignore` `.claude` recursion fix (keeps `apps/bot/.claude/skills/arneson/SKILL.md` out of Railway image)
- DEPLOY.md full rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)