### PR TITLE
feat(V0.7-A.1): substrate prep — imagegen MCP + per-character slash + MCP scoping

### DIFF
--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -1,9 +1,15 @@
 /**
- * Publish slash commands to Discord (V0.7-A.0).
+ * Publish slash commands to Discord (V0.7-A.0 → V0.7-A.1).
  *
  * One-shot script — run after character set or command schema changes.
- * Registers `/ruggy`, `/satoshi`, and any additional characters loaded
- * via the standard CHARACTERS env mechanism.
+ * Registers every command declared by every loaded character. Characters
+ * that don't declare `slash_commands` get the V0.7-A.0 default `/<id>
+ * prompt:<text> ephemeral:<bool>` (chat handler).
+ *
+ * V0.7-A.1: characters can now declare divergent command sets in their
+ * `character.json`. Eileen's framing: "commands are diff otherwise they'd
+ * be reporting the same shit." E.g. /satoshi (chat) + /satoshi-image
+ * (imagegen handler).
  *
  * Usage:
  *   # guild-only (immediate propagation in a single guild · use during dev):
@@ -25,22 +31,15 @@
  * is the only secret in `.env` strictly required for this script.
  */
 
-import { loadCharacters } from '../src/character-loader.ts';
+import { loadCharacters, resolveSlashCommands } from '../src/character-loader.ts';
+import type { SlashCommandOption, SlashCommandSpec } from '@freeside-characters/persona-engine';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 
-interface CommandOption {
+interface DiscordCommandSchema {
   name: string;
   description: string;
-  /** Discord application command option type. STRING=3, BOOLEAN=5. */
-  type: number;
-  required?: boolean;
-}
-
-interface CommandSchema {
-  name: string;
-  description: string;
-  options: CommandOption[];
+  options: SlashCommandOption[];
 }
 
 async function main(): Promise<void> {
@@ -66,7 +65,25 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const commands: CommandSchema[] = characters.map((c) => buildCommand(c.id, c.displayName ?? c.id));
+  // Flatten every character's resolved (declared or defaulted) commands
+  // into one Discord-shaped registration payload. Reject duplicates loud
+  // — Discord silently overwrites by name, but a clash within our own
+  // codebase is a config error worth surfacing rather than papering over.
+  const commands: DiscordCommandSchema[] = [];
+  const ownerByName = new Map<string, string>();
+  for (const c of characters) {
+    for (const spec of resolveSlashCommands(c)) {
+      const existingOwner = ownerByName.get(spec.name);
+      if (existingOwner) {
+        console.error(
+          `publish-commands: duplicate command name /${spec.name} declared by both ${existingOwner} and ${c.id}`,
+        );
+        process.exit(1);
+      }
+      ownerByName.set(spec.name, c.id);
+      commands.push(toDiscordSchema(spec));
+    }
+  }
 
   const url = guildId
     ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
@@ -75,7 +92,8 @@ async function main(): Promise<void> {
   const scope = guildId ? `guild ${guildId}` : 'GLOBAL (1-hour propagation)';
   console.log(`publish-commands: registering ${commands.length} commands → ${scope}`);
   for (const cmd of commands) {
-    console.log(`  · /${cmd.name} — ${cmd.description}`);
+    const owner = ownerByName.get(cmd.name) ?? 'unknown';
+    console.log(`  · /${cmd.name} (${owner}) — ${cmd.description}`);
   }
 
   const response = await fetch(url, {
@@ -101,15 +119,11 @@ async function main(): Promise<void> {
   }
 }
 
-function buildCommand(id: string, displayName: string): CommandSchema {
-  const lower = displayName.toLowerCase();
+function toDiscordSchema(spec: SlashCommandSpec): DiscordCommandSchema {
   return {
-    name: id,
-    description: `talk to ${lower}`,
-    options: [
-      { name: 'prompt', description: `what to say to ${lower}`, type: 3, required: true },
-      { name: 'ephemeral', description: 'only you see the reply', type: 5, required: false },
-    ],
+    name: spec.name,
+    description: spec.description,
+    options: spec.options ?? [],
   };
 }
 

--- a/apps/bot/scripts/smoke-interactions.ts
+++ b/apps/bot/scripts/smoke-interactions.ts
@@ -16,7 +16,13 @@ import {
   splitForDiscord,
 } from '@freeside-characters/persona-engine';
 import { startInteractionServer } from '../src/discord-interactions/server.ts';
-import { loadCharacters } from '../src/character-loader.ts';
+import {
+  defaultSlashCommands,
+  loadCharacters,
+  resolveSlashCommandTarget,
+  resolveSlashCommands,
+} from '../src/character-loader.ts';
+import type { CharacterConfig } from '@freeside-characters/persona-engine';
 // V0.7-A.1 imagegen substrate scaffold — smoke at the substrate boundary
 // rather than through the SDK loop (the LLM-driven invocation is exercised
 // end-to-end by the dispatch handler smoke once #2 commands land).
@@ -111,6 +117,67 @@ async function main(): Promise<void> {
   if (!stub.url.startsWith('https://placehold.co/imagegen?')) fail(`imagegen placeholder URL shape broken: ${stub.url}`);
   if (typeof stub.seed !== 'number') fail(`imagegen seed should be number, got ${typeof stub.seed}`);
   ok('imagegen · invokeStability placeholder returns valid GenerateOutput shape');
+
+  // ── per-character slash command resolution smoke (V0.7-A.1 #2) ────
+  const ruggyConfig: CharacterConfig = {
+    id: 'ruggy',
+    displayName: 'Ruggy',
+    personaPath: '/tmp/ruggy.md',
+  };
+  const ruggyDefault = defaultSlashCommands(ruggyConfig);
+  if (ruggyDefault.length !== 1 || ruggyDefault[0]?.name !== 'ruggy' || ruggyDefault[0]?.handler !== 'chat') {
+    fail(`defaultSlashCommands shape broken for ruggy: ${JSON.stringify(ruggyDefault)}`);
+  } else {
+    ok('slash · default fallback yields /ruggy chat handler');
+  }
+  const ruggyResolved = resolveSlashCommands(ruggyConfig);
+  if (ruggyResolved.length !== 1 || ruggyResolved[0]?.name !== 'ruggy') {
+    fail('resolveSlashCommands should fallback to default when slash_commands undefined');
+  } else {
+    ok('slash · resolveSlashCommands falls back to default when undeclared');
+  }
+
+  const satoshiConfig: CharacterConfig = {
+    id: 'satoshi',
+    displayName: 'Satoshi',
+    personaPath: '/tmp/satoshi.md',
+    slash_commands: [
+      { name: 'satoshi', description: 'talk to satoshi', handler: 'chat', options: [] },
+      { name: 'satoshi-image', description: 'image', handler: 'imagegen', options: [] },
+    ],
+  };
+  const satoshiResolved = resolveSlashCommands(satoshiConfig);
+  if (satoshiResolved.length !== 2 || satoshiResolved[1]?.handler !== 'imagegen') {
+    fail(`resolveSlashCommands should pass through declared commands: ${JSON.stringify(satoshiResolved)}`);
+  } else {
+    ok('slash · resolveSlashCommands passes through declared 2-command set');
+  }
+
+  const characterFleet = [ruggyConfig, satoshiConfig];
+  const ruggyTarget = resolveSlashCommandTarget('ruggy', characterFleet);
+  if (!ruggyTarget || ruggyTarget.character.id !== 'ruggy' || ruggyTarget.spec.handler !== 'chat') {
+    fail('resolveSlashCommandTarget should route /ruggy → ruggy/chat');
+  } else {
+    ok('slash · /ruggy resolves to ruggy + chat handler');
+  }
+  const satoshiTarget = resolveSlashCommandTarget('satoshi', characterFleet);
+  if (!satoshiTarget || satoshiTarget.character.id !== 'satoshi' || satoshiTarget.spec.handler !== 'chat') {
+    fail('resolveSlashCommandTarget should route /satoshi → satoshi/chat');
+  } else {
+    ok('slash · /satoshi resolves to satoshi + chat handler');
+  }
+  const imageTarget = resolveSlashCommandTarget('satoshi-image', characterFleet);
+  if (!imageTarget || imageTarget.character.id !== 'satoshi' || imageTarget.spec.handler !== 'imagegen') {
+    fail('resolveSlashCommandTarget should route /satoshi-image → satoshi/imagegen');
+  } else {
+    ok('slash · /satoshi-image resolves to satoshi + imagegen handler');
+  }
+  const unknownTarget = resolveSlashCommandTarget('rumple', characterFleet);
+  if (unknownTarget !== null) {
+    fail('resolveSlashCommandTarget should return null for unknown commands');
+  } else {
+    ok('slash · unknown command resolves to null');
+  }
 
   // ── HTTP server smoke ─────────────────────────────────────────────
   process.env.DISCORD_PUBLIC_KEY = DUMMY_PUBLIC_KEY;

--- a/apps/bot/scripts/smoke-interactions.ts
+++ b/apps/bot/scripts/smoke-interactions.ts
@@ -17,6 +17,13 @@ import {
 } from '@freeside-characters/persona-engine';
 import { startInteractionServer } from '../src/discord-interactions/server.ts';
 import { loadCharacters } from '../src/character-loader.ts';
+// V0.7-A.1 imagegen substrate scaffold — smoke at the substrate boundary
+// rather than through the SDK loop (the LLM-driven invocation is exercised
+// end-to-end by the dispatch handler smoke once #2 commands land).
+import {
+  invokeStability,
+  isImagegenConfigured,
+} from '@freeside-characters/persona-engine/orchestrator/imagegen';
 
 const PORT = Number(process.env.SMOKE_PORT ?? '34501');
 const DUMMY_PUBLIC_KEY = '0'.repeat(64); // 32-byte hex, valid format · won't verify real sigs
@@ -84,6 +91,26 @@ async function main(): Promise<void> {
   const longChunks = splitForDiscord(longParas, 2000);
   if (longChunks.length !== 2) fail(`split paragraph break expected 2 chunks, got ${longChunks.length}`);
   else ok('split · paragraph break preserved');
+
+  // ── imagegen MCP scaffold smoke ───────────────────────────────────
+  const emptyConfig = {} as Parameters<typeof isImagegenConfigured>[0];
+  if (isImagegenConfigured(emptyConfig)) fail('imagegen env gate should be false on empty config');
+  else ok('imagegen · env gate false when AWS_REGION + model id unset');
+
+  const wiredConfig = {
+    AWS_REGION: 'us-west-2',
+    BEDROCK_STABILITY_MODEL_ID: 'stability.stable-image-ultra-v1:0',
+    AWS_BEARER_TOKEN_BEDROCK: 'stub',
+  } as Parameters<typeof invokeStability>[0];
+  if (!isImagegenConfigured(wiredConfig)) fail('imagegen env gate should be true when both env set');
+  else ok('imagegen · env gate true when AWS_REGION + model id set');
+
+  const stub = await invokeStability(wiredConfig, { prompt: 'a satoshi at dusk', style: 'cinematic' });
+  if (!stub.placeholder) fail('imagegen placeholder body should set placeholder=true');
+  if (stub.model !== 'stability.stable-image-ultra-v1:0') fail(`imagegen model echo broken: ${stub.model}`);
+  if (!stub.url.startsWith('https://placehold.co/imagegen?')) fail(`imagegen placeholder URL shape broken: ${stub.url}`);
+  if (typeof stub.seed !== 'number') fail(`imagegen seed should be number, got ${typeof stub.seed}`);
+  ok('imagegen · invokeStability placeholder returns valid GenerateOutput shape');
 
   // ── HTTP server smoke ─────────────────────────────────────────────
   process.env.DISCORD_PUBLIC_KEY = DUMMY_PUBLIC_KEY;

--- a/apps/bot/scripts/smoke-interactions.ts
+++ b/apps/bot/scripts/smoke-interactions.ts
@@ -30,6 +30,8 @@ import {
   invokeStability,
   isImagegenConfigured,
 } from '@freeside-characters/persona-engine/orchestrator/imagegen';
+import { buildAllowedTools } from '@freeside-characters/persona-engine/orchestrator';
+import type { McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 
 const PORT = Number(process.env.SMOKE_PORT ?? '34501');
 const DUMMY_PUBLIC_KEY = '0'.repeat(64); // 32-byte hex, valid format · won't verify real sigs
@@ -177,6 +179,47 @@ async function main(): Promise<void> {
     fail('resolveSlashCommandTarget should return null for unknown commands');
   } else {
     ok('slash · unknown command resolves to null');
+  }
+
+  // ── per-character MCP scoping smoke (V0.7-A.1 #3) ─────────────────
+  // Fake an mcpServers map matching the substrate's registration shape.
+  // Stub config values pass the type check; buildAllowedTools never reads
+  // server contents, only the keys map.
+  const fakeStubServer = { type: 'sdk' } as unknown as McpServerConfig;
+  const fakeMcpServers: Record<string, McpServerConfig> = {
+    score: fakeStubServer,
+    codex: fakeStubServer,
+    emojis: fakeStubServer,
+    rosenzu: fakeStubServer,
+    freeside_auth: fakeStubServer,
+    imagegen: fakeStubServer,
+  };
+
+  // V0.6 parity — undefined mcps means all registered servers allowed.
+  const allTools = buildAllowedTools(fakeMcpServers);
+  if (allTools.length !== 6) fail(`mcp scoping · expected 6 wildcard tools when mcps undefined, got ${allTools.length}`);
+  else ok('mcp scoping · undefined character.mcps allows ALL registered servers');
+
+  // ruggy scope — score/codex/emojis/rosenzu/freeside_auth, no imagegen.
+  const ruggyTools = buildAllowedTools(fakeMcpServers, ['score', 'codex', 'emojis', 'rosenzu', 'freeside_auth']);
+  if (ruggyTools.length !== 5) fail(`mcp scoping · ruggy expected 5 tools, got ${ruggyTools.length}`);
+  else if (ruggyTools.includes('mcp__imagegen__*')) fail('mcp scoping · ruggy should NOT have imagegen access');
+  else if (!ruggyTools.includes('mcp__score__*')) fail('mcp scoping · ruggy should have score access');
+  else ok('mcp scoping · ruggy allowed=[score,codex,emojis,rosenzu,freeside_auth] · no imagegen');
+
+  // satoshi scope — codex + imagegen only.
+  const satoshiTools = buildAllowedTools(fakeMcpServers, ['codex', 'imagegen']);
+  if (satoshiTools.length !== 2) fail(`mcp scoping · satoshi expected 2 tools, got ${satoshiTools.length}`);
+  else if (satoshiTools.includes('mcp__score__*')) fail('mcp scoping · satoshi should NOT have score access');
+  else if (!satoshiTools.includes('mcp__imagegen__*')) fail('mcp scoping · satoshi should have imagegen access');
+  else ok('mcp scoping · satoshi allowed=[codex,imagegen] · no score');
+
+  // Names not registered are silently dropped — character intent ∩ runtime registration.
+  const partialTools = buildAllowedTools(fakeMcpServers, ['codex', 'phantom_mcp']);
+  if (partialTools.length !== 1 || partialTools[0] !== 'mcp__codex__*') {
+    fail(`mcp scoping · phantom server should be dropped, got ${JSON.stringify(partialTools)}`);
+  } else {
+    ok('mcp scoping · names not registered are silently dropped (intent ∩ registered)');
   }
 
   // ── HTTP server smoke ─────────────────────────────────────────────

--- a/apps/bot/src/character-loader.ts
+++ b/apps/bot/src/character-loader.ts
@@ -40,6 +40,9 @@ interface CharacterJson {
   /** V0.7-A.1: per-character slash command set. Omit for default
    *  `/<id> prompt:<text> ephemeral:<bool>` (V0.7-A.0 parity). */
   slash_commands?: SlashCommandSpec[];
+  /** V0.7-A.1: per-character MCP scope (digest path only). Omit for
+   *  bot-wide MCP access (V0.6 parity). */
+  mcps?: string[];
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -77,6 +80,7 @@ export function loadCharacter(id: string): CharacterConfig {
     webhookUsername: json.webhookUsername,
     anchoredArchetypes: json.anchoredArchetypes as CharacterConfig['anchoredArchetypes'],
     slash_commands: json.slash_commands,
+    mcps: json.mcps,
   };
 }
 

--- a/apps/bot/src/character-loader.ts
+++ b/apps/bot/src/character-loader.ts
@@ -16,7 +16,11 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { CharacterConfig, EmojiAffinityKind } from '@freeside-characters/persona-engine';
+import type {
+  CharacterConfig,
+  EmojiAffinityKind,
+  SlashCommandSpec,
+} from '@freeside-characters/persona-engine';
 
 interface CharacterJson {
   id: string;
@@ -33,6 +37,9 @@ interface CharacterJson {
   webhookUsername?: string;
   /** V0.6-D voice/v4: anchored cabal archetypes (1-2 per character). */
   anchoredArchetypes?: string[];
+  /** V0.7-A.1: per-character slash command set. Omit for default
+   *  `/<id> prompt:<text> ephemeral:<bool>` (V0.7-A.0 parity). */
+  slash_commands?: SlashCommandSpec[];
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -69,9 +76,53 @@ export function loadCharacter(id: string): CharacterConfig {
     webhookAvatarUrl: json.webhookAvatarUrl,
     webhookUsername: json.webhookUsername,
     anchoredArchetypes: json.anchoredArchetypes as CharacterConfig['anchoredArchetypes'],
+    slash_commands: json.slash_commands,
   };
 }
 
 export function loadCharacters(): CharacterConfig[] {
   return selectedCharacterIds().map(loadCharacter);
+}
+
+/**
+ * Default slash command for a character that doesn't declare its own.
+ * Preserves the V0.7-A.0 shape (`/<id> prompt:<text> ephemeral:<bool>`)
+ * routed through the `chat` handler. Lookup-friendly so dispatch + publish
+ * both see the same fallback.
+ */
+export function defaultSlashCommands(c: CharacterConfig): SlashCommandSpec[] {
+  const lower = (c.displayName ?? c.id).toLowerCase();
+  return [
+    {
+      name: c.id,
+      description: `talk to ${lower}`,
+      handler: 'chat',
+      options: [
+        { name: 'prompt', description: `what to say to ${lower}`, type: 3, required: true },
+        { name: 'ephemeral', description: 'only you see the reply', type: 5, required: false },
+      ],
+    },
+  ];
+}
+
+/** Returns the character's declared slash commands or the V0.7-A.0 default. */
+export function resolveSlashCommands(c: CharacterConfig): SlashCommandSpec[] {
+  return c.slash_commands ?? defaultSlashCommands(c);
+}
+
+/**
+ * Resolve which character owns a given slash command name and what handler
+ * the command should route to. Returns null when no character claims the
+ * name. Single-pass lookup across all characters' declared (or defaulted)
+ * commands — preserves the kickoff spec's command-name → handler mapping.
+ */
+export function resolveSlashCommandTarget(
+  commandName: string,
+  characters: CharacterConfig[],
+): { character: CharacterConfig; spec: SlashCommandSpec } | null {
+  for (const c of characters) {
+    const match = resolveSlashCommands(c).find((s) => s.name === commandName);
+    if (match) return { character: c, spec: match };
+  }
+  return null;
 }

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  appendToLedger,
   composeReply,
   getBotClient,
   getOrCreateChannelWebhook,
@@ -33,7 +34,11 @@ import {
   splitForDiscord,
   type CharacterConfig,
   type Config,
+  type LedgerEntry,
+  type SlashCommandHandler,
 } from '@freeside-characters/persona-engine';
+import { invokeStability } from '@freeside-characters/persona-engine/orchestrator/imagegen';
+import { resolveSlashCommandTarget } from '../character-loader.ts';
 import {
   InteractionResponseType,
   InteractionType,
@@ -132,17 +137,26 @@ export async function dispatchSlashCommand(
     );
   }
 
-  // ─── Resolve target character ──────────────────────────────────────
+  // ─── Resolve target command + handler ──────────────────────────────
+  // V0.7-A.1: characters may declare divergent commands (e.g. /satoshi-
+  // image alongside /satoshi). Lookup is by command NAME, not character
+  // id, since the two diverged at this phase.
   const commandName = interaction.data?.name;
   if (!commandName) {
     return ephemeralReply('no command name in interaction.');
   }
-  const character = characters.find((c) => c.id === commandName);
-  if (!character) {
+  const target = resolveSlashCommandTarget(commandName, characters);
+  if (!target) {
+    const available = characters
+      .flatMap((c) => (c.slash_commands ?? []).map((s) => s.name).concat(c.slash_commands ? [] : [c.id]))
+      .map((n) => `/${n}`)
+      .join(', ');
     return ephemeralReply(
-      `unknown character: \`${commandName}\`. available: ${characters.map((c) => `/${c.id}`).join(', ') || '(none loaded)'}`,
+      `unknown command: \`${commandName}\`. available: ${available || '(none loaded)'}`,
     );
   }
+  const { character, spec } = target;
+  const handler = spec.handler;
 
   // ─── Read options ──────────────────────────────────────────────────
   const prompt = readStringOption(interaction, 'prompt');
@@ -158,6 +172,7 @@ export async function dispatchSlashCommand(
     interaction,
     config,
     character,
+    handler,
     prompt: prompt.trim(),
     ephemeral,
     channelId,
@@ -182,18 +197,35 @@ interface AsyncWorkerArgs {
   interaction: DiscordInteraction;
   config: Config;
   character: CharacterConfig;
+  handler: SlashCommandHandler;
   prompt: string;
   ephemeral: boolean;
   channelId: string;
   invoker: { id: string; username: string };
 }
 
+/**
+ * V0.7-A.1: handler-aware async dispatch. Each handler shares the same
+ * delivery primitives (deliverViaWebhook / deliverViaInteraction, the
+ * 14m30s timeout, the circuit breaker) but produces its own reply chunks.
+ * New handlers register here as additional cases — `chat` and `imagegen`
+ * land first.
+ */
 async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
+  switch (args.handler) {
+    case 'chat':
+      return doReplyChat(args);
+    case 'imagegen':
+      return doReplyImagegen(args);
+  }
+}
+
+async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
   const { interaction, config, character, prompt, ephemeral, channelId, invoker } = args;
   const t0 = Date.now();
 
   console.log(
-    `interactions: ${character.id} dispatch · invoker=${invoker.username} ` +
+    `interactions: ${character.id}/chat dispatch · invoker=${invoker.username} ` +
       `channel=${channelId} ephemeral=${ephemeral} prompt="${truncate(prompt, 80)}"`,
   );
 
@@ -214,7 +246,7 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
 
     if (result === TIMEOUT_SENTINEL) {
       console.error(
-        `interactions: ${character.id} TIMEOUT after ${Date.now() - t0}ms · channel=${channelId}`,
+        `interactions: ${character.id}/chat TIMEOUT after ${Date.now() - t0}ms · channel=${channelId}`,
       );
       await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'timeout'));
       return;
@@ -222,7 +254,7 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
 
     if (!result) {
       console.warn(
-        `interactions: ${character.id} composeReply returned null · channel=${channelId}`,
+        `interactions: ${character.id}/chat composeReply returned null · channel=${channelId}`,
       );
       await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'empty'));
       return;
@@ -249,7 +281,7 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
         );
       } catch (webhookErr) {
         console.warn(
-          `interactions: ${character.id} webhook delivery failed · falling back to PATCH:`,
+          `interactions: ${character.id}/chat webhook delivery failed · falling back to PATCH:`,
           webhookErr,
         );
         invalidateWebhookCache(channelId);
@@ -258,7 +290,7 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
     }
 
     console.log(
-      `interactions: ${character.id} delivered · ` +
+      `interactions: ${character.id}/chat delivered · ` +
         `channel=${channelId} chunks=${result.chunks.length} ` +
         `compose_ms=${result.contextUsed.durationMs} ` +
         `total_ms=${Date.now() - t0} ` +
@@ -267,7 +299,7 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
     );
   } catch (err) {
     console.error(
-      `interactions: ${character.id} dispatch failed · channel=${channelId}`,
+      `interactions: ${character.id}/chat dispatch failed · channel=${channelId}`,
       err,
     );
     try {
@@ -278,6 +310,127 @@ async function doReplyAsync(args: AsyncWorkerArgs): Promise<void> {
       console.error(`interactions: PATCH-original after error also failed:`, patchErr);
     }
   }
+}
+
+/**
+ * V0.7-A.1 imagegen handler. Calls invokeStability directly (no LLM
+ * intermediation) — the slash arg `prompt:` IS the image prompt. The
+ * autoprompt-driven path (where the LLM decides to imagegen mid-reply)
+ * is V0.7-A.x persona-iteration territory and uses the imagegen MCP
+ * through the digest pipeline; this handler is the manual surface
+ * (Eileen: "manual /satoshi-image prompt:..." per kickoff §unblocks).
+ */
+async function doReplyImagegen(args: AsyncWorkerArgs): Promise<void> {
+  const { interaction, config, character, prompt, ephemeral, channelId, invoker } = args;
+  const t0 = Date.now();
+
+  console.log(
+    `interactions: ${character.id}/imagegen dispatch · invoker=${invoker.username} ` +
+      `channel=${channelId} ephemeral=${ephemeral} prompt="${truncate(prompt, 80)}"`,
+  );
+
+  try {
+    const result = await Promise.race([
+      invokeStability(config, { prompt }),
+      timeoutAfter(TOKEN_LIFETIME_MS),
+    ]);
+
+    if (result === TIMEOUT_SENTINEL) {
+      console.error(
+        `interactions: ${character.id}/imagegen TIMEOUT after ${Date.now() - t0}ms · channel=${channelId}`,
+      );
+      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'timeout'));
+      return;
+    }
+
+    const reply = formatImagegenReply(character, result);
+    const chunks = splitForDiscord(reply, DISCORD_CHAR_LIMIT);
+
+    // Ledger discipline: append both the user's prompt and the imagegen
+    // result so subsequent chat-mode invocations in this channel see
+    // context that an image was generated. Mirrors composeReply's
+    // ledger pattern.
+    const nowIso = new Date().toISOString();
+    const userEntry: LedgerEntry = {
+      role: 'user',
+      content: prompt,
+      authorId: invoker.id,
+      authorUsername: invoker.username,
+      timestamp: nowIso,
+    };
+    const characterEntry: LedgerEntry = {
+      role: 'character',
+      content: `[imagegen] ${result.url}`,
+      characterId: character.id,
+      authorId: character.id,
+      authorUsername: character.displayName ?? character.id,
+      timestamp: new Date().toISOString(),
+    };
+    appendToLedger(channelId, userEntry);
+    appendToLedger(channelId, characterEntry);
+
+    if (ephemeral) {
+      await deliverViaInteraction(interaction, character, chunks, true);
+    } else {
+      try {
+        await deliverViaWebhook(
+          interaction,
+          config,
+          character,
+          channelId,
+          chunks,
+          prompt,
+          invoker.username,
+        );
+      } catch (webhookErr) {
+        console.warn(
+          `interactions: ${character.id}/imagegen webhook delivery failed · falling back to PATCH:`,
+          webhookErr,
+        );
+        invalidateWebhookCache(channelId);
+        await deliverViaInteraction(interaction, character, chunks, false);
+      }
+    }
+
+    console.log(
+      `interactions: ${character.id}/imagegen delivered · ` +
+        `channel=${channelId} model=${result.model} seed=${result.seed} ` +
+        `placeholder=${result.placeholder} total_ms=${Date.now() - t0} ` +
+        `via=${ephemeral ? 'patch' : 'webhook'}`,
+    );
+  } catch (err) {
+    console.error(
+      `interactions: ${character.id}/imagegen dispatch failed · channel=${channelId}`,
+      err,
+    );
+    try {
+      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'error'));
+    } catch (patchErr) {
+      console.error(`interactions: PATCH-original after imagegen error also failed:`, patchErr);
+    }
+  }
+}
+
+/**
+ * Format the imagegen reply for Discord delivery. When the substrate is
+ * in scaffold mode (Eileen's Bedrock Stability invoke not yet landed),
+ * the result.placeholder flag is true and we annotate so collaborators
+ * see the URL is synthetic rather than burning time wondering why
+ * placehold.co looks broken.
+ */
+function formatImagegenReply(
+  character: CharacterConfig,
+  result: { url: string; model: string; seed: number; placeholder: boolean },
+): string {
+  const displayName = character.displayName ?? character.id;
+  if (result.placeholder) {
+    return (
+      `**${displayName}** · imagegen scaffold\n\n` +
+      `${result.url}\n` +
+      `_model=${result.model} · seed=${result.seed} · placeholder=true · awaiting Eileen's Stability invoke PR_`
+    );
+  }
+  return `${result.url}\n_${displayName} · model=${result.model} · seed=${result.seed}_`;
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -38,7 +38,7 @@ import {
   type SlashCommandHandler,
 } from '@freeside-characters/persona-engine';
 import { invokeStability } from '@freeside-characters/persona-engine/orchestrator/imagegen';
-import { resolveSlashCommandTarget } from '../character-loader.ts';
+import { resolveSlashCommands, resolveSlashCommandTarget } from '../character-loader.ts';
 import {
   InteractionResponseType,
   InteractionType,
@@ -147,9 +147,11 @@ export async function dispatchSlashCommand(
   }
   const target = resolveSlashCommandTarget(commandName, characters);
   if (!target) {
+    // Single source of truth for available commands — resolveSlashCommands
+    // handles the declared-vs-default fallback identically here and at
+    // publish time, so this listing can never drift from what's registered.
     const available = characters
-      .flatMap((c) => (c.slash_commands ?? []).map((s) => s.name).concat(c.slash_commands ? [] : [c.id]))
-      .map((n) => `/${n}`)
+      .flatMap((c) => resolveSlashCommands(c).map((s) => `/${s.name}`))
       .join(', ');
     return ephemeralReply(
       `unknown command: \`${commandName}\`. available: ${available || '(none loaded)'}`,
@@ -346,27 +348,21 @@ async function doReplyImagegen(args: AsyncWorkerArgs): Promise<void> {
     const reply = formatImagegenReply(character, result);
     const chunks = splitForDiscord(reply, DISCORD_CHAR_LIMIT);
 
-    // Ledger discipline: append both the user's prompt and the imagegen
-    // result so subsequent chat-mode invocations in this channel see
-    // context that an image was generated. Mirrors composeReply's
-    // ledger pattern.
-    const nowIso = new Date().toISOString();
-    const userEntry: LedgerEntry = {
-      role: 'user',
-      content: prompt,
-      authorId: invoker.id,
-      authorUsername: invoker.username,
-      timestamp: nowIso,
-    };
+    // Ledger discipline (V0.7-A.1 imagegen): append a SINGLE character
+    // marker entry — no user-prompt entry (image prompts aren't chat
+    // utterances) and no URL in content (the URL is delivery metadata,
+    // not utterance text · letting it leak into chat-mode prompt context
+    // pollutes the LLM's view of the conversation). The marker keeps the
+    // prompt summary so subsequent chat invocations have continuity
+    // ("what scene did you generate?") without LLM-quoteable URLs.
     const characterEntry: LedgerEntry = {
       role: 'character',
-      content: `[imagegen] ${result.url}`,
+      content: `[generated an image · prompt: "${truncate(prompt, 80)}"]`,
       characterId: character.id,
       authorId: character.id,
       authorUsername: character.displayName ?? character.id,
       timestamp: new Date().toISOString(),
     };
-    appendToLedger(channelId, userEntry);
     appendToLedger(channelId, characterEntry);
 
     if (ephemeral) {

--- a/apps/character-ruggy/character.json
+++ b/apps/character-ruggy/character.json
@@ -9,6 +9,7 @@
     "fallback": "ruggy"
   },
   "anchoredArchetypes": ["Storyteller", "GM"],
+  "mcps": ["score", "codex", "emojis", "rosenzu", "freeside_auth"],
   "webhookAvatarUrl": "https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/staging/apps/character-ruggy/avatar.png",
   "webhookUsername": "Ruggy",
   "webhookAvatarTarget": "https://assets.0xhoneyjar.xyz/freeside-characters/ruggy/avatar.png — canonical target per SDD §0.2 per-world URL contract; bridge URL above points at the staging branch's avatar.png (operator-uploaded 2026-04-30); swap to canonical when assets.0xhoneyjar.xyz CDN cycle reaches /freeside-characters/",

--- a/apps/character-satoshi/character.json
+++ b/apps/character-satoshi/character.json
@@ -9,6 +9,7 @@
     "fallback": "mibera"
   },
   "anchoredArchetypes": ["Veteran", "Chaos-Agent"],
+  "mcps": ["codex", "imagegen"],
   "emojiNote": "satoshi posts plain — emojis are ruggy's affordance. Rare hermetic gesture only (e.g. spiraling for chain-paradox moments). emojiAffinity scoped to mibera-only as a safety bound: if satoshi DOES reach for an emoji, it's mibera-coded never ruggy-coded.",
   "webhookAvatarUrl": "https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/staging/apps/character-satoshi/avatar.png",
   "webhookUsername": "Satoshi",

--- a/apps/character-satoshi/character.json
+++ b/apps/character-satoshi/character.json
@@ -13,6 +13,25 @@
   "webhookAvatarUrl": "https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/staging/apps/character-satoshi/avatar.png",
   "webhookUsername": "Satoshi",
   "webhookAvatarTarget": "https://assets.0xhoneyjar.xyz/freeside-characters/satoshi/avatar.png — canonical target per SDD §0.2; bridge URL above points at staging branch's avatar.png (operator-uploaded 2026-04-30); swap to canonical when assets.0xhoneyjar.xyz CDN cycle reaches /freeside-characters/. The irys URL gateway.irys.xyz/7rpvw.../satoshi.png in construct-mibera-codex grail #4488 is dead per operator 2026-04-30 — needs codex-side fix.",
+  "slash_commands": [
+    {
+      "name": "satoshi",
+      "description": "talk to satoshi",
+      "handler": "chat",
+      "options": [
+        { "name": "prompt", "description": "what to say to satoshi", "type": 3, "required": true },
+        { "name": "ephemeral", "description": "only you see the reply", "type": 5, "required": false }
+      ]
+    },
+    {
+      "name": "satoshi-image",
+      "description": "satoshi generates an image",
+      "handler": "imagegen",
+      "options": [
+        { "name": "prompt", "description": "image prompt — be explicit about subject + scene + light", "type": 3, "required": true }
+      ]
+    }
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md",
     "codexAnchors": "codex-anchors.md",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,6 +143,7 @@ Key design rules baked into V0.7-A.0:
 | `orchestrator/rosenzu/` | In-bot SDK MCP — Lynch primitives, KANSEI vectors | `@anthropic-ai/claude-agent-sdk` |
 | `orchestrator/emojis/` | In-bot SDK MCP — 43-emoji THJ catalog with mood tags + `.run/emoji-recent.jsonl` cache | `@anthropic-ai/claude-agent-sdk` |
 | `orchestrator/freeside_auth/` | In-bot SDK MCP — wallet → handle/discord/mibera_id resolution against Railway Postgres | `@anthropic-ai/claude-agent-sdk`, `pg` |
+| `orchestrator/imagegen/` | In-bot SDK MCP — Bedrock Stability text-to-image (V0.7-A.1 substrate scaffold · `generate` body stubbed pending Eileen's invoke PR · `suggest_style` is static archetype lookup) | `@anthropic-ai/claude-agent-sdk` |
 | `orchestrator/cabal/gygax.ts` | Cabal subagent (retired from per-fire compose 2026-04-30 · preserved for future `/cabal` command) | — |
 | `deliver/webhook.ts` | Pattern B delivery · `getOrCreateChannelWebhook` + `sendViaWebhook` (digest) + `sendChatReplyViaWebhook` (V0.7-A.0 chat) | `discord.js` |
 | `deliver/embed.ts` | Per-post-type embed shape (digest/weaver/callout = embed; micro/lore/question = plain) | — |
@@ -157,16 +158,16 @@ Key design rules baked into V0.7-A.0:
 | `character-loader.ts` | Reads `apps/character-<id>/character.json` → `CharacterConfig` · honors `CHARACTERS` env |
 | `cli/digest-once.ts` | One-shot CLI for testing — fires single digest sweep then exits |
 | `discord-interactions/server.ts` | V0.7-A.0 `Bun.serve` HTTP endpoint · Ed25519 verify · `/health` + `/webhooks/discord` |
-| `discord-interactions/dispatch.ts` | V0.7-A.0 slash dispatch · anti-spam guard · 14m30s timeout · circuit breaker · webhook-or-PATCH delivery routing |
+| `discord-interactions/dispatch.ts` | V0.7-A.0 slash dispatch · anti-spam guard · 14m30s timeout · circuit breaker · webhook-or-PATCH delivery routing · V0.7-A.1 handler-aware routing (`chat` / `imagegen`) |
 | `discord-interactions/types.ts` | Discord Interactions API types (`InteractionType`, `InteractionResponseType`, `MessageFlags`) |
-| `scripts/publish-commands.ts` | One-shot · registers `/ruggy` + `/satoshi` slash commands via Discord API |
-| `scripts/smoke-interactions.ts` | Smoke test · ledger ring buffer + server endpoints |
+| `scripts/publish-commands.ts` | One-shot · flattens every character's declared (or defaulted) slash commands and registers via Discord API |
+| `scripts/smoke-interactions.ts` | Smoke test · ledger ring buffer + server endpoints + imagegen + slash routing + MCP scoping |
 
 ### `apps/character-<id>/` — characters
 
 | File | What |
 |---|---|
-| `character.json` | `CharacterConfig` shape · id · displayName · personaFile · webhookAvatarUrl · anchoredArchetypes |
+| `character.json` | `CharacterConfig` shape · id · displayName · personaFile · webhookAvatarUrl · anchoredArchetypes · `slash_commands` (V0.7-A.1+) · `mcps` (V0.7-A.1+) |
 | `persona.md` | Source of truth for voice · system prompt template · per-post-type fragments · gumi-locked content + operator-iterated affirmative voice anchor |
 | `codex-anchors.md` | Per-character mibera-codex SOIL · which archetypes resonate · which lineage |
 | `voice-anchors.md` | Cross-post-type voice texture · operator-curated past utterances |
@@ -207,6 +208,78 @@ Swap-out matrix:
 
 Independent. Pure-offline = both on. Voice-validation path:
 `STUB_MODE=true LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=…`
+
+## Per-character divergence (V0.7-A.1)
+
+Eileen 2026-04-30: "commands are diff otherwise they'd be reporting the same
+shit." V0.7-A.1 introduced two orthogonal divergence axes that each character
+declares in `character.json`:
+
+```mermaid
+flowchart TB
+    subgraph chars["apps/character-*"]
+      ruggy_cfg["🐻 ruggy/character.json<br/>slash: /ruggy chat (default)<br/>mcps: [score, codex, emojis, rosenzu, freeside_auth]"]
+      satoshi_cfg["🌀 satoshi/character.json<br/>slash: /satoshi chat + /satoshi-image imagegen<br/>mcps: [codex, imagegen]"]
+    end
+
+    subgraph publish["publish path"]
+      flatten["flatten across characters<br/>reject duplicate names loud"]
+      discord_api["Discord API<br/>register all commands"]
+    end
+
+    subgraph dispatch_path["dispatch path (slash invocation)"]
+      resolve["resolveSlashCommandTarget<br/>name → character + handler"]
+      route["switch (handler)"]
+      chat_path["chat handler<br/>composeReply (no MCPs)"]
+      imagegen_path["imagegen handler<br/>invokeStability (direct)"]
+    end
+
+    subgraph digest_path["digest path (cron-driven)"]
+      orch["runOrchestratorQuery"]
+      filter["buildAllowedTools<br/>(serverNames ∩ character.mcps)"]
+      sdk["Claude Agent SDK · query()<br/>permissionMode: dontAsk"]
+    end
+
+    ruggy_cfg --> flatten
+    satoshi_cfg --> flatten
+    flatten --> discord_api
+
+    ruggy_cfg --> resolve
+    satoshi_cfg --> resolve
+    resolve --> route
+    route --> chat_path
+    route --> imagegen_path
+
+    ruggy_cfg --> orch
+    satoshi_cfg --> orch
+    orch --> filter
+    filter --> sdk
+
+    classDef cfg fill:#fff3cd,stroke:#856404
+    classDef pub fill:#cce5ff,stroke:#004085
+    classDef disp fill:#e5f5e0,stroke:#41ab5d
+    classDef digest fill:#f0e5fc,stroke:#7e3ff2
+    class ruggy_cfg,satoshi_cfg cfg
+    class flatten,discord_api pub
+    class resolve,route,chat_path,imagegen_path disp
+    class orch,filter,sdk digest
+```
+
+**Slash commands** are flattened across all characters at publish time and
+routed by command-name lookup at dispatch time. Default fallback gives every
+character a `/<id>` chat command without explicit declaration; characters
+extend by declaring `slash_commands` with additional names + handlers.
+
+**MCP scoping** affects ONLY the digest path. The substrate still registers
+all MCPs (env-gated) bot-wide; per-character `mcps` filters the
+`allowedTools` whitelist passed to the SDK loop. `permissionMode: 'dontAsk'`
+denies anything outside that whitelist — character intent narrows what's
+reachable, but doesn't expand it (names not registered are dropped).
+
+Chat-mode replies (`composeReply`) and the imagegen handler both bypass MCPs
+entirely by construction, so per-character scoping there is unnecessary —
+the chat persona prompt is the only voice surface, and imagegen calls
+`invokeStability` directly without LLM intermediation.
 
 ## Why discord.js (Gateway) + Bun.serve (HTTP)
 

--- a/docs/CHARACTER-AUTHORING.md
+++ b/docs/CHARACTER-AUTHORING.md
@@ -36,6 +36,27 @@ apps/character-<id>/
     "primary": "mibera",
     "fallback": "ruggy"
   },
+  "anchoredArchetypes": ["Veteran", "Chaos-Agent"],
+  "mcps": ["codex", "imagegen"],
+  "slash_commands": [
+    {
+      "name": "satoshi",
+      "description": "talk to satoshi",
+      "handler": "chat",
+      "options": [
+        { "name": "prompt", "description": "what to say to satoshi", "type": 3, "required": true },
+        { "name": "ephemeral", "description": "only you see the reply", "type": 5, "required": false }
+      ]
+    },
+    {
+      "name": "satoshi-image",
+      "description": "satoshi generates an image",
+      "handler": "imagegen",
+      "options": [
+        { "name": "prompt", "description": "image prompt — be explicit about subject + scene + light", "type": 3, "required": true }
+      ]
+    }
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },
@@ -51,7 +72,83 @@ apps/character-<id>/
 | `personaFile` | yes | path relative to character dir (typically `persona.md`). |
 | `exemplarsDir` | no | path relative to character dir. Omit → no In-Context Exemplars (rule-based voice only). |
 | `emojiAffinity` | no | hint for emoji MCP. Currently informational; V0.6-D wires into MCP filtering. |
+| `anchoredArchetypes` | no | 1-2 cabal archetypes that genuinely map to who the character IS (not rotating filters). |
+| `slash_commands` | no | per-character slash commands (V0.7-A.1+). Omit for default `/<id> chat` shape. See §slash commands. |
+| `mcps` | no | per-character MCP scope on the digest path (V0.7-A.1+). Omit for bot-wide access. See §MCP scoping. |
 | `stage` | no | `character` (V0.6) or `daemon` (V0.7+ once mint machinery lands). |
+
+## Slash commands (V0.7-A.1+)
+
+Eileen's framing 2026-04-30: "commands are diff otherwise they'd be reporting
+the same shit." Each character can declare its own command set in
+`character.json`. When omitted, the substrate auto-generates the V0.7-A.0
+default `/<id> prompt:<text> ephemeral:<bool>` routed to the `chat` handler
+— so existing characters keep working without changes.
+
+```jsonc
+"slash_commands": [
+  {
+    "name": "satoshi",
+    "description": "talk to satoshi",
+    "handler": "chat",
+    "options": [
+      { "name": "prompt", "description": "what to say to satoshi", "type": 3, "required": true },
+      { "name": "ephemeral", "description": "only you see the reply", "type": 5, "required": false }
+    ]
+  },
+  {
+    "name": "satoshi-image",
+    "description": "satoshi generates an image",
+    "handler": "imagegen",
+    "options": [
+      { "name": "prompt", "description": "image prompt", "type": 3, "required": true }
+    ]
+  }
+]
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Discord command name. Must match `^[-_\p{L}\p{N}]{1,32}$`. |
+| `description` | yes | 1-100 char description shown in Discord autocomplete. |
+| `handler` | yes | Substrate-side handler. `chat` (composeReply pipeline · V0.7-A.0) or `imagegen` (Bedrock Stability · V0.7-A.1). Future: `stats`, `lore`, etc. |
+| `options` | no | Discord application command options. `type` values: 3=STRING, 4=INTEGER, 5=BOOLEAN, 10=NUMBER. |
+
+The substrate flattens all characters' commands at publish time and rejects
+duplicate names loud. Run `bun run apps/bot/scripts/publish-commands.ts`
+after editing — Discord caches command schemas (1-hour TTL globally,
+instant in single-guild mode).
+
+## MCP scoping (V0.7-A.1+)
+
+Per-character MCP access on the digest path. Names listed in `mcps` are the
+servers the character is allowed to call from `runOrchestratorQuery`. Names
+not currently registered (env-gated MCPs like `codex` when `CODEX_MCP_URL`
+is unset) are silently dropped — the field expresses INTENT; what's actually
+available is the intersection with what the substrate has wired.
+
+```jsonc
+// ruggy — reporter · data-grounded · no imagegen (won't hallucinate-and-illustrate)
+"mcps": ["score", "codex", "emojis", "rosenzu", "freeside_auth"]
+
+// satoshi — mibera-agent · cross-realms · no score (stays gnomic, not zone-stat analyst)
+"mcps": ["codex", "imagegen"]
+```
+
+When `mcps` is omitted, the character has access to ALL registered MCPs
+(V0.6 parity). Affects ONLY the digest path. Chat-mode replies
+(`composeReply`) bypass MCPs entirely by design and are unaffected.
+
+Currently registered MCP names (substrate-side):
+
+| Name | Source | When registered |
+|---|---|---|
+| `rosenzu` | `orchestrator/rosenzu/` | always (in-process SDK MCP) |
+| `emojis` | `orchestrator/emojis/` | always (in-process SDK MCP) |
+| `freeside_auth` | `orchestrator/freeside_auth/` | always (warns + falls back to truncated wallet when DB unavailable) |
+| `score` | zerker's HTTP MCP | when `MCP_KEY` is set |
+| `codex` | gumi's mibera-codex HTTP MCP | when `CODEX_MCP_URL` is set |
+| `imagegen` | `orchestrator/imagegen/` | when `AWS_REGION` + `BEDROCK_STABILITY_MODEL_ID` set |
 
 ## `persona.md` conventions
 

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./types": "./src/types.ts",
-    "./config": "./src/config.ts"
+    "./config": "./src/config.ts",
+    "./orchestrator/imagegen": "./src/orchestrator/imagegen/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./types": "./src/types.ts",
     "./config": "./src/config.ts",
+    "./orchestrator": "./src/orchestrator/index.ts",
     "./orchestrator/imagegen": "./src/orchestrator/imagegen/index.ts"
   },
   "scripts": {

--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -44,6 +44,11 @@ const ConfigSchema = z.object({
   /** Bedrock model id (e.g. anthropic.claude-sonnet-4-5-20250929-v1:0).
    *  Per-deploy override; Eileen sets this to her region's available model. */
   BEDROCK_MODEL_ID: z.string().optional(),
+  /** Bedrock Stability model id for imagegen (e.g.
+   *  stability.stable-image-ultra-v1:0 or stability.stable-diffusion-xl-v1).
+   *  Separate from BEDROCK_MODEL_ID (chat-mode Claude). When set together
+   *  with AWS_REGION, the orchestrator registers the imagegen MCP. */
+  BEDROCK_STABILITY_MODEL_ID: z.string().optional(),
   /** AWS region for Bedrock runtime. Eileen sets to her access region. */
   AWS_REGION: z.string().optional(),
 

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -16,7 +16,15 @@
  */
 
 // Public types
-export type { CharacterConfig, ZoneId, PostType, EmojiAffinityKind } from './types.ts';
+export type {
+  CharacterConfig,
+  ZoneId,
+  PostType,
+  EmojiAffinityKind,
+  SlashCommandSpec,
+  SlashCommandHandler,
+  SlashCommandOption,
+} from './types.ts';
 export type { Config } from './config.ts';
 export type { FireRequest, SchedulerHandles, ScheduleArgs } from './cron/scheduler.ts';
 export type { PostComposeResult } from './compose/composer.ts';

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -24,6 +24,7 @@ export type {
   SlashCommandSpec,
   SlashCommandHandler,
   SlashCommandOption,
+  DiscordApplicationCommandOptionType,
 } from './types.ts';
 export type { Config } from './config.ts';
 export type { FireRequest, SchedulerHandles, ScheduleArgs } from './cron/scheduler.ts';

--- a/packages/persona-engine/src/orchestrator/imagegen/bedrock-client.ts
+++ b/packages/persona-engine/src/orchestrator/imagegen/bedrock-client.ts
@@ -1,0 +1,89 @@
+/**
+ * Bedrock Stability invoke — substrate scaffold (V0.7-A.1).
+ *
+ * Mirrors the invokeChatBedrock stub pattern in compose/reply.ts. Ships a
+ * type-shaped boundary so substrate plumbing (orchestrator wiring, MCP
+ * tool surface, dispatch handler) can land first, then Eileen replaces
+ * the stub body with the real `@aws-sdk/client-bedrock-runtime`
+ * InvokeModelCommand against the Stability model her region exposes
+ * (e.g. `stability.stable-image-ultra-v1:0`).
+ *
+ * What ships now (this file):
+ *   - isImagegenConfigured(config)  — env presence check substrate uses
+ *     to conditionally register the imagegen MCP server
+ *   - invokeStability(config, input) — placeholder body that round-trips
+ *     prompt/style/seed in a synthetic URL so the MCP tool surface is
+ *     end-to-end exercisable in dev (smoke test + /satoshi-image dispatch)
+ *
+ * What Eileen lands (her PR):
+ *   - Add `@aws-sdk/client-bedrock-runtime` to persona-engine deps
+ *   - Replace the placeholder body with InvokeModelCommand using
+ *     `text_prompts`/`cfg_scale`/`seed` per her model's body spec
+ *   - Image bytes → upload target (S3 / R2 / Discord attachment) → URL
+ *
+ * Auth path (already plumbed in config.ts via Eileen's bedrock-typing
+ * scaffold): AWS_BEARER_TOKEN_BEDROCK (newer bearer-token auth) OR
+ * BEDROCK_API_KEY. The substrate config carries them; this client reads
+ * from the passed Config object rather than process.env directly so test
+ * fixtures + per-character env scoping work uniformly.
+ */
+
+import type { Config } from '../../config.ts';
+import type { GenerateInput, GenerateOutput } from './types.ts';
+
+export function isImagegenConfigured(config: Config): boolean {
+  return Boolean(config.AWS_REGION && config.BEDROCK_STABILITY_MODEL_ID);
+}
+
+export async function invokeStability(
+  config: Config,
+  input: GenerateInput,
+): Promise<GenerateOutput> {
+  if (!isImagegenConfigured(config)) {
+    throw new Error(
+      'imagegen: AWS_REGION and BEDROCK_STABILITY_MODEL_ID are required to invoke Stability',
+    );
+  }
+  if (!config.AWS_BEARER_TOKEN_BEDROCK && !config.BEDROCK_API_KEY) {
+    throw new Error(
+      'imagegen: AWS_BEARER_TOKEN_BEDROCK or BEDROCK_API_KEY required for Bedrock auth',
+    );
+  }
+
+  const seed = input.seed ?? deterministicSeed(input.prompt);
+  return {
+    url: buildPlaceholderUrl(input, seed),
+    model: config.BEDROCK_STABILITY_MODEL_ID!,
+    seed,
+    placeholder: true,
+  };
+}
+
+function buildPlaceholderUrl(input: GenerateInput, seed: number): string {
+  // Round-trip context into the URL so dispatch logs and Eileen's local
+  // QA see exactly what the substrate handed the (eventually-real) SDK
+  // call. Truncate prompt at 80 chars to keep the URL within standard
+  // length budgets — the LLM can echo the full prompt back in prose.
+  const params = new URLSearchParams({
+    placeholder: '1',
+    prompt: input.prompt.slice(0, 80),
+    seed: String(seed),
+  });
+  if (input.style) params.set('style', input.style);
+  if (input.aspect_ratio) params.set('aspect', input.aspect_ratio);
+  return `https://placehold.co/imagegen?${params.toString()}`;
+}
+
+/**
+ * Cheap deterministic seed derivation when the caller didn't pass one —
+ * gives reproducible-enough placeholder URLs in tests without pulling in
+ * a hash dep. Eileen can replace with crypto.randomBytes when the real
+ * Stability call lands and reproducibility matters.
+ */
+function deterministicSeed(prompt: string): number {
+  let h = 5381;
+  for (let i = 0; i < prompt.length; i++) {
+    h = ((h << 5) + h + prompt.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}

--- a/packages/persona-engine/src/orchestrator/imagegen/bedrock-client.ts
+++ b/packages/persona-engine/src/orchestrator/imagegen/bedrock-client.ts
@@ -79,11 +79,16 @@ function buildPlaceholderUrl(input: GenerateInput, seed: number): string {
  * gives reproducible-enough placeholder URLs in tests without pulling in
  * a hash dep. Eileen can replace with crypto.randomBytes when the real
  * Stability call lands and reproducibility matters.
+ *
+ * `>>> 0` coerces the int32 to unsigned-32-bit, dodging the
+ * `Math.abs(INT32_MIN) === INT32_MIN` edge case (Math.abs has no positive
+ * int32 representation for -2147483648, so the result would still be
+ * negative · breaks any downstream `nonnegative` zod check).
  */
 function deterministicSeed(prompt: string): number {
   let h = 5381;
   for (let i = 0; i < prompt.length; i++) {
     h = ((h << 5) + h + prompt.charCodeAt(i)) | 0;
   }
-  return Math.abs(h);
+  return h >>> 0;
 }

--- a/packages/persona-engine/src/orchestrator/imagegen/index.ts
+++ b/packages/persona-engine/src/orchestrator/imagegen/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Imagegen substrate barrel — public surface of the imagegen MCP module.
+ *
+ * Exposed via `@freeside-characters/persona-engine/orchestrator/imagegen`
+ * so the bot's smoke + diagnostics can exercise the substrate primitives
+ * without crossing the workspace boundary or widening the main index.ts.
+ *
+ * The orchestrator wires `createImagegenServer` + `isImagegenConfigured`
+ * directly via the relative path; this barrel exists for external consumers
+ * (smoke, future diagnostics) only.
+ */
+
+export { invokeStability, isImagegenConfigured } from './bedrock-client.ts';
+export {
+  ImageStyleSchema,
+  ImageAspectRatioSchema,
+  type ImageStyle,
+  type ImageAspectRatio,
+  type GenerateInput,
+  type GenerateOutput,
+  type SuggestStyleInput,
+  type SuggestStyleOutput,
+} from './types.ts';

--- a/packages/persona-engine/src/orchestrator/imagegen/server.ts
+++ b/packages/persona-engine/src/orchestrator/imagegen/server.ts
@@ -1,0 +1,138 @@
+/**
+ * Imagegen — in-bot SDK MCP server (V0.7-A.1 substrate prep · scaffold).
+ *
+ * Pattern mirror of rosenzu/server.ts and emojis/server.ts: in-process
+ * `createSdkMcpServer` registered conditionally by the orchestrator when
+ * Bedrock Stability env is configured.
+ *
+ * Two tools:
+ *   - generate        — Bedrock Stability text-to-image (placeholder body
+ *                       until Eileen lands the real InvokeModelCommand)
+ *   - suggest_style   — codex-archetype → style hint (static table for
+ *                       scaffold; future iteration can hit codex MCP for
+ *                       grounded archetype lookup)
+ *
+ * Per-character scoping (V0.7-A.3 wiring lands separately): satoshi gets
+ * `imagegen` access; ruggy does NOT (he stays data-grounded; won't
+ * hallucinate-and-illustrate). Until A.3 ships, the orchestrator
+ * registers this server bot-wide when env is set — chat-mode replies
+ * already bypass MCPs entirely so ruggy's voice register is uncontested.
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { invokeStability } from './bedrock-client.ts';
+import {
+  ImageAspectRatioSchema,
+  ImageStyleSchema,
+  type ImageStyle,
+  type SuggestStyleOutput,
+} from './types.ts';
+import type { Config } from '../../config.ts';
+
+function ok(value: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+/**
+ * Static archetype → style hint table. Covers the 9 cabal archetypes
+ * (gygax) plus a generic mibera/ruggy split. The LLM treats this as a
+ * suggestion, not a constraint — it can override per-prompt if the scene
+ * needs a different register. The rationale field gives the model a
+ * one-line cue to ground the choice.
+ */
+const ARCHETYPE_STYLE: Record<string, { style: ImageStyle; rationale: string }> = {
+  Storyteller: { style: 'illustration', rationale: 'narrator voice — lean into illustrated scene-set rather than photorealism' },
+  GM: { style: 'cinematic', rationale: 'session-presence — wide-frame composition reads as table-top stage' },
+  Veteran: { style: 'photorealistic', rationale: 'long-view register — grounded materiality over stylization' },
+  'Chaos-Agent': { style: 'abstract', rationale: 'unstable register — abstraction lets the unease land without literal anchors' },
+  Optimizer: { style: 'illustration', rationale: 'systems-thinking voice — clean diagrammatic illustration' },
+  Newcomer: { style: 'photorealistic', rationale: 'fresh-eyes register — concrete textures, no stylization veil' },
+  'Rules-Lawyer': { style: 'illustration', rationale: 'ledger voice — tidy compositional clarity' },
+  'Anxious-Player': { style: 'cinematic', rationale: 'emotional weight — cinematic light + shallow focus' },
+  Explorer: { style: 'cinematic', rationale: 'discovery voice — wide vista + atmospheric depth' },
+  // Lowercase fallbacks for tool-call ergonomics (LLMs sometimes lowercase)
+  storyteller: { style: 'illustration', rationale: 'narrator voice — illustrated scene-set' },
+  veteran: { style: 'photorealistic', rationale: 'long-view register — grounded materiality' },
+  'chaos-agent': { style: 'abstract', rationale: 'unstable register — abstraction over literal anchors' },
+};
+
+const MOOD_OVERRIDES: Record<string, ImageStyle> = {
+  hermetic: 'abstract',
+  cypherpunk: 'cinematic',
+  warm: 'illustration',
+  ghibli: 'illustration',
+  glitch: 'pixel-art',
+  retro: 'pixel-art',
+};
+
+function suggestStyle(archetype: string, mood?: string): SuggestStyleOutput {
+  const moodKey = mood?.toLowerCase().trim();
+  if (moodKey && MOOD_OVERRIDES[moodKey]) {
+    return {
+      archetype,
+      mood: moodKey,
+      style: MOOD_OVERRIDES[moodKey]!,
+      rationale: `mood "${moodKey}" steers toward ${MOOD_OVERRIDES[moodKey]!} regardless of archetype`,
+    };
+  }
+  const hit = ARCHETYPE_STYLE[archetype] ?? ARCHETYPE_STYLE[archetype.trim()];
+  if (hit) {
+    return { archetype, mood: moodKey ?? null, style: hit.style, rationale: hit.rationale };
+  }
+  return {
+    archetype,
+    mood: moodKey ?? null,
+    style: 'illustration',
+    rationale: `unknown archetype "${archetype}" — defaulting to illustration as the safest neutral`,
+  };
+}
+
+/**
+ * Build the imagegen MCP server bound to a specific runtime config.
+ *
+ * The orchestrator passes `config` so the bedrock client reads model id
+ * + region + auth from the already-validated zod parse rather than
+ * process.env. Mirrors the freeside_auth pattern of capturing pool state
+ * at module load — but here state is just the config reference, so we
+ * factor it as a builder function called from buildMcpServers.
+ */
+export function createImagegenServer(config: Config) {
+  return createSdkMcpServer({
+    name: 'imagegen',
+    version: '0.1.0',
+    tools: [
+      tool(
+        'generate',
+        'Generate an image from a text prompt via Bedrock Stability. Returns { url, model, seed, placeholder } — when `placeholder: true`, the substrate is in scaffold mode (Eileen\'s SDK body not yet landed) and the URL is synthetic. Call this when a character explicitly chooses to illustrate (e.g. /satoshi-image, or autoprompt-driven imagegen). Cost-aware: invoke once per reply, not per attempt — the seed is the variance lever, not repeated calls.',
+        {
+          prompt: z.string().min(1).describe('Text-to-image prompt. Be explicit about subject, scene, lighting; the model is literal.'),
+          style: ImageStyleSchema.optional().describe('Visual style hint. Call mcp__imagegen__suggest_style first if unsure.'),
+          aspect_ratio: ImageAspectRatioSchema.optional().describe('Output aspect ratio. 1:1 default; 16:9 for landscape; 9:16 for vertical/Discord-mobile.'),
+          seed: z.number().int().nonnegative().optional().describe('Optional seed for reproducibility. Omit for fresh variance per call.'),
+        },
+        async ({ prompt, style, aspect_ratio, seed }) => {
+          const result = await invokeStability(config, { prompt, style, aspect_ratio, seed });
+          return ok(result);
+        },
+      ),
+
+      tool(
+        'suggest_style',
+        'Returns a style hint derived from a character archetype (and optional mood). Use this BEFORE calling generate when you don\'t already have a strong style intent. Rationale field tells you WHY the style was picked — overrideable per-prompt if the scene calls for something else. Backed by a static archetype table; future iteration may hit codex MCP for grounded lookup.',
+        {
+          archetype: z.string().min(1).describe('Character archetype (e.g. "Storyteller", "Veteran", "Chaos-Agent") — typically the character\'s anchored archetype.'),
+          mood: z.string().optional().describe('Optional mood override (e.g. "hermetic", "cypherpunk", "warm"). When set and recognized, takes precedence over archetype.'),
+        },
+        async ({ archetype, mood }) => {
+          return ok(suggestStyle(archetype, mood));
+        },
+      ),
+    ],
+  });
+}
+
+export const IMAGEGEN_TOOL_PREFIX = 'mcp__imagegen__';
+export const IMAGEGEN_ALLOWED_TOOLS = [`${IMAGEGEN_TOOL_PREFIX}*`];

--- a/packages/persona-engine/src/orchestrator/imagegen/types.ts
+++ b/packages/persona-engine/src/orchestrator/imagegen/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Imagegen — input/output schemas (V0.7-A.1 substrate prep).
+ *
+ * Boundary contract between the MCP tool surface and the bedrock-client
+ * implementation. Anything the LLM passes through `mcp__imagegen__generate`
+ * lands here; anything the substrate hands Eileen's Bedrock Stability
+ * invoke also lands here. Keep this file the single source of truth for
+ * the imagegen tool shape so the MCP server, the bedrock client, and any
+ * future substrate consumer never disagree.
+ */
+
+import { z } from 'zod';
+
+export const ImageStyleSchema = z.enum([
+  'photorealistic',
+  'illustration',
+  'abstract',
+  'cinematic',
+  'pixel-art',
+]);
+export type ImageStyle = z.infer<typeof ImageStyleSchema>;
+
+export const ImageAspectRatioSchema = z.enum(['1:1', '16:9', '9:16']);
+export type ImageAspectRatio = z.infer<typeof ImageAspectRatioSchema>;
+
+export interface GenerateInput {
+  prompt: string;
+  style?: ImageStyle;
+  aspect_ratio?: ImageAspectRatio;
+  seed?: number;
+}
+
+export interface GenerateOutput {
+  url: string;
+  model: string;
+  seed: number;
+  /**
+   * Substrate-side flag: true when the bedrock client returned a synthetic
+   * placeholder URL (Eileen's SDK invoke body not yet landed). Lets the
+   * dispatch handler decorate the reply with a "scaffold mode" notice.
+   */
+  placeholder: boolean;
+}
+
+export interface SuggestStyleInput {
+  archetype: string;
+  mood?: string;
+}
+
+export interface SuggestStyleOutput {
+  archetype: string;
+  mood: string | null;
+  style: ImageStyle;
+  rationale: string;
+}

--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -33,6 +33,8 @@ import type { PostType } from '../compose/post-types.ts';
 import { rosenzuServer } from './rosenzu/server.ts';
 import { freesideAuthServer } from './freeside_auth/server.ts';
 import { emojisServer } from './emojis/server.ts';
+import { createImagegenServer } from './imagegen/server.ts';
+import { isImagegenConfigured } from './imagegen/bedrock-client.ts';
 // V0.6-C reconciliation 2026-04-30: cabalGygaxAgent retired from per-fire
 // compose path per gumi correction §0.5 #1 — the 9 cabal archetypes are
 // AUDIENCE postures, not character voice modes. The subagent code is
@@ -101,6 +103,17 @@ function buildMcpServers(config: Config): Record<string, McpServerConfig> {
       type: 'http',
       url: `${config.CODEX_MCP_URL}/mcp`,
     };
+  }
+
+  // imagegen-mcp (Bedrock Stability text-to-image) — V0.7-A.1 substrate
+  // scaffold. Registered when AWS_REGION + BEDROCK_STABILITY_MODEL_ID
+  // are set. Body is a placeholder stub awaiting Eileen's PR; the tool
+  // surface is exercisable today via /satoshi-image dispatch. Per-
+  // character scope (ruggy=no-imagegen, satoshi=imagegen) lands with
+  // V0.7-A.3 — until then, chat-mode bypasses MCPs entirely so ruggy's
+  // voice register is uncontested even when this server is registered.
+  if (isImagegenConfigured(config)) {
+    servers.imagegen = createImagegenServer(config);
   }
 
   return servers;

--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -130,10 +130,26 @@ function buildMcpServers(config: Config): Record<string, McpServerConfig> {
  * compose path per gumi correction §0.5 #1. If a future subagent needs
  * Task dispatch (e.g. the /cabal post-design reception tester running
  * separately from compose), re-add then.
+ *
+ * V0.7-A.1 (per-character MCP scoping): when `characterMcps` is provided,
+ * the allowed list filters to servers whose names appear in that array.
+ * Names that aren't currently registered are silently dropped — the
+ * character expresses INTENT; what's actually available is the
+ * intersection with what the substrate has wired. When `characterMcps`
+ * is undefined, all registered servers are allowed (V0.6 parity).
+ *
+ * Exported (rather than file-private) so the substrate's smoke tests can
+ * exercise the scoping logic without booting the Claude Agent SDK loop.
  */
-function buildAllowedTools(mcpServers: Record<string, McpServerConfig>): string[] {
-  const mcpTools = Object.keys(mcpServers).map((name) => `mcp__${name}__*`);
-  return mcpTools;
+export function buildAllowedTools(
+  mcpServers: Record<string, McpServerConfig>,
+  characterMcps?: string[],
+): string[] {
+  const allNames = Object.keys(mcpServers);
+  const enabled = characterMcps
+    ? allNames.filter((name) => characterMcps.includes(name))
+    : allNames;
+  return enabled.map((name) => `mcp__${name}__*`);
 }
 
 /**
@@ -168,7 +184,7 @@ export async function runOrchestratorQuery(
   }
 
   const mcpServers = buildMcpServers(config);
-  const allowedTools = buildAllowedTools(mcpServers);
+  const allowedTools = buildAllowedTools(mcpServers, req.character.mcps);
 
   const options: Options = {
     systemPrompt: req.systemPrompt,

--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -186,6 +186,24 @@ export async function runOrchestratorQuery(
   const mcpServers = buildMcpServers(config);
   const allowedTools = buildAllowedTools(mcpServers, req.character.mcps);
 
+  // V0.7-A.1 observability: when a character's declared mcps name servers
+  // not currently registered (env-gated MCP not configured, OR a typo in
+  // character.json), they're silently dropped from the allowedTools
+  // intersection. Surface that to the operator so a missed env var or a
+  // misspelled scope name doesn't masquerade as "the LLM just chose not
+  // to use the tool." Logged once per fire — for V0.6 cron cadence (1-2
+  // fires/day) this is negligible noise; if it ever becomes load-bearing
+  // we can dedup by (characterId, droppedSet) at startup.
+  if (req.character.mcps) {
+    const registered = Object.keys(mcpServers);
+    const dropped = req.character.mcps.filter((n) => !registered.includes(n));
+    if (dropped.length > 0) {
+      console.warn(
+        `orchestrator: character ${req.character.id} declared mcps [${dropped.join(', ')}] not currently registered — dropped from allowedTools`,
+      );
+    }
+  }
+
   const options: Options = {
     systemPrompt: req.systemPrompt,
     model: config.ANTHROPIC_MODEL,

--- a/packages/persona-engine/src/types.ts
+++ b/packages/persona-engine/src/types.ts
@@ -71,6 +71,58 @@ export interface CharacterConfig {
    * with satoshi's voice is correct reception, not a bug.
    */
   anchoredArchetypes?: CabalArchetype[];
+
+  /**
+   * V0.7-A.1: per-character slash command set. Eileen's framing
+   * (2026-04-30): "commands are diff otherwise they'd be reporting the
+   * same shit." When omitted, the substrate auto-generates the default
+   * `/<id> prompt:<text> ephemeral:<bool>` command (V0.7-A.0 parity)
+   * routed to the `chat` handler.
+   *
+   * Examples:
+   *   ruggy   = undefined           → default /ruggy chat
+   *   satoshi = [/satoshi (chat),
+   *              /satoshi-image (imagegen)]
+   *
+   * The substrate flattens commands across all loaded characters at
+   * publish time (see apps/bot/scripts/publish-commands.ts) and routes
+   * by command name + handler at dispatch time
+   * (apps/bot/src/discord-interactions/dispatch.ts).
+   */
+  slash_commands?: SlashCommandSpec[];
+}
+
+/**
+ * V0.7-A.1: a single slash command declared by a character. Maps 1:1 to
+ * Discord's Application Command shape so character.json can declare
+ * commands without runtime translation. The `handler` field is the
+ * substrate-side hook — `chat` runs through composeReply (V0.7-A.0
+ * pipeline), `imagegen` runs through the imagegen MCP scaffold.
+ *
+ * Future handlers (`stats`, `lore`, `score`, etc.) extend the union; the
+ * dispatch switch is the single point of registration.
+ */
+export interface SlashCommandSpec {
+  /** Discord command name (lowercase, hyphenated). Must match Discord's
+   *  /^[-_\p{L}\p{N}]{1,32}$/ regex. */
+  name: string;
+  /** 1-100 char description shown in Discord's autocomplete UI. */
+  description: string;
+  /** Substrate-side handler that runs when this command fires. */
+  handler: SlashCommandHandler;
+  /** Discord application command options (0-25). type values: 3=STRING,
+   *  4=INTEGER, 5=BOOLEAN, 10=NUMBER (canonical Discord enum). */
+  options?: SlashCommandOption[];
+}
+
+export type SlashCommandHandler = 'chat' | 'imagegen';
+
+export interface SlashCommandOption {
+  name: string;
+  description: string;
+  /** Discord application command option type. Common: 3=STRING, 5=BOOLEAN. */
+  type: number;
+  required?: boolean;
 }
 
 /**

--- a/packages/persona-engine/src/types.ts
+++ b/packages/persona-engine/src/types.ts
@@ -90,6 +90,26 @@ export interface CharacterConfig {
    * (apps/bot/src/discord-interactions/dispatch.ts).
    */
   slash_commands?: SlashCommandSpec[];
+
+  /**
+   * V0.7-A.1: per-character MCP scope. Names of MCP servers the character
+   * is allowed to call from its digest path. When omitted, the character
+   * has access to ALL registered MCPs (V0.6 parity). Names not currently
+   * registered (e.g. codex when CODEX_MCP_URL unset) are silently dropped
+   * — the field expresses INTENT; what's actually available is the
+   * intersection with what the substrate has wired.
+   *
+   * Examples:
+   *   ruggy   = ['score', 'codex', 'emojis', 'rosenzu', 'freeside_auth']
+   *             // reporter · data-grounded · no imagegen
+   *   satoshi = ['codex', 'imagegen']
+   *             // mibera-agent · cross-realms · no score lookups
+   *
+   * Affects ONLY the digest path (runOrchestratorQuery). Chat-mode
+   * replies (composeReply) bypass MCPs entirely by design and are
+   * unaffected by this field.
+   */
+  mcps?: string[];
 }
 
 /**

--- a/packages/persona-engine/src/types.ts
+++ b/packages/persona-engine/src/types.ts
@@ -140,10 +140,20 @@ export type SlashCommandHandler = 'chat' | 'imagegen';
 export interface SlashCommandOption {
   name: string;
   description: string;
-  /** Discord application command option type. Common: 3=STRING, 5=BOOLEAN. */
-  type: number;
+  /** Discord application command option type. We currently use the basic
+   *  scalar set: 3=STRING, 4=INTEGER, 5=BOOLEAN, 10=NUMBER. The full
+   *  Discord enum also covers SUB_COMMAND (1), SUB_COMMAND_GROUP (2), and
+   *  the entity-reference types (USER/CHANNEL/ROLE/MENTIONABLE/ATTACHMENT).
+   *  Extend this union when a character needs one of those. */
+  type: DiscordApplicationCommandOptionType;
   required?: boolean;
 }
+
+/** Subset of Discord's ApplicationCommandOptionType enum currently used by
+ *  the character substrate. Narrowing to a literal union catches typos at
+ *  compile time — `type: 99` would type-check under plain `number` and
+ *  fail only at Discord publish (400 Bad Request). */
+export type DiscordApplicationCommandOptionType = 3 | 4 | 5 | 10;
 
 /**
  * The 9 cabal-gygax phantom-player archetypes — AUDIENCE postures, NOT


### PR DESCRIPTION
## Summary

V0.7-A.1 substrate prep — three atomic items prepping the bot so Eileen
can land bedrock provider, image generation (Stability AI on Bedrock),
and per-character commands without friction. Per
`grimoires/bonfire/specs/kickoff-substrate-prep-eileen-2026-04-30.md`.

Three commits, ordered for build sequence:

- **`217c63e`** — `feat(imagegen-mcp)`: Bedrock Stability text-to-image MCP scaffold (`packages/persona-engine/src/orchestrator/imagegen/`). Mirrors rosenzu/emojis pattern · `generate` body stubbed pending Eileen's `@aws-sdk/client-bedrock-runtime` invoke PR · `suggest_style` is a static archetype lookup table.
- **`0f376ef`** — `feat(slash-commands)`: per-character command sets with handler routing. `CharacterConfig.slash_commands?` lets each character declare its own commands; substrate flattens at publish, dispatches by name + handler. `SlashCommandHandler` union (`chat | imagegen`) is extensible. Satoshi declares /satoshi (chat) + /satoshi-image (imagegen); ruggy keeps V0.7-A.0 default `/ruggy` chat shape.
- **`88c52f5`** — `feat(mcp-scoping)`: per-character MCP scope on the digest path. `CharacterConfig.mcps?` filters `buildAllowedTools` so ruggy=[score,codex,emojis,rosenzu,freeside_auth] (no imagegen) and satoshi=[codex,imagegen] (no score). Affects ONLY runOrchestratorQuery; chat-mode bypasses MCPs by design.

## Test plan

- [x] `bun run typecheck` clean at every commit
- [x] `bun run apps/bot/scripts/smoke-interactions.ts` green at every commit (22 substrate-boundary checks: ledger, splitForDiscord, imagegen env-gate + placeholder shape, slash routing across 4 cases, MCP scoping across 4 cases, HTTP server health/auth)
- [ ] `bun run apps/bot/scripts/publish-commands.ts` against the dev guild (operator-side · needs bot token + app id) → confirm `/satoshi-image` registers
- [ ] Live-fire `/ruggy` digest → confirm allowedTools reflects the 5-MCP scope (ruggy still has score, no imagegen attempts in the SDK loop)
- [ ] Live-fire `/satoshi-image prompt:test` → expect placeholder reply with `placeholder=true · awaiting Eileen's Stability invoke PR` annotation
- [ ] Set `BEDROCK_STABILITY_MODEL_ID` + `AWS_REGION` env on Railway once Eileen confirms her region's model id

## Out of scope (deferred)

- `CharacterConfig.llmProvider` (per-character LLM provider override) — operator-deferred 2026-04-30
- dAMP-96 personality derivation (loa-finn integration) — separate kickoff once #1-3 land
- Per-character bot tokens / per-character Discord apps — single-service collapse decision 2026-04-30
- Bedrock support in the digest path — Claude Agent SDK doesn't support Bedrock for tool-call rounds; chat-mode is the bedrock path

## Backwards compatibility

- Characters without `slash_commands` keep V0.7-A.0 shape (`/<id> prompt:<text> ephemeral:<bool>` chat handler)
- Characters without `mcps` get bot-wide MCP access (V0.6 parity)
- imagegen MCP only registers when `AWS_REGION` + `BEDROCK_STABILITY_MODEL_ID` are set; dormant otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)