### PR TITLE
feat(score): SCORE_BEARER for routing via mcp.0xhoneyjar.xyz/score

### DIFF
--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -14,9 +14,17 @@ const ConfigSchema = z.object({
   LLM_PROVIDER: z.enum(['stub', 'anthropic', 'freeside', 'bedrock', 'auto']).default('auto'),
 
   // ─── score-mcp (zerker — production data path) ────────────────────────
+  // Direct path (V0.5-): SCORE_API_URL=https://score-api-production.up.railway.app, MCP_KEY set, SCORE_BEARER unset.
+  // Gateway path (V0.7+): SCORE_API_URL=https://mcp.0xhoneyjar.xyz/score, MCP_KEY + SCORE_BEARER both set.
+  // The gateway is registry-shaped: it declares each upstream's auth via the federation manifest;
+  // callers compose the request from the declaration. SCORE_BEARER passes the gateway gate;
+  // X-MCP-Key (sourced from MCP_KEY) satisfies the upstream's announced auth.
   SCORE_API_URL: z.string().url().default('https://score-api-production.up.railway.app'),
   SCORE_API_KEY: z.string().optional(),
   MCP_KEY: z.string().optional(),
+  /** Bearer for the freeside-mcp-gateway gate. Matches the gateway's
+   *  `TENANT_SCORE_API_KEY` env. Unset = direct route (no gateway gate). */
+  SCORE_BEARER: z.string().optional(),
 
   // ─── codex-mcp (gumi — mibera-codex lookup, public, no auth) ──────────
   /**

--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -86,7 +86,13 @@ function buildMcpServers(config: Config): Record<string, McpServerConfig> {
     servers.score = {
       type: 'http',
       url: `${config.SCORE_API_URL}/mcp`,
-      headers: { 'X-MCP-Key': config.MCP_KEY },
+      headers: {
+        'X-MCP-Key': config.MCP_KEY,
+        // SCORE_BEARER is the gateway gate; harmless when score is reached
+        // direct (upstream ignores Authorization). Set both env vars to
+        // route via mcp.0xhoneyjar.xyz/score.
+        ...(config.SCORE_BEARER ? { Authorization: `Bearer ${config.SCORE_BEARER}` } : {}),
+      },
     };
   }
 

--- a/packages/persona-engine/src/score/client.ts
+++ b/packages/persona-engine/src/score/client.ts
@@ -50,13 +50,20 @@ function parseSseEnvelope<T>(body: string): McpJsonRpcEnvelope<T> {
   return JSON.parse(json) as McpJsonRpcEnvelope<T>;
 }
 
-async function mcpInit(url: string, key: string): Promise<McpInitResult> {
+function authHeaders(key: string, bearer?: string): Record<string, string> {
+  return {
+    'X-MCP-Key': key,
+    ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+  };
+}
+
+async function mcpInit(url: string, key: string, bearer?: string): Promise<McpInitResult> {
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
-      'X-MCP-Key': key,
+      ...authHeaders(key, bearer),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',
@@ -88,7 +95,7 @@ async function mcpInit(url: string, key: string): Promise<McpInitResult> {
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
-      'X-MCP-Key': key,
+      ...authHeaders(key, bearer),
       'Mcp-Session-Id': sessionId,
     },
     body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
@@ -103,13 +110,14 @@ async function mcpToolCall<T>(
   sessionId: string,
   toolName: string,
   toolArgs: Record<string, unknown>,
+  bearer?: string,
 ): Promise<T> {
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
-      'X-MCP-Key': key,
+      ...authHeaders(key, bearer),
       'Mcp-Session-Id': sessionId,
     },
     body: JSON.stringify({
@@ -147,11 +155,16 @@ export async function fetchZoneDigest(config: Config, zone: ZoneId): Promise<Zon
   }
 
   const url = `${config.SCORE_API_URL}/mcp`;
-  const { sessionId } = await mcpInit(url, config.MCP_KEY);
-  return mcpToolCall<ZoneDigest>(url, config.MCP_KEY, sessionId, 'get_zone_digest', {
-    zone,
-    window: 'weekly',
-  });
+  const bearer = config.SCORE_BEARER;
+  const { sessionId } = await mcpInit(url, config.MCP_KEY, bearer);
+  return mcpToolCall<ZoneDigest>(
+    url,
+    config.MCP_KEY,
+    sessionId,
+    'get_zone_digest',
+    { zone, window: 'weekly' },
+    bearer,
+  );
 }
 
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `SCORE_BEARER` env var (additive, optional). When set, score-mcp calls include `Authorization: Bearer ${SCORE_BEARER}` alongside the existing `X-MCP-Key`, enabling score traffic to route via the freeside-mcp-gateway at `mcp.0xhoneyjar.xyz/score` while preserving direct-route behavior when unset.

## Doctrine

Per **gateway-as-registry** (`~/vault/wiki/concepts/gateway-as-registry.md`, 2026-05-01): the gateway gates its own routing surface; the upstream announces its own auth requirement; the caller composes from both declarations.

Two distinct auth surfaces, two distinct keys, one composed request:

```
POST mcp.0xhoneyjar.xyz/score/mcp
Authorization: Bearer ${SCORE_BEARER}    ← gateway gate (registry policy)
X-MCP-Key: ${MCP_KEY}                    ← upstream auth (broadcast)
```

The gateway holds zero upstream secrets — caller composes the request from gateway's gate declaration + upstream's broadcast.

## Files

| file | change |
| --- | --- |
| `packages/persona-engine/src/config.ts` | `SCORE_BEARER` (additive, optional) + path-comment header |
| `packages/persona-engine/src/orchestrator/index.ts` | `Authorization` header alongside `X-MCP-Key` when `SCORE_BEARER` set |
| `packages/persona-engine/src/score/client.ts` | thread `bearer?` through `mcpInit` / `mcpToolCall`; new `authHeaders()` helper |

## Test plan

- [x] `bun run typecheck` clean (persona-engine + bot)
- [ ] post-deploy: set `SCORE_BEARER` + flip `SCORE_API_URL=https://mcp.0xhoneyjar.xyz/score` on Railway
- [ ] post-deploy: ruggy/satoshi narrative still grounded (next digest)
- [ ] backward-compat: `SCORE_BEARER` unset → V0.5+ direct-route behavior preserved (zero behavior change)

## Operator runtime ops (post-merge)

| step | where |
| --- | --- |
| set `SCORE_BEARER` on freeside-characters Railway | matches gateway's `TENANT_SCORE_API_KEY` (companion PR: 0xHoneyJar/freeside-mcp-gateway#2) |
| flip `SCORE_API_URL` on freeside-characters Railway | `https://score-api-production.up.railway.app` → `https://mcp.0xhoneyjar.xyz/score` |
| deploy | Railway auto |
| verify | next ruggy/satoshi digest stays grounded; gateway logs show `/score/mcp` traffic |

## Companion PR

- 0xHoneyJar/freeside-mcp-gateway#2 — gateway side (visibility filter · access gate · score tenant declaration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)