### PR TITLE
feat(loa): mount Loa framework on freeside-characters

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/architect.md

--- a/.claude/commands/archive-cycle.md
+++ b/.claude/commands/archive-cycle.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/archive-cycle.md

--- a/.claude/commands/audit-deployment.md
+++ b/.claude/commands/audit-deployment.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/audit-deployment.md

--- a/.claude/commands/audit-sprint.md
+++ b/.claude/commands/audit-sprint.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/audit-sprint.md

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/audit.md

--- a/.claude/commands/autonomous.md
+++ b/.claude/commands/autonomous.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/autonomous.md

--- a/.claude/commands/bug.md
+++ b/.claude/commands/bug.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/bug.md

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/build.md

--- a/.claude/commands/compound.md
+++ b/.claude/commands/compound.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/compound.md

--- a/.claude/commands/constructs.md
+++ b/.claude/commands/constructs.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/constructs.md

--- a/.claude/commands/contribute.md
+++ b/.claude/commands/contribute.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/contribute.md

--- a/.claude/commands/deploy-production.md
+++ b/.claude/commands/deploy-production.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/deploy-production.md

--- a/.claude/commands/enhance.md
+++ b/.claude/commands/enhance.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/enhance.md

--- a/.claude/commands/eval.md
+++ b/.claude/commands/eval.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/eval.md

--- a/.claude/commands/feedback.md
+++ b/.claude/commands/feedback.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/feedback.md

--- a/.claude/commands/flatline-review.md
+++ b/.claude/commands/flatline-review.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/flatline-review.md

--- a/.claude/commands/gpt-review.md
+++ b/.claude/commands/gpt-review.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/gpt-review.md

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/implement.md

--- a/.claude/commands/ledger.md
+++ b/.claude/commands/ledger.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/ledger.md

--- a/.claude/commands/loa-eject.md
+++ b/.claude/commands/loa-eject.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/loa-eject.md

--- a/.claude/commands/loa-setup.md
+++ b/.claude/commands/loa-setup.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/loa-setup.md

--- a/.claude/commands/loa.md
+++ b/.claude/commands/loa.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/loa.md

--- a/.claude/commands/mount.md
+++ b/.claude/commands/mount.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/mount.md

--- a/.claude/commands/oracle-analyze.md
+++ b/.claude/commands/oracle-analyze.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/oracle-analyze.md

--- a/.claude/commands/oracle.md
+++ b/.claude/commands/oracle.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/oracle.md

--- a/.claude/commands/permission-audit.md
+++ b/.claude/commands/permission-audit.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/permission-audit.md

--- a/.claude/commands/plan-and-analyze.md
+++ b/.claude/commands/plan-and-analyze.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/plan-and-analyze.md

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/plan.md

--- a/.claude/commands/post-pr-validation.md
+++ b/.claude/commands/post-pr-validation.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/post-pr-validation.md

--- a/.claude/commands/propose-learning.md
+++ b/.claude/commands/propose-learning.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/propose-learning.md

--- a/.claude/commands/reality.md
+++ b/.claude/commands/reality.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/reality.md

--- a/.claude/commands/red-team.md
+++ b/.claude/commands/red-team.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/red-team.md

--- a/.claude/commands/retrospective-batch.md
+++ b/.claude/commands/retrospective-batch.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/retrospective-batch.md

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/retrospective.md

--- a/.claude/commands/review-sprint.md
+++ b/.claude/commands/review-sprint.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/review-sprint.md

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/review.md

--- a/.claude/commands/ride.md
+++ b/.claude/commands/ride.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/ride.md

--- a/.claude/commands/rtfm.md
+++ b/.claude/commands/rtfm.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/rtfm.md

--- a/.claude/commands/run-bridge.md
+++ b/.claude/commands/run-bridge.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/run-bridge.md

--- a/.claude/commands/run-halt.md
+++ b/.claude/commands/run-halt.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/run-halt.md

--- a/.claude/commands/run-resume.md
+++ b/.claude/commands/run-resume.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/run-resume.md

--- a/.claude/commands/run-sprint-plan.md
+++ b/.claude/commands/run-sprint-plan.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/run-sprint-plan.md

--- a/.claude/commands/run-status.md
+++ b/.claude/commands/run-status.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/run-status.md

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/run.md

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/ship.md

--- a/.claude/commands/simstim.md
+++ b/.claude/commands/simstim.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/simstim.md

--- a/.claude/commands/skill-audit.md
+++ b/.claude/commands/skill-audit.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/skill-audit.md

--- a/.claude/commands/sprint-plan.md
+++ b/.claude/commands/sprint-plan.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/sprint-plan.md

--- a/.claude/commands/toggle-gpt-review.md
+++ b/.claude/commands/toggle-gpt-review.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/toggle-gpt-review.md

--- a/.claude/commands/translate-ride.md
+++ b/.claude/commands/translate-ride.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/translate-ride.md

--- a/.claude/commands/translate.md
+++ b/.claude/commands/translate.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/translate.md

--- a/.claude/commands/update-loa.md
+++ b/.claude/commands/update-loa.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/update-loa.md

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,0 +1,1 @@
+../../.loa/.claude/commands/validate.md

--- a/.claude/overrides/README.md
+++ b/.claude/overrides/README.md
@@ -1,0 +1,7 @@
+# User Overrides
+
+Files here override the symlinked framework content.
+This directory is NOT a symlink - you own these files.
+
+To override a skill, copy it from .loa/.claude/skills/{name}/ to here.
+To override a command, copy from .loa/.claude/commands/{name}.md.

--- a/.claude/skills/auditing-security
+++ b/.claude/skills/auditing-security
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/auditing-security

--- a/.claude/skills/autonomous-agent
+++ b/.claude/skills/autonomous-agent
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/autonomous-agent

--- a/.claude/skills/bridgebuilder-review
+++ b/.claude/skills/bridgebuilder-review
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/bridgebuilder-review

--- a/.claude/skills/browsing-constructs
+++ b/.claude/skills/browsing-constructs
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/browsing-constructs

--- a/.claude/skills/bug-triaging
+++ b/.claude/skills/bug-triaging
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/bug-triaging

--- a/.claude/skills/butterfreezone-gen
+++ b/.claude/skills/butterfreezone-gen
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/butterfreezone-gen

--- a/.claude/skills/continuous-learning
+++ b/.claude/skills/continuous-learning
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/continuous-learning

--- a/.claude/skills/deploying-infrastructure
+++ b/.claude/skills/deploying-infrastructure
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/deploying-infrastructure

--- a/.claude/skills/designing-architecture
+++ b/.claude/skills/designing-architecture
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/designing-architecture

--- a/.claude/skills/discovering-requirements
+++ b/.claude/skills/discovering-requirements
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/discovering-requirements

--- a/.claude/skills/enhancing-prompts
+++ b/.claude/skills/enhancing-prompts
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/enhancing-prompts

--- a/.claude/skills/eval-running
+++ b/.claude/skills/eval-running
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/eval-running

--- a/.claude/skills/flatline-knowledge
+++ b/.claude/skills/flatline-knowledge
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/flatline-knowledge

--- a/.claude/skills/flatline-reviewer
+++ b/.claude/skills/flatline-reviewer
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/flatline-reviewer

--- a/.claude/skills/flatline-scorer
+++ b/.claude/skills/flatline-scorer
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/flatline-scorer

--- a/.claude/skills/flatline-skeptic
+++ b/.claude/skills/flatline-skeptic
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/flatline-skeptic

--- a/.claude/skills/gpt-reviewer
+++ b/.claude/skills/gpt-reviewer
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/gpt-reviewer

--- a/.claude/skills/implementing-tasks
+++ b/.claude/skills/implementing-tasks
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/implementing-tasks

--- a/.claude/skills/loa-setup
+++ b/.claude/skills/loa-setup
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/loa-setup

--- a/.claude/skills/managing-credentials
+++ b/.claude/skills/managing-credentials
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/managing-credentials

--- a/.claude/skills/mounting-framework
+++ b/.claude/skills/mounting-framework
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/mounting-framework

--- a/.claude/skills/planning-sprints
+++ b/.claude/skills/planning-sprints
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/planning-sprints

--- a/.claude/skills/red-teaming
+++ b/.claude/skills/red-teaming
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/red-teaming

--- a/.claude/skills/reviewing-code
+++ b/.claude/skills/reviewing-code
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/reviewing-code

--- a/.claude/skills/riding-codebase
+++ b/.claude/skills/riding-codebase
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/riding-codebase

--- a/.claude/skills/rtfm-testing
+++ b/.claude/skills/rtfm-testing
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/rtfm-testing

--- a/.claude/skills/run-bridge
+++ b/.claude/skills/run-bridge
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/run-bridge

--- a/.claude/skills/run-mode
+++ b/.claude/skills/run-mode
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/run-mode

--- a/.claude/skills/simstim-workflow
+++ b/.claude/skills/simstim-workflow
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/simstim-workflow

--- a/.claude/skills/spiraling
+++ b/.claude/skills/spiraling
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/spiraling

--- a/.claude/skills/translating-for-executives
+++ b/.claude/skills/translating-for-executives
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/translating-for-executives

--- a/.claude/skills/validating-construct-manifest
+++ b/.claude/skills/validating-construct-manifest
@@ -1,0 +1,1 @@
+../../.loa/.claude/skills/validating-construct-manifest

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,19 @@ coverage/
 
 # bot runtime state (emoji recent-used cache, etc.)
 apps/bot/.run/
+
+# LOA SUBMODULE SYMLINKS (added by mount-submodule.sh)
+# Symlinks to .loa/ submodule — recreated on mount
+.claude/scripts
+.claude/protocols
+.claude/hooks
+.claude/data
+.claude/schemas
+.claude/loa/CLAUDE.loa.md
+.claude/loa/reference
+.claude/loa/feedback-ontology.yaml
+.claude/loa/learnings
+.claude/settings.json
+.claude/checksums.json
+.loa-state/
+.claude.backup.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule ".loa"]
+	path = .loa
+	url = https://github.com/0xHoneyJar/loa.git
+	branch = main

--- a/.loa-version.json
+++ b/.loa-version.json
@@ -1,0 +1,17 @@
+{
+  "framework_version": "v1.108.0",
+  "schema_version": 2,
+  "installation_mode": "submodule",
+  "submodule": {
+    "path": ".loa",
+    "ref": "v1.108.0",
+    "commit": "303cd27efcb758f177c3eb4ad9b7770e935ed457"
+  },
+  "last_sync": "2026-05-02T00:59:00Z",
+  "zones": {
+    "system": ".claude",
+    "submodule": ".loa/.claude",
+    "state": ["grimoires/loa", ".beads"],
+    "app": ["src", "lib", "app"]
+  }
+}

--- a/.loa.config.yaml
+++ b/.loa.config.yaml
@@ -1,0 +1,47 @@
+# Loa Framework Configuration (Submodule Mode)
+# This file is yours to customize - framework updates will never modify it
+
+# Installation mode (DO NOT CHANGE - use mount-loa.sh to switch to standard)
+installation_mode: submodule
+
+# Submodule settings
+submodule:
+  path: .loa
+  # ref: main  # Uncomment to track specific ref
+
+# =============================================================================
+# Persistence Mode
+# =============================================================================
+persistence_mode: standard
+
+# =============================================================================
+# Integrity Enforcement
+# =============================================================================
+# Note: Submodule mode uses git submodule integrity instead of checksums
+integrity_enforcement: warn
+
+# =============================================================================
+# Agent Configuration
+# =============================================================================
+disabled_agents: []
+
+# =============================================================================
+# Structured Memory
+# =============================================================================
+memory:
+  notes_file: grimoires/loa/NOTES.md
+  trajectory_dir: grimoires/loa/a2a/trajectory
+  trajectory_retention_days: 30
+
+# =============================================================================
+# Context Hygiene
+# =============================================================================
+compaction:
+  enabled: true
+  threshold: 5
+
+# =============================================================================
+# Integrations
+# =============================================================================
+integrations:
+  - github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,8 @@
+@.claude/loa/CLAUDE.loa.md
+
 # freeside-characters
+
+> Loa framework loads first via the `@` import above; project-specific guidance below takes precedence per Loa's user-overrides convention.
 
 Participation-agent umbrella for the Honey Jar ecosystem. Substrate
 (`packages/persona-engine`) handles cron, MCP orchestration, Discord

--- a/grimoires/loa/NOTES.md
+++ b/grimoires/loa/NOTES.md
@@ -1,0 +1,31 @@
+# Agent Working Memory (NOTES.md)
+
+> This file persists agent context across sessions and compaction cycles.
+> Updated automatically by agents. Manual edits are preserved.
+
+## Active Sub-Goals
+<!-- Current objectives being pursued -->
+
+- **V0.7-A.1 environment substrate** — kickoff brief at `grimoires/loa/specs/build-environment-substrate-v07a1.md`. Phases B-E still to ship after this Phase A (mount) PR lands. Spec is the canonical sprint-plan input for the next session inside this repo.
+
+## Discovered Technical Debt
+<!-- Issues found during implementation that need future attention -->
+
+- **`docs/` ↔ `grimoires/loa/specs/legacy-imports/` duplication** — mount PR copied AGENTS.md, ARCHITECTURE.md, CIVIC-LAYER.md, MULTI-REGISTER.md, CHARACTER-AUTHORING.md into legacy-imports/ without removing originals. Follow-up cleanup: pick canonical home (likely grimoires/), rewrite intra-repo references, delete duplicates. Track as separate PR.
+
+## Blockers & Dependencies
+<!-- External factors affecting progress -->
+
+## Session Continuity
+<!-- Key context to restore on next session -->
+| Timestamp | Agent | Summary |
+|-----------|-------|---------|
+| 2026-05-01 | mounting-framework | Mounted Loa v1.108.0 as submodule; State Zone initialized; CLAUDE.md gained `@.claude/loa/CLAUDE.loa.md` import; build-environment-substrate-v07a1.md ported into grimoires/loa/specs/ |
+
+## Decision Log
+<!-- Major decisions with rationale -->
+
+| Date | Decision | Rationale | Decided By |
+|------|----------|-----------|------------|
+| 2026-05-01 | Submodule mode mount (not checkout) pinned to v1.108.0 | Matches bonfire's pattern; sharing one Loa version across operator repos avoids drift; pin allows controlled bumps via `git submodule update --remote .loa` | operator + ARCH (Ostrom) |
+| 2026-05-01 | Phase A ships as standalone PR; substrate work (Phases B-E) deferred to follow-up sessions inside this repo | Clean workflow boundary — once Loa is mounted, B-E run through `/sprint-plan` + `/implement` gates with beads tracking. Avoids "while-I'm-here" scope creep on a framework-mount PR (Barth scope discipline) | operator + SHIP (Barth) |

--- a/grimoires/loa/specs/build-environment-substrate-v07a1.md
+++ b/grimoires/loa/specs/build-environment-substrate-v07a1.md
@@ -1,0 +1,613 @@
+---
+spec: build-environment-substrate-v07a1
+target_repo: 0xHoneyJar/freeside-characters
+target_branch: main (post v0.8.0 ship · 1391b13)
+external_work_plan: true   # Loa not mounted on target yet — Phase A mounts; subsequent artifacts migrate to freeside-characters/grimoires/loa/specs/
+session: 06 (kickoff · V0.7-A.1 environment substrate)
+date: 2026-05-01
+mode: ARCH (Ostrom · invariants/blast-radius) + craft lens (Alexander · prompt material) + SHIP discipline (Barth · scope cuts)
+status: kickoff (planned)
+parent_brief: ./listener-router-substrate.md
+prior_session: ./build-listener-substrate-v07a0.md (V0.7-A.0 slash commands shipped)
+companion_spec: ./satoshi-ruggy-experiment-validation.md (voice-fidelity validation continues in parallel)
+related:
+  - ./kickoff-substrate-prep-eileen-2026-04-30.md (substrate prep — items #1, #2, #3 all shipped via 0.8.0)
+  - ../research/gemini-deep-research-output-multi-character-bot-substrate-2026-04-30.md (production patterns)
+persona_load_order:
+  - ~/bonfire/.claude/constructs/packs/the-arcade/identity/OSTROM.md
+  - ~/bonfire/.claude/constructs/packs/artisan/identity/ALEXANDER.md
+  - ~/bonfire/.claude/constructs/packs/the-arcade/identity/BARTH.md
+---
+
+# Session 06 — Agent environment substrate (V0.7-A.1)
+
+> **One-line context**: V0.6 shipped digest-only Pattern B. V0.7-A.0 shipped slash commands + chat-reply path. V0.8.0 (Eileen) shipped Bedrock chat + Bedrock Stability imagegen + per-character MCP scoping + per-character commands. **What's missing**: agents are write-aware (post into channels) but not **environment-aware** — they don't know which Mibera Codex location they're in, who else is here, or how to invoke their tools naturally per ChatGPT-style. This session builds the thin awareness substrate that closes the gap.
+
+---
+
+## The reframe (operator, 2026-05-01)
+
+> "agents to be kind of more aware of their environment ... within the Discord context, it's important that we're very clear about how the different channels represent different locations within the Mibera Codex ... having it feel directionally aligned with the daemon means that there's actual awareness and spatial awareness ... very similar to how ChatGPT works from a user perspective, a lot of these things happen automatically."
+
+**Translation**: build the substrate that lets each character know **where they are**, **what tools they have**, **who else is here**, and **how their personality should govern tool invocation**. ChatGPT does this implicitly via system-prompt + tool inference — we replicate the pattern grounded in the substrate we already have (codex MCP, rosenzu MCP, score MCP, character.json, channel↔zone wiring).
+
+The reframe is **substrate over feature**: not a new product surface, but the foundation that makes future surfaces feel natural.
+
+---
+
+## Substrate findings (dig synthesis)
+
+### Critical gap: chat-mode bypasses MCPs
+
+`packages/persona-engine/src/compose/reply.ts:14, 204-208` — the chat-reply path **does not register MCP servers**. This is the structural reason the agents feel un-tool-aware in chat: they literally don't have access to score / codex / rosenzu / imagegen during slash-command replies. Digest path uses orchestrator (full MCP suite); chat path uses naive `invokeChat()` (no tools).
+
+**Fix**: wire chat-mode through the orchestrator with the character's declared `mcps` scope. Ruggy chats with score+codex+emojis+rosenzu+freeside_auth; Satoshi chats with codex+imagegen. The personality + environment context guides invocation; the MODEL decides when.
+
+### Rosenzu IS the spatial substrate (already) · extending into temporal/social = "read_room"
+
+`packages/persona-engine/src/orchestrator/rosenzu/server.ts:45-66+` exposes 5 tools (Kevin Lynch lens — node / district / edge / path / inner_sanctum + KANSEI palette + threshold-as-door): `get_current_district`, `audit_spatial_threshold`, `fetch_landmarks`, `furnish_kansei`, `threshold`. **Spatial half of the lens.**
+
+**Operator reframe (2026-05-01)**: Discord awareness should integrate with **"reading the room"** — the temporal/social counterpart to spatial awareness. Same Lynch lens applied to the **moment-shape** of a channel: who's here · how warm is the activity · what's the tonal weight right now · what's the recent vibe.
+
+**Resolution**: rosenzu adds a 6th tool — `read_room({zone, recent_message_count, recent_message_summary, presence, minutes_since_last_post})` — that derives the temporal/social read from substrate-assembled inputs. **Place** (district + landmarks + KANSEI baseline) **+ Moment** (temperature + density + tonal weight + vibe hint) is the rosenzu-canonical pair. Phase C extends rosenzu and the environment-context builder pre-calls it for inline grounding (model can also re-call mid-turn if it wants a fresh read).
+
+### Reverse channel→zone map missing
+
+`config.ts:166-177` (`getZoneChannelId(zone) → channelId`) is the **forward** direction only. The reverse (`getZoneForChannel(channelId) → ZoneId`) doesn't exist. Without it, no chat handler can answer "which codex location am I in?" without a hand-rolled lookup. Phase B builds the canonical reverse.
+
+### Persona prompt has injection seams (already)
+
+`persona/loader.ts:236-248` (digest) + `:392-399+` (reply) substitute placeholders like `{{CODEX_PRELUDE}}`, `{{VOICE_ANCHORS}}`, `{{CODEX_ANCHORS}}`, `{{EXEMPLARS}}`. Adding `{{ENVIRONMENT}}` slots into the same machinery. **No new infrastructure** — extend the substitution table.
+
+### Per-character MCP scoping LIVE (V0.8.0)
+
+`orchestrator/index.ts:150-159` (`buildAllowedTools`) already filters by `character.mcps`. Ruggy: `[score, codex, emojis, rosenzu, freeside_auth]`. Satoshi: `[codex, imagegen]`. The schema works. Chat-mode wiring inherits this filter for free.
+
+### Webhook density isn't the wall (Pattern B headroom verified)
+
+- Discord webhook count cap per channel: ~10-15 (older sources say 10; current widely-cited 15). Operator's "10" is plausible.
+- **But Pattern B uses ONE shell webhook with per-message identity override.** PluralKit proxies hundreds of identities through 1 webhook per channel. Identity density is uncapped at the substrate level.
+- The actual ceiling: **5 messages / 5 sec channel-wide rate** (~60 msg/min, shared bucket across senders). Plus 5 req/2sec per webhook execute.
+- For 10+ character experiment: Pattern B is fine. Constraint is firing rate, not identity count.
+
+---
+
+## Architecture (Ostrom)
+
+### Invariants — these MUST NOT change
+
+1. **Civic-layer separation** (Eileen 2026-04-20 vault canon): substrate (system-agent) governs cadence/delivery/MCP; characters (participation-agent) supply voice. The environment substrate stays system-agent — it doesn't speak.
+2. **Pattern B is canonical** (one shell, per-message identity override). Identity density is decoupled from webhook count. We do NOT split into per-character webhooks.
+3. **Persona governs invocation style; environment provides context; tools are the surface.** Three orthogonal axes; never collapse into each other.
+4. **Construct ecosystem is the canonical capability spine.** Each capability the agents have IS a construct: **rosenzu = place + moment** (Lynch spatial + temporal/social via `read_room`), codex = lore, score = activity, imagegen = expression. Mount Loa to make this explicit.
+5. **Memory deferred to V0.7-B+.** This substrate carries no per-character ledger. Recent room context (last-N messages per channel) IS allowed — that's not memory, it's reading the room.
+6. **Slash commands stay primary surface for V0.7-A.1.** Tupperbox/MidJourney pattern: minimize friction, match user expectation. Chat-as-conversational comes via slash → reply (already V0.7-A.0).
+7. **Affirmative blueprints, never negative fences** (Gemini DR / vault `[[negative-constraint-echo]]`). Persona prompts describe what TO do, never what NOT to. The environment substrate inherits this discipline.
+
+### Blast radius
+
+| artifact | change | risk |
+|---|---|---|
+| `apps/bot/src/lib/channel-zone-map.ts` | NEW · canonical reverse map | LOW · pure derivation from existing env vars |
+| `packages/persona-engine/src/compose/environment.ts` | NEW · `buildEnvironmentContext(character, channelId)` builder | LOW · pure function, no side effects |
+| `packages/persona-engine/src/persona/loader.ts` | ADD `{{ENVIRONMENT}}` placeholder + substitution | LOW · additive to existing substitution table |
+| `packages/persona-engine/src/compose/reply.ts` | WIRE through orchestrator with character.mcps scope (currently bypasses MCPs entirely) | **MEDIUM** · changes chat path's tool surface |
+| `apps/character-{ruggy,satoshi}/character.json` | ADD optional `tool_invocation_style: string` | LOW · additive |
+| `apps/character-{ruggy,satoshi}/persona.md` | TWEAK to reference environment naturally | LOW · prose · /voice workshop territory |
+| `freeside-characters/` (root) | NEW · Loa mount via `/mount` (Phase A) | MEDIUM · framework integration · reversible |
+| `apps/bot/scripts/density-experiment.ts` | NEW · 10+ character Pattern B smoke (Phase F · optional) | LOW · scratch script · no prod path |
+
+**Total**: 4 NEW files, 3 MODIFIED, 1 framework mount. No deletions. Proxy / Pattern B / digest path bytes-untouched.
+
+### What breaks if I'm wrong
+
+| failure mode | reversibility |
+|---|---|
+| reverse map wrong → wrong zone metadata leaks into chat | `getZoneForChannel` is pure; fix env var or map; no migration |
+| chat-mode MCP wiring breaks `composeReply` | feature-flag the orchestrator path via env (`CHAT_MODE=orchestrator\|naive`); fall back to naive |
+| persona drifts because environment context too verbose | environment builder has a max-token cap; trim from least-canonical first (recent activity) |
+| 10-character density experiment hits 5-msg/5-sec rate | already known constraint; backoff documented; no production path involved |
+| Loa mount conflicts with existing scripts | mount in feature branch first; verify dev workflow; merge or revert |
+
+Reversibility is policy. Every change in this session is one revert from the previous state.
+
+---
+
+## Component specifications (Alexander craft lens)
+
+### `channel-zone-map.ts` — material specification
+
+**Material**: pure TypeScript, no runtime deps. Reads `config.SCORE_API_URL` schema once at module load. Exports two pure functions.
+
+```ts
+// apps/bot/src/lib/channel-zone-map.ts
+import type { Config } from '@freeside-characters/persona-engine/config';
+import type { ZoneId } from '@freeside-characters/persona-engine/types';
+
+const ZONE_CHANNEL_FORWARD: Record<ZoneId, keyof Config> = {
+  'stonehenge': 'DISCORD_CHANNEL_STONEHENGE',
+  'bear-cave': 'DISCORD_CHANNEL_BEAR_CAVE',
+  'el-dorado': 'DISCORD_CHANNEL_EL_DORADO',
+  'owsley-lab': 'DISCORD_CHANNEL_OWSLEY_LAB',
+};
+
+export function getZoneForChannel(config: Config, channelId: string): ZoneId | undefined {
+  for (const [zone, envKey] of Object.entries(ZONE_CHANNEL_FORWARD)) {
+    if (config[envKey as keyof Config] === channelId) return zone as ZoneId;
+  }
+  return undefined;
+}
+
+export function getCodexAnchorForZone(zone: ZoneId): { name: string; dimension: string; emoji: string } {
+  // pulls from packages/persona-engine/src/score/types.ts ZONE_TO_DIMENSION + zone metadata
+  // (or hits codex-mcp lookup_zone at runtime if CODEX_MCP_URL set — see Phase D below)
+}
+```
+
+**Rhythm**: function-pair shape — forward lookup + reverse lookup. Symmetric.
+
+**Color-as-information**: zones HAVE colors (codex grail palettes). The reverse map exposes them so the environment context can include "this zone's color signature is X" if the character cares (rosenzu does; satoshi might cite it gnomically; ruggy might emoji-flag it).
+
+### `environment.ts` — the awareness substrate
+
+**Material**: pure-function builder. Takes (character config, channelId, optional recent messages) → returns a structured prompt-fragment string.
+
+```ts
+// packages/persona-engine/src/compose/environment.ts
+
+export function buildEnvironmentContext(args: {
+  character: CharacterConfig;
+  channelId: string;
+  config: Config;
+  recentMessages?: ConversationMessage[];  // last-N from channel ledger
+  otherCharactersHere?: string[];          // from CHARACTERS env split
+}): string {
+  const zone = getZoneForChannel(args.config, args.channelId);
+  const codexAnchor = zone ? getCodexAnchorForZone(zone) : null;
+
+  // structured block — concise, scannable, parseable by the LLM
+  return [
+    `## Environment`,
+    zone
+      ? `You are in ${codexAnchor?.emoji ?? ''} #${zone} — ${codexAnchor?.name ?? 'this zone'} (${codexAnchor?.dimension ?? '—'} dimension).`
+      : `You are in a Discord channel outside the codex-mapped zones.`,
+    args.otherCharactersHere?.length
+      ? `Other characters present: ${args.otherCharactersHere.join(', ')}.`
+      : `You are the only character in this channel right now.`,
+    args.character.tool_invocation_style
+      ? `Tool guidance: ${args.character.tool_invocation_style}`
+      : null,
+    args.recentMessages?.length
+      ? `Recent room context: ${args.recentMessages.slice(-5).map(m => `[${m.author}] ${m.content.slice(0, 80)}`).join(' · ')}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+```
+
+**Rhythm**: `## Environment` heading + 4-5 lines. Short. Parses cleanly. No prose paragraphs.
+
+**Weight**: this block is REFERENCE for the LLM, not voice. It sits ABOVE the character's persona block. Persona dominates voice; environment grounds context.
+
+**Motion**: zero. Static at the start of each LLM invocation. Cached per (character, channel, recent-message-window).
+
+**Color-as-information**: emojis from the codex zone (🪩 stonehenge, 🐻 bear-cave, etc.) act as zone-identity anchors. They're also the rosenzu beat-prefixes, so character output that picks them up reads as "I know where I am."
+
+### Persona loader extension (`persona/loader.ts`)
+
+Add `{{ENVIRONMENT}}` to the substitution table. Position: after `{{CODEX_PRELUDE}}` and before `{{VOICE_ANCHORS}}` — environment context grounds the LLM before voice anchors lock the register.
+
+```ts
+// in buildPromptPair() and buildReplyPromptPair()
+const env = args.environmentContext ?? '';  // optional — not all callers know channel
+return template
+  .replace('{{CODEX_PRELUDE}}', codexPrelude)
+  .replace('{{ENVIRONMENT}}', env)
+  .replace('{{VOICE_ANCHORS}}', voiceAnchors)
+  // ... rest unchanged
+```
+
+**Backward compat**: if a persona template doesn't include `{{ENVIRONMENT}}`, the substitution is a no-op — empty replacement. Existing prompts continue working unchanged.
+
+### Chat-mode MCP wiring (`compose/reply.ts`)
+
+**The critical fix**. Currently chat path bypasses MCPs (line 14, 204-208 comment says "Chat-mode bypasses MCPs entirely by design"). That design was V0.7-A.0 minimum-viable. V0.7-A.1 promotes the design: chat goes through orchestrator with character-scoped MCPs.
+
+```ts
+// in composeReply()
+import { runOrchestratorQuery } from '../orchestrator/index.js';
+
+// instead of: const result = await invokeChat(promptPair);
+const result = await runOrchestratorQuery({
+  promptPair,
+  character: args.character,           // already has .mcps[]
+  config: args.config,
+  postType: 'chat',                    // NEW — orchestrator branches
+  conversationHistory: args.recentMessages,
+});
+```
+
+**Orchestrator extension**: `runOrchestratorQuery` accepts `postType: 'chat'`. For chat, system prompt includes environment context (via `buildEnvironmentContext`); tools are filtered by `character.mcps` (existing); model is the per-character-LLM-provider (anthropic / freeside / bedrock per `LLM_PROVIDER`).
+
+**ChatGPT-natural invocation comes from this**: the model has tools attached, the persona declares invocation style, the environment provides context. Model decides when to call. No hand-rolled classifier.
+
+### `tool_invocation_style` — character-level guidance
+
+Each character.json gets an OPTIONAL `tool_invocation_style: string` describing **how the persona prefers to use tools**. This is operator-authored prose — affirmative blueprints, no fences.
+
+```jsonc
+// apps/character-ruggy/character.json
+{
+  "id": "ruggy",
+  ...
+  "mcps": ["score", "codex", "emojis", "rosenzu", "freeside_auth"],
+  "tool_invocation_style": "Use score for zone-stat questions and digest-shaped factual queries. Use codex when someone names an archetype/grail/factor and you want to ground the reference. Use rosenzu when you describe spatial transitions or zone-to-zone movement. Use emojis composition for vibe-flag punctuation. Use freeside_auth when wallet identity comes up. Use imagegen sparingly — only when describing a zone-shift visually adds something words can't. Default to text; tools augment."
+}
+
+// apps/character-satoshi/character.json
+{
+  "id": "satoshi",
+  ...
+  "mcps": ["codex", "imagegen"],
+  "tool_invocation_style": "Use codex when a grail or archetype reference would land more accurately. Use imagegen at natural pause points where a visual metaphor amplifies the gnomic close. You are a messenger between worlds — your tools help you cite cleanly across zones, not perform expertise. The dense-block register holds; imagegen is the punctuation."
+}
+```
+
+This text gets injected into the environment block (via `buildEnvironmentContext`). It's NOT in the persona — persona is voice; this is invocation-style guidance.
+
+**Why character-level not persona-level**: the persona file should stay voice-fidelity-locked (per gumi's /voice workshop discipline). Tool-invocation guidance is operational; it changes when tools change. Keeping it in character.json lets us iterate on tool guidance without touching the persona.
+
+---
+
+## Build sequence (Barth — V1 ship scope)
+
+Six phases. Phase A is independent (Loa mount). Phases B-E are the substrate proper. Phase F is optional density experiment.
+
+### Phase A — Mount Loa on freeside-characters (~1h)
+
+**Why first**: enables construct integration discipline + grimoire authoring + access to construct ecosystem (archivist for memory primitives, keeper for observation, etc.). Operator explicit ask.
+
+**Steps**:
+
+1. Stand at `~/Documents/GitHub/freeside-characters/` (current branch: `main`)
+2. Run `/mount` (the loa-setup skill) — wizard prompts for project shape
+3. **Project profile to declare**: this is a **Discord-character runtime** repo. Adopt minimal construct set:
+   - **archivist** (memory architecture — for V0.7-B's character ledger)
+   - **observer** (KEEPER — runtime observation; pairs with smoke + cross-character experiments)
+   - **artisan** (ALEXANDER — voice/material craft; pairs with /voice workshops)
+   - **the-arcade** (OSTROM/BARTH — structural review + scope discipline for cycles)
+   - SKIP: gtm-collective (not needed), k-hole (research-mode; out-of-scope for character runtime)
+4. Verify: `cat .loa.config.yaml`, `ls .claude/`, `ls grimoires/loa/`, `cat BUTTERFREEZONE.md`
+5. **Update CLAUDE.md** to reflect freeside-characters reality (current CLAUDE.md exists — Loa wraps around it)
+6. Migrate any existing `docs/AGENTS.md` and architecture refs into `grimoires/loa/specs/`
+7. Run `/butterfreezone` to seed the BFZ canon
+8. Verify: gateway is mounted; subsequent kickoffs in this repo write to `freeside-characters/grimoires/loa/specs/`
+
+**Verify**:
+- `~/Documents/GitHub/freeside-characters/.loa.config.yaml` exists
+- `bun run typecheck` still clean (Loa shouldn't touch package code)
+- `git log -1 --stat` shows mount commit pattern (`mount: install loa framework v1.107.x` or similar)
+
+**Blast radius**: framework only. No source code changes. Reversible by `git revert` of the mount commit.
+
+**Commit**: dedicated PR `feat(loa): mount loa framework on freeside-characters` — separate concern from environment substrate.
+
+---
+
+### Phase B — channel-zone reverse map (~30min)
+
+**Files**:
+- `apps/bot/src/lib/channel-zone-map.ts` (NEW)
+
+**Pattern**: pure functions. Forward map already in `config.ts:166-177`. New file builds reverse + adds zone-metadata accessor.
+
+**Implementation** (paste from §Component specs above; ~40 lines).
+
+**Verify**:
+- Unit smoke: `bun run --cwd apps/bot tsx scripts/smoke-zone-map.ts` (NEW · 10 lines · asserts forward+reverse round-trip)
+- `getZoneForChannel(config, '1234567890')` returns `undefined` for unknown
+- `getZoneForChannel(config, env.DISCORD_CHANNEL_STONEHENGE)` returns `'stonehenge'`
+
+**Blast radius**: 1 file, 1 NEW. Zero existing code touched.
+
+---
+
+### Phase C — environment context builder + rosenzu read_room (~1.5h)
+
+**Files**:
+- `packages/persona-engine/src/orchestrator/rosenzu/server.ts` (extend with `read_room` tool)
+- `packages/persona-engine/src/orchestrator/rosenzu/lynch-primitives.ts` (add `deriveTemperature`, `deriveSocialDensity`, `composeTonalWeight` helpers)
+- `packages/persona-engine/src/compose/environment.ts` (NEW · pre-calls rosenzu.read_room internally)
+- `packages/persona-engine/src/persona/loader.ts` (extend substitution table)
+- `apps/character-{ruggy,satoshi}/character.json` (add `tool_invocation_style` field)
+
+**Pattern A — extend rosenzu with `read_room` tool**:
+
+```ts
+// in rosenzu/server.ts — 6th tool registration
+tool(
+  'read_room',
+  'Reads the temporal/social state of a zone-mapped channel right now. Returns activity temperature (cold/cool/warm/hot), social density (solo/paired/cluster/crowd), tonal weight against the zone KANSEI baseline, and a brief vibe hint. Pair with get_current_district (place) for full place+moment grounding before composing any reply.',
+  {
+    zone: ZoneSchema,
+    recent_message_count: z.number().min(0).max(50).default(20),
+    recent_message_summary: z.string().optional().describe('substrate-assembled summary of last-N messages'),
+    presence: z.array(z.string()).optional().describe('user/character handles currently active'),
+    minutes_since_last_post: z.number().optional(),
+  },
+  async ({ zone, recent_message_count, recent_message_summary, presence, minutes_since_last_post }) => {
+    const profile = ZONE_SPATIAL[zone as SpatialZoneId];
+    const temperature = deriveTemperature(recent_message_count, minutes_since_last_post);
+    const social_density = deriveSocialDensity(presence?.length ?? 0);
+    const tonal_weight = composeTonalWeight(profile.base_kansei, temperature);
+
+    return ok({
+      zone,
+      temperature,           // cold | cool | warm | hot
+      social_density,        // solo | paired | small-cluster | crowd
+      tonal_weight,          // KANSEI palette adjusted for temperature
+      presence: presence ?? [],
+      recent_vibe_hint: recent_message_summary
+        ? `${profile.archetype} register · ${recent_message_summary.slice(0, 120)}`
+        : null,
+      grounding: `${profile.archetype} · ${profile.era} · currently ${temperature}`,
+    });
+  },
+),
+```
+
+**Pattern B — environment.ts pre-calls room read inline**:
+
+```ts
+// packages/persona-engine/src/compose/environment.ts
+import { rosenzuServer } from '../orchestrator/rosenzu/server.js';
+
+export async function buildEnvironmentContext(args: {
+  character: CharacterConfig;
+  channelId: string;
+  config: Config;
+  recentMessages?: ConversationMessage[];
+  otherCharactersHere?: string[];
+}): Promise<string> {
+  const zone = getZoneForChannel(args.config, args.channelId);
+  const codexAnchor = zone ? getCodexAnchorForZone(zone) : null;
+
+  // pre-fetch the room read (substrate assembles args; rosenzu tool derives)
+  const roomRead = zone
+    ? await callRosenzuTool('read_room', {
+        zone,
+        recent_message_count: args.recentMessages?.length ?? 0,
+        recent_message_summary: summarizeRecent(args.recentMessages),
+        presence: [...(args.otherCharactersHere ?? []), ...(args.recentMessages?.map(m => m.author) ?? [])].filter(uniq),
+        minutes_since_last_post: minutesSince(args.recentMessages?.at(-1)?.timestamp),
+      })
+    : null;
+
+  return [
+    `## Environment`,
+    zone
+      ? `You are in ${codexAnchor?.emoji ?? ''} #${zone} — ${codexAnchor?.name ?? 'this zone'} (${codexAnchor?.dimension ?? '—'} dimension).`
+      : `You are in a Discord channel outside the codex-mapped zones.`,
+    roomRead
+      ? `Room read: ${roomRead.temperature} · ${roomRead.social_density} · ${roomRead.grounding}${roomRead.recent_vibe_hint ? ' · ' + roomRead.recent_vibe_hint : ''}`
+      : null,
+    args.otherCharactersHere?.length
+      ? `Other characters present: ${args.otherCharactersHere.join(', ')}.`
+      : null,
+    args.character.tool_invocation_style
+      ? `Tool guidance: ${args.character.tool_invocation_style}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+```
+
+**The model can ALSO re-call `rosenzu.read_room` mid-turn** if it wants a fresh read after a pause or context shift — the inline pre-fetch is a starting frame, not a frozen snapshot.
+
+**Persona-template extension**: each character's persona template gets `{{ENVIRONMENT}}` placeholder positioned between `{{CODEX_PRELUDE}}` and `{{VOICE_ANCHORS}}`. If a character template doesn't reference it, no-op (empty substitution).
+
+**Verify**:
+- Unit smoke for new derivation helpers: `deriveTemperature(20, 1) === 'hot'` · `deriveSocialDensity(5) === 'small-cluster'` · `composeTonalWeight(base, 'hot')` returns warmer KANSEI delta
+- `rosenzu.read_room` callable via mock-agent: returns structured `{temperature, social_density, tonal_weight, presence, recent_vibe_hint, grounding}`
+- `buildEnvironmentContext({character: ruggy, channelId: STONEHENGE_ID, config})` returns block containing zone emoji + room-read line + ruggy's `tool_invocation_style`
+- Unknown channelId fallback: graceful "outside the codex-mapped zones" with no room-read line (rosenzu only called when zone resolves)
+- `bun run typecheck` clean
+- Snapshot test on environment block: stable output for fixed input
+
+**Blast radius**: 1 NEW file (environment.ts), 2 MODIFIED files (rosenzu server + lynch-primitives), 1 MODIFIED (persona/loader.ts), 2 CONFIG files (character.json). Rosenzu's existing 5 tools are bytes-untouched — `read_room` is purely additive.
+
+**Distillation hook**: rosenzu now serves both halves of the lens — **place (Lynch spatial) + moment (Lynch temporal/social)**. The combined pattern is a candidate for promotion into `[[reading-the-room]]` vault doctrine post-stabilization.
+
+---
+
+### Phase D — chat-mode MCP wiring (~1.5h · MEDIUM-risk)
+
+**Files**:
+- `packages/persona-engine/src/compose/reply.ts` (refactor)
+- `packages/persona-engine/src/orchestrator/index.ts` (extend `runOrchestratorQuery` to accept `postType: 'chat'`)
+
+**Critical**: this is the substrate change that closes the operator's actual gap. Chat path currently has zero tool surface. After this phase, chat replies have access to the full per-character MCP scope.
+
+**Pattern**:
+
+1. Extend `OrchestratorQueryRequest` type with `postType: 'digest' | 'chat'` and optional `conversationHistory`.
+2. In `runOrchestratorQuery`:
+   - If `postType === 'chat'`: build environment context via `buildEnvironmentContext`, inject into system prompt
+   - If `postType === 'digest'`: existing behavior unchanged
+   - Both branches: `allowedTools = buildAllowedTools(servers, character.mcps)` (already exists)
+3. In `composeReply`: replace `invokeChat(promptPair)` with `runOrchestratorQuery({postType: 'chat', ...})`
+4. **Feature flag**: env `CHAT_MODE=orchestrator|naive` — default `orchestrator` once verified, fall back to `naive` if regression
+
+**Verify**:
+- Chat smoke: `/ruggy prompt:"what's stonehenge looking like this week?"` invoked locally; expect ruggy to call `mcp__score__get_zone_digest` (visible in trajectory log) before replying
+- `/satoshi prompt:"who is the grail of crossings?"` → satoshi calls `mcp__codex__lookup_grail`
+- Per-character isolation holds: ruggy chat doesn't have imagegen tool (not in his mcps); satoshi chat doesn't have score
+- No double-invocation (digest path stays separate)
+- Backward compat: setting `CHAT_MODE=naive` reverts to V0.8.0 behavior (no tool calls in chat)
+
+**Blast radius**: 2 files MODIFIED. The orchestrator extension is additive (new branch on `postType`). The reply.ts change is a delegation flip. Reversible via env flag.
+
+---
+
+### Phase E — persona-prose iteration (~30min)
+
+**Files**:
+- `apps/character-ruggy/persona.md` (tweak)
+- `apps/character-satoshi/persona.md` (tweak)
+
+**Why**: the environment block now appears in the system prompt. The persona should be aware that environment exists (in voice-fidelity terms — "you know where you are; reference it naturally") and should NOT duplicate the environment context (avoid redundant zone-naming).
+
+**Pattern**: minimal edits. Reference the environment block once in voice instruction. Affirmative blueprint, no fences.
+
+**Ruggy add**:
+> "An environment block at the top of your context tells you which zone you're in and what you have access to. Reference the zone naturally — your factor knowledge composes with the location. Don't restate the environment; let it color your voice."
+
+**Satoshi add**:
+> "Your context begins with an environment block describing the zone and tools available. Cite the zone obliquely when it strengthens a grail reference. Don't enumerate tools or environment — your gnomic register handles awareness without commentary."
+
+**/voice workshop pairing**: per the companion spec (`satoshi-ruggy-experiment-validation.md`), persona changes should run through the gumi-correct /voice workshop. **Defer the workshop** for this kickoff — Phase E lands a minimal seed; iteration belongs to a /voice cycle.
+
+**Verify**:
+- 3 dry-run digests + 3 dry-run chats per character: format/voice fidelity holds (strip-the-name informal: ≥80% per gumi blind-judge)
+- No fence creep ("never mention zone explicitly" — that's negative-constraint-echo bait)
+
+**Blast radius**: 2 prose files. Reversible.
+
+---
+
+### Phase F — webhook density experiment (~1h · OPTIONAL)
+
+**Files**:
+- `apps/bot/scripts/density-experiment.ts` (NEW · scratch)
+
+**Goal**: empirically measure Pattern B character density per channel. Operator hypothesis: 10 characters; gemini DR says 5 msg/5 sec channel-wide. Verify.
+
+**Method**:
+
+1. Set up a private test channel (operator's dev guild)
+2. Pre-register 12 distinct character "identities" in code (no DB; in-memory)
+3. Fire 12 sequential `executeWebhook` calls with distinct `username`+`avatar_url` per call
+4. Measure: success rate, time-to-completion, any 429 responses, any rate-limit headers
+5. Repeat with concurrent fire (Promise.all)
+6. Document findings → vault page `[[discord-pattern-b-density]]`
+
+**Verify**:
+- Sequential 12-character fire succeeds within bucket (5/5sec → spreads across ~12-15 seconds)
+- Concurrent fire hits 429; backoff handler kicks in; eventual success
+- Username 80-char ceiling enforced (per gemini DR)
+
+**Outcome**: empirical answer to "can we run 10+ characters in a channel?" + vault doctrine page documenting Pattern B headroom.
+
+**Blast radius**: scratch script only. No production path.
+
+---
+
+## Design rules (Alexander craft lens)
+
+### The environment block as material
+
+- **Position**: above persona, below codex prelude. Grounds context before voice anchors lock register.
+- **Size budget**: target ≤300 tokens. Hard cap at 500. If exceeded, drop "recent activity" first (least canonical), then "other characters here."
+- **Format**: structured headed block (`## Environment`), 4-6 lines, scannable. NOT prose paragraphs.
+- **Vocabulary**: zone names use canonical slugs (stonehenge, bear-cave, el-dorado, owsley-lab) PLUS the codex emoji. Never invent zone names; never abbreviate.
+- **Color-as-information**: zone emojis at the start of zone references serve as visual anchor. Match codex zone palette.
+- **Rhythm**: each line is one fact. No nested bullets. The LLM parses better when the structure is flat.
+
+### Tool-invocation guidance as material
+
+- **Affirmative blueprints exclusively** (vault `[[negative-constraint-echo]]`): "use codex for grail references" not "don't make up grail names."
+- **Per-tool one-line max**: brevity is precision. Long guidance reads as fence; short reads as posture.
+- **Persona-flavored vocabulary**: ruggy's guidance can use "yo / peep"; satoshi's stays editorial. The TONE of the guidance should match the character so the LLM reads it as continuation of voice, not external instruction.
+- **Default to text; tools augment**: every guidance should end with this floor. Image-gen / score / codex are NOT default modes — they're invoked when they add something words don't.
+
+### Chat-mode tool feedback (Discord UX)
+
+- **Typing indicator** during tool round-trip (port from moltbot per `[[listener-router-substrate]]`): `POST /channels/{id}/typing` fire-and-forget.
+- **No tool-call exposure in reply**: the user sees character text. The fact that ruggy hit score-mcp is invisible (logged in trajectory, not surfaced).
+- **Image-gen reply shape**: when imagegen fires, the character's text reply ACCOMPANIES the image (caption-shape, not standalone image). This matches ChatGPT model — text + image is one unit.
+
+### Webhook delivery hygiene (per Gemini DR)
+
+- 80-char cap on dynamic webhook username (Discord hardware reject). Verify in code.
+- Bot-author skip + webhook_id check at earliest ingestion (cross-bot reply-loop prevention).
+- 14m30s timeout wrapper on LLM round-trips (avoid orphan-PATCH on expired interaction tokens).
+- Circuit breaker: 3 consecutive 403s on a channel webhook → blacklist channel ID + halt processing.
+
+---
+
+## What NOT to build (Barth scope cut)
+
+- ❌ **Per-character memory ledger** — V0.7-B+. The substrate carries no persistent memory. Recent room context (read-only) is the floor; per-character durable state is its own kickoff.
+- ❌ **Cross-character coordination via shared file** (Ralph Wiggum / OpenClaw pattern) — V0.7-B+. Defer until two-character chat shows actual collision.
+- ❌ **PAA voice-fidelity CI** — V0.8+ per the companion spec; this kickoff doesn't add automated voice classifiers.
+- ❌ **Image-gen autoprompt classifier** — out of substrate. Persona iteration governs invocation; if model under-invokes, tune `tool_invocation_style`. No regex / keyword matcher.
+- ❌ **New zones** (tl, irl) — score-mibera doesn't back them yet. Future.
+- ❌ **MessageContent intent / general listener** — V0.7-A.2 (per parent brief). This kickoff stays in slash-command surface.
+- ❌ **DM environment** — V0.7-A.x. Slightly different shape (no zone, only DM intimacy register). Defer.
+- ❌ **Per-character LLM provider override** — already deferred per kickoff-substrate-prep §out-of-scope.
+- ❌ **dAMP-96 personality derivation** — its own kickoff; depends on Phase D landing first.
+- ❌ **"While I'm here, let me also..."** — banned. Phase scope is locked. Polish backlog goes to `grimoires/loa/agenda/` once Loa mounts.
+
+---
+
+## Verify (session exit gate)
+
+| check | how |
+|---|---|
+| Phase A | `~/Documents/GitHub/freeside-characters/.loa.config.yaml` exists; `bun typecheck` clean; mount commit on its own branch/PR |
+| Phase B | `bun tsx apps/bot/scripts/smoke-zone-map.ts` round-trips forward+reverse; unknown channelId returns undefined |
+| Phase C | rosenzu `read_room` tool registered + unit smokes for `deriveTemperature` / `deriveSocialDensity` / `composeTonalWeight`; snapshot test on `buildEnvironmentContext` produces stable output (incl. room-read line); `bun typecheck` clean; persona templates substitute `{{ENVIRONMENT}}` correctly; rosenzu existing 5 tools bytes-untouched |
+| Phase D | `/ruggy prompt:"zone digest?"` invokes `mcp__score__get_zone_digest` (visible in trajectory); `/satoshi prompt:"grail?"` invokes `mcp__codex__lookup_grail`; `CHAT_MODE=naive` reverts to v0.8.0 behavior |
+| Phase E | 3 dry-run digests + 3 dry-run chats per character; voice fidelity holds; no fence creep |
+| Phase F (optional) | density-experiment.ts smoke; vault page `[[discord-pattern-b-density]]` filed with empirical findings |
+| ALL | `bun run typecheck` clean (workspace-wide); `bun test` clean; per-character MCP scope honored |
+
+🛑 **Stop at any phase boundary if voice fidelity regresses** (per companion spec strip-the-name baseline). Phases A-C are independently safe; Phase D has revert-via-env-flag escape hatch.
+
+🎯 **Done-bar**: agents naturally invoke score / codex / rosenzu / imagegen during chat replies (per ChatGPT-model). Voice fidelity holds (≥80% strip-the-name informal). Loa mounted. Environment context legible in trajectory logs.
+
+---
+
+## §coordination needed
+
+1. **Eileen** — review Phase E persona prose (gumi-correct discipline); confirm `tool_invocation_style` text for satoshi reads as continuation of his register, not external instruction. /voice workshop is the longer-form follow-up.
+2. **Gumi** — async awareness; this kickoff doesn't touch codex authority, but rosenzu zone metadata pulls from her domain. The codex-mcp `lookup_zone` tool will be the canonical data source once Phase D wires chat-mode access.
+3. **Operator** — confirm scope cuts (Barth's NO list); ratify Loa construct selection (archivist + observer + artisan + the-arcade); approve Phase F experiment in dev guild.
+4. **Density experiment safe channel** — operator provisions a test channel in dev guild. NOT a public production channel (avoid spam noise).
+
+---
+
+## Key references
+
+| topic | file / URL |
+|---|---|
+| parent brief | `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md` |
+| V0.7-A.0 build doc (prior session) | `~/bonfire/grimoires/bonfire/specs/build-listener-substrate-v07a0.md` |
+| companion experiment spec | `~/bonfire/grimoires/bonfire/specs/satoshi-ruggy-experiment-validation.md` |
+| substrate prep + Eileen items | `~/bonfire/grimoires/bonfire/specs/kickoff-substrate-prep-eileen-2026-04-30.md` |
+| gemini deep research findings | `~/bonfire/grimoires/bonfire/research/gemini-deep-research-output-multi-character-bot-substrate-2026-04-30.md` |
+| persona/loader.ts injection seams | `packages/persona-engine/src/persona/loader.ts:171-272` (digest), `:365-399+` (chat) |
+| chat path (current MCP-bypass) | `packages/persona-engine/src/compose/reply.ts:14, 204-208` |
+| orchestrator + buildAllowedTools | `packages/persona-engine/src/orchestrator/index.ts:150-159` |
+| rosenzu spatial tools | `packages/persona-engine/src/orchestrator/rosenzu/server.ts:45-66+` |
+| forward zone-channel map | `packages/persona-engine/src/config.ts:166-177` |
+| vault: civic-layer doctrine | `~/vault/wiki/concepts/agent-native-civic-architecture.md` |
+| vault: pattern-b-shell-bot | `~/vault/wiki/concepts/pattern-b-shell-bot.md` |
+| vault: negative-constraint-echo (HIGH-impact) | `~/vault/wiki/concepts/negative-constraint-echo.md` |
+| vault: explicit-invocation-anti-spam | `~/vault/wiki/concepts/explicit-invocation-anti-spam.md` |
+| vault: midi-as-storytelling-register | `~/vault/wiki/concepts/midi-as-storytelling-register.md` |
+| vault: gateway-as-registry (registry-broadcast doctrine) | `~/vault/wiki/concepts/gateway-as-registry.md` (filed 2026-05-01) |
+| target repo | `~/Documents/GitHub/freeside-characters` |
+| operator harness env vars | `OPERATOR_API_KEY`, `TENANT_SCORE_API_KEY`, `SCORE_BEARER`, `CODEX_MCP_URL` |
+
+---
+
+⏱ **Estimated**: 4-5 hours for Phases A-E (sprint scope). Phase F is optional, ~1h. /voice workshop iteration on Phase E is its own follow-up cycle.
+
+🎯 **Done-bar**: agents are environment-aware in chat replies; tools fire naturally per persona+context; Loa mounted; voice fidelity holds.
+
+🌀 **Distillation candidates** (post-stabilization):
+- `[[reading-the-room]]` vault doctrine — rosenzu's place+moment pair (Lynch spatial × KANSEI temporal/social) as a portable lens for any agent runtime that needs environment grounding. The 6-tool rosenzu surface becomes the reference implementation.
+- `discord-awareness` construct — channel↔location mapping + environment-context-builder + tool-invocation-style schema as a composable surface. Composes with rosenzu (place + moment) + observer (KEEPER · runtime-observation) + archivist (memory architecture for V0.7-B character ledger).

--- a/grimoires/loa/specs/legacy-imports/AGENTS.md
+++ b/grimoires/loa/specs/legacy-imports/AGENTS.md
@@ -1,0 +1,254 @@
+# Agents — Start Here
+
+You're an AI agent (Claude, Codex, Eileen's agent, future ones) landing in
+this repository. This doc is your map. Read it in order; the rest of the
+docs follow naturally from here.
+
+## What this repo is, in 3 lines
+
+1. **A multi-character Discord bot** — currently shipping ruggy (festival NPC
+   narrator, lowercase OG voice) and satoshi (mibera-codex agent, sentence-case
+   cypherpunk register). Slash commands `/ruggy` and `/satoshi` invite either
+   character into Discord conversations. Weekly cron also fires per-zone digests.
+
+2. **Two layers, hard boundary** — `packages/persona-engine/` is the
+   substrate (system-agent layer). `apps/character-<id>/` are characters
+   (participation-agent layer). Characters never import substrate internals;
+   the only coupling is the `CharacterConfig` type contract.
+
+3. **Pattern B identity for delivery** — one shell bot account ("Ruggy#1157")
+   owns the Discord identity. Per-message webhook overrides (PluralKit-style)
+   render each character with their own avatar + name in the channel. This
+   applies to both digest writes and slash-command replies.
+
+## Read these docs in this order
+
+| # | Doc | Why |
+|---|---|---|
+| 1 | [`../README.md`](../README.md) | Smol orientation · architecture diagrams · run instructions |
+| 2 | This doc | What you're reading. Map. |
+| 3 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Full architectural picture · module responsibilities · dependency rules · swap-out matrix |
+| 4 | [`CIVIC-LAYER.md`](CIVIC-LAYER.md) | The doctrine behind substrate ≠ character separation (Eileen's puruhani-as-spine framing) |
+| 5 | [`MULTI-REGISTER.md`](MULTI-REGISTER.md) | Why each character has a locked voice register · gumi corrections · cabal archetypes are AUDIENCE not CHARACTER modes |
+| 6 | [`CHARACTER-AUTHORING.md`](CHARACTER-AUTHORING.md) | How to add a new character to the umbrella |
+| 7 | [`DISCORD-INTERACTIONS-SETUP.md`](DISCORD-INTERACTIONS-SETUP.md) | V0.7-A.0 slash command setup · Discord developer portal config · Railway env |
+| 8 | [`DEPLOY.md`](DEPLOY.md) | Railway / ECS deploy paths |
+| 9 | [`../CLAUDE.md`](../CLAUDE.md) | Repo conventions for agents working in this codebase · Don't-Do list · two-layer model invariants |
+| 10 | [`../apps/character-ruggy/persona.md`](../apps/character-ruggy/persona.md) · [`../apps/character-satoshi/persona.md`](../apps/character-satoshi/persona.md) | The voices themselves · system prompt templates · per-post-type fragments |
+
+## Mental model anchors
+
+These are the load-bearing facts. Internalize before touching code.
+
+### 1. The CharacterConfig boundary
+
+The `CharacterConfig` type at `packages/persona-engine/src/types.ts` is the
+ONLY legitimate import a character can have from the substrate. Characters
+declare what they are via `character.json` + persona markdown; the substrate
+loads them via `loadCharacters()` and dispatches.
+
+```mermaid
+flowchart LR
+  char_json["character.json<br/>id, displayName, personaFile, ..."]:::char
+  persona_md["persona.md<br/>system prompt template + fragments"]:::char
+
+  char_json --> loader["character-loader.ts<br/>(apps/bot)"]
+  persona_md -.->|read at runtime| pe["persona-engine<br/>substrate"]
+  loader -->|"CharacterConfig"| pe
+
+  classDef char fill:#fff3cd,stroke:#856404
+```
+
+Any work that adds substrate features should preserve this contract. If you
+need a new per-character knob, extend `CharacterConfig`. If you need a new
+runtime behavior, add it to the substrate. Don't blur the layers.
+
+### 2. Two delivery pipelines, one substrate
+
+```mermaid
+flowchart LR
+  cron["⏰ cron"] --> digest_compose["composer.ts<br/>composeForCharacter"]
+  slash["⌨️ /slash"] --> chat_compose["compose/reply.ts<br/>composeReply"]
+  digest_compose --> webhook["deliver/webhook.ts<br/>(Pattern B)"]
+  chat_compose --> webhook
+  webhook --> discord["💬 Discord channel"]
+
+  classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+  class digest_compose,chat_compose,webhook sub
+```
+
+- **Write side (V0.6 · digest)** — `composeForCharacter` runs the full Claude
+  Agent SDK with MCPs (score, rosenzu, emojis, freeside_auth). Multi-turn
+  with tool calls. Heavy.
+- **Read side (V0.7-A.0 · chat)** — `composeReply` runs single-turn SDK with
+  empty MCP servers. No tools. Persona + conversation ledger only. Light.
+
+Both deliver via `deliver/webhook.ts` (Pattern B). Slash replies prepend a
+quote of the user's prompt for channel context. Ephemeral slash replies use
+interaction PATCH instead (webhooks can't be ephemeral).
+
+### 3. Anti-spam invariant — load-bearing
+
+Characters respond ONLY to explicit user invocations. The rule survives
+every phase:
+
+- Bot-author messages skip (`interaction.user?.bot === true`)
+- Webhook-author messages skip (defense-in-depth; some Discord versions don't reliably set the bot flag)
+- Channel presence alone never triggers a reply
+- Name-string matching ("hey ruggy") never triggers — only Discord-native triggers (slash, @mention, reply-to-bot)
+- Cross-character chains never auto-trigger; if a user invokes `@ruggy @satoshi` in one message, BOTH respond (operator-ratified) but only because the user explicitly asked for both
+
+If your code lets a character auto-respond on anything other than explicit
+user intent, it's wrong.
+
+### 4. Voice fidelity is iterative
+
+Each character's persona.md has a locked voice register (gumi-curated for
+satoshi · ogr ruggy-bot canon for ruggy). The LLM compose path tries to
+preserve it but can drift, especially on multi-turn under opus-4-7's
+wider interpretive surface.
+
+When drift is observed:
+
+- **Persona-level fix** — replace negative constraints ("NOT lowercase") with
+  affirmative blueprints ("Sentence case throughout — every sentence begins
+  with a capital letter") per Gemini DR's negative-constraint-echo finding.
+- **Substrate-level reinforcement** — the `CONVERSATION_MODE_OVERRIDE` block
+  in `persona/loader.ts` adds chat-mode-specific anchors ("Your case is YOURS")
+  to counter the LLM mirroring user/peer registers in the ledger.
+
+Both layers exist by design. Don't move logic from one to the other unless
+you're sure of the trade.
+
+## Where the action happens
+
+Key files mapped to what they do.
+
+```
+packages/persona-engine/src/
+├── types.ts                    ← CharacterConfig contract (the boundary)
+├── config.ts                   ← Zod env schema
+├── compose/
+│   ├── composer.ts             ← Digest pipeline (write side)
+│   ├── reply.ts                ← Chat-mode pipeline (V0.7-A.0 read side)
+│   └── agent-gateway.ts        ← LLM_PROVIDER routing (stub/anthropic/freeside)
+├── persona/loader.ts           ← buildPromptPair + buildReplyPromptPair + CONVERSATION_MODE_OVERRIDE
+├── conversation/ledger.ts      ← Per-channel ring buffer (V0.7-A.0)
+├── orchestrator/index.ts       ← Claude Agent SDK runtime (digest path with MCPs)
+└── deliver/webhook.ts          ← Pattern B sends (digest + chat both go through here)
+
+apps/bot/src/
+├── index.ts                    ← Entry point · wires everything
+├── character-loader.ts         ← Reads apps/character-<id>/character.json
+└── discord-interactions/
+    ├── server.ts               ← Bun.serve HTTP endpoint (V0.7-A.0)
+    ├── dispatch.ts             ← Slash dispatch + delivery routing
+    └── types.ts                ← Discord Interactions API types
+
+apps/character-<id>/
+├── character.json              ← CharacterConfig shape
+├── persona.md                  ← Voice + system prompt template (gumi-curated for satoshi)
+├── codex-anchors.md            ← Per-character lore tilt
+├── voice-anchors.md            ← Operator-curated past utterances (ruggy)
+└── exemplars/                  ← Per-post-type ICE samples
+```
+
+## Current state (2026-04-30)
+
+| Status | Surface |
+|---|---|
+| 🟢 shipped | V0.6 substrate split (digest cron · Pattern B identity · per-character webhook) |
+| 🟢 shipped | V0.7-A.0 slash command surface (`/ruggy`, `/satoshi` · interactions HTTP webhook · per-channel ledger · quote-prepend · Pattern B for chat replies · circuit breaker · 14m30s timeout guard) |
+| 🟢 shipped | Opus 4.7 default (digest + chat both) · Anthropic-direct via Claude Agent SDK |
+| 🟢 deployed | Railway prod-ruggy (`prod-ruggy-production.up.railway.app`) · 4 zones THJ guild · slash commands registered guild-scoped to project-purupuru staging |
+| 🟡 in design | V0.7-A.1 — gateway intents + messageCreate observe-only (immediately follows A.0 per cadence note in `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md`) |
+| 🟡 in design | Bedrock LLM provider — Eileen's local-satoshi setup ([`EILEEN-LOCAL-SATOSHI.md`](EILEEN-LOCAL-SATOSHI.md)) |
+| 🟡 queued | `/usage` slash + JSONL token tracking · `.dockerignore` `.claude` recursion fix · ruggy persona negative-constraint audit |
+
+## Pending V0.7 → V0.7-B roadmap
+
+The full roadmap lives at `~/bonfire/grimoires/bonfire/specs/listener-router-substrate.md`
+(operator's planning area, outside this repo). Phase summary:
+
+| Phase | Surface |
+|---|---|
+| ✅ V0.7-A.0 | Slash commands · barebones interactive surface |
+| 🟡 V0.7-A.1 | Gateway intents + messageCreate observe-only (extends ledger to room-aware) |
+| 🟡 V0.7-A.2 | Channel-context substrate (port to durable store if restart-loss is felt) |
+| 🟡 V0.7-A.3 | Router + reply API for messageCreate (@USER mentions · reply-to-bot) |
+| 🟡 V0.7-A.4 | Classifier (regex first, then LLM) — decides respond-vs-skip |
+| 🟡 V0.7-A.5 | ❓-reaction "who wrote this?" affordance (port from Tupperbox shape) |
+| 🟡 V0.7-A.6 | Rename shell bot from "Ruggy" to neutral ("Freeside") |
+| 🟡 V0.7-B.1 | Cross-character trigger primitive (governance: no infinite loops) |
+| 🟡 V0.7-B.2 | Stage 2 [EXP] — character ↔ character interactions |
+
+## Anti-patterns — DON'T
+
+- **Don't import substrate internals from a character.** Characters declare via JSON + markdown.
+  Substrate dispatches.
+- **Don't add a database for V0.7-A.0 conversation memory.** In-process ledger only.
+  Persistence becomes a problem when restart-loss is felt by humans, not before.
+- **Don't auto-respond.** Anti-spam invariant. Explicit user invocation only.
+- **Don't bypass `composeReply` / `composeForCharacter`.** They wire the persona +
+  voice register lock + provider routing. Going around them = voice drift + cost surprises.
+- **Don't edit gumi-locked persona content destructively.** Locked sections (e.g.
+  `## Voice rules (gumi-locked 2026-04-29)` in satoshi's persona.md) are operator-iteration
+  boundaries. Augment with new sections, don't rewrite.
+- **Don't use the Claude Agent SDK for chat-mode replies expecting it's free.**
+  Chat-mode `composeReply` configures `mcpServers: {}, allowedTools: [], maxTurns: 1, effort: 'low'` for cost reasons.
+  Adding tools or turns to chat-mode bloats per-reply cost.
+- **Don't ship a slash command without registering it via `apps/bot/scripts/publish-commands.ts`.**
+  Code-side `dispatchSlashCommand` won't be invoked unless Discord knows about the command.
+
+## Common workflows
+
+### Adding a new character
+
+See [`CHARACTER-AUTHORING.md`](CHARACTER-AUTHORING.md). Skeleton:
+
+1. Create `apps/character-<id>/` with `character.json` + `persona.md` + `package.json`
+2. Add to `CHARACTERS` env (e.g., `CHARACTERS=ruggy,satoshi,newchar`)
+3. Run `bun run apps/bot/scripts/publish-commands.ts` to register `/<id>` slash
+4. (Optional) Per-character webhook avatar uploaded to assets CDN
+
+### Iterating on a character's voice
+
+Voice changes live at the character level (`apps/character-<id>/persona.md`).
+Substrate changes (`packages/persona-engine/src/persona/loader.ts`) apply
+across all characters — be careful which layer you touch.
+
+For locked content (e.g. gumi's satoshi voice rules), prefer ADDITIVE
+operator-iterated sections over destructive edits. See the
+"VOICE REGISTER LOCK (affirmative anchor)" pattern in satoshi's persona.md
+for an example.
+
+### Local development with Discord interactions
+
+The slash command surface needs a publicly-reachable HTTPS endpoint Discord can
+POST to. For local dev:
+
+1. Run bot with `DISCORD_PUBLIC_KEY=...` env (gets endpoint started)
+2. Run ngrok / cloudflared tunnel to localhost:3001 → public HTTPS URL
+3. Temporarily swap Discord developer portal Interactions Endpoint URL to the tunnel URL
+4. Iterate (bun --watch auto-restarts on code changes)
+5. Swap portal URL back to Railway domain when done
+
+## Reference: planning docs (operator-side, not in repo)
+
+Some context lives in the operator's planning area at `~/bonfire/grimoires/bonfire/`:
+
+- `specs/listener-router-substrate.md` — full V0.7-A → V0.7-B roadmap brief
+- `specs/build-listener-substrate-v07a0.md` — V0.7-A.0 build doc (this ship)
+- `research/gemini-deep-research-output-multi-character-bot-substrate-2026-04-30.md` — Gemini DR findings (negative-constraint echo, MidJourney pattern, etc.)
+- `context/ruggy-creative-direction-seed-2026-04-29.md` — voice tightening direction
+
+If you need that context and it's not in the repo, ask the operator. Don't
+re-derive from training-priors.
+
+## Questions an agent might ask before acting
+
+- "Is this a substrate change or a character change?" → Check what files you'd touch. If `apps/character-<id>/` only → character change. If `packages/persona-engine/` → substrate change. If both → reconsider; usually one is enough.
+- "Should I deploy now?" → Local first via ngrok if iterating; Railway via `railway up` (no GitHub auto-deploy connected) when ready.
+- "Should I commit?" → Confirm with operator unless they've granted explicit autonomy. The repo's history is operator-curated.
+- "Is this voice drift or a feature?" → Check the character's `persona.md`. If the rule is in the doc and being violated, it's drift. If the doc is silent, it's underspecified.
+- "Is the conversation ledger persistent?" → No. In-process only. Restart loses it. By design.

--- a/grimoires/loa/specs/legacy-imports/ARCHITECTURE.md
+++ b/grimoires/loa/specs/legacy-imports/ARCHITECTURE.md
@@ -1,0 +1,345 @@
+# Architecture
+
+Multi-character Discord bot. V0.6 split substrate from characters. V0.7-A.0
+added the read-side surface (slash commands → chat-mode replies) alongside
+the existing write-side (cron-driven digest delivery). Single bot process,
+two character profiles, two delivery paths sharing one substrate.
+
+> Earlier "V1 webhook + polling" framing has been superseded. Git history
+> (`b3bf205` → `46dda38` V0.6 substrate split → `60aaf51` V0.7-A.0 ship)
+> carries the V0.2 → V0.7-A.0 evolution.
+
+## Layers
+
+```mermaid
+flowchart TB
+    subgraph apps["apps/"]
+      bot["📦 apps/bot/<br/>thin runtime · loads characters · wires substrate to Discord"]
+      char_ruggy["🐻 apps/character-ruggy/<br/>persona.md · codex-anchors.md · voice-anchors.md"]
+      char_satoshi["🌀 apps/character-satoshi/<br/>persona.md · codex-anchors.md"]
+    end
+
+    subgraph packages["packages/"]
+      pe["🧪 packages/persona-engine/<br/>SUBSTRATE — system-agent layer"]
+      proto["📜 packages/protocol/<br/>(placeholder · sealed schemas)"]
+    end
+
+    bot -->|imports| pe
+    bot -->|loads| char_ruggy
+    bot -->|loads| char_satoshi
+
+    char_ruggy -.->|"CharacterConfig (no internal imports)"| pe
+    char_satoshi -.->|CharacterConfig| pe
+
+    classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+    classDef char fill:#fff3cd,stroke:#856404
+    classDef bot fill:#d4edda,stroke:#155724
+    class pe sub
+    class char_ruggy,char_satoshi char
+    class bot bot
+```
+
+The boundary is the `CharacterConfig` type contract (`packages/persona-engine/src/types.ts`). Characters
+NEVER import substrate internals; they declare what they are via `character.json` + persona
+markdown, and the substrate dispatches.
+
+## Two pipelines, one substrate
+
+Both write side (digest cron) and read side (slash commands) compose through
+`packages/persona-engine/`. They differ in trigger source, prompt shape, and
+delivery mechanics.
+
+```mermaid
+flowchart TB
+    subgraph triggers["Triggers"]
+      cron["⏰ cron/scheduler<br/>weekly · pop-in · weaver"]:::trig
+      slash["⌨️ /ruggy /satoshi<br/>Discord interaction POST"]:::trig
+    end
+
+    subgraph compose["Substrate compose"]
+      digest_compose["composer.ts<br/>composeForCharacter<br/>full SDK · MCPs · maxTurns 12"]:::sub
+      chat_compose["compose/reply.ts<br/>composeReply<br/>single-turn SDK · no MCPs"]:::sub
+    end
+
+    subgraph context["Context primitives"]
+      persona["persona/loader.ts<br/>buildPromptPair / buildReplyPromptPair"]:::ctx
+      ledger["conversation/ledger.ts<br/>per-channel ring buffer (50)"]:::ctx
+    end
+
+    subgraph deliver["Pattern B delivery"]
+      webhook["deliver/webhook.ts<br/>per-character avatar + username override"]:::deliv
+      embed["deliver/embed.ts<br/>(digest only · embed shape)"]:::deliv
+    end
+
+    cron --> digest_compose
+    slash --> chat_compose
+    digest_compose --> persona
+    chat_compose --> persona
+    chat_compose --> ledger
+    digest_compose --> embed
+    digest_compose --> webhook
+    chat_compose --> webhook
+    webhook --> discord["💬 Discord channel<br/>(Pattern B identity per message)"]
+
+    classDef trig fill:#fff3cd,stroke:#856404
+    classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+    classDef ctx fill:#f0e5fc,stroke:#7e3ff2
+    classDef deliv fill:#e5f5e0,stroke:#41ab5d
+```
+
+## Read side (V0.7-A.0)
+
+Discord interaction webhook + chat-mode pipeline. Bot listens on
+`INTERACTIONS_PORT` (default 3001 · falls back to `PORT` for Railway/Heroku).
+
+```mermaid
+flowchart LR
+  user["👤 /satoshi prompt:hi"] --> discord1["Discord"]
+  discord1 -->|"signed POST"| ep["📡 /webhooks/discord<br/>Bun.serve · Ed25519 verify · PING/PONG"]
+  ep --> dispatch["🎯 dispatch<br/>anti-spam guard<br/>resolve character<br/>parse options"]
+  dispatch -->|"<3s"| ack["⚡ DEFERRED ACK"]
+  ack -.->|"async"| compose["🧪 composeReply<br/>buildReplyPromptPair · ledger snapshot · single-turn SDK"]
+  compose --> deliver["📨 channel webhook<br/>quote-prepend · Pattern B identity"]
+  deliver --> delete["🗑️ DELETE @original<br/>(cleanup deferred placeholder)"]
+  deliver --> discord2["💬 Satoshi reply lands"]
+
+  classDef sub fill:#cce5ff,stroke:#004085,stroke-width:2px
+  classDef io fill:#fff3cd,stroke:#856404
+  class dispatch,compose sub
+  class ep,deliver,delete io
+```
+
+Key design rules baked into V0.7-A.0:
+
+- **Anti-spam invariant** — characters reply ONLY to explicit user invocations. Bot-author messages skip · webhook-author messages skip · channel presence alone never triggers.
+- **Token-expiry guard** — composeReply wrapped in 14m30s `Promise.race` (Discord interaction tokens hard-expire at 15:00 with no refresh; PATCH after that returns 404 + freezes the UI).
+- **Follow-up rate limit** — chunks beyond the first throttle at 1.5s gaps to stay under Discord's 5/2sec interaction follow-up ceiling.
+- **Circuit breaker** — 3 consecutive 403s on a channel webhook → blacklist that channel ID in-memory until process restart. Prevents Cloudflare's 10K-invalid-req/10min global ban from cascading.
+- **Ephemeral fallback** — `ephemeral:true` invocations use interaction PATCH (webhooks can't be ephemeral); non-ephemeral uses Pattern B webhook for character-identity rendering.
+- **Quote-prepend** — non-ephemeral replies prepend a Discord blockquote of the user's prompt so other channel members see context (slash-command argument values aren't shown in Discord's invocation header).
+
+## Module responsibilities
+
+### `packages/persona-engine/src/` — substrate
+
+| Module | Responsibility | External deps |
+|---|---|---|
+| `index.ts` | Public API barrel · what `apps/bot/` imports | — |
+| `types.ts` | `CharacterConfig` (the contract), `ZoneId`, `PostType`, `EmojiAffinityKind` | — |
+| `config.ts` | Zod-validated env (LLM_PROVIDER, cadences, channels, INTERACTIONS_PORT, DISCORD_PUBLIC_KEY) | `zod` |
+| `cron/scheduler.ts` | Three concurrent cadences (digest backbone, pop-in random, weaver weekly) with per-zone fire lock | `node-cron` |
+| `score/client.ts` | score-mcp client over JSON-RPC + SSE OR synthetic ZoneDigest in stub mode | `fetch` |
+| `score/types.ts` | Mirror score-vault contracts (ZoneDigest / RawStats / NarrativeShape) | — |
+| `score/codex-context.ts` | Mibera Codex `llms.txt` prelude loader | — |
+| `persona/loader.ts` | `buildPromptPair` (digest) + `buildReplyPromptPair` (chat-mode · V0.7-A.0) · CONVERSATION_MODE_OVERRIDE · per-post-type fragment + placeholder substitution | — |
+| `persona/exemplar-loader.ts` | ICE (in-context exemplars) loader, random select up to 5 per call | — |
+| `compose/composer.ts` | `composeForCharacter` — digest pipeline · invokes orchestrator with full MCP stack | — |
+| `compose/reply.ts` | `composeReply` — V0.7-A.0 chat-mode pipeline · single-turn SDK · ledger snapshot · `splitForDiscord` | `@anthropic-ai/claude-agent-sdk` |
+| `compose/agent-gateway.ts` | Explicit provider routing (`stub` / `anthropic` / `freeside` / `auto`) for digest path | — |
+| `compose/headline-lock.ts` | Substrate-level guard enforcing canonical zone emoji in digest headline | — |
+| `compose/post-types.ts` | 6 post-type specs (digest/micro/weaver/lore_drop/question/callout) + data-fit guards | — |
+| `conversation/ledger.ts` | V0.7-A.0 in-process `Map<channelId, RingBuffer<50>>` · drop-oldest · no persistence | — |
+| `orchestrator/index.ts` | Claude Agent SDK `query()` runtime wiring mcpServers + subagents + allowedTools (digest path) | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/rosenzu/` | In-bot SDK MCP — Lynch primitives, KANSEI vectors | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/emojis/` | In-bot SDK MCP — 43-emoji THJ catalog with mood tags + `.run/emoji-recent.jsonl` cache | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/freeside_auth/` | In-bot SDK MCP — wallet → handle/discord/mibera_id resolution against Railway Postgres | `@anthropic-ai/claude-agent-sdk`, `pg` |
+| `orchestrator/imagegen/` | In-bot SDK MCP — Bedrock Stability text-to-image (V0.7-A.1 substrate scaffold · `generate` body stubbed pending Eileen's invoke PR · `suggest_style` is static archetype lookup) | `@anthropic-ai/claude-agent-sdk` |
+| `orchestrator/cabal/gygax.ts` | Cabal subagent (retired from per-fire compose 2026-04-30 · preserved for future `/cabal` command) | — |
+| `deliver/webhook.ts` | Pattern B delivery · `getOrCreateChannelWebhook` + `sendViaWebhook` (digest) + `sendChatReplyViaWebhook` (V0.7-A.0 chat) | `discord.js` |
+| `deliver/embed.ts` | Per-post-type embed shape (digest/weaver/callout = embed; micro/lore/question = plain) | — |
+| `deliver/post.ts` | `deliverZoneDigest` — bot.send → webhook → dry-run routing | `discord.js` |
+| `deliver/client.ts` | `discord.js` Gateway client with reconnect-on-disconnect | `discord.js` |
+
+### `apps/bot/src/` — runtime
+
+| Module | Responsibility |
+|---|---|
+| `index.ts` | Entry point · loads characters · wires cron + interactions · graceful shutdown |
+| `character-loader.ts` | Reads `apps/character-<id>/character.json` → `CharacterConfig` · honors `CHARACTERS` env |
+| `cli/digest-once.ts` | One-shot CLI for testing — fires single digest sweep then exits |
+| `discord-interactions/server.ts` | V0.7-A.0 `Bun.serve` HTTP endpoint · Ed25519 verify · `/health` + `/webhooks/discord` |
+| `discord-interactions/dispatch.ts` | V0.7-A.0 slash dispatch · anti-spam guard · 14m30s timeout · circuit breaker · webhook-or-PATCH delivery routing · V0.7-A.1 handler-aware routing (`chat` / `imagegen`) |
+| `discord-interactions/types.ts` | Discord Interactions API types (`InteractionType`, `InteractionResponseType`, `MessageFlags`) |
+| `scripts/publish-commands.ts` | One-shot · flattens every character's declared (or defaulted) slash commands and registers via Discord API |
+| `scripts/smoke-interactions.ts` | Smoke test · ledger ring buffer + server endpoints + imagegen + slash routing + MCP scoping |
+
+### `apps/character-<id>/` — characters
+
+| File | What |
+|---|---|
+| `character.json` | `CharacterConfig` shape · id · displayName · personaFile · webhookAvatarUrl · anchoredArchetypes · `slash_commands` (V0.7-A.1+) · `mcps` (V0.7-A.1+) |
+| `persona.md` | Source of truth for voice · system prompt template · per-post-type fragments · gumi-locked content + operator-iterated affirmative voice anchor |
+| `codex-anchors.md` | Per-character mibera-codex SOIL · which archetypes resonate · which lineage |
+| `voice-anchors.md` | Cross-post-type voice texture · operator-curated past utterances |
+| `creative-direction.md` | FEEL-side direction notes |
+| `ledger.md` | Per-character session log · what changed when |
+| `exemplars/` | Per-post-type past utterances for ICE injection |
+| `avatar.png` | Pattern B identity image · operator-uploaded |
+
+## Dependency rules
+
+| Module | Knows | Doesn't know |
+|---|---|---|
+| `packages/persona-engine/score/*` | score-mcp protocol | discord, llm |
+| `packages/persona-engine/orchestrator/*` | SDK runtime + each construct's discipline | delivery |
+| `packages/persona-engine/persona/*` | markdown → strings (pure) | data |
+| `packages/persona-engine/compose/*` | compose pipelines (digest + chat) | persistent state |
+| `packages/persona-engine/deliver/*` | Discord transport (Gateway + webhooks) | LLM internals |
+| `packages/persona-engine/conversation/*` | in-process ring buffer (pure) | LLM |
+| `apps/bot/discord-interactions/*` | HTTP endpoint + slash dispatch | persona, score directly (delegates to substrate) |
+| `apps/bot/index.ts` | wiring · loads characters · starts schedule + interactions server | — |
+| `apps/character-<id>/*` | nothing about substrate internals | substrate code |
+
+Swap-out matrix:
+
+| Swap | Rest unchanged |
+|---|---|
+| `deliver/*` → email · status page · Slack · terminal | voice + constructs |
+| `score/*` → other bookkeeping layer | persona + constructs |
+| persona doc → sibling character | construct stack |
+| zones → different topology | rosenzu profile + cron pivot |
+| add MCP | register in `buildMcpServers`, LLM picks up via persona |
+| add LLM provider | extend `agent-gateway.ts` resolver + `compose/reply.ts` chat path |
+
+## Stub modes — two orthogonal axes
+
+- **`STUB_MODE=true`** (default) — synthetic `ZoneDigest` by day-of-week (normal/quiet/spike/thin). Bypasses score-mcp.
+- **`LLM_PROVIDER=stub`** — canned digest output, no LLM call. Bypasses Anthropic SDK + freeside gateway.
+
+Independent. Pure-offline = both on. Voice-validation path:
+`STUB_MODE=true LLM_PROVIDER=anthropic ANTHROPIC_API_KEY=…`
+
+## Per-character divergence (V0.7-A.1)
+
+Eileen 2026-04-30: "commands are diff otherwise they'd be reporting the same
+shit." V0.7-A.1 introduced two orthogonal divergence axes that each character
+declares in `character.json`:
+
+```mermaid
+flowchart TB
+    subgraph chars["apps/character-*"]
+      ruggy_cfg["🐻 ruggy/character.json<br/>slash: /ruggy chat (default)<br/>mcps: [score, codex, emojis, rosenzu, freeside_auth]"]
+      satoshi_cfg["🌀 satoshi/character.json<br/>slash: /satoshi chat + /satoshi-image imagegen<br/>mcps: [codex, imagegen]"]
+    end
+
+    subgraph publish["publish path"]
+      flatten["flatten across characters<br/>reject duplicate names loud"]
+      discord_api["Discord API<br/>register all commands"]
+    end
+
+    subgraph dispatch_path["dispatch path (slash invocation)"]
+      resolve["resolveSlashCommandTarget<br/>name → character + handler"]
+      route["switch (handler)"]
+      chat_path["chat handler<br/>composeReply (no MCPs)"]
+      imagegen_path["imagegen handler<br/>invokeStability (direct)"]
+    end
+
+    subgraph digest_path["digest path (cron-driven)"]
+      orch["runOrchestratorQuery"]
+      filter["buildAllowedTools<br/>(serverNames ∩ character.mcps)"]
+      sdk["Claude Agent SDK · query()<br/>permissionMode: dontAsk"]
+    end
+
+    ruggy_cfg --> flatten
+    satoshi_cfg --> flatten
+    flatten --> discord_api
+
+    ruggy_cfg --> resolve
+    satoshi_cfg --> resolve
+    resolve --> route
+    route --> chat_path
+    route --> imagegen_path
+
+    ruggy_cfg --> orch
+    satoshi_cfg --> orch
+    orch --> filter
+    filter --> sdk
+
+    classDef cfg fill:#fff3cd,stroke:#856404
+    classDef pub fill:#cce5ff,stroke:#004085
+    classDef disp fill:#e5f5e0,stroke:#41ab5d
+    classDef digest fill:#f0e5fc,stroke:#7e3ff2
+    class ruggy_cfg,satoshi_cfg cfg
+    class flatten,discord_api pub
+    class resolve,route,chat_path,imagegen_path disp
+    class orch,filter,sdk digest
+```
+
+**Slash commands** are flattened across all characters at publish time and
+routed by command-name lookup at dispatch time. Default fallback gives every
+character a `/<id>` chat command without explicit declaration; characters
+extend by declaring `slash_commands` with additional names + handlers.
+
+**MCP scoping** affects ONLY the digest path. The substrate still registers
+all MCPs (env-gated) bot-wide; per-character `mcps` filters the
+`allowedTools` whitelist passed to the SDK loop. `permissionMode: 'dontAsk'`
+denies anything outside that whitelist — character intent narrows what's
+reachable, but doesn't expand it (names not registered are dropped).
+
+Chat-mode replies (`composeReply`) and the imagegen handler both bypass MCPs
+entirely by construction, so per-character scoping there is unnecessary —
+the chat persona prompt is the only voice surface, and imagegen calls
+`invokeStability` directly without LLM intermediation.
+
+## Why discord.js (Gateway) + Bun.serve (HTTP)
+
+- **Gateway (`discord.js`)** — V0.5-A migration from V0.2 webhooks. Used for:
+  - Per-zone channel routing (4 channels, 1 bot user) — webhooks force 1-channel-per-url
+  - Reconnect-on-disconnect lifecycle
+  - Webhook fetch/create per channel (Pattern B requires Manage Webhooks)
+  - V0.7-A.1 will extend with messageCreate handler + privileged MessageContent intent
+- **HTTP endpoint (`Bun.serve`)** — V0.7-A.0 addition for Discord Interactions:
+  - Slash commands deliver via signed POST, not Gateway events
+  - Ed25519 verification + PING/PONG handshake
+  - Bun's WebCrypto supports Ed25519 since 1.1+ (no third-party crypto lib)
+
+## Why no DB
+
+State that persists across runs:
+
+- **score-mcp** — activity history (zerker's domain)
+- **midi_profiles** — wallet→identity (loa-freeside's domain)
+- **`apps/bot/.run/*.jsonl`** — emoji recent-used cache (file-backed, cross-process)
+- **conversation ledger** — IN-PROCESS ONLY (V0.7-A.0). Restart loses it by design; persistence becomes a problem only when felt.
+
+Everything else is recomputed: persona is markdown, schedule is cron, digest is fetched fresh per fire. If V2+ adds per-guild config (cadence override, mute-until), digest history, error/retry state, or persistent character memory — small SQLite + Drizzle is planned. Not before.
+
+## Construct extractability
+
+Pattern is portable. To deploy a sibling character:
+
+```mermaid
+flowchart LR
+    persona["📜 character.json + persona.md<br/>+ codex-anchors.md + voice-anchors.md"]:::var
+    avatar["🖼️ avatar.png<br/>+ webhookAvatarUrl"]:::var
+    codex_per["📚 per-character codex anchors<br/>(your character's lore tilt)"]:::var
+
+    scaffold["⚙️ shared substrate<br/>packages/persona-engine/<br/>character-agnostic"]:::shared
+    surface["🎯 Discord (today)<br/>or Slack · email · ops · …"]:::var
+
+    persona --> scaffold
+    avatar --> scaffold
+    codex_per --> scaffold
+    scaffold --> surface
+
+    classDef var fill:#fff3cd,stroke:#856404
+    classDef shared fill:#d4edda,stroke:#155724,stroke-width:2px
+```
+
+🟨 = per-character variable. 🟩 = stays the same across siblings.
+
+The only required per-character files are `character.json` + `persona.md` (with system prompt template + per-post-type fragments). Everything else is optional enrichment.
+
+## Future shape
+
+| Addition | Trigger | Module |
+|---|---|---|
+| messageCreate handler + observe-only ledger extension | V0.7-A.1 (immediately after A.0 per cadence note) | `apps/bot/src/discord-interactions/gateway-listener.ts` |
+| @USER mention routing | V0.7-A.3 | `apps/bot/src/discord-interactions/router.ts` |
+| Bedrock LLM provider | Eileen's local-satoshi setup | `compose/reply.ts` extension + `compose/agent-gateway.ts` resolver |
+| `/usage` slash + JSONL token tracking | cost awareness | `apps/bot/src/discord-interactions/dispatch.ts` + `apps/bot/scripts/usage-report.ts` |
+| `recent-posts.jsonl` cache + MCP | content-variance pressure | new `orchestrator/memory/` MCP |
+| Conversation ledger persistence | restart-loss becomes felt | `conversation/ledger.ts` extension to SQLite |
+| Slash command for `/usage` cost reporting | operator awareness | `apps/bot/src/discord-interactions/dispatch.ts` |
+| Multi-guild config | another guild adopts a character | SQLite + Drizzle |
+| Schemas published by characters | sibling persona coordination | `packages/protocol/` (currently empty placeholder) |

--- a/grimoires/loa/specs/legacy-imports/CHARACTER-AUTHORING.md
+++ b/grimoires/loa/specs/legacy-imports/CHARACTER-AUTHORING.md
@@ -1,0 +1,278 @@
+# Character authoring
+
+How to add a new participation-agent profile under
+`apps/character-<id>/`. Read `CIVIC-LAYER.md` first — it explains why
+characters are markdown + JSON only and the substrate handles all runtime.
+
+## Folder shape
+
+```
+apps/character-<id>/
+├── character.json        ← substrate-readable manifest
+├── persona.md            ← REQUIRED — voice + system-prompt template + post-type fragments
+├── creative-direction.md ← optional — the "why" arc; tensions and decisions
+├── exemplars/            ← optional — per-post-type voice exemplars (ICE)
+│   ├── digest/
+│   ├── micro/
+│   ├── weaver/
+│   ├── lore_drop/
+│   ├── question/
+│   └── callout/
+├── ledger.md             ← optional but recommended — what the character speaks, when
+├── README.md             ← optional — civic-layer placement explanation
+└── package.json          ← workspace member declaration
+```
+
+## `character.json` contract
+
+```jsonc
+{
+  "$schema": "https://freeside-characters/schema/character.v0.json",
+  "id": "satoshi",
+  "displayName": "Satoshi",
+  "personaFile": "persona.md",
+  "exemplarsDir": "exemplars",
+  "emojiAffinity": {
+    "primary": "mibera",
+    "fallback": "ruggy"
+  },
+  "anchoredArchetypes": ["Veteran", "Chaos-Agent"],
+  "mcps": ["codex", "imagegen"],
+  "slash_commands": [
+    {
+      "name": "satoshi",
+      "description": "talk to satoshi",
+      "handler": "chat",
+      "options": [
+        { "name": "prompt", "description": "what to say to satoshi", "type": 3, "required": true },
+        { "name": "ephemeral", "description": "only you see the reply", "type": 5, "required": false }
+      ]
+    },
+    {
+      "name": "satoshi-image",
+      "description": "satoshi generates an image",
+      "handler": "imagegen",
+      "options": [
+        { "name": "prompt", "description": "image prompt — be explicit about subject + scene + light", "type": 3, "required": true }
+      ]
+    }
+  ],
+  "doc": {
+    "creativeDirection": "creative-direction.md"
+  },
+  "stage": "character",
+  "stageNotes": "Brief explanation of stage choice."
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | stable handle. Must match the folder name (`apps/character-satoshi/` → `id: "satoshi"`). |
+| `displayName` | no | human-readable label. Defaults to `id`. |
+| `personaFile` | yes | path relative to character dir (typically `persona.md`). |
+| `exemplarsDir` | no | path relative to character dir. Omit → no In-Context Exemplars (rule-based voice only). |
+| `emojiAffinity` | no | hint for emoji MCP. Currently informational; V0.6-D wires into MCP filtering. |
+| `anchoredArchetypes` | no | 1-2 cabal archetypes that genuinely map to who the character IS (not rotating filters). |
+| `slash_commands` | no | per-character slash commands (V0.7-A.1+). Omit for default `/<id> chat` shape. See §slash commands. |
+| `mcps` | no | per-character MCP scope on the digest path (V0.7-A.1+). Omit for bot-wide access. See §MCP scoping. |
+| `stage` | no | `character` (V0.6) or `daemon` (V0.7+ once mint machinery lands). |
+
+## Slash commands (V0.7-A.1+)
+
+Eileen's framing 2026-04-30: "commands are diff otherwise they'd be reporting
+the same shit." Each character can declare its own command set in
+`character.json`. When omitted, the substrate auto-generates the V0.7-A.0
+default `/<id> prompt:<text> ephemeral:<bool>` routed to the `chat` handler
+— so existing characters keep working without changes.
+
+```jsonc
+"slash_commands": [
+  {
+    "name": "satoshi",
+    "description": "talk to satoshi",
+    "handler": "chat",
+    "options": [
+      { "name": "prompt", "description": "what to say to satoshi", "type": 3, "required": true },
+      { "name": "ephemeral", "description": "only you see the reply", "type": 5, "required": false }
+    ]
+  },
+  {
+    "name": "satoshi-image",
+    "description": "satoshi generates an image",
+    "handler": "imagegen",
+    "options": [
+      { "name": "prompt", "description": "image prompt", "type": 3, "required": true }
+    ]
+  }
+]
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Discord command name. Must match `^[-_\p{L}\p{N}]{1,32}$`. |
+| `description` | yes | 1-100 char description shown in Discord autocomplete. |
+| `handler` | yes | Substrate-side handler. `chat` (composeReply pipeline · V0.7-A.0) or `imagegen` (Bedrock Stability · V0.7-A.1). Future: `stats`, `lore`, etc. |
+| `options` | no | Discord application command options. `type` values: 3=STRING, 4=INTEGER, 5=BOOLEAN, 10=NUMBER. |
+
+The substrate flattens all characters' commands at publish time and rejects
+duplicate names loud. Run `bun run apps/bot/scripts/publish-commands.ts`
+after editing — Discord caches command schemas (1-hour TTL globally,
+instant in single-guild mode).
+
+## MCP scoping (V0.7-A.1+)
+
+Per-character MCP access on the digest path. Names listed in `mcps` are the
+servers the character is allowed to call from `runOrchestratorQuery`. Names
+not currently registered (env-gated MCPs like `codex` when `CODEX_MCP_URL`
+is unset) are silently dropped — the field expresses INTENT; what's actually
+available is the intersection with what the substrate has wired.
+
+```jsonc
+// ruggy — reporter · data-grounded · no imagegen (won't hallucinate-and-illustrate)
+"mcps": ["score", "codex", "emojis", "rosenzu", "freeside_auth"]
+
+// satoshi — mibera-agent · cross-realms · no score (stays gnomic, not zone-stat analyst)
+"mcps": ["codex", "imagegen"]
+```
+
+When `mcps` is omitted, the character has access to ALL registered MCPs
+(V0.6 parity). Affects ONLY the digest path. Chat-mode replies
+(`composeReply`) bypass MCPs entirely by design and are unaffected.
+
+Currently registered MCP names (substrate-side):
+
+| Name | Source | When registered |
+|---|---|---|
+| `rosenzu` | `orchestrator/rosenzu/` | always (in-process SDK MCP) |
+| `emojis` | `orchestrator/emojis/` | always (in-process SDK MCP) |
+| `freeside_auth` | `orchestrator/freeside_auth/` | always (warns + falls back to truncated wallet when DB unavailable) |
+| `score` | zerker's HTTP MCP | when `MCP_KEY` is set |
+| `codex` | gumi's mibera-codex HTTP MCP | when `CODEX_MCP_URL` is set |
+| `imagegen` | `orchestrator/imagegen/` | when `AWS_REGION` + `BEDROCK_STABILITY_MODEL_ID` set |
+
+## `persona.md` conventions
+
+The persona doc is BOTH the human-facing voice document AND the substrate's
+system-prompt source. It uses three substrate-canonical conventions:
+
+### 1. System-prompt template section
+
+The doc must contain a section header `## System prompt template` followed by
+a fenced code block (use ```` ```` four-tick fences so embedded ``` triple-fences
+don't break it). The fenced content IS the template the substrate substitutes
+placeholders into:
+
+````markdown
+## System prompt template
+
+```
+You are <character voice...>
+
+{{POST_TYPE_GUIDANCE}}
+
+{{EXEMPLARS}}
+
+═══ INPUT PAYLOAD ═══
+
+zone: {{ZONE_ID}}
+post type: {{POST_TYPE}}
+
+{{POST_TYPE_OUTPUT_INSTRUCTION}}
+```
+````
+
+The marker `═══ INPUT PAYLOAD ═══` (note the box-drawing chars) splits the
+template into a system-prompt half (everything before) and a user-message half
+(everything after). The substrate enforces this split.
+
+### 2. Per-post-type fragments
+
+Six post-types must each have a fragment block:
+
+```markdown
+<!-- @FRAGMENT: digest -->
+Guidance specific to digest posts goes here. Tone, constraints, examples.
+<!-- @/FRAGMENT -->
+
+<!-- @FRAGMENT: micro -->
+Guidance for micro posts.
+<!-- @/FRAGMENT -->
+
+<!-- @FRAGMENT: weaver -->
+…
+<!-- @/FRAGMENT -->
+```
+
+Required fragment names: `digest`, `micro`, `weaver`, `lore_drop`, `question`,
+`callout`. Missing one will throw at compose-time.
+
+### 3. Placeholders
+
+The substrate substitutes these placeholders during prompt build:
+
+| Placeholder | What gets substituted |
+|---|---|
+| `{{ZONE_ID}}` | current zone (e.g. `bear-cave`) |
+| `{{POST_TYPE}}` | current post type (e.g. `digest`) |
+| `{{POST_TYPE_GUIDANCE}}` | the post-type's fragment block content |
+| `{{POST_TYPE_OUTPUT_INSTRUCTION}}` | brief "write the post now" instruction |
+| `{{CODEX_PRELUDE}}` | Mibera Codex `llms.txt` content (~2k tokens) |
+| `{{EXEMPLARS}}` | In-Context Exemplar block (empty if no exemplars on disk) |
+
+## Exemplars (ICE)
+
+In-Context Exemplars are real past posts the LLM matches against — far more
+load-bearing for voice fidelity than rule-based prompts. To add exemplars for
+a post-type, drop `*.md` files into `exemplars/<post-type>/`. The substrate
+randomly samples up to 5 per fire (Fisher-Yates shuffle) and injects them into
+`{{EXEMPLARS}}`.
+
+Frontmatter is optional. If present (`---\n…\n---\n`), it's stripped before
+injection. Files named `README.md` are skipped.
+
+## Enabling a character at runtime
+
+The bot reads the `CHARACTERS` env var (comma-separated character ids):
+
+```bash
+CHARACTERS=ruggy             # default — only ruggy
+CHARACTERS=satoshi           # only satoshi
+CHARACTERS=ruggy,satoshi     # both (V0.6-D routing decides who speaks per fire)
+```
+
+Default is `ruggy`. The first character in the list is the "primary" — for
+the digest path, all fires dispatch through the primary (V0.6-A behavior).
+V0.6-D will add per-fire affinity routing. V0.7-A.0 slash commands route
+explicitly to the invoked character regardless of primary.
+
+## Smoke-test a new character
+
+After adding files, run:
+
+```bash
+# Typecheck — catches missing files, malformed character.json
+bun run typecheck
+
+# Stub-mode dry-run — exercises the compose pipeline without external calls
+STUB_MODE=true LLM_PROVIDER=stub CHARACTERS=<id> POST_TYPE=digest \
+  ZONES=stonehenge bun run digest:once
+```
+
+If both pass, the character loads and the substrate accepts it. Voice quality
+needs a real LLM call (`LLM_PROVIDER=anthropic`) and human review.
+
+## Stage promotion (character → daemon, V0.7+)
+
+Per Eileen's `puruhani-as-spine.md` canon, characters elevate to **daemons**
+when ALL FOUR conditions land:
+
+1. **dNFT mint machinery** — token-bound account (ERC-6551) per character
+2. **State-transition handlers** — Dormant → Stirring → Breathing → Soul
+3. **Designed-voice templates** — replace pure-LLM with template-driven voice
+4. **Memory ledger** — jani's storage architecture; 5-way memory matrix
+
+Until then, `stage: "character"` is the right shape and the codex grail page
+(or analogous canonical text) is the identity anchor. Don't introduce
+"freeside-daemon" terminology or behaviors until the machinery exists —
+applying the daemon vocabulary prematurely conflates this work with Eileen's
+puruhani-daemon canon.

--- a/grimoires/loa/specs/legacy-imports/CIVIC-LAYER.md
+++ b/grimoires/loa/specs/legacy-imports/CIVIC-LAYER.md
@@ -1,0 +1,105 @@
+# Civic-layer doctrine
+
+> **Eileen 2026-04-20** (vault: `agent-native-civic-architecture.md`):
+> *"Do not let system agents and participation agents blur together. If they
+> blur, you get exactly the kind of legitimacy collapse that [other platforms]
+> weren't about: head and power unclear, authority hard to appeal, moderation
+> epistemic capture, and rule confusion between speaker and governor."*
+
+This is the load-bearing structural commitment of `freeside-characters`. It is
+not an architectural preference — it is an operator-stated principle that
+pre-dates V0.6-A.
+
+## The split
+
+| Layer | Role | What it does | What it never does |
+|---|---|---|---|
+| **System agents** (governors) | institutional theme | cron, delivery, MCP orchestration, persona+exemplar loading, score-mcp client | speak; carry voice; hold character identity |
+| **Participation agents** (speakers) | members / contributors | persona, voice, creative direction, exemplars, emoji affinity | govern cadence; touch Discord client; enumerate themselves |
+
+A participation agent is a **speaker**. A system agent is a **governor**. The
+two MUST NOT be conflated. Authority and appeal are different from voice and
+register. When they blur, legitimacy collapses.
+
+## How the codebase enforces it
+
+### Package boundary (compile-time)
+
+`packages/persona-engine/` is the **substrate** (system-agent layer). Its
+public API is exposed only through `src/index.ts` (the barrel). Everything
+else is internal.
+
+`apps/character-<id>/` is the **participation-agent profile** (speaker layer).
+In V0.6-A these directories contain ONLY markdown + JSON + a manifest
+`character.json`. No TypeScript code. The substrate cannot be bypassed because
+there's no runtime to do the bypassing in the character folder.
+
+`apps/bot/` is the **runtime entry**. It loads characters from filesystem,
+dispatches fires through the substrate. It imports the substrate via the
+workspace package (`@freeside-characters/persona-engine`); it does NOT reach
+into substrate internals via relative paths. Characters cannot be loaded
+without the bot mediating.
+
+### Filesystem boundary (run-time)
+
+The substrate **never enumerates `apps/character-*/` on its own**. Discovery
+of which characters exist is the bot's job (`apps/bot/src/character-loader.ts`
+reads the `CHARACTERS` env var, walks to known character directories, parses
+their `character.json`, and hands `CharacterConfig` values to the substrate).
+
+If the substrate ever needs to know "which characters exist?", that's a smell —
+it's reaching into the speaker layer. Route through the bot's character-loader
+instead.
+
+### Type boundary (semantic)
+
+`CharacterConfig` (in `packages/persona-engine/src/types.ts`) is the canonical
+contract:
+
+```ts
+interface CharacterConfig {
+  id: string;
+  personaPath: string;
+  exemplarsDir?: string;
+  emojiAffinity?: { primary?: 'ruggy' | 'mibera'; fallback?: 'ruggy' | 'mibera' };
+  displayName?: string;
+}
+```
+
+This is the legitimate boundary between layers. Anything character-specific
+goes in here. Substrate functions accept `CharacterConfig`; characters supply
+the underlying files.
+
+## Violations to catch in review
+
+Watch for these patterns — each one collapses the layer split:
+
+1. **Character-specific code in `packages/persona-engine/`** — e.g. an
+   if-statement that checks `character.id === 'ruggy'` to branch behavior.
+   The substrate is character-agnostic by construction.
+
+2. **Filesystem walks in the substrate** — e.g. `readdirSync('apps')` from
+   inside persona-engine. The substrate doesn't know `apps/` exists.
+
+3. **Substrate internals imported across packages** — e.g.
+   `import { something } from '@freeside-characters/persona-engine/src/orchestrator/cabal/gygax.ts'`.
+   Always import from the barrel (`@freeside-characters/persona-engine`).
+
+4. **TS code in `apps/character-<id>/`** — characters are markdown + JSON in
+   V0.6-A. If runtime logic creeps into a character folder, it should move
+   to the substrate (with `CharacterConfig` injection) or to the bot.
+
+5. **Cross-character imports** — character A imports from character B. Each
+   character profile is independent; cross-character behaviors live in the
+   substrate's routing layer (V0.6-D).
+
+## Why this matters for V0.6+
+
+When V0.7+ elevates characters to **daemons** (per Eileen's puruhani-as-spine
+canon — dNFT mint, ERC-6551 TBA, designed-voice templates), the daemon will
+take ownership of identity. At that point the civic-layer split must STILL
+hold: the daemon is the speaker, the substrate is still the governor.
+
+A blur today (a character that secretly governs, or a substrate that secretly
+speaks) becomes an unfixable mess once mint machinery is in the loop. The
+structural split now is what keeps V0.7+ tractable.

--- a/grimoires/loa/specs/legacy-imports/MULTI-REGISTER.md
+++ b/grimoires/loa/specs/legacy-imports/MULTI-REGISTER.md
@@ -1,0 +1,185 @@
+# Multi-register doctrine
+
+> **Eileen on Purupuru's daemon voice across 5 surfaces** (vault:
+> `storytelling-game-social-convergence.md`):
+> *"Whisper · Tactician · Companion · Broadcaster · Witness — same character,
+> different registers. The player moves between rooms and the daemon is
+> already there, remembering what happened in the last room."*
+
+A character is **multi-register by design**. One identity, N voices. The
+register depends on the surface, the moment, and the data shape. This is the
+forcing function that makes "one shell, many speakers" the right architecture
+— and why the Discord 50-bot limit is a feature, not a constraint.
+
+## Reframe (gumi 2026-04-29 walkthrough · issue #1)
+
+The original V0.6-A draft of this doc framed the cabal-gygax archetypes as a
+character voice axis (filtering 9 archetypes → "natural fits" → per-fire
+rotation). **That was the wrong shape.** Per gumi's correction (issue #1 ·
+Correction 1):
+
+> *"the cabal-gygax archetypes aren't satoshi's moods — they're different
+> player postures. rather than filtering the 9 down to natural fits, pick
+> 1–2 archetypes that genuinely map to the character and base register
+> variation there. fewer lenses, deeper voice."*
+
+The 9 cabal archetypes are **AUDIENCE POSTURES** — how readers RECEIVE a
+locked voice — not modes the character speaks through. Filtering them as
+"character moods" was a category error. This doc reframes accordingly.
+
+## How multi-register manifests in `freeside-characters`
+
+Each character carries register variation along **one axis** (post-types) plus
+**identity properties** (anchored archetypes — character traits, not rotating
+filters).
+
+### The axis: post-type registers (character-supplied)
+
+Each character's `persona.md` declares fragment blocks for the 6 post-types.
+Each fragment is a register shift. The same character speaks differently in
+each:
+
+| Post-type | Register shift |
+|---|---|
+| `digest` | structured, stat-quoting, weekly-review register |
+| `micro` | casual drop-in, observation-only, no greeting/closing |
+| `weaver` | cross-zone connection-naming, threshold-noting register |
+| `lore_drop` | codex-anchored reference, head-nod-to-regulars |
+| `question` | open-ended invitation, low-pressure |
+| `callout` | calm voice over alarm-shaped data |
+
+These are character-defined — Ruggy's six registers differ from Satoshi's
+six (e.g. ruggy's callout leads with 🚨; satoshi's callout is structural-only
+and never uses 🚨). The substrate doesn't prescribe what each register sounds
+like; it just guarantees the right fragment is in scope when the right
+post-type fires.
+
+### The identity: anchored archetypes (character traits, NOT rotating filters)
+
+Each character locks 1-2 archetype identities baked into the persona prompt.
+These are character TRAITS that operationalize through voice rules — NOT
+runtime modes the character switches between per fire.
+
+| Character | Anchored archetypes (gumi-locked / operator-picked) |
+|---|---|
+| **Ruggy** | Storyteller + GM (festival NPC narrating arcs across zones) |
+| **Satoshi** | Veteran + Chaos-Agent (the long view + uncertainty as observation) |
+
+The other 7 archetypes per character are **culled**. They don't apply to that
+character. A Newcomer-postured reader will find satoshi confusing — that's
+correct reception, not a bug. The voice rules in each character's `persona.md`
+operationalize the anchored archetypes; the labels are shorthand for trait
+clusters, not levers the LLM pulls.
+
+## Cabal-gygax: post-design RECEPTION TESTER (not compose)
+
+The cabal-gygax subagent persists in code at
+`packages/persona-engine/src/orchestrator/cabal/gygax.ts` but is **retired
+from per-fire compose** (V0.6-C reconciliation 2026-04-30 per gumi correction
+§0.5 #1).
+
+A future `/cabal` command runs cabal POST-DESIGN against published posts:
+
+```
+published satoshi posts
+   ↓
+/cabal --all "satoshi-week-1"
+   ↓
+each archetype reads the post and reports:
+  Veteran:        "this resonates — pattern recognition lives here"
+  Chaos-Agent:    "the uncertainty handling is satoshi-shaped"
+  Newcomer:       "I am confused, this register doesn't onboard me"
+  Optimizer:      "no mechanic-detail here, this isn't for me"
+  ...
+   ↓
+audience-divergence findings = playtest data for the operator
+```
+
+The findings are not "the voice is wrong." They're "this voice resonates with
+these audience postures, diverges from those." Newcomer-confusion is
+acceptable when the character is anchored as Veteran + Chaos-Agent — the
+character isn't FOR Newcomers. That's the gumi-canonical use of cabal.
+
+## Why this matters
+
+### "The strongest dNFT is the most meaningful companion"
+
+Per Eileen (`puruhani-as-spine.md`), the goal isn't autonomous mibera-agent. It
+is a **meaningful companion** that miberas (community members) actually build
+relationship with. Voice fidelity across post-type registers is the
+load-bearing capability — recognizing that the digest-Ruggy and the micro-Ruggy
+and the callout-Ruggy are all the same Ruggy, just speaking in different
+shapes.
+
+If a character flattens to one register ("ruggy says the same thing every
+time"), it stops being a companion and becomes a feed. Multi-register doctrine
+prevents that flattening — without rotating through audience postures.
+
+### Cross-character co-existence
+
+V0.6-C lands satoshi alongside ruggy. They don't compete for "the bot's voice"
+— each carries their own post-type register-set + their own anchored
+archetypes. Eileen explicit: *"if ruggy say something, can satoshi
+read/write?"* — that's V0.6-D phase 2, the cross-character interaction layer
+that the multi-register architecture makes possible.
+
+## Three cross-cutting doctrines (gumi 2026-04-29 · all characters)
+
+These doctrines apply beyond satoshi to the character architecture broadly:
+
+1. **Performed silence > literal silence** — when a character has nothing of
+   substance to say, they STAGE the silence rather than going dark. Brief
+   dismissal (`"there is nothing of note here"`) or italicized stage-direction
+   (`*satoshi observes the room and shakes his head*`). Active presence
+   without content beats absence. Generalizable.
+
+2. **Messenger ≠ terse** — words are the tool, not the enemy. Sparseness comes
+   from precision and intentionality, not from rationing syllables. This is
+   character-specific to satoshi but the principle holds generally: voice
+   constraints come from voice, not from word-count.
+
+3. **Hermes moves between worlds** — for satoshi specifically, zone
+   flexibility is identity, not exception. Generalizes: a character's
+   relationship to the substrate's surfaces (zones / channels) is part of
+   their identity, not platform-imposed.
+
+## What the substrate enforces
+
+- The right post-type fragment is loaded for each fire (no leakage between
+  post-types)
+- Exemplars are sampled per-character per-post-type (no cross-character
+  voice contamination)
+- Anchored archetypes ride in the persona prompt as identity properties (no
+  runtime mode-switching)
+- Cabal-gygax dispatch is **NOT** in compose path (retired V0.6-C per gumi
+  correction)
+
+The substrate does NOT prescribe:
+
+- What each character's 6 post-type registers sound like (character supplies)
+- Which 1-2 archetypes anchor a character (character supplies via persona +
+  metadata)
+- Which registers a character even uses (a future character could omit
+  `callout` if it doesn't fit them)
+
+## V0.6 → V0.7 trajectory
+
+In V0.6 (character-stage), registers are LLM-driven with rule-based + ICE
+guidance. In V0.7+ (daemon-stage, per `puruhani-daemon.md`), registers
+elevate to **designed-voice templates** with LLM as final-pass voice-in-context.
+The multi-register architecture survives the transition unchanged — what
+changes is the substitution mechanism (templates instead of system-prompt
+fragments).
+
+The cabal-gygax post-design `/cabal` command lives across both stages: at
+character-stage it tests audience reception of LLM-generated posts; at
+daemon-stage it tests audience reception of template-generated posts. Same
+mechanism, different inputs.
+
+## Provenance
+
+- Original draft: V0.6-B 2026-04-29 (with the 6×9=54 framing — wrong shape)
+- Reframed: V0.6-C reconciliation 2026-04-30 per gumi correction §0.5 #1
+  (issue #1 walkthrough)
+- Cabal retirement from per-fire compose: substrate orchestrator updated
+  same date


### PR DESCRIPTION
## Summary

Phase A of the V0.7-A.1 environment-substrate cycle. Mounts Loa as a git submodule pinned to v1.108.0 (matches bonfire), with `.claude/` symlinks into the submodule and a State Zone at `grimoires/loa/`. **Substrate work itself (Phases B-E) lands in follow-up PRs inside this repo** — clean workflow boundary, beads tracking starts in the next session.

- **Submodule pin**: `.loa @ v1.108.0` (commit `303cd27`); `.gitmodules` tracks `branch=main` for controlled bumps via `git submodule update --remote .loa`
- **Symlinks**: `.claude/{commands,skills,scripts,protocols,hooks,data,schemas}` point into the submodule; `.claude/overrides/` is user-owned
- **State Zone**: `grimoires/loa/{NOTES.md, specs/, context/, discovery/, a2a/}`
- **CLAUDE.md**: gains `@.claude/loa/CLAUDE.loa.md` import at the top; existing 150 lines of project guidance preserved verbatim and remain authoritative per Loa user-overrides convention
- **Architectural docs ported** into `grimoires/loa/specs/legacy-imports/` (AGENTS, ARCHITECTURE, CIVIC-LAYER, MULTI-REGISTER, CHARACTER-AUTHORING). Originals in `docs/` preserved; cleanup tracked in `grimoires/loa/NOTES.md` for a follow-up PR
- **Build doc seeded**: `grimoires/loa/specs/build-environment-substrate-v07a1.md` is the canonical input for the next session's `/sprint-plan` + `/implement` of Phases B-E

## Why Phase A is its own PR

Per the build spec (operator's bonfire planning vault) and confirmed at session kickoff: framework mount is a separate concern from the substrate work it enables. Once Loa is mounted in this repo, B-E run through `/sprint-plan` + `/implement` with beads tracking — the cleanest workflow boundary is a Loa-less repo *before* this PR, a Loa-mounted repo *after*.

## What's NOT in this PR

- Phases B-E (channel↔zone reverse map, rosenzu `read_room` + environment-context builder, chat-mode MCP wiring, persona prose tweak) — next session
- `docs/` ↔ `grimoires/loa/specs/legacy-imports/` deduplication — separate PR (logged as Discovered Technical Debt in NOTES.md)
- Construct pack installation (archivist + observer + artisan + the-arcade per spec) — declared in the build doc as a discipline/canon decision; physical adoption deferred to next session if needed
- BUTTERFREEZONE seeding — Loa now provides `/butterfreezone`; can run in next session

## Test plan

- [x] `bun run typecheck` clean (workspace-wide: `packages/persona-engine` + `apps/bot`) — Loa mount is symlinks + state files only, doesn't touch package code
- [x] `.loa-version.json` reports `framework_version: v1.108.0` (no stale-stamp; resolved correctly via `git describe --tags` on submodule HEAD)
- [x] `.claude/commands/ride.md` symlink resolves to `../../.loa/.claude/commands/ride.md`
- [x] Submodule SHA matches v1.108.0 tag (`303cd27`)
- [ ] `git submodule update --init` works on a fresh clone (reviewer can verify)
- [ ] In a fresh Claude Code session in this repo, `/loa` recognises the framework mount and reports next steps

## Reversibility

Single-commit PR — `git revert HEAD` removes everything. Submodule deinit via standard `git submodule deinit -f .loa && git rm -f .loa` if a deeper rollback is wanted. No app code is touched, no production paths shift.

## Followups (tracked in `grimoires/loa/NOTES.md`)

- Deduplicate `docs/` ↔ `grimoires/loa/specs/legacy-imports/` once next session decides canonical home for architectural refs
- Phase B–E build-out per `grimoires/loa/specs/build-environment-substrate-v07a1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)