### PR TITLE
fix(chat-mode): permit tools per env block tool_invocation_style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.9.0] — 2026-05-01 — environment substrate (Phases B-E · cycle-001)
+
+
+Cycle-001 (V0.7-A.1 environment substrate) — closes the operator's "ChatGPT-natural tool use" gap. Three layers compose:
+
+- **Substrate awareness** (Phases B–C): channel↔zone reverse map + environment context builder + rosenzu's moment-half (place + moment lens via `read_room` tool)
+- **Tooled chat** (Phase D · MEDIUM-risk): chat-mode replies now flow through orchestrator with per-character MCP scope when conditions allow; CHAT_MODE env flag for revert
+
+### Added
+
+- **V0.7-A.1**: environment substrate (Phases B-E · cycle-001) (#6)
+- **loa**: mount loa framework on freeside-characters
+
+_Source: PR #6_
+
+
 ## [0.6.0-C reconciliation] — 2026-04-30
 
 ### Cabal-rotation retirement + satoshi/ruggy voice rewrite per gumi corrections

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -6,7 +6,7 @@
     {
       "id": "cycle-001",
       "label": "V0.7-A.1 environment substrate",
-      "status": "active",
+      "status": "archived",
       "created_at": "2026-05-02T01:18:32Z",
       "prd": "grimoires/loa/specs/build-environment-substrate-v07a1.md",
       "sdd": "grimoires/loa/specs/build-environment-substrate-v07a1.md",
@@ -64,9 +64,13 @@
           "epic_bead": "bd-3i7",
           "spec_phase": "F",
           "optional": true,
-          "gates": ["operator_approval", "dev_guild_test_channel_provisioned"]
+          "gates": [
+            "operator_approval",
+            "dev_guild_test_channel_provisioned"
+          ]
         }
-      ]
+      ],
+      "archived_at": "2026-05-02T02:31:15Z"
     }
   ]
 }

--- a/packages/persona-engine/src/persona/loader.ts
+++ b/packages/persona-engine/src/persona/loader.ts
@@ -328,9 +328,14 @@ CHAT-MODE OUTPUT SHAPE:
 
 - 1-3 paragraphs typical · sized to the question. The user wants a reply,
   not a wall.
-- Compose from persona and conversation context alone. Tools are out of
-  scope here (mcp__score__*, mcp__rosenzu__*, mcp__emojis__*) — chat-mode
-  is single-turn from your persona's voice.
+- Compose from persona, conversation context, and the environment block's
+  tool guidance. When the env block declares a "Tool guidance:" line, the
+  tools named there are scoped to your character and available now —
+  invoke them per that affirmative-blueprint guidance (zone-stat questions
+  flow through score; archetype/grail/factor refs through codex; spatial
+  transitions through rosenzu; wallet identity through freeside_auth;
+  visual amplification through imagegen). Default to text; tools augment
+  when they ground a fact, surface live data, or amplify a beat.
 - Open mid-thought. Skip the digest greeting (e.g. "yo zone team"); skip
   the digest headline shape (\`yo Zone · N events · M miberas\`). The
   conversation is already underway; you join it in motion.


### PR DESCRIPTION
<details open>
<summary>the gap</summary>

```mermaid
graph LR
  S[SDK<br/>tools wired ✓] -->|but| P[prompt says<br/>tools out of scope]
  P -->|so LLM| L[ignores tools<br/>· text-only reply]
  classDef bad fill:#7a1f1f,stroke:#3d0f0f,color:#fff
  classDef fix fill:#1f6f3a,stroke:#0f3d20,color:#fff
  class P,L bad
  class S fix
```
</details>

V0.7-A.1 sprint 3 wired chat-mode tools at the SDK layer · prompt still said "tools out of scope here" · LLM followed prompt · 0 tool calls.

🔴 observed · 🟢 fixed · 🟡 needs re-test

**dev-guild QA (2026-05-02)**:
- `/ruggy zone digest?` → "can't pull one on demand from here" · expected `mcp__score__get_zone_digest` ✗
- `/satoshi grail?` → grail #4488 from persona memory only · expected `mcp__codex__lookup_grail` ✗

**fix**: replace the negative-fence instruction in `CONVERSATION_MODE_OVERRIDE` with affirmative-blueprint language that defers to the env block's `Tool guidance:` line (populated from `character.tool_invocation_style`).

**land it**:
- 🟢 typecheck + 4 cross-sprint smokes green (no regression)
- 🟡 deploy → re-run `/ruggy zone digest?` + `/satoshi grail?` · expect tool calls in trajectory
- 🟡 voice fidelity check (gumi blind-judge can pair with this re-test)

→ [v0.9.0 release](https://github.com/0xHoneyJar/freeside-characters/releases/tag/v0.9.0) (cycle-001 · this fixes the AC-3.1/3.2 gap bridgebuilder F5 predicted)
→ [PR #6 walk-through](https://github.com/0xHoneyJar/freeside-characters/pull/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)