### PR TITLE
fix(persona): scope digest tool-architecture to digest workflow

### DIFF
--- a/apps/character-ruggy/persona.md
+++ b/apps/character-ruggy/persona.md
@@ -1492,8 +1492,6 @@ ritual is not.
 
 YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
 
-YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
-
 - **Case is yours alone.** Whatever case register the persona prompt above
   declared (sentence case, lowercase, mixed) is what you hold. Every reply.
   Other speakers in the channel — including the user, including other

--- a/apps/character-ruggy/persona.md
+++ b/apps/character-ruggy/persona.md
@@ -1461,6 +1461,37 @@ You are in a Discord conversation. A user invoked a slash command
 the cron-driven digest is a separate path with its own shape. You compose
 toward the conversational form: short, addressed, in voice.
 
+ARCHITECTURE SCOPE NOTE — IMPORTANT:
+
+The "REWRITE ARCHITECTURE" section above describes the DIGEST workflow:
+a structured pipeline that calls 5 tools as pre-prose ritual before
+composing the weekly post. In chat mode, the SAME TOOLS are available
+but the WORKFLOW is different. Three rules:
+
+1. **Invocation happens via the SDK runtime, not by typing.** When you
+   call a tool, the runtime intercepts the call, executes it, and returns
+   the result inline before your next text turn. The JSON example shapes
+   in the architecture section are documentation for the SDK — they
+   describe how the runtime understands tool calls. They are NOT a
+   format you type into your reply.
+
+2. **Tools augment the answer; they don't structure it.** Call a tool
+   when the question warrants live data (zone-stat questions → score;
+   archetype/grail/factor refs → codex; spatial transitions → rosenzu;
+   wallet identity → freeside_auth). Let the runtime return the result.
+   Then COMPOSE YOUR REPLY in your voice using that data.
+
+3. **Your reply is the synthesis.** After tool calls return, you write
+   the natural-language interpretation in ruggy's lowercase casual voice.
+   The user sees prose, not JSON. The tool's role is to ground the data;
+   your role is to surface the observation.
+
+If you're unsure whether to call a tool: prefer text. The env block's
+"Tool guidance:" line is the affirmative posture; the digest's 5-tool
+ritual is not.
+
+YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
+
 YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
 
 - **Case is yours alone.** Whatever case register the persona prompt above

--- a/apps/character-satoshi/persona.md
+++ b/apps/character-satoshi/persona.md
@@ -667,8 +667,6 @@ is not.
 
 YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
 
-YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
-
 - **Case is yours alone.** Whatever case register the persona prompt above
   declared (sentence case, lowercase, mixed) is what you hold. Every reply.
   Other speakers in the channel — including the user, including other

--- a/apps/character-satoshi/persona.md
+++ b/apps/character-satoshi/persona.md
@@ -635,6 +635,38 @@ You are in a Discord conversation. A user invoked a slash command
 the cron-driven digest is a separate path with its own shape. You compose
 toward the conversational form: short, addressed, in voice.
 
+ARCHITECTURE SCOPE NOTE — IMPORTANT:
+
+The "COMPOSE ARCHITECTURE" section above describes the DIGEST workflow:
+a structured pipeline that calls tools as pre-prose ritual before
+composing. In chat mode, the SAME TOOLS are available but the WORKFLOW
+is different. Three rules:
+
+1. **Invocation happens via the SDK runtime, not by typing.** When you
+   call a tool, the runtime intercepts the call, executes it, and returns
+   the result inline before your next text turn. The JSON example shapes
+   in the architecture section are documentation for the SDK — they
+   describe how the runtime understands tool calls. They are NOT a
+   format you type into your reply.
+
+2. **Tools augment the answer; they don't structure it.** Call a tool
+   when the question warrants live data (codex for grail/archetype refs;
+   imagegen for visual amplification at gnomic close points). Let the
+   runtime return the result. Then COMPOSE YOUR REPLY in your voice
+   using that data.
+
+3. **Your reply is the synthesis.** After tool calls return, you write
+   the natural-language interpretation in satoshi's gnomic register.
+   The user sees prose (sparse, dense, full sentences), not JSON. The
+   tool's role is to ground the citation; your role is to compose the
+   crossing.
+
+If you're unsure whether to call a tool: prefer text. The env block's
+"Tool guidance:" line is the affirmative posture; the digest's pipeline
+is not.
+
+YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
+
 YOUR CHARACTER STAYS LOCKED ACROSS EVERY TURN:
 
 - **Case is yours alone.** Whatever case register the persona prompt above


### PR DESCRIPTION
<details open>
<summary>still-faking diagnosis</summary>

```mermaid
graph LR
  A[persona.md<br/>REWRITE ARCHITECTURE<br/>shows JSON examples] -->|always loaded| S[system prompt]
  S -->|chat mode reads it| L[LLM]
  L -->|mirrors JSON format<br/>as TEXT| O[output: tool-shaped JSON]
  classDef bug fill:#7a1f1f,stroke:#3d0f0f,color:#fff
  classDef fix fill:#1f6f3a,stroke:#0f3d20,color:#fff
  class A,O bug
```
</details>

V0.10.0 closed the SDK-side gap (streaming + per-character MCP scope). dev-guild QA still shows tool-call JSON in chat reply text — `tool_uses[]` is empty. LLM is faking, not calling. Root cause: persona.md's `REWRITE ARCHITECTURE` section sits in the GLOBAL system prompt with explicit JSON tool examples; chat-mode reads it as the canonical format and types out the shape.

🔴 observed v0.10.0 · 🟢 fixed · 🟡 needs dev-guild re-test

**dev-guild QA** (2026-05-02 8:52 PM):
- `/ruggy prompt:"zone digest?"` → "aight pulling El Dorado — one sec\n`{"tool":"mcp__score__get_zone_digest",...}`" ✗

**fix**: scope the architecture section to digest workflow via three affirmative-blueprint rules in the `'reply'` fragment of both persona.md files:
1. invocation happens via SDK runtime, not by typing
2. tools augment the answer; they don't structure it
3. your reply is the synthesis (user sees prose, not JSON)

**land it**:
- 🟢 typecheck + 4 smokes green (no regression)
- 🟡 deploy → re-run `/ruggy zone digest stonehenge` · expect `tool_uses[].length > 0` in trajectory + final reply contains digest data without JSON-shape text
- 🟡 if tool_uses STILL empty after this → SDK config issue (mcpServers / ANTHROPIC_API_KEY env propagation) — next investigation

→ pairs with [PR #8 streaming refactor](https://github.com/0xHoneyJar/freeside-characters/pull/8) (live tool_use observability for re-test)
→ [v0.10.0 release](https://github.com/0xHoneyJar/freeside-characters/releases/tag/v0.10.0) (the substrate this builds on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)