### PR TITLE
fix(orchestrator): Bedrock-aware SDK auth · close the chat-tool gap

### DIFF
--- a/apps/bot/scripts/smoke-chat-routing.ts
+++ b/apps/bot/scripts/smoke-chat-routing.ts
@@ -151,16 +151,19 @@ type ChatMode = 'auto' | 'orchestrator' | 'naive';
 function expectedRoute(chatMode: ChatMode, provider: Provider): 'orchestrator' | 'naive' {
   if (chatMode === 'naive') return 'naive';
   if (chatMode === 'orchestrator') return 'orchestrator';
-  // auto: orchestrator when anthropic, naive otherwise
-  return provider === 'anthropic' ? 'orchestrator' : 'naive';
+  // V0.11.1: auto routes to orchestrator for SDK-eligible providers
+  // (anthropic OR bedrock); naive for stub/freeside.
+  return provider === 'anthropic' || provider === 'bedrock' ? 'orchestrator' : 'naive';
 }
 
 console.log('');
 console.log('CHAT_MODE routing matrix (auto · orchestrator · naive × providers):');
 
 const cases: Array<{ mode: ChatMode; provider: Provider; expected: 'orchestrator' | 'naive' }> = [
+  // V0.11.1: bedrock is now SDK-eligible (Bedrock-routed orchestrator).
+  // anthropic + bedrock both → orchestrator under auto mode.
   { mode: 'auto', provider: 'anthropic', expected: 'orchestrator' },
-  { mode: 'auto', provider: 'bedrock', expected: 'naive' },
+  { mode: 'auto', provider: 'bedrock', expected: 'orchestrator' },
   { mode: 'auto', provider: 'freeside', expected: 'naive' },
   { mode: 'auto', provider: 'stub', expected: 'naive' },
   { mode: 'orchestrator', provider: 'anthropic', expected: 'orchestrator' },

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -202,15 +202,22 @@ interface ChatInvokeArgs {
  * character's per-character MCP scope) or the naive `invokeChat()` path.
  *
  *   CHAT_MODE=naive          — always naive
- *   CHAT_MODE=orchestrator   — always orchestrator (errors if non-anthropic)
- *   CHAT_MODE=auto (default) — orchestrator when provider is anthropic;
- *                              naive otherwise
+ *   CHAT_MODE=orchestrator   — always orchestrator (errors if not SDK-eligible)
+ *   CHAT_MODE=auto (default) — orchestrator when provider is SDK-eligible
+ *                              (anthropic OR bedrock); naive for stub/freeside
+ *
+ * V0.11.1: bedrock is now SDK-eligible. The orchestrator's `buildSdkEnv`
+ * sets CLAUDE_CODE_USE_BEDROCK=1 + AWS bearer token when LLM_PROVIDER=bedrock,
+ * and the Anthropic Agent SDK routes through Bedrock with full tool support
+ * via inference profile model IDs (per Loa PR #662). This unblocks chat-mode
+ * tool calling for the operator's Bedrock-backed Opus 4.7 deployment.
  */
 function shouldUseOrchestrator(config: Config): boolean {
   if (config.CHAT_MODE === 'naive') return false;
   if (config.CHAT_MODE === 'orchestrator') return true;
-  // auto: orchestrator only if anthropic is the resolved provider.
-  return resolveChatProvider(config) === 'anthropic';
+  // auto: orchestrator when provider is SDK-eligible (anthropic OR bedrock).
+  const provider = resolveChatProvider(config);
+  return provider === 'anthropic' || provider === 'bedrock';
 }
 
 /**

--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -241,6 +241,16 @@ function resolveOrchestratorBackend(config: Config): SdkBackend {
         `orchestrator: LLM_PROVIDER='${config.LLM_PROVIDER}' is not SDK-eligible. ` +
           `Use the invokeChat shim in compose/reply.ts for stub/freeside paths.`,
       );
+    default: {
+      // Bridgebuilder F1 (PR #11) · exhaustiveness guard. If LLM_PROVIDER
+      // ever widens (e.g., adds 'vertex' or 'foundry') without a matching
+      // case, this assertion fails at compile time so the issue is loud.
+      const _exhaustive: never = config.LLM_PROVIDER;
+      throw new Error(
+        `orchestrator: unhandled LLM_PROVIDER='${_exhaustive}'. ` +
+          `Add a case to resolveOrchestratorBackend.`,
+      );
+    }
   }
 }
 
@@ -298,9 +308,12 @@ function buildSdkEnv(config: Config, backend: SdkBackend): Record<string, string
       // shape) instead of AWS_BEARER_TOKEN_BEDROCK (Loa PR #662 shape).
       env.AWS_BEARER_TOKEN_BEDROCK = config.BEDROCK_API_KEY;
     }
-    // Explicitly UNSET ANTHROPIC_API_KEY in the subprocess so the SDK
-    // doesn't accidentally route firstParty when bedrock is intended.
-    env.ANTHROPIC_API_KEY = undefined;
+    // Explicitly DELETE ANTHROPIC_API_KEY from the subprocess env so the
+    // SDK doesn't accidentally route firstParty when bedrock is intended.
+    // Bridgebuilder F3 (PR #11): setting to `undefined` is unreliable —
+    // Node's child_process may inherit from parent. `delete` is the safe
+    // pattern for env-var removal.
+    delete env.ANTHROPIC_API_KEY;
   } else {
     env.ANTHROPIC_API_KEY = config.ANTHROPIC_API_KEY!;
   }

--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -205,15 +205,78 @@ export function buildAllowedTools(
 }
 
 /**
+ * Resolve the SDK backend for the orchestrator path. The Anthropic Agent
+ * SDK supports anthropic.com (firstParty) AND Bedrock as backends via
+ * the `CLAUDE_CODE_USE_BEDROCK=1` env var. We pick based on
+ * `LLM_PROVIDER` so a single deployment can route Claude (Opus 4.7) via
+ * either path. Stub/freeside aren't SDK-eligible — they fall through
+ * to the naive `invokeChat` shim in compose/reply.ts.
+ *
+ * Per Loa PR #662 (jani · 2026-04-30): Bedrock model identifiers use
+ * inference profile IDs (`us.anthropic.claude-opus-4-7`), NOT the bare
+ * `anthropic.claude-opus-4-7` form (which returns HTTP 400). Default
+ * follows that convention.
+ */
+type SdkBackend = 'anthropic' | 'bedrock';
+
+function resolveOrchestratorBackend(config: Config): SdkBackend {
+  switch (config.LLM_PROVIDER) {
+    case 'bedrock':
+      return 'bedrock';
+    case 'anthropic':
+      return 'anthropic';
+    case 'auto':
+      // Operator-aware default: bedrock takes precedence when its bearer
+      // token is present (V0.8.0 satoshi setup + Loa PR #662 stack).
+      // Fall back to anthropic key. If neither, throw at the runtime
+      // check below.
+      if (config.AWS_BEARER_TOKEN_BEDROCK || config.BEDROCK_API_KEY) return 'bedrock';
+      if (config.ANTHROPIC_API_KEY) return 'anthropic';
+      return 'anthropic'; // unreachable in practice; runtime guard catches
+    case 'stub':
+    case 'freeside':
+      // Not SDK-eligible. Caller should route through invokeChat instead;
+      // we throw here to surface the misuse.
+      throw new Error(
+        `orchestrator: LLM_PROVIDER='${config.LLM_PROVIDER}' is not SDK-eligible. ` +
+          `Use the invokeChat shim in compose/reply.ts for stub/freeside paths.`,
+      );
+  }
+}
+
+/**
+ * Inference profile / model alias for the active backend. Anthropic SDK
+ * resolves these as model IDs against the chosen backend. We default to
+ * Opus 4.7 in both shapes — Bedrock takes the inference profile form,
+ * anthropic.com takes the bare alias.
+ */
+function resolveSdkModel(config: Config, backend: SdkBackend): string {
+  if (backend === 'bedrock') {
+    return (
+      config.BEDROCK_TEXT_MODEL_ID ?? 'us.anthropic.claude-opus-4-7'
+    );
+  }
+  return config.ANTHROPIC_MODEL;
+}
+
+/**
  * Build the env passed to the SDK subprocess.
  *
  * When ruggy runs inside another Claude Code session (e.g. during dev),
  * inheriting `CLAUDECODE=1` + `CLAUDE_CODE_ENTRYPOINT` etc. flips the
  * SDK into bridge-mode auth, which then fails ("Invalid API key"). We
- * scrub those vars so the SDK uses direct Anthropic API auth via
- * `ANTHROPIC_API_KEY` in production and dev alike.
+ * scrub those vars FIRST to ensure we control the auth path.
+ *
+ * Then we set the active backend explicitly:
+ *   - anthropic: ANTHROPIC_API_KEY (direct firstParty auth)
+ *   - bedrock:   CLAUDE_CODE_USE_BEDROCK=1 + AWS_BEARER_TOKEN_BEDROCK
+ *               + AWS_REGION (Bearer-token flow per Loa PR #662)
+ *
+ * AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN are
+ * preserved if present (SigV4 fallback for environments without bearer
+ * token; the SDK auto-detects).
  */
-function buildSdkEnv(config: Config): Record<string, string | undefined> {
+function buildSdkEnv(config: Config, backend: SdkBackend): Record<string, string | undefined> {
   const env: Record<string, string | undefined> = {};
   for (const [k, v] of Object.entries(process.env)) {
     if (k.startsWith('CLAUDE_CODE_') || k === 'CLAUDECODE' || k === 'CLAUDE_PLUGIN_DATA') {
@@ -221,7 +284,26 @@ function buildSdkEnv(config: Config): Record<string, string | undefined> {
     }
     env[k] = v;
   }
-  env.ANTHROPIC_API_KEY = config.ANTHROPIC_API_KEY!;
+
+  if (backend === 'bedrock') {
+    // Activate Bedrock backend. The SDK reads CLAUDE_CODE_USE_BEDROCK
+    // to route through Bedrock instead of api.anthropic.com.
+    env.CLAUDE_CODE_USE_BEDROCK = '1';
+    env.AWS_REGION = config.BEDROCK_TEXT_REGION || config.AWS_REGION;
+    if (config.AWS_BEARER_TOKEN_BEDROCK) {
+      env.AWS_BEARER_TOKEN_BEDROCK = config.AWS_BEARER_TOKEN_BEDROCK;
+    }
+    if (config.BEDROCK_API_KEY && !env.AWS_BEARER_TOKEN_BEDROCK) {
+      // Fallback alias — operator may have set BEDROCK_API_KEY (V0.8.0
+      // shape) instead of AWS_BEARER_TOKEN_BEDROCK (Loa PR #662 shape).
+      env.AWS_BEARER_TOKEN_BEDROCK = config.BEDROCK_API_KEY;
+    }
+    // Explicitly UNSET ANTHROPIC_API_KEY in the subprocess so the SDK
+    // doesn't accidentally route firstParty when bedrock is intended.
+    env.ANTHROPIC_API_KEY = undefined;
+  } else {
+    env.ANTHROPIC_API_KEY = config.ANTHROPIC_API_KEY!;
+  }
   return env;
 }
 
@@ -229,9 +311,28 @@ export async function runOrchestratorQuery(
   config: Config,
   req: OrchestratorRequest,
 ): Promise<OrchestratorResponse> {
-  if (!config.ANTHROPIC_API_KEY) {
+  const backend = resolveOrchestratorBackend(config);
+
+  // Per-backend preflight: anthropic needs ANTHROPIC_API_KEY; bedrock
+  // needs AWS bearer token (or AWS creds for SigV4 fallback). Surface
+  // the missing-credential failure mode loudly rather than silently
+  // routing through with bad auth.
+  if (backend === 'anthropic' && !config.ANTHROPIC_API_KEY) {
     throw new Error(
-      'orchestrator: ANTHROPIC_API_KEY required for SDK path. Set it or switch LLM_PROVIDER to stub/freeside.',
+      'orchestrator: ANTHROPIC_API_KEY required for LLM_PROVIDER=anthropic. ' +
+        'Set ANTHROPIC_API_KEY, switch LLM_PROVIDER to bedrock, or use stub/freeside.',
+    );
+  }
+  if (
+    backend === 'bedrock' &&
+    !config.AWS_BEARER_TOKEN_BEDROCK &&
+    !config.BEDROCK_API_KEY &&
+    !process.env.AWS_ACCESS_KEY_ID
+  ) {
+    throw new Error(
+      'orchestrator: Bedrock backend requires AWS_BEARER_TOKEN_BEDROCK ' +
+        '(per Loa PR #662) OR AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (SigV4 fallback). ' +
+        'None set — set credentials or switch LLM_PROVIDER.',
     );
   }
 
@@ -258,7 +359,7 @@ export async function runOrchestratorQuery(
 
   const options: Options = {
     systemPrompt: req.systemPrompt,
-    model: config.ANTHROPIC_MODEL,
+    model: resolveSdkModel(config, backend),
     mcpServers,
     allowedTools,
     permissionMode: 'dontAsk',
@@ -279,7 +380,7 @@ export async function runOrchestratorQuery(
     // overkill for cron-driven cadence; medium is ~15s/zone. drop to
     // 'low' if voice holds and we want closer to V0.4.5 latency.
     effort: 'medium',
-    env: buildSdkEnv(config),
+    env: buildSdkEnv(config, backend),
     stderr: (data) => {
       if (config.LOG_LEVEL === 'debug') {
         console.error(`[sdk] ${data.trimEnd()}`);


### PR DESCRIPTION
<details open>
<summary>the reorientation: Bedrock IS the provider</summary>

```mermaid
graph LR
  C[LLM_PROVIDER=bedrock<br/>+ AWS_BEARER_TOKEN_BEDROCK] --> R{resolveOrchestratorBackend}
  R -->|bedrock| BE[buildSdkEnv:<br/>CLAUDE_CODE_USE_BEDROCK=1<br/>+ AWS env passthrough]
  BE --> SDK[Anthropic Agent SDK<br/>routes via Bedrock]
  SDK --> M[Opus 4.7 inference profile<br/>us.anthropic.claude-opus-4-7]
  M --> T[mcp__score__* tools fire]
  R -->|anthropic| AE[buildSdkEnv:<br/>ANTHROPIC_API_KEY only]
  AE --> SDK
  classDef ship fill:#1f6f3a,stroke:#0f3d20,color:#fff
  class C,BE,SDK,M,T,AE ship
```
</details>

four prior fixes (v0.9.1, v0.10.0, v0.10.1, v0.11.0) didn't close it because I had the wrong mental model. Bedrock IS the operator's canonical Claude provider per Loa PR #662 — same Opus 4.7, routed via Bedrock. The Anthropic Agent SDK supports Bedrock via `CLAUDE_CODE_USE_BEDROCK=1`. Our orchestrator was hard-wired to STRIP that var to prevent bridge-mode auth, locking out Bedrock entirely.

🟢 fixed · 🟡 needs operator dev-guild deploy + reproduce

**fix layers**:

| layer | change |
|---|---|
| `orchestrator/index.ts` | `resolveOrchestratorBackend(config)` switch on LLM_PROVIDER · `resolveSdkModel(config, backend)` defaults Bedrock to `us.anthropic.claude-opus-4-7` · `buildSdkEnv(config, backend)` activates `CLAUDE_CODE_USE_BEDROCK=1` + AWS env passthrough when bedrock; sets ANTHROPIC_API_KEY otherwise · per-backend preflight replaces blanket guard |
| `compose/reply.ts` | `shouldUseOrchestrator` returns true for `provider in {anthropic, bedrock}` (was anthropic-only). Stub/freeside still naive. |
| `smoke-chat-routing.ts` | matrix updated: `auto + bedrock → orchestrator` (was naive) |

**verify after deploy** (with v0.11.0 telemetry):
- 🟢 `[chat-route] useOrchestrator=true resolvedProvider=bedrock`
- 🟢 `interactions: ruggy/chat tool_uses=1 names=[mcp__score__get_zone_digest] text_len=...`
- 🟢 reply contains real digest data, no JSON-shape leak

**stop merge if**: smoke-chat-routing fails post-rebuild (matrix mismatch) · typecheck regresses

→ [Loa PR #662](https://github.com/0xHoneyJar/loa/pull/662) · jani's Bedrock integration · model IDs + AWS_BEARER_TOKEN_BEDROCK convention
→ [v0.11.0](https://github.com/0xHoneyJar/freeside-characters/releases/tag/v0.11.0) · the telemetry that confirmed H2
→ [kickoff brief](https://github.com/0xHoneyJar/freeside-characters/blob/main/grimoires/loa/specs/kickoff-tool-call-faking-investigation-2026-05-02.md) · session-09 DIG

🤖 Generated with [Claude Code](https://claude.com/claude-code)