### PR TITLE
fix(orchestrator): accumulate assistant text · fallback when result empty

### DIFF
--- a/packages/persona-engine/src/orchestrator/index.ts
+++ b/packages/persona-engine/src/orchestrator/index.ts
@@ -402,21 +402,28 @@ export async function runOrchestratorQuery(
   };
 
   let text = '';
+  let accumulatedAssistantText = '';
   let usage: Record<string, unknown> | undefined;
   const toolUses: ToolUseEvent[] = [];
 
   // V0.7-A.1 streaming refactor (pattern: ruggy-v2/src/agent.ts):
   // We previously skipped every event except `result.success`, which made
-  // mid-flight tool_use blocks invisible. Now we extract tool_use from
-  // `assistant` messages so the dispatcher can surface them to Discord
-  // (and trajectory logs see what the LLM actually invoked vs narrated).
-  // Final synthesized text still comes from `result.success.result` —
-  // pre-tool-call narration accumulated mid-stream is intentionally not
-  // returned to the caller (the SDK handles synthesis after tool round-trip).
+  // mid-flight tool_use blocks invisible. Now we extract tool_use AND text
+  // from `assistant` messages so the dispatcher can surface tools to Discord
+  // AND we have a fallback when `result.success.result` comes back empty
+  // (observed on Bedrock-routed responses post-V0.11.1: SDK reports success
+  // but the result field is empty even though the LLM produced text in
+  // assistant turns · ruggy-v2 has shipped this fallback pattern for months).
   for await (const message of query({ prompt: req.userMessage, options })) {
     if (message.type === 'assistant') {
       for (const block of message.message.content) {
-        if (block.type === 'tool_use') {
+        if (block.type === 'text') {
+          // V0.11.2: accumulate text from each assistant turn (ruggy-v2 pattern).
+          // The final synthesis turn lands here even when the SDK doesn't
+          // populate `result.success.result` — Bedrock-routed responses
+          // sometimes leave the result field empty.
+          accumulatedAssistantText += block.text;
+        } else if (block.type === 'tool_use') {
           const event: ToolUseEvent = {
             name: block.name,
             id: block.id,
@@ -437,7 +444,7 @@ export async function runOrchestratorQuery(
     if (message.type !== 'result') continue;
 
     if (message.subtype === 'success') {
-      text = message.result;
+      text = message.result || '';
       usage = {
         duration_ms: message.duration_ms,
         duration_api_ms: message.duration_api_ms,
@@ -456,8 +463,26 @@ export async function runOrchestratorQuery(
     );
   }
 
+  // V0.11.2: fallback chain. If the SDK's `result.success.result` came
+  // back empty (observed on Bedrock-routed multi-tool responses), use the
+  // text accumulated from assistant turns — that's where the LLM's actual
+  // output lives. Only throw when BOTH paths produced nothing.
+  if (!text && accumulatedAssistantText) {
+    console.warn(
+      `orchestrator: result.success.result was empty; falling back to ` +
+        `accumulated assistant text (${accumulatedAssistantText.length} chars · ` +
+        `${toolUses.length} tool_uses)`,
+    );
+    text = accumulatedAssistantText;
+  }
+
   if (!text) {
-    throw new Error('orchestrator: SDK query completed without an assistant text response');
+    throw new Error(
+      'orchestrator: SDK query completed without an assistant text response. ' +
+        `tool_uses=${toolUses.length} accumulated_text_length=0. ` +
+        'Likely causes: maxTurns hit before synthesis · model returned no text · ' +
+        'Bedrock auth/model-ID mismatch.',
+    );
   }
 
   return { text, meta: usage, toolUses };


### PR DESCRIPTION
<details open>
<summary>v0.11.1 worked · new failure mode</summary>

```mermaid
graph LR
  A[v0.11.1 Bedrock fix] --> B[3 tool_use events fired ✓]
  B --> C{result.success.result}
  C -->|empty · Bedrock quirk| E[orchestrator throws]
  C -->|has text| OK[reply lands]
  D[v0.11.2 fix] -.->|accumulate assistant text| F[fallback chain]
  F --> OK
  classDef ship fill:#1f6f3a,stroke:#0f3d20,color:#fff
  classDef bug fill:#7a1f1f,stroke:#3d0f0f,color:#fff
  class A,B,F,OK ship
  class C,E bug
```
</details>

v0.11.1 unblocked Bedrock chat-mode tool calling — three tool_use events fired (`mcp__score__get_zone_digest` + 2x `mcp__emojis__*`) ✓. But the orchestrator threw at `index.ts:460` because `message.result` came back empty after the multi-tool round-trip. Bedrock-routed responses sometimes leave the result field empty even when the LLM produced text in assistant turns.

🟢 fixed · 🟡 needs operator dev-guild deploy

**root cause**: our orchestrator only read `result.success.result` (PR #8 streaming refactor). ruggy-v2's pattern accumulates text from EACH assistant.message.content[] block AND falls back to accumulated text when result is empty. We didn't accumulate; we just threw.

**fix** (matches ruggy-v2 `src/agent.ts:367-384`):
```ts
if (block.type === 'text') {
  accumulatedAssistantText += block.text;
}
// ...
text = message.result || accumulatedAssistantText;
```

Only throw when BOTH paths produced nothing. Error message now includes toolUses count + accumulated_text_length for future diagnostics.

**verify after deploy**:
- 🟢 tool_uses fire (already working post-v0.11.1)
- 🟢 LLM synthesizes text in assistant turn(s) → accumulated
- 🟢 fallback uses accumulated when result empty → user sees real digest data

**also for the operator** — codex MCP setup:
```
CODEX_MCP_URL=https://mcp.0xhoneyjar.xyz/codex
```
NOT `https://mcp.0xhoneyjar.xyz/codex/mcp` — our code at `orchestrator/index.ts:149` appends `/mcp` to the env value. The full URL `https://mcp.0xhoneyjar.xyz/codex/mcp` you pasted is what the SDK will hit; the env var holds the BASE.

→ pattern: [ruggy-v2 src/agent.ts:367-384](https://github.com/0xHoneyJar/ruggy-v2/blob/main/src/agent.ts#L367-L384)
→ [v0.11.1](https://github.com/0xHoneyJar/freeside-characters/releases/tag/v0.11.1) · the fix this builds on

🤖 Generated with [Claude Code](https://claude.com/claude-code)