### PR TITLE
Customize imagegen Discord caption

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -468,7 +468,8 @@ async function doReplyImagegen(args: AsyncWorkerArgs): Promise<void> {
           );
         }
 
-        const caption = formatImagegenCaption(character, result, prompt, invoker.username);
+        const caption = `${character.displayName ?? character.id} in Freeside`;
+
         await sendImageReplyViaWebhook(webhook, character, {
           content: caption,
           imageBytes,


### PR DESCRIPTION
Updates the Discord imagegen caption so generated images no longer show model/seed metadata.