### PR TITLE
fix(deliver): V0.7-A.4 cap mistune + hermes 403 (PR #24 follow-up)

### DIFF
--- a/packages/persona-engine/src/deliver/embed-with-image.test.ts
+++ b/packages/persona-engine/src/deliver/embed-with-image.test.ts
@@ -94,7 +94,9 @@ describe('composeWithImage · happy path', () => {
         {
           ref: '@g4488',
           name: 'Satoshi-as-Hermes',
-          image_url: 'https://assets.0xhoneyjar.xyz/Mibera/grails/hermes.PNG',
+          // V0.7-A.4 patch (2026-05-03): was hermes.PNG (403); flipped to
+          // mercury.png to mirror CANONICAL_GRAIL_URLS source change.
+          image_url: 'https://assets.0xhoneyjar.xyz/Mibera/grails/mercury.png',
         },
       ],
     );
@@ -104,7 +106,7 @@ describe('composeWithImage · happy path', () => {
     expect(result.files![0]!.name).toBe('g4488.png');
     // F10 polish: attachedUrls reflects image_url alt-key URL too
     expect(result.attachedUrls).toEqual([
-      'https://assets.0xhoneyjar.xyz/Mibera/grails/hermes.PNG',
+      'https://assets.0xhoneyjar.xyz/Mibera/grails/mercury.png',
     ]);
   });
 });
@@ -289,12 +291,15 @@ describe('composeWithImage · F5 SSRF graceful degrade', () => {
 
 describe('composeWithImage · F6 size cap', () => {
   test('content-length above cap returns text-only', async () => {
+    // V0.7-A.4 patch (2026-05-03): cap bumped 8MB → 12MB to accept measured
+    // 9MB grails (`greek.png` PROD evidence · STAMETS DIG). Test size bumped
+    // to 13MB to still exercise the rejection path.
     globalThis.fetch = mock(async () => {
       return new Response(PNG_MAGIC as unknown as BodyInit, {
         status: 200,
         headers: {
           'Content-Type': 'image/png',
-          'Content-Length': String(9 * 1024 * 1024), // 9MB > 8MB cap
+          'Content-Length': String(13 * 1024 * 1024), // 13MB > 12MB cap
         },
       });
     }) as unknown as typeof globalThis.fetch;
@@ -308,9 +313,10 @@ describe('composeWithImage · F6 size cap', () => {
   });
 
   test('post-fetch byteLength above cap returns text-only (no Content-Length)', async () => {
-    // Server omits Content-Length but ships >8MB body. The post-arrayBuffer
+    // Server omits Content-Length but ships >12MB body. The post-arrayBuffer
     // belt-and-braces check should trip and degrade.
-    const oversize = new Uint8Array(9 * 1024 * 1024); // 9MB, all zeros
+    // V0.7-A.4 patch (2026-05-03): bumped to 13MB to clear the new 12MB cap.
+    const oversize = new Uint8Array(13 * 1024 * 1024); // 13MB, all zeros
     globalThis.fetch = mock(async () => {
       return new Response(oversize as unknown as BodyInit, {
         status: 200,
@@ -324,6 +330,38 @@ describe('composeWithImage · F6 size cap', () => {
     );
     expect(result.content).toBe('reply.');
     expect(result.files).toBeUndefined();
+  });
+
+  test('V0.7-A.4 patch: 9MB image accepted under new 12MB cap (PROD regression)', async () => {
+    // V0.7-A.4 patch (2026-05-03 · cycle-A · STAMETS DIG): PROD log evidence
+    // showed `greek.png` 9.0MB rejected at the prior 8MB cap →
+    // `[embed-with-image] rejected oversize image (content-length 9003216 >
+    // 8388608)` → `attached=0` even when the LLM correctly resolved a grail.
+    // The 12MB cap MUST accept this case. Pre-fix this test would have failed
+    // (rejected as oversize); post-fix it passes — proves the cap is sized
+    // for the actual substrate.
+    const ninemb = new Uint8Array(9 * 1024 * 1024); // 9MB, mimics greek.png
+    globalThis.fetch = mock(async () => {
+      return new Response(ninemb as unknown as BodyInit, {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/png',
+          'Content-Length': String(9 * 1024 * 1024),
+        },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await composeWithImage(
+      'reply.',
+      [{ ref: '@g876', image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/greek.png' }],
+    );
+    expect(result.content).toBe('reply.');
+    expect(result.files).toBeDefined();
+    expect(result.files!.length).toBe(1);
+    expect(result.files![0]!.data.byteLength).toBe(9 * 1024 * 1024);
+    expect(result.attachedUrls).toEqual([
+      'https://assets.0xhoneyjar.xyz/Mibera/grails/greek.png',
+    ]);
   });
 });
 

--- a/packages/persona-engine/src/deliver/embed-with-image.ts
+++ b/packages/persona-engine/src/deliver/embed-with-image.ts
@@ -111,8 +111,14 @@ const DEFAULT_FETCH_TIMEOUT_MS = 5000;
  */
 const ALLOWED_SCHEMES = new Set(['https:']);
 const ALLOWED_IMAGE_HOSTS = new Set(['assets.0xhoneyjar.xyz']);
-/** 8MB — well under Discord's 25MB single-attachment cap; per spec §2 invariant 6. */
-const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+/** 12MB — well under Discord's 25MB single-attachment cap; per spec §2 invariant 6.
+ *  V0.7-A.4 patch (2026-05-03): bumped 8MB → 12MB after PROD log evidence
+ *  (cycle-A · STAMETS DIG) showed `greek.png` 9.0MB rejected at 8MB cap →
+ *  `attached=0` even when LLM correctly resolved a grail. Measured grail set
+ *  ranges 5-9MB; 12MB covers worst case with headroom for Cycle B variant
+ *  rollout. Discord per-attachment limit is 25MB free / 100MB Nitro · 12MB
+ *  is comfortably under. Mirrored in grail-cache.ts MAX_PREFETCH_BYTES. */
+const MAX_ATTACHMENT_BYTES = 12 * 1024 * 1024;
 
 /**
  * Allowlist gate for image URLs sourced from external tool results.

--- a/packages/persona-engine/src/deliver/grail-cache.test.ts
+++ b/packages/persona-engine/src/deliver/grail-cache.test.ts
@@ -168,17 +168,19 @@ describe('initGrailCache · failures are non-blocking', () => {
   });
 
   test('F3 follow-up: oversize Content-Length response counts as failed', async () => {
-    // F3 follow-up (2026-05-02): boot prefetch now caps per-entry at 5MB
-    // (defense-in-depth · mirrors live-fetch path). Pre-fix the prefetch
-    // would store any size verbatim, breaking memory residency claims at
-    // V1.5 scale. Post-fix oversize Content-Length is rejected before
-    // arrayBuffer.
+    // F3 follow-up (2026-05-02): boot prefetch caps per-entry (defense-in-depth ·
+    // mirrors live-fetch path). Pre-fix the prefetch would store any size
+    // verbatim, breaking memory residency claims at V1.5 scale. Post-fix
+    // oversize Content-Length is rejected before arrayBuffer.
+    // V0.7-A.4 patch (2026-05-03): cap bumped 5MB → 12MB to cover measured
+    // 5-9MB grail set (PROD log evidence · STAMETS DIG). Test sizes bumped
+    // to still exercise the rejection path under the new cap.
     globalThis.fetch = mock(async () => {
       return new Response(PNG_MAGIC as unknown as BodyInit, {
         status: 200,
         headers: {
           'Content-Type': 'image/png',
-          'Content-Length': String(6 * 1024 * 1024), // 6MB > 5MB cap
+          'Content-Length': String(13 * 1024 * 1024), // 13MB > 12MB cap
         },
       });
     }) as unknown as typeof globalThis.fetch;
@@ -193,7 +195,8 @@ describe('initGrailCache · failures are non-blocking', () => {
   test('F3 follow-up: oversize body without Content-Length rejected (belt-and-braces)', async () => {
     // Some CDNs omit Content-Length on chunked transfers; the post-arrayBuffer
     // byteLength check catches that case.
-    const oversize = new Uint8Array(6 * 1024 * 1024); // 6MB, all zeros
+    // V0.7-A.4 patch (2026-05-03): bumped to 13MB to clear the new 12MB cap.
+    const oversize = new Uint8Array(13 * 1024 * 1024); // 13MB, all zeros
     globalThis.fetch = mock(async () => {
       return new Response(oversize as unknown as BodyInit, {
         status: 200,
@@ -206,6 +209,59 @@ describe('initGrailCache · failures are non-blocking', () => {
     expect(result.fetched).toBe(0);
     expect(result.failed).toBe(1);
     expect(_grailCacheSizeForTests()).toBe(0);
+  });
+
+  test('V0.7-A.4 patch: 9MB grail accepted under new 12MB cap (PROD regression)', async () => {
+    // V0.7-A.4 patch (2026-05-03 · cycle-A · STAMETS DIG): PROD log evidence
+    // showed 6/7 grails rejected at the prior 5MB cap because measured grail
+    // PNGs are 5-9MB. The 12MB cap MUST accept the worst-measured case
+    // (`greek.png` 9.0MB) AND a representative grail (`black-hole.png` 6.4MB).
+    // Pre-fix this test would have failed (rejected as oversize); post-fix it
+    // passes — proves the cap is sized for the actual substrate.
+    const ninemb = new Uint8Array(9 * 1024 * 1024); // 9MB, mimics greek.png
+    globalThis.fetch = mock(async () => {
+      return new Response(ninemb as unknown as BodyInit, {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/png',
+          'Content-Length': String(9 * 1024 * 1024),
+        },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await initGrailCache({ urls: [TEST_URL] });
+
+    expect(result.fetched).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(_grailCacheSizeForTests()).toBe(1);
+    expect(getGrailBytes(TEST_URL)?.byteLength).toBe(9 * 1024 * 1024);
+  });
+});
+
+describe('CANONICAL_GRAIL_URLS · V0.7-A.4 patch (hermes 403 → mercury fix)', () => {
+  test('mercury.png is in the canonical V1 list (Roman name for Hermes · #4488)', () => {
+    // V0.7-A.4 patch (2026-05-03): hermes.PNG returned 403 from S3 in PROD
+    // (file genuinely doesn't exist). Replaced with mercury.png (Roman name
+    // for the same archetype, grail #4488 Satoshi-as-Hermes) — verified 200
+    // at 6.8MB. Cycle B URL canonicalization will replace this hardcoded
+    // patch with substrate-discovered URLs.
+    const urls = _canonicalGrailUrlsForTests();
+    expect(
+      urls.includes('https://assets.0xhoneyjar.xyz/Mibera/grails/mercury.png'),
+    ).toBe(true);
+  });
+
+  test('hermes.PNG is NOT in the canonical V1 list (was 403 in PROD)', () => {
+    // Asserts the broken URL stays out — guards against an accidental revert
+    // of the V0.7-A.4 patch. If a future contributor re-adds hermes.PNG, this
+    // test will catch it before another PROD prefetch failure.
+    const urls = _canonicalGrailUrlsForTests();
+    expect(
+      urls.includes('https://assets.0xhoneyjar.xyz/Mibera/grails/hermes.PNG'),
+    ).toBe(false);
+    expect(
+      urls.includes('https://assets.0xhoneyjar.xyz/Mibera/grails/hermes.png'),
+    ).toBe(false);
   });
 });
 

--- a/packages/persona-engine/src/deliver/grail-cache.ts
+++ b/packages/persona-engine/src/deliver/grail-cache.ts
@@ -58,18 +58,20 @@ const cache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Per-entry size cap for boot prefetch (F3 follow-up · 2026-05-02).
+ * Per-entry size cap for boot prefetch (F3 follow-up · 2026-05-02 ·
+ * V0.7-A.4 patch 2026-05-03).
  * Mirrors the live-fetch path's MAX_ATTACHMENT_BYTES guard in
- * `embed-with-image.ts`: any boot fetch >5MB is dropped before landing in
+ * `embed-with-image.ts`: any boot fetch >12MB is dropped before landing in
  * cache. The hardcoded V1 URL list is on the trusted CDN so this is a
  * defense-in-depth bound, not a primary defense — when V1.5 swaps in
  * dynamic discovery via `mcp__codex__list_archetypes`, the cap becomes
  * load-bearing because the URL list will originate from substrate-mutable
- * input. Stays below the 8MB live-fetch cap because boot is a budget
- * window (~10s for 7 URLs) and a single oversize entry would skew the
- * memory residency claim.
+ * input. V0.7-A.4 PROD log evidence (cycle-A · STAMETS DIG): measured grail
+ * set 5-9MB · prior 5MB cap rejected 6/7 grails at boot · bumped to 12MB
+ * to cover worst case + headroom. Stays at parity with live-fetch
+ * MAX_ATTACHMENT_BYTES.
  */
-const MAX_PREFETCH_BYTES = 5 * 1024 * 1024;
+const MAX_PREFETCH_BYTES = 12 * 1024 * 1024;
 
 /** Guard against multiple boot prefetches racing each other (e.g. dev-mode
  *  HMR or test reentrance). Holds the in-flight Promise; cleared once the
@@ -116,7 +118,9 @@ const CANONICAL_GRAIL_URLS: ReadonlyArray<string> = [
   // 876  Black Hole (concept) — V0.7-A.3 SC1 reference
   'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.png',
   // 4488 Satoshi-as-Hermes (ancestor) — V0.7-A.3 SC2 reference
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/hermes.PNG',
+  // V0.7-A.4 patch: hermes.PNG was 403; mercury.png (Roman name for Hermes)
+  // verified 200 · Cycle B URL canonicalization will replace this
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/mercury.png',
   // 235  Scorpio (zodiac) — V0.7-A.3 §11 transformation regression
   'https://assets.0xhoneyjar.xyz/Mibera/grails/scorpio.png',
   // 6458 Fire (element) — V0.7-A.3 §11 transformation regression


### PR DESCRIPTION
## tldr

PROD log evidence on 2026-05-03 showed V0.7-A.4 grail-cache (PR #24 squash 1eddb60) failing immediately after deploy. 3 distinct faults compounding. This is the tactical Cycle A patch — keeps bot replying with images while substrate Cycle B matures at `freeside-storage`.

## evidence

Surface 1 — boot prefetch (railway logs · service \"freeside characters\" · env=production):

```
[grail-cache] prefetch oversize (content-length 6389884 > 5242880) url=...black-hole.png
[grail-cache] prefetch failed status=403 url=...hermes.PNG
[grail-cache] prefetch oversize ... scorpio.png past.png fire.png aquarius.png
grail-cache: init 1/7 (V1 subset) cached in 898ms (6 failed · live-fetch fallback)
```

Surface 2 — cold-budget telemetry (ruggy first cold call after deploy):

```
[embed-with-image] rejected oversize image (content-length 9003216 > 8388608): ...greek.png
[cold-budget] character=ruggy compose_ms=25015 total_ms=25554 attached=0 cache_hits=0
```

Spec said: `init 7/7 cached in <10s · cache_hits=1 · attached=1 · cold compose_ms <15000`. Actual: `1/7 cached · cache_hits=0 · attached=0 · 25015ms`. Clear regression vs PR #24 intended behavior.

## root cause cluster (3 faults)

| # | fault | scope |
|---|---|---|
| 1 | `MAX_PREFETCH_BYTES=5MB` cap rejects 5/7 grails (measured 5-9MB) | `grail-cache.ts:72` |
| 2 | `CANONICAL_GRAIL_URLS` contains `hermes.PNG` (404 from S3) | `grail-cache.ts:119` |
| 3 | `MAX_ATTACHMENT_BYTES=8MB` cap rejects `greek.png` (9.0MB) on live-fetch | `embed-with-image.ts:115` |

Substrate truth (curl HEAD against `assets.0xhoneyjar.xyz`):

| URL | HTTP | Bytes |
|---|---|---|
| `black-hole.png` | 200 | 6.4 MB |
| `hermes.png` / `hermes.PNG` | 403 | — |
| `mercury.png` | 200 | 6.8 MB |
| `scorpio.png` | 200 | 6.6 MB |
| `fire.png` | 200 | 6.3 MB |
| `past.png` | 200 | 6.5 MB |
| `aquarius.png` | 200 | 6.1 MB |
| `pluto.png` | 200 | 5.0 MB |
| `greek.png` | 200 | 9.0 MB |

Mercury is the Roman name for Hermes — canonical for grail #4488 Satoshi-as-Hermes.

## bundle (3 surgical changes · 1 PR)

**Change 1** — `packages/persona-engine/src/deliver/grail-cache.ts:72`
`MAX_PREFETCH_BYTES`: `5 * 1024 * 1024` → `12 * 1024 * 1024`

**Change 2** — `packages/persona-engine/src/deliver/embed-with-image.ts:115`
`MAX_ATTACHMENT_BYTES`: `8 * 1024 * 1024` → `12 * 1024 * 1024`

**Change 3** — `packages/persona-engine/src/deliver/grail-cache.ts:119`
`hermes.PNG` (403) → `mercury.png` (200) + inline comment naming the patch as Cycle B URL-canonicalization successor

12MB ceiling chosen because Discord per-attachment limit is 25MB free / 100MB Nitro · comfortably under, with headroom for Cycle B variant rollout.

## tests

- 53/53 deliver tests pass · 193/193 persona-engine · 46/46 bot · `bun run typecheck` green
- Existing F3 (boot) + F6 (live-fetch) cap rejection tests bumped to 13MB to still exercise the rejection path under the new 12MB cap
- Existing `image_url` happy-path test fixture flipped to `mercury.png` to mirror canonical source change
- 4 new regression tests:
  - `V0.7-A.4 patch: 9MB grail accepted under new 12MB cap (PROD regression)` (boot path)
  - `V0.7-A.4 patch: 9MB image accepted under new 12MB cap (PROD regression)` (live-fetch path)
  - `mercury.png is in the canonical V1 list (Roman name for Hermes · #4488)`
  - `hermes.PNG is NOT in the canonical V1 list (was 403 in PROD)` — guard against revert

## Cycle B coupling note

Substrate extraction is in parallel at `~/Documents/GitHub/freeside-storage` (`/plan-and-analyze` for `@freeside-storage/asset-pipeline` Effect-Schema/Service). Cycle B will replace this hardcoded patch with substrate-discovered URLs:

- `AssetService.fetchOptimal(ref, constraints)` returns canonical-URL-resolved bytes
- Variant transforms (sharp inline OR generate-once-and-mirror) move sizing concerns out of consumers
- `grail-cache.ts` becomes a thin consumer of `AssetService.fetchOptimal`
- First migration target after substrate ships

Cycle A (this PR) is tactical · stops the bleeding while substrate matures.

## V0.7-A.5 status

PARKED until this lands. Multi-image cycle cannot fire until the cache is functional (cache_hits>0 on cold call) — STAMETS DIG row 2 vs row 3 fork remains open until post-deploy telemetry confirms whether Bedrock/qmd is the dominant remaining contributor.

## evidence artifacts

- `grimoires/loa/qa/captures/V07A4/STAMETS-decision-2026-05-03.md` — full root cause + decision tree
- `grimoires/loa/qa/captures/V07A4/surface-1-boot-prefetch-PROD.txt` — boot prefetch evidence
- `grimoires/loa/qa/captures/V07A4/surface-2-cold-budget-PROD.txt` — cold-budget telemetry evidence

## verification after merge

1. Redeploy via Railway (auto-deploy on merge to main)
2. Tail boot logs for `init 7/7 cached` (target — was `1/7` pre-fix)
3. `/satoshi` cold call → confirm `cache_hits>0 attached>0 compose_ms<15000`
4. If `compose_ms` still ~25s with `cache_hits>0`, STAMETS DIG row 2 fires → defer V0.7-A.5, investigate Bedrock/qmd cold cycle
5. If `compose_ms<15000` with `cache_hits>0`, STAMETS DIG row 1 closes → V0.7-A.5 unparks

Operator session register: /smol

🤖 Generated with [Claude Code](https://claude.com/claude-code)