### PR TITLE
fix(deliver): prefer .webp variants (CMP-boundary finding 4)

### DIFF
--- a/packages/persona-engine/src/deliver/embed-with-image.test.ts
+++ b/packages/persona-engine/src/deliver/embed-with-image.test.ts
@@ -94,11 +94,12 @@ describe('composeWithImage · happy path', () => {
         {
           ref: '@g4488',
           name: 'Satoshi-as-Hermes',
-          // V0.7-A.4 patch (2026-05-03): was hermes.PNG (403); hotfix flipped
-          // to canonical satoshi-as-hermes.png per persona.md + codex-anchors
-          // (mercury was wrong file · property of #4488 not the filename).
-          // CMP-boundary 2026-05-04: subsequently flipped .png → .webp
-          // ([[chat-medium-presentation-boundary]] doctrine finding 4 · ~50× smaller).
+          // Canonical satoshi-as-hermes.webp per persona.md + codex-anchors.
+          // History: hermes.PNG returned 403 (V0.7-A.4 cycle-A); 2026-05-03
+          // hotfix flipped to satoshi-as-hermes.png (mercury was wrong file —
+          // property of #4488, not the filename); 2026-05-04 CMP-boundary
+          // flipped .png → .webp ([[chat-medium-presentation-boundary]]
+          // doctrine finding 4 · ~50× smaller).
           image_url: 'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp',
         },
       ],

--- a/packages/persona-engine/src/deliver/embed-with-image.test.ts
+++ b/packages/persona-engine/src/deliver/embed-with-image.test.ts
@@ -68,7 +68,7 @@ describe('composeWithImage · happy path', () => {
         {
           ref: '@g876',
           name: 'Black Hole',
-          image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.png',
+          image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp',
         },
       ],
     );
@@ -76,12 +76,12 @@ describe('composeWithImage · happy path', () => {
     expect(result.content).toBe('voice text here.');
     expect(result.files).toBeDefined();
     expect(result.files!.length).toBe(1);
-    expect(result.files![0]!.name).toBe('g876.png');
-    expect(result.files![0]!.contentType).toBe('image/png');
+    expect(result.files![0]!.name).toBe('g876.webp');
+    expect(result.files![0]!.contentType).toBe('image/webp');
     expect(result.files![0]!.data.byteLength).toBeGreaterThan(0);
     // F10 polish: attachedUrls present + matches the source URL of the file
     expect(result.attachedUrls).toEqual([
-      'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.png',
+      'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp',
     ]);
   });
 
@@ -97,17 +97,17 @@ describe('composeWithImage · happy path', () => {
           // V0.7-A.4 patch (2026-05-03): was hermes.PNG (403); hotfix flipped
           // to canonical satoshi-as-hermes.png per persona.md + codex-anchors
           // (mercury was wrong file · property of #4488 not the filename).
-          image_url: 'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.png',
+          image_url: 'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp',
         },
       ],
     );
 
     expect(result.files).toBeDefined();
     expect(result.files!.length).toBe(1);
-    expect(result.files![0]!.name).toBe('g4488.png');
+    expect(result.files![0]!.name).toBe('g4488.webp');
     // F10 polish: attachedUrls reflects image_url alt-key URL too
     expect(result.attachedUrls).toEqual([
-      'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.png',
+      'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp',
     ]);
   });
 });
@@ -371,7 +371,7 @@ describe('composeWithImage · F6 size cap', () => {
 // ──────────────────────────────────────────────────────────────────────
 
 describe('composeWithImage · V0.7-A.4 cache-first fast path', () => {
-  const CACHED_URL = 'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.png';
+  const CACHED_URL = 'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp';
   const CACHED_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xde, 0xad, 0xbe, 0xef]);
 
   test('cache hit returns cached bytes WITHOUT invoking fetch', async () => {

--- a/packages/persona-engine/src/deliver/embed-with-image.test.ts
+++ b/packages/persona-engine/src/deliver/embed-with-image.test.ts
@@ -97,6 +97,8 @@ describe('composeWithImage · happy path', () => {
           // V0.7-A.4 patch (2026-05-03): was hermes.PNG (403); hotfix flipped
           // to canonical satoshi-as-hermes.png per persona.md + codex-anchors
           // (mercury was wrong file · property of #4488 not the filename).
+          // CMP-boundary 2026-05-04: subsequently flipped .png → .webp
+          // ([[chat-medium-presentation-boundary]] doctrine finding 4 · ~50× smaller).
           image_url: 'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp',
         },
       ],
@@ -372,6 +374,11 @@ describe('composeWithImage · F6 size cap', () => {
 
 describe('composeWithImage · V0.7-A.4 cache-first fast path', () => {
   const CACHED_URL = 'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp';
+  // Arbitrary opaque sentinel bytes for cache-hit assertion. NOT format-bearing —
+  // the test asserts byte-equality of the round-trip (cache → composer output),
+  // never that the bytes are valid WebP. Using PNG-magic prefix + 0xdeadbeef keeps
+  // the sentinel visually distinctive in test failures. (CMP-boundary
+  // bridgebuilder F3 LOW · 2026-05-04 · clarification not behavior change.)
   const CACHED_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xde, 0xad, 0xbe, 0xef]);
 
   test('cache hit returns cached bytes WITHOUT invoking fetch', async () => {

--- a/packages/persona-engine/src/deliver/grail-cache.test.ts
+++ b/packages/persona-engine/src/deliver/grail-cache.test.ts
@@ -238,16 +238,16 @@ describe('initGrailCache · failures are non-blocking', () => {
   });
 });
 
-describe('CANONICAL_GRAIL_URLS · V0.7-A.4 patch (hermes 403 → satoshi-as-hermes fix)', () => {
-  test('satoshi-as-hermes.png is in the canonical V1 list (#4488)', () => {
-    // V0.7-A.4 patch (2026-05-03): hermes.PNG returned 403 from S3 in PROD.
-    // Hotfix later that day flipped to canonical satoshi-as-hermes.png per
-    // apps/character-satoshi/persona.md + codex-anchors.md (mercury was a
-    // PROPERTY of #4488 · not the filename). Verified 200 at 7.4MB. Cycle B
-    // URL canonicalization will replace this hardcoded patch.
+describe('CANONICAL_GRAIL_URLS · CMP-boundary 2026-05-04 webp prefer', () => {
+  test('satoshi-as-hermes.webp is in the canonical V1 list (#4488)', () => {
+    // CMP-boundary 2026-05-04 hotfix per [[chat-medium-presentation-boundary]]
+    // doctrine finding 4 · CANONICAL_GRAIL_URLS flipped .png to .webp · ~50x win.
+    // V0.7-A.4 patch history (2026-05-03): hermes.PNG returned 403 from S3 in
+    // PROD. Hotfix flipped to canonical satoshi-as-hermes.png. CMP-boundary
+    // hotfix flipped extension to .webp (verified 200 · 361KB · was 7.4MB PNG).
     const urls = _canonicalGrailUrlsForTests();
     expect(
-      urls.includes('https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.png'),
+      urls.includes('https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp'),
     ).toBe(true);
   });
 

--- a/packages/persona-engine/src/deliver/grail-cache.ts
+++ b/packages/persona-engine/src/deliver/grail-cache.ts
@@ -124,6 +124,17 @@ const CANONICAL_GRAIL_URLS: ReadonlyArray<string> = [
   // still work. Cycle B asset-pipeline AssetService.fetchOptimal({acceptFormats:['webp','png']})
   // is the architectural-grade replacement for this hardcoded preference.
   //
+  // Pre-merge verification (CMP-boundary bridgebuilder F1 HIGH · 2026-05-04):
+  // all 7 URLs verified HTTP 200 · content-type image/webp · sizes match comment
+  // (curl HEAD per URL). CDN: CloudFront · Cache-Control: immutable max-age=1y.
+  // Operational expectation: the asset pipeline (manually managed in V1; Cycle B
+  // AssetService in V1.5+) MUST guarantee both .webp + .png variants exist at
+  // canonical paths. If a .webp variant is removed/regenerated incorrectly, the
+  // boot-prefetch warns (see prefetchOne) but the cache-miss live-fetch path will
+  // ALSO fail (no .webp→.png fallback in V1) — operator MUST regenerate the .webp
+  // or revert this constant to .png. V1.5 fetchOptimal({acceptFormats}) makes this
+  // resilient via per-entry format negotiation.
+  //
   // 876  Black Hole (concept) — V0.7-A.3 SC1 reference
   'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp',
   // 4488 Satoshi-as-Hermes (ancestor) — V0.7-A.3 SC2 reference
@@ -262,8 +273,14 @@ async function prefetchOne(url: string, timeoutMs: number): Promise<boolean> {
       redirect: 'error',
     });
     if (!res.ok) {
+      // F2 follow-up (CMP-boundary 2026-05-04): louder warning for canonical
+      // URL miss. V1 has no .webp→.png fallback (Cycle B AssetService territory),
+      // so a 404/403 here means the cache-miss live-fetch path will ALSO fail
+      // and the bot will deliver text-only for this grail. Operator MUST
+      // regenerate the missing variant or revert CANONICAL_GRAIL_URLS.
       console.warn(
-        `[grail-cache] prefetch failed status=${res.status} url=${url}`,
+        `[grail-cache] CANONICAL prefetch failed · status=${res.status} url=${url} ` +
+          `· no fallback in V1 · regenerate variant or revert constant`,
       );
       return false;
     }

--- a/packages/persona-engine/src/deliver/grail-cache.ts
+++ b/packages/persona-engine/src/deliver/grail-cache.ts
@@ -115,24 +115,33 @@ let initInFlight: Promise<InitResult> | null = null;
  * unreachable at boot.
  */
 const CANONICAL_GRAIL_URLS: ReadonlyArray<string> = [
+  // CMP-boundary 2026-05-04: flipped .png → .webp · per [[chat-medium-presentation-boundary]]
+  // doctrine finding 4. WebP variants exist at canonical paths · ~50× smaller.
+  // Sizes: black-hole 121KB · satoshi-as-hermes 361KB · scorpio 212KB · fire 83KB ·
+  // past 121KB · pluto 64KB · aquarius 229KB → ~1.2MB total cache (was ~50MB+ as PNGs).
+  // Discord renders WebP natively · zero visual change · resolves V07A4 cap-mistune
+  // tail concerns. MAX_BYTES_PER_ENTRY stays at 12MB so future PNG-format additions
+  // still work. Cycle B asset-pipeline AssetService.fetchOptimal({acceptFormats:['webp','png']})
+  // is the architectural-grade replacement for this hardcoded preference.
+  //
   // 876  Black Hole (concept) — V0.7-A.3 SC1 reference
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.png',
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp',
   // 4488 Satoshi-as-Hermes (ancestor) — V0.7-A.3 SC2 reference
   // hotfix 2026-05-03: Cycle A initially used mercury.png (wrong file ·
   // mercury is a PROPERTY of #4488, not the filename). Canonical per
   // apps/character-satoshi/persona.md:7,11 + codex-anchors.md is
-  // satoshi-as-hermes.png. Cycle B URL canonicalization replaces this.
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.png',
+  // satoshi-as-hermes. Cycle B URL canonicalization replaces this.
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp',
   // 235  Scorpio (zodiac) — V0.7-A.3 §11 transformation regression
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/scorpio.png',
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/scorpio.webp',
   // 6458 Fire (element) — V0.7-A.3 §11 transformation regression
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/fire.png',
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/fire.webp',
   // 4221 Past (concept) — V0.7-A.3 SC3 cite
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/past.png',
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/past.webp',
   // 1606 Pluto (planet) — V0.7-A.3 SC2 cite
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/pluto.png',
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/pluto.webp',
   // 6805 Aquarius (zodiac) — V0.7-A.3 SC2 cite
-  'https://assets.0xhoneyjar.xyz/Mibera/grails/aquarius.png',
+  'https://assets.0xhoneyjar.xyz/Mibera/grails/aquarius.webp',
 ];
 
 /** Boot-prefetch options. Defaults match spec §4.2 reference impl. */


### PR DESCRIPTION
## context

Operator surfaced 4 friction points in WITNESS-shape Discord QA on 2026-05-04. All collapsed to one missing translation layer · crystallized as new vault doctrine `[[chat-medium-presentation-boundary]]`. This PR addresses **finding 4 · webp prefer**.

## change

Flip `CANONICAL_GRAIL_URLS` from `.png` → `.webp` for all 7 V1 grails. Pre-flight verified all 7 webp variants exist at canonical paths · sizes 64KB–361KB (~1.2MB total cache vs ~50MB+ as PNGs).

## why

- V07A4 cap-mistune tail concerns (5MB cap blocked 6/7 grails as PNG) → dissolves with webp
- Boot prefetch faster · cache holds less memory
- Discord renders WebP natively · zero visual change to user
- Composes with [[metadata-as-integration-contract]] (canonical URL stable · variant resolved at presentation-time)
- Bridges to Cycle B asset-pipeline AssetService.fetchOptimal architecture

## tests

53/53 pass · typecheck clean. Updated:
- `grail-cache.test.ts` canonical-list assertion
- `embed-with-image.test.ts` canonical-CDN fixtures + filename + contentType

## refs

- vault doctrine (NEW): `[[chat-medium-presentation-boundary]]` · finding 4
- V07A4 hotfix history: PR #26 (cap mistune) + 03ca840 (mercury → satoshi-as-hermes)
- Cycle B asset-pipeline kickoff: `~/bonfire/grimoires/bonfire/specs/freeside-asset-pipeline-substrate-extraction-kickoff-2026-05-03.md`

## status

DRAFT — awaiting bridgebuilder review per operator standing rule (agent quota reset after 7:50pm PT).