### PR TITLE
fix(compose): translate @g<id> → Mibera #<id> (CMP-boundary finding 2)

### DIFF
--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -311,18 +311,60 @@ export async function composeReplyWithEnrichment(
       finalChunks = splitForDiscord(stripped, DISCORD_CHAR_LIMIT);
     }
   }
-  // Single source of truth: payload.content always matches finalContent.
+  // CMP-boundary 2026-05-04 (vault doctrine `[[chat-medium-presentation-boundary]]`
+  // finding 2): translate backend `@g<id>` annotation into NFT-style display
+  // `Mibera #<id>` BEFORE the user-visible chunks lock in. The `@g` shape is
+  // load-bearing for the upstream grail-ref-guard (hallucination detection)
+  // but operator-felt friction: "I prefer if there's a translation layer that
+  // actually translates it to kind of normal speak ... actual NFT number
+  // cleanly and the name of the collection" (2026-05-04 /smol session).
+  // Substrate refs persist UNCHANGED in `grailRefValidation` + telemetry —
+  // only `content` + `chunks` get the chat-medium translation.
+  const displayContent = translateGrailRefsForChat(finalContent);
+  const displayChunks =
+    displayContent === finalContent
+      ? finalChunks
+      : splitForDiscord(displayContent, DISCORD_CHAR_LIMIT);
+
+  // Single source of truth: payload.content always matches displayContent.
   // No mutation of composeWithImage's returned object.
-  const payload = { ...initialPayload, content: finalContent };
+  const payload = { ...initialPayload, content: displayContent };
 
   return {
     ...result,
-    content: finalContent,
-    chunks: finalChunks,
+    content: displayContent,
+    chunks: displayChunks,
     payload,
     toolResults: captured,
     grailRefValidation: inspected.validation,
   };
+}
+
+/**
+ * Translate backend `@g<id>` grail refs into chat-medium NFT-style display.
+ *
+ * CMP-boundary 2026-05-04 finding 2 (vault doctrine
+ * `[[chat-medium-presentation-boundary]]`): the `@g<id>` shape is the
+ * canonical backend annotation that `grail-ref-guard.ts` validates against
+ * the canonical-43 set. It must persist in voice-text input so the guard's
+ * hallucination detection stays load-bearing. But the user-visible chat
+ * presentation should read as `Mibera #<id>` — operator-friendly NFT-style
+ * naming per operator framing 2026-05-04: "actual NFT number cleanly and
+ * the name of the collection, obviously within brackets or within the code
+ * area."
+ *
+ * Implementation: simple regex substitution. Preserves any surrounding
+ * backticks / parentheses the LLM emits — the wrapping characters stay,
+ * only the inner ref shape changes (e.g. `(\`@g876\`)` → `(\`Mibera #876\`)`).
+ *
+ * Future enrichment (V1.5 / cycle B asset-pipeline composition): swap
+ * `Mibera #<id>` for `<NAME> · Mibera #<id>` by joining against codex MCP
+ * cache (e.g. "Black Hole · Mibera #876"). Deferred per operator
+ * "richer T2 = NICE-TO-HAVE · DEFER" framing — adds latency + codex MCP
+ * coupling for diminishing-returns enrichment.
+ */
+export function translateGrailRefsForChat(text: string): string {
+  return text.replace(/@g(\d+)/g, 'Mibera #$1');
 }
 
 /**

--- a/packages/persona-engine/src/compose/translate-grail-refs.test.ts
+++ b/packages/persona-engine/src/compose/translate-grail-refs.test.ts
@@ -1,0 +1,112 @@
+/**
+ * translateGrailRefsForChat tests · CMP-boundary 2026-05-04 finding 2.
+ *
+ * Verifies that the chat-medium presentation translation:
+ *   - replaces `@g<id>` → `Mibera #<id>` for any digit-id shape
+ *   - preserves surrounding characters (parens, backticks, punctuation)
+ *   - handles multiple refs in the same text
+ *   - is idempotent on already-translated text
+ *   - leaves non-grail-shape strings alone (e.g. handles, channel mentions)
+ *
+ * Per [[chat-medium-presentation-boundary]] doctrine: backend `@g<id>` is
+ * load-bearing for grail-ref-guard hallucination detection · this transform
+ * runs at the substrate→chat-medium boundary so the user sees NFT-style
+ * display while substrate refs persist in telemetry/validation.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { translateGrailRefsForChat } from './reply.ts';
+
+describe('translateGrailRefsForChat · single ref', () => {
+  test('translates bare @g<id> in mid-sentence', () => {
+    expect(
+      translateGrailRefsForChat('closest read is Black Hole @g876 — concept-tier'),
+    ).toBe('closest read is Black Hole Mibera #876 — concept-tier');
+  });
+
+  test('preserves surrounding parentheses', () => {
+    expect(
+      translateGrailRefsForChat('closest read is Black Hole (@g876) — concept-tier'),
+    ).toBe('closest read is Black Hole (Mibera #876) — concept-tier');
+  });
+
+  test('preserves surrounding backticks (Discord code-area styling)', () => {
+    expect(
+      translateGrailRefsForChat('closest read is Black Hole (`@g876`) — concept-tier'),
+    ).toBe('closest read is Black Hole (`Mibera #876`) — concept-tier');
+  });
+
+  test('handles multi-digit IDs (4488)', () => {
+    expect(translateGrailRefsForChat('@g4488 is Satoshi-as-Hermes')).toBe(
+      'Mibera #4488 is Satoshi-as-Hermes',
+    );
+  });
+});
+
+describe('translateGrailRefsForChat · multiple refs', () => {
+  test('translates all refs in the same text', () => {
+    expect(
+      translateGrailRefsForChat('compare @g876 with @g4488 and @g235'),
+    ).toBe('compare Mibera #876 with Mibera #4488 and Mibera #235');
+  });
+
+  test('handles same ref repeated', () => {
+    expect(translateGrailRefsForChat('@g876 then @g876 again')).toBe(
+      'Mibera #876 then Mibera #876 again',
+    );
+  });
+});
+
+describe('translateGrailRefsForChat · idempotence', () => {
+  test('already-translated text is unchanged', () => {
+    const already = 'closest read is Mibera #876 — concept-tier';
+    expect(translateGrailRefsForChat(already)).toBe(already);
+  });
+
+  test('text with no refs returns input unchanged', () => {
+    const plain = 'just a chat message with no grail refs at all';
+    expect(translateGrailRefsForChat(plain)).toBe(plain);
+  });
+});
+
+describe('translateGrailRefsForChat · non-grail shapes left alone', () => {
+  test('Discord channel mention (`#stonehenge` style) untouched', () => {
+    expect(translateGrailRefsForChat('see #stonehenge channel')).toBe(
+      'see #stonehenge channel',
+    );
+  });
+
+  test('user @mention untouched', () => {
+    expect(translateGrailRefsForChat('@soju asked: the dark grail')).toBe(
+      '@soju asked: the dark grail',
+    );
+  });
+
+  test('@g without digits untouched', () => {
+    expect(translateGrailRefsForChat('@grail and @general are not grail refs')).toBe(
+      '@grail and @general are not grail refs',
+    );
+  });
+
+  test('digits without @g prefix untouched', () => {
+    expect(translateGrailRefsForChat('PR #876 and issue #4488')).toBe(
+      'PR #876 and issue #4488',
+    );
+  });
+});
+
+describe('translateGrailRefsForChat · empty + edge cases', () => {
+  test('empty string returns empty string', () => {
+    expect(translateGrailRefsForChat('')).toBe('');
+  });
+
+  test('single @g876 alone', () => {
+    expect(translateGrailRefsForChat('@g876')).toBe('Mibera #876');
+  });
+
+  test('multi-line text preserves line breaks', () => {
+    expect(translateGrailRefsForChat('line one @g876\nline two @g4488')).toBe(
+      'line one Mibera #876\nline two Mibera #4488',
+    );
+  });
+});


### PR DESCRIPTION
## context

Operator surfaced 4 friction points in WITNESS-shape Discord QA on 2026-05-04. All collapsed to one missing translation layer · crystallized as new vault doctrine `[[chat-medium-presentation-boundary]]`. This PR addresses **finding 2 · @g→display translation**.

## change

Add `translateGrailRefsForChat(text)` post-process to compose/reply.ts. Applied at the END of `composeReplyWithEnrichment` (after grail-ref-guard inspect + stripAttachedImageUrls) so substrate refs persist in `grailRefValidation` and telemetry · only user-visible `content` + `chunks` get translated.

## why

- Operator framing 2026-05-04: "actual NFT number cleanly and the name of the collection, obviously within brackets or within the code area"
- `@g<id>` IS load-bearing for grail-ref-guard hallucination detection — must persist substrate-side
- Translation lives at the chat-medium-presentation-boundary per doctrine
- NFT-style display matches the broader Mibera ecosystem vocabulary

## tests

27 pass / 0 fail · 15 new tests for `translateGrailRefsForChat` + 12 existing envelope tests still green:
- single ref · multiple refs · idempotence · non-grail-shapes-untouched · empty + edge cases

## non-goals (deferred)

- Codex MCP enrichment (`Black Hole · Mibera #876`) → V1.5 / cycle B composition · adds latency for diminishing returns
- Templating literal substitutions (`{{ZONE_ID}}` → `stonehenge`) → separate finding · not addressed here

## refs

- vault doctrine (NEW): `[[chat-medium-presentation-boundary]]` · finding 2
- WITNESS QA evidence: 2026-05-04 6:14PM PT operator dogfood
- composes with `[[discord-native-register]]` · `[[metadata-as-integration-contract]]`

## status

DRAFT — awaiting bridgebuilder review per operator standing rule (agent quota reset after 7:50pm PT).

note: parallel PRs in flight on same package:
- PR #27 `fix/cmp-boundary-webp-prefer` (T3 · finding 4 · grail-cache.ts only · no overlap)
- T3' agent · `fix/cmp-boundary-attachment-citation-order` (finding 3 · TOUCHES same compose/reply.ts file · expect rebase one direction)