### PR TITLE
fix(compose): attach by voice citation order (CMP-boundary finding 3)

### DIFF
--- a/packages/persona-engine/src/compose/order-attachments-by-citation.test.ts
+++ b/packages/persona-engine/src/compose/order-attachments-by-citation.test.ts
@@ -116,6 +116,38 @@ describe('orderAttachmentsByCitation · uncited candidates go last', () => {
   });
 });
 
+describe('orderAttachmentsByCitation · digit-prefix collision (bridgebuilder PR #29 MED)', () => {
+  test('@g876 candidate is UNCITED when text only contains @g8761 (longer id with same prefix)', () => {
+    // Bridgebuilder finding `ref-substring-collision`: bare `text.indexOf('@g876')`
+    // would match position 12 inside '@g8761' (same prefix). Negative-lookahead
+    // `@g876(?!\d)` correctly says "not cited" because the next char IS a digit.
+    const G8761: CodexGrailResult = {
+      ref: '@g8761',
+      name: 'Some Long-Id Grail',
+      image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/some-long.webp',
+    };
+    const text = 'voice cites @g8761 only';
+    const result = orderAttachmentsByCitation(text, [BLACK_HOLE, G8761]);
+    // G8761 cited at pos 12 → first · BLACK_HOLE uncited → second
+    // (pre-fix would put BLACK_HOLE first because indexOf('@g876') = 12 ties G8761
+    // and stable-sort preserves input order [BLACK_HOLE, G8761])
+    expect(result.map((c) => c.ref)).toEqual(['@g8761', '@g876']);
+  });
+
+  test('both prefix-overlapping refs cited · each matches its own occurrence', () => {
+    const G8761: CodexGrailResult = {
+      ref: '@g8761',
+      name: 'Long-Id',
+      image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/x.webp',
+    };
+    // text cites @g876 at pos 5, @g8761 at pos 18
+    const text = 'cite @g876 then @g8761 too';
+    const result = orderAttachmentsByCitation(text, [G8761, BLACK_HOLE]);
+    // BLACK_HOLE first (cited earlier at pos 5) · G8761 second (pos 18)
+    expect(result.map((c) => c.ref)).toEqual(['@g876', '@g8761']);
+  });
+});
+
 describe('orderAttachmentsByCitation · edge cases', () => {
   test('empty candidates returns empty array', () => {
     const result = orderAttachmentsByCitation('any text', []);

--- a/packages/persona-engine/src/compose/order-attachments-by-citation.test.ts
+++ b/packages/persona-engine/src/compose/order-attachments-by-citation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * orderAttachmentsByCitation tests · CMP-boundary 2026-05-04 finding 3.
+ *
+ * Verifies that grail candidates are sorted by their first-citation position
+ * in voice text BEFORE composeWithImage attaches. With default maxAttachments=1,
+ * candidates[0] wins · ordering matters or the user sees image-text mismatch.
+ *
+ * Operator dogfood evidence (2026-05-03 6:14PM PT):
+ *   prompt: /satoshi prompt:"the dark grail"
+ *   search_codex returned: [Fire 0.88, Black Hole 0.92]
+ *   voice text cited: Black Hole (@g876)
+ *   wrong outcome (pre-fix): Fire image attached (candidates[0] = Fire)
+ *   fix: orderAttachmentsByCitation moves Black Hole to slot[0] because
+ *        @g876 appears before @g6458 in the voice text (only @g876 cited).
+ *
+ * Per [[chat-medium-presentation-boundary]] doctrine: substrate-correct
+ * candidate retrieval (search_codex by relevance) needs presentation-time
+ * reordering to align with what the LLM actually voiced.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { orderAttachmentsByCitation } from './reply.ts';
+import type { CodexGrailResult } from '../deliver/embed-with-image.ts';
+
+const FIRE: CodexGrailResult = {
+  ref: '@g6458',
+  name: 'Fire',
+  image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/fire.webp',
+};
+const BLACK_HOLE: CodexGrailResult = {
+  ref: '@g876',
+  name: 'Black Hole',
+  image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.webp',
+};
+const HERMES: CodexGrailResult = {
+  ref: '@g4488',
+  name: 'Satoshi-as-Hermes',
+  image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp',
+};
+const SCORPIO: CodexGrailResult = {
+  ref: '@g235',
+  name: 'Scorpio',
+  image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/scorpio.webp',
+};
+
+describe('orderAttachmentsByCitation · the operator-dogfood bug case', () => {
+  test('voice cites only @g876 · candidates [Fire, Black Hole] reorder to [Black Hole, Fire]', () => {
+    // EXACT REPRODUCTION of the 2026-05-03 6:14PM PT operator dogfood:
+    // search_codex returned [Fire 0.88, Black Hole 0.92] (Fire first by
+    // relevance order). Voice text cited only Black Hole. Pre-fix: Fire
+    // image attached. Post-fix: Black Hole image attached.
+    const voiceText =
+      'no "dark" grail straight up, but closest read is Black Hole (@g876) — concept-tier, mibera drawn inside the void, whole piece evokes uncertainty.';
+    const candidates = [FIRE, BLACK_HOLE];
+    const ordered = orderAttachmentsByCitation(voiceText, candidates);
+    expect(ordered.map((c) => c.ref)).toEqual(['@g876', '@g6458']);
+    expect(ordered[0]).toBe(BLACK_HOLE); // Black Hole moved to slot[0]
+    expect(ordered[1]).toBe(FIRE); // Fire moved to slot[1] (uncited · preserves relative order)
+  });
+});
+
+describe('orderAttachmentsByCitation · single candidate', () => {
+  test('single candidate cited in text returned as-is', () => {
+    const text = 'Black Hole @g876 is the void.';
+    const result = orderAttachmentsByCitation(text, [BLACK_HOLE]);
+    expect(result).toEqual([BLACK_HOLE]);
+  });
+
+  test('single candidate uncited still returned as-is', () => {
+    const text = 'no grail refs in this text';
+    const result = orderAttachmentsByCitation(text, [BLACK_HOLE]);
+    expect(result).toEqual([BLACK_HOLE]);
+  });
+});
+
+describe('orderAttachmentsByCitation · multiple candidates · in-order citations', () => {
+  test('two candidates cited in input order returns input order', () => {
+    const text = 'compare @g876 with @g6458';
+    const result = orderAttachmentsByCitation(text, [BLACK_HOLE, FIRE]);
+    expect(result).toEqual([BLACK_HOLE, FIRE]);
+  });
+
+  test('three candidates all cited in input order', () => {
+    const text = '@g4488 then @g876 then @g235';
+    const result = orderAttachmentsByCitation(text, [HERMES, BLACK_HOLE, SCORPIO]);
+    expect(result.map((c) => c.ref)).toEqual(['@g4488', '@g876', '@g235']);
+  });
+});
+
+describe('orderAttachmentsByCitation · multiple candidates · reverse-citation order', () => {
+  test('three candidates cited in reverse order returns reversed', () => {
+    const text = '@g235 first then @g876 then @g4488';
+    const result = orderAttachmentsByCitation(text, [HERMES, BLACK_HOLE, SCORPIO]);
+    expect(result.map((c) => c.ref)).toEqual(['@g235', '@g876', '@g4488']);
+  });
+});
+
+describe('orderAttachmentsByCitation · uncited candidates go last', () => {
+  test('one cited + one uncited · cited goes first', () => {
+    const text = 'just @g876 here';
+    const result = orderAttachmentsByCitation(text, [FIRE, BLACK_HOLE]);
+    expect(result.map((c) => c.ref)).toEqual(['@g876', '@g6458']);
+  });
+
+  test('two uncited preserve relative input order (stable sort)', () => {
+    const text = 'no refs at all';
+    const result = orderAttachmentsByCitation(text, [FIRE, BLACK_HOLE, SCORPIO]);
+    expect(result.map((c) => c.ref)).toEqual(['@g6458', '@g876', '@g235']);
+  });
+
+  test('cited-uncited-cited input · cited move to front in citation order', () => {
+    const text = '@g876 referenced and @g235 too';
+    const result = orderAttachmentsByCitation(text, [HERMES, SCORPIO, FIRE, BLACK_HOLE]);
+    // BLACK_HOLE first (cited at pos 0), SCORPIO second (cited later), then uncited HERMES + FIRE in input order
+    expect(result.map((c) => c.ref)).toEqual(['@g876', '@g235', '@g4488', '@g6458']);
+  });
+});
+
+describe('orderAttachmentsByCitation · edge cases', () => {
+  test('empty candidates returns empty array', () => {
+    const result = orderAttachmentsByCitation('any text', []);
+    expect(result).toEqual([]);
+  });
+
+  test('candidate with no ref field goes to end', () => {
+    const noRef: CodexGrailResult = {
+      name: 'Some Grail',
+      image: 'https://assets.0xhoneyjar.xyz/Mibera/grails/x.webp',
+    };
+    const text = 'cite @g876 here';
+    const result = orderAttachmentsByCitation(text, [noRef, BLACK_HOLE]);
+    expect(result.map((c) => c.name)).toEqual(['Black Hole', 'Some Grail']);
+  });
+
+  test('does not mutate input array', () => {
+    const text = '@g876 first';
+    const input = [FIRE, BLACK_HOLE];
+    orderAttachmentsByCitation(text, input);
+    expect(input.map((c) => c.ref)).toEqual(['@g6458', '@g876']); // input unchanged
+  });
+
+  test('same ref repeated in text · uses first occurrence', () => {
+    const text = '@g6458 and @g876 and @g876 again';
+    const result = orderAttachmentsByCitation(text, [BLACK_HOLE, FIRE]);
+    // Fire @ pos 0, Black Hole @ pos 11
+    expect(result.map((c) => c.ref)).toEqual(['@g6458', '@g876']);
+  });
+});

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -418,19 +418,44 @@ export function orderAttachmentsByCitation(
   // Build position map per candidate. Position = index of first match in
   // text, or Infinity if uncited (sorts to end). Stable sort preserves
   // relative order among uncited (and cited-at-same-position) entries.
+  //
+  // Bridgebuilder PR #29 MED `ref-substring-collision` (2026-05-04):
+  // bare `text.indexOf('@g876')` matches `@g8761` as a prefix substring
+  // (same digit-prefix collision class as the bug this fix targets).
+  // Use a negative-lookahead regex `\\g<id>(?!\\d)` to require a digit
+  // boundary so `@g876` does NOT match inside `@g8761`.
   const positions = candidates.map((c, idx) => {
     const ref = c.ref;
-    if (typeof ref !== 'string' || ref.length === 0) {
+    if (typeof ref !== 'string') {
       return { c, pos: Number.POSITIVE_INFINITY, idx };
     }
-    const found = text.indexOf(ref);
-    return { c, pos: found < 0 ? Number.POSITIVE_INFINITY : found, idx };
+    const pos = findRefPosition(text, ref);
+    return { c, pos, idx };
   });
   positions.sort((a, b) => {
     if (a.pos !== b.pos) return a.pos - b.pos;
     return a.idx - b.idx; // stable: preserve input order on ties
   });
   return positions.map((p) => p.c);
+}
+
+/**
+ * Find the first occurrence of a grail ref in text WITHOUT digit-prefix
+ * collisions. `@g876` must not match inside `@g8761` (different grail).
+ *
+ * Returns the match index, or `Number.POSITIVE_INFINITY` if not found
+ * (so positions can be naturally compared in the sort).
+ */
+function findRefPosition(text: string, ref: string): number {
+  // Escape regex metacharacters in ref (defensive · ref is `@g<digits>` so
+  // typically just `@` which isn't special, but if codex MCP ever returns
+  // a ref with regex-special chars, escape protects us).
+  const escaped = ref.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Negative-lookahead `(?!\d)` requires the char after ref to be NOT a
+  // digit (or end-of-string), preventing `@g876` from matching `@g8761`.
+  const re = new RegExp(escaped + '(?!\\d)');
+  const match = re.exec(text);
+  return match ? match.index : Number.POSITIVE_INFINITY;
 }
 
 /**

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -293,7 +293,25 @@ export async function composeReplyWithEnrichment(
   // eliminates the prior `payload.content = stripped` mutation + dropped
   // the `extractAttachedUrls(...).slice(...)` workaround whose ordering
   // assumption (input order = attached order) was the F4 invariant smell.
-  const grailCandidates = extractGrailCandidates(captured);
+  // CMP-boundary 2026-05-04 finding 3 (vault doctrine
+  // `[[chat-medium-presentation-boundary]]`): order candidates by their
+  // first citation in the voice text BEFORE composeWithImage attaches.
+  // Default maxAttachments=1 means slot[0] wins · ordering matters.
+  //
+  // Operator dogfood `/satoshi prompt:"the dark grail"` (2026-05-03 6:14PM PT)
+  // surfaced the bug: voice cited Black Hole (@g876) but Fire image attached
+  // because search_codex returned [Fire, Black Hole] · candidates[0] was Fire.
+  // search_codex result order is RELEVANCE-ranked (Fire 0.88 lost to Black Hole
+  // 0.92 by 0.04) but voice authoritatively cited Black Hole — image must
+  // match voice citation, not search relevance.
+  //
+  // V0.7-A.5 SDD §4.2 specifies this helper for the multi-attach cycle ·
+  // extracted standalone here as a CMP-boundary micro-fix · multi-attach
+  // (maxAttachments>1) stays parked in V0.7-A.5 cycle.
+  const grailCandidates = orderAttachmentsByCitation(
+    inspected.text,
+    extractGrailCandidates(captured),
+  );
   const initialPayload = await composeWithImage(inspected.text, grailCandidates);
   const attachedUrls = initialPayload.attachedUrls ?? [];
 
@@ -365,6 +383,54 @@ export async function composeReplyWithEnrichment(
  */
 export function translateGrailRefsForChat(text: string): string {
   return text.replace(/@g(\d+)/g, 'Mibera #$1');
+}
+
+/**
+ * Order grail candidates by their first-citation position in voice text.
+ *
+ * CMP-boundary 2026-05-04 finding 3 (vault doctrine
+ * `[[chat-medium-presentation-boundary]]`): with default maxAttachments=1,
+ * `composeWithImage` attaches `candidates[0]`. If that order doesn't match
+ * the voice text's citation order, the user sees image-text mismatch.
+ *
+ * Operator dogfood `/satoshi prompt:"the dark grail"` (2026-05-03 6:14PM PT)
+ * surfaced this: search_codex returned [Fire 0.88, Black Hole 0.92] but
+ * voice authoritatively cited Black Hole. composeWithImage attached Fire
+ * (candidates[0] by search relevance) — wrong image for the cited grail.
+ *
+ * V0.7-A.5 SDD §4.2 specifies this helper for the multi-attach cycle ·
+ * extracted standalone here as a CMP-boundary micro-fix · multi-attach
+ * (maxAttachments>1) stays parked in V0.7-A.5 cycle scope.
+ *
+ * Algorithm:
+ *   1. For each candidate with a `ref` field of shape `@g<id>`, find first
+ *      occurrence position of that ref in `text`.
+ *   2. Sort candidates by citation position (earliest first).
+ *   3. Candidates with no `ref` OR whose ref is uncited go to the END,
+ *      preserving relative input order (stable sort).
+ *
+ * Returns a NEW array · does not mutate input.
+ */
+export function orderAttachmentsByCitation(
+  text: string,
+  candidates: CodexGrailResult[],
+): CodexGrailResult[] {
+  // Build position map per candidate. Position = index of first match in
+  // text, or Infinity if uncited (sorts to end). Stable sort preserves
+  // relative order among uncited (and cited-at-same-position) entries.
+  const positions = candidates.map((c, idx) => {
+    const ref = c.ref;
+    if (typeof ref !== 'string' || ref.length === 0) {
+      return { c, pos: Number.POSITIVE_INFINITY, idx };
+    }
+    const found = text.indexOf(ref);
+    return { c, pos: found < 0 ? Number.POSITIVE_INFINITY : found, idx };
+  });
+  positions.sort((a, b) => {
+    if (a.pos !== b.pos) return a.pos - b.pos;
+    return a.idx - b.idx; // stable: preserve input order on ties
+  });
+  return positions.map((p) => p.c);
 }
 
 /**


### PR DESCRIPTION
## context

Closes the last of the 4 CMP-boundary findings surfaced in 2026-05-04 WITNESS QA. PRs #27 (webp · finding 4) and #28 (@g translation · finding 2) merged earlier · channel-id env vars set (finding 1) · this PR addresses **finding 3 · attachment-citation-order**.

## the bug

Operator dogfood (2026-05-03 6:14PM PT screenshot):
```
prompt:    /satoshi prompt:"the dark grail"
voice:     "no 'dark' grail straight up, but closest read is Black Hole (@g876)"
attached:  Mibera/grails/fire.png  ← WRONG (warm-orange figure with yellow orb)
expected:  Mibera/grails/black-hole.png  ← the void
```

Root cause: `search_codex` returned `[Fire 0.88, Black Hole 0.92]` ranked by relevance · `composeWithImage` attached `candidates[0]` (Fire). Voice authoritatively cited Black Hole. Image-voice misalignment.

## change

Add `orderAttachmentsByCitation(text, candidates)` helper · apply BEFORE `composeWithImage` so `candidates[0]` matches the first @g ref in voice text.

```typescript
const grailCandidates = orderAttachmentsByCitation(
  inspected.text,
  extractGrailCandidates(captured),
);
const initialPayload = await composeWithImage(inspected.text, grailCandidates);
```

## tests

40/40 compose-suite tests pass · 13 new tests for `orderAttachmentsByCitation` including EXACT reproduction of the 2026-05-03 operator-dogfood bug case.

## non-goals

Multi-attach (maxAttachments>1) stays parked in V0.7-A.5 cycle. This PR extracts ONE helper from the V0.7-A.5 SDD §4.2 spec.

## refs

- vault doctrine: `[[chat-medium-presentation-boundary]]` finding 3
- WITNESS QA evidence: 2026-05-04 6:14PM PT operator dogfood
- V0.7-A.5 SDD §4.2 (still parked · this is the standalone extraction)
- composes with PRs #27 (webp · finding 4) + #28 (@g translation · finding 2) + T1 env config (finding 1) · CMP-boundary fully closed