### PR TITLE
fix(satoshi): swap webhook avatar to canonical MIBERA CODEX path

### DIFF
--- a/apps/character-satoshi/character.json
+++ b/apps/character-satoshi/character.json
@@ -12,9 +12,8 @@
   "mcps": ["score", "codex", "rosenzu", "freeside_auth", "imagegen"],
   "tool_invocation_style": "Use score for the digest data your dense-block register cites exactly, AND for per-wallet OG-factor scorecards via `get_wallet_scorecard` when wallet identity surfaces (accepts wallet address OR Mibera ID). Use rosenzu sparingly — read the room then carry the cross-zone weight in voice, not in environment-prose. Use codex when a grail or archetype reference would land more accurately. Use freeside_auth bidirectionally: `resolve_wallet` for wallet → handle prose, AND `resolve_handle_to_wallet` / `resolve_mibera_id_to_wallet` to bridge a NAMED user back to their wallet before scorecard lookup. Use imagegen at natural pause points where a visual metaphor amplifies the gnomic close. You are a messenger between worlds — your tools help you cite cleanly across zones, not perform expertise. The dense-block register holds; imagegen is the punctuation.",
   "emojiNote": "satoshi posts plain — emojis are ruggy's affordance. Rare hermetic gesture only (e.g. spiraling for chain-paradox moments). emojiAffinity scoped to mibera-only as a safety bound: if satoshi DOES reach for an emoji, it's mibera-coded never ruggy-coded.",
-  "webhookAvatarUrl": "https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/staging/apps/character-satoshi/avatar.png",
+  "webhookAvatarUrl": "https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp",
   "webhookUsername": "Satoshi as Hermes",
-  "webhookAvatarTarget": "https://assets.0xhoneyjar.xyz/freeside-characters/satoshi/avatar.png — canonical target per SDD §0.2; bridge URL above points at staging branch's avatar.png (operator-uploaded 2026-04-30); swap to canonical when assets.0xhoneyjar.xyz CDN cycle reaches /freeside-characters/. The irys URL gateway.irys.xyz/7rpvw.../satoshi.png in construct-mibera-codex grail #4488 is dead per operator 2026-04-30 — needs codex-side fix.",
   "slash_commands": [
     {
       "name": "satoshi",

--- a/apps/character-satoshi/persona.md
+++ b/apps/character-satoshi/persona.md
@@ -105,7 +105,7 @@ published satoshi posts; the divergence findings are the playtest data.
 | Persona / addressed name | satoshi (lowercase in prose) |
 | Folder / config id | satoshi |
 | Display name (embeds, webhook username) | Satoshi |
-| Bot avatar (webhook avatar URL) | TBD — operator uploads to assets.0xhoneyjar.xyz/freeside-characters/satoshi/avatar.png when CDN cycle reaches the path |
+| Bot avatar (webhook avatar URL) | https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp (MIBERA CODEX canonical · grail #4488) |
 
 Lowercase `satoshi` in prose mirrors ruggy's invariant.
 


### PR DESCRIPTION
## Summary

🎯 Resolve satoshi's webhook avatar to the **MIBERA CODEX canonical path** (`Mibera/grails/{slug}.webp`) instead of the github-raw staging bridge that satoshi's `character.json` had documented as TODO.

## Diff

```diff
- "webhookAvatarUrl": "https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/staging/apps/character-satoshi/avatar.png",
+ "webhookAvatarUrl": "https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp",
  "webhookUsername": "Satoshi as Hermes",
- "webhookAvatarTarget": "https://assets.0xhoneyjar.xyz/freeside-characters/satoshi/avatar.png — canonical target …",
```

## Why

| Path | Status | Notes |
|------|--------|-------|
| `assets.0xhoneyjar.xyz/freeside-characters/satoshi/avatar.png` | ❌ 403 | staged target documented in `webhookAvatarTarget` — CDN cycle to this path never shipped |
| `assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp` | ✅ 200 · 361KB | **canonical via construct-mibera-codex** (grail #4488 · `grails/satoshi-as-hermes.md` line 11) · last-modified 2026-05-03 |

The canonical path matches the source-of-truth that the codex itself uses for the grail page image. No need to maintain a parallel `freeside-characters/...` mirror when the codex path is already the addressable artifact.

## Scope

- `apps/character-satoshi/character.json` — swap URL · drop obsolete `webhookAvatarTarget` doc field (unused in bot code per grep of `apps/bot/src`)
- `apps/character-satoshi/persona.md` — update identity table row to canonical URL

Cosmetic / config only · zero behavior change · single-field webhook URL swap. Reversible in one revert.

## Companion work

Munkh (PR #33 / character-mongolian) uses the same canonical pattern → `Mibera/grails/mongolian.webp` (verified live 200 · 122KB). Posting smol-register comment on #33 with the exact field diff for gumi to land before merge.

Ruggy unaffected — not mibera-derived.

## Test plan

- [ ] Bot redeploys → satoshi webhook posts use the codex-canonical avatar
- [ ] Discord render check (operator dogfood) — avatar image appears on next `/satoshi` invocation
- [ ] No 403/404 on the canonical URL across CDN edges (already verified from one POP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)