### PR TITLE
fix(emoji): repair bare `<:ID>` shortcodes via 2-pass translator (closes #35)

### DIFF
--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -52,7 +52,7 @@ import {
   type GrailRefValidation,
 } from '../deliver/grail-ref-guard.ts';
 import { stripAttachedImageUrls } from '../deliver/strip-image-urls.ts';
-import { EMOJIS, findByName, renderEmoji } from '../orchestrator/emojis/registry.ts';
+import { EMOJIS, findById, findByName, renderEmoji } from '../orchestrator/emojis/registry.ts';
 import {
   appendToLedger,
   getLedgerSnapshot,
@@ -459,10 +459,24 @@ const KNOWN_EMOJI_PREFIXES: ReadonlySet<string> = new Set(
 );
 
 export function translateEmojiShortcodes(text: string): string {
+  // Issue #35 (2026-05-04): repair bare `<:ID>` and `<a:ID>` tokens. The LLM
+  // (or upstream MCP tool result) sometimes emits the ID-only form without
+  // the `:name:` segment — Discord renders that as plain text since the
+  // canonical shape is `<:NAME:ID>`. Look up by ID and re-emit the correct
+  // shape; pass through if the snowflake isn't in the registry (covers
+  // `<:randomNumber>` non-emoji false positives).
+  const idNormalized = text.replace(/<a?:(\d{17,20})>/g, (match, id: string) => {
+    const entry = findById(id);
+    return entry ? renderEmoji(entry) : match;
+  });
+
   // Bridgebuilder PR #32 pass-1 LOW `F1-whitespace-artifact`: consume one
   // preceding space when dropping a hallucinated shortcode so we don't leak
   // double-spaces / trailing whitespace into Discord output.
-  return text.replace(/( ?):([a-zA-Z][a-zA-Z0-9_]*):/g, (match, leadingSpace: string, name: string) => {
+  // Issue #35 lookbehind: skip `:name:` patterns that sit inside an
+  // already-valid `<:name:id>` or `<a:name:id>` token (otherwise pass-2
+  // would corrupt valid shortcodes pass-1 just emitted).
+  return idNormalized.replace(/( ?)(?<!<a?):([a-zA-Z][a-zA-Z0-9_]*):/g, (match, leadingSpace: string, name: string) => {
     const entry = findByName(name);
     if (entry) {
       // Hit · render Discord format · keep the leading space.

--- a/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
+++ b/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
@@ -94,6 +94,62 @@ describe('translateEmojiShortcodes · non-custom shortcodes left alone', () => {
   });
 });
 
+describe('translateEmojiShortcodes · bare <:ID> repair (issue #35)', () => {
+  // Operator dogfood 2026-05-04 9:39 AM PT · ruggy webhook in El Capitan thread
+  // emitted `<:1138775429482819645>` (one colon · ID-only · missing :name:).
+  // Discord's canonical form is `<:NAME:ID>` so the malformed token rendered
+  // as raw text. Pass-1 of translateEmojiShortcodes now repairs ID-only tokens
+  // by registry lookup; valid tokens emitted by pass-1 must NOT be re-corrupted
+  // by pass-2's :name: regex (negative lookbehind handles this).
+
+  test('bare <:ID> for static emoji is repaired to <:name:id>', () => {
+    // ruggy ID 1138775429482819645 · the exact operator-dogfood case
+    const out = translateEmojiShortcodes('text <:1138775429482819645> tail');
+    expect(out).toBe('text <:ruggy:1138775429482819645> tail');
+  });
+
+  test('bare <a:ID> for animated emoji is repaired to <a:name:id>', () => {
+    // ruggy_dab ID 1142035114008772608 · animated:true
+    const out = translateEmojiShortcodes('we ate <a:1142035114008772608>');
+    expect(out).toBe('we ate <a:ruggy_dab:1142035114008772608>');
+  });
+
+  test('already-valid <:name:id> is preserved (lookbehind prevents re-corruption)', () => {
+    const valid = '<:ruggy:1138775429482819645>';
+    expect(translateEmojiShortcodes(valid)).toBe(valid);
+  });
+
+  test('already-valid <a:name:id> is preserved (lookbehind prevents re-corruption)', () => {
+    const valid = '<a:ruggy_dab:1142035114008772608>';
+    expect(translateEmojiShortcodes(valid)).toBe(valid);
+  });
+
+  test('unknown snowflake <:ID> falls through unchanged (not every <:NUM> is emoji)', () => {
+    // 17-20 digit number not in registry · could be a Discord channel/user
+    // mention quirk or other shape · do not corrupt.
+    const out = translateEmojiShortcodes('mystery <:9999999999999999999>');
+    expect(out).toBe('mystery <:9999999999999999999>');
+  });
+
+  test('multiple bare IDs in same text all repair', () => {
+    const out = translateEmojiShortcodes(
+      '<:1138775429482819645> then <a:1142035114008772608>',
+    );
+    expect(out).toBe(
+      '<:ruggy:1138775429482819645> then <a:ruggy_dab:1142035114008772608>',
+    );
+  });
+
+  test('mix of bare <:ID> and :name: forms both translate', () => {
+    const out = translateEmojiShortcodes(
+      '<:1138775429482819645> :ruggy_dab: done',
+    );
+    expect(out).toBe(
+      '<:ruggy:1138775429482819645> <a:ruggy_dab:1142035114008772608> done',
+    );
+  });
+});
+
 describe('translateEmojiShortcodes · edge cases', () => {
   test('empty string returns empty', () => {
     expect(translateEmojiShortcodes('')).toBe('');


### PR DESCRIPTION
## Summary

Closes #35.

Operator dogfood 2026-05-04 9:39 AM PT surfaced a malformed Discord emoji shortcode in ruggy webhook output (`<:1138775429482819645>` — one colon · ID-only · missing the `:name:` segment). Discord rendered it as plain text. Root-caused via **codex headless** (Codex / GPT-5 via codex-companion runtime · paired with Claude Opus 4.7).

## Diff

**`packages/persona-engine/src/compose/reply.ts`** — 2-pass translator:

```diff
-import { EMOJIS, findByName, renderEmoji } from '../orchestrator/emojis/registry.ts';
+import { EMOJIS, findById, findByName, renderEmoji } from '../orchestrator/emojis/registry.ts';

 export function translateEmojiShortcodes(text: string): string {
+  // Pass 1: repair bare <:ID> and <a:ID> tokens by registry ID lookup
+  const idNormalized = text.replace(/<a?:(\d{17,20})>/g, (match, id) => {
+    const entry = findById(id);
+    return entry ? renderEmoji(entry) : match;
+  });
-  return text.replace(/( ?):([a-zA-Z][a-zA-Z0-9_]*):/g, ...);
+  // Pass 2: :name: regex with lookbehind to skip inside <:name:id> tokens
+  return idNormalized.replace(/( ?)(?<!<a?):([a-zA-Z][a-zA-Z0-9_]*):/g, ...);
```

## Why

The translator only handled raw `:name:` shortcodes (PR #32's CMP-boundary cycle) and ignored bare `<:ID>` / `<a:ID>` tokens. Registry already had everything needed — `findById()` at `registry.ts:475`, `renderEmoji()` at `registry.ts:470`, entry for the dogfood ID at `registry.ts:313` (name `ruggy`). The translator just didn't call them for the ID-only case.

**Adjacent bug also caught:** the existing `:name:` regex would match inside an already-valid `<:name:id>` token on a re-pass and corrupt it. The new `(?<!<a?)` negative lookbehind prevents that.

## Tests

`packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts` — **+7 new cases**:
- bare `<:ID>` for static emoji repaired (operator-dogfood reproduction · ID `1138775429482819645`)
- bare `<a:ID>` for animated emoji repaired (ID `1142035114008772608`)
- already-valid `<:name:id>` preserved (idempotence · lookbehind protection)
- already-valid `<a:name:id>` preserved
- unknown snowflake `<:9999...>` falls through unchanged (not every `<:NUM>` is an emoji)
- multiple bare IDs in same text all translate
- mix of bare `<:ID>` and `:name:` forms both translate

```
22 pass · 0 fail · 23 expect() calls · 236ms
```

## Doctrine alignment

`[[chat-medium-presentation-boundary]]` proof point #1 — the cycle that just shipped (PR #32) handled the raw `:name:` form. This PR lands the bare-`<:ID>` complement, closing the proof point.

## Confidence

High on the fix shape. One open thread: whether bare `<:ID>` originated LLM-side or score-mibera-side. The 9:39 AM transcript isn't in the repo, but the fix is correct either way — the chat-medium-presentation boundary lives in the bot regardless.

## Test plan

- [x] Unit tests pass (22/22)
- [ ] Bot redeploy → operator-dogfood with `/ruggy "what's ${someone}'s score"` → second emoji renders correctly
- [ ] Watch the `[emoji-translate]` debug log for any unexpected drops over the next 24h

## Provenance

- Filed: issue #35 (operator dogfood screenshot · El Capitan thread 2026-05-04 9:39 AM PT)
- Investigated: codex-rescue Agent · Codex via codex-companion runtime · ~4.5min wall · 34k tokens · cited file:line for everything
- Implemented + tested: Claude Opus 4.7 · paired with operator (zksoju)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · with Codex headless co-authoring