### PR TITLE
fix(docker): include apps/character-mongolian in container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,14 @@ FROM oven/bun:1.3-alpine AS base
 WORKDIR /app
 
 # ─── workspace metadata first — keeps layer cache hot when source ─────
-# changes but deps don't. V0.6 monorepo has 5 workspaces:
+# changes but deps don't. V0.6 monorepo has 6 workspaces:
 #   apps/bot · apps/character-ruggy · apps/character-satoshi
-#   packages/persona-engine · packages/protocol
+#   apps/character-mongolian · packages/persona-engine · packages/protocol
 COPY package.json bun.lock ./
 COPY apps/bot/package.json ./apps/bot/
 COPY apps/character-ruggy/package.json ./apps/character-ruggy/
 COPY apps/character-satoshi/package.json ./apps/character-satoshi/
+COPY apps/character-mongolian/package.json ./apps/character-mongolian/
 COPY packages/persona-engine/package.json ./packages/persona-engine/
 COPY packages/protocol/package.json ./packages/protocol/
 
@@ -44,6 +45,7 @@ COPY apps/bot ./apps/bot
 # selects which to load.
 COPY apps/character-ruggy ./apps/character-ruggy
 COPY apps/character-satoshi ./apps/character-satoshi
+COPY apps/character-mongolian ./apps/character-mongolian
 
 # tsconfig for Bun's TS resolution
 COPY tsconfig.json ./


### PR DESCRIPTION
## Deploy-blocker fast-follow on PR #33

Bot crashed on staging deploy after the Munkh ship:

```
error: character-loader: /app/apps/character-mongolian/character.json
       not found. Did you create apps/character-mongolian/character.json?
  at loadCharacter (/app/apps/bot/src/character-loader.ts:66:15)
```

Repeated for every CHARACTERS env entry — bot fatal exit · all character services down.

## Root cause (codex-rescue)

`apps/character-mongolian/character.json` exists on `main` (PR #33 commit `0898903`). The runtime container does not — the **Dockerfile only copied `character-ruggy` + `character-satoshi`**, not mongolian. The new sibling sat outside the build context.

> Codex (gpt-5 via codex-companion runtime) ran in 4.2min · returned root-cause + diff with file:line citations · operator-paired with Claude Opus 4.7 for verification + apply.

## Fix

Two `COPY` adds in `Dockerfile`:

```diff
 COPY apps/character-ruggy/package.json ./apps/character-ruggy/
 COPY apps/character-satoshi/package.json ./apps/character-satoshi/
+COPY apps/character-mongolian/package.json ./apps/character-mongolian/
```

```diff
 COPY apps/character-ruggy ./apps/character-ruggy
 COPY apps/character-satoshi ./apps/character-satoshi
+COPY apps/character-mongolian ./apps/character-mongolian
```

Header comment also bumped from \"5 workspaces\" → \"6 workspaces\" to track the actual count.

## Codex's second claim was wrong (verified before applying)

Codex flagged a follow-up blocker: *\"persona.md missing `## System prompt template` section\"*. Verified against the file — the section IS present at `apps/character-mongolian/persona.md:238` (`## System prompt template — paste-ready for V0.6-C`). Loader at `packages/persona-engine/src/persona/loader.ts:33` requires exactly `## System prompt template` (case + spacing match). No persona edit needed.

## Why this slipped past PR #33 review

The PR added curator authoring (persona, character.json, codex-anchors, etc) but didn't surface the Dockerfile dependency. The build context is implicit — adding a new character app requires both a workspace-metadata `package.json` copy AND a full source-dir copy. Worth a follow-up DX note in `apps/character-template/README.md` or similar (NOT in scope for this fix).

## Test plan

- [ ] Container rebuild on Railway → bot startup succeeds with `CHARACTERS=mongolian`, `CHARACTERS=ruggy`, `CHARACTERS=satoshi` envs
- [ ] `/mongolian` slash command renders (still needs webhook avatar fields filled per smol comment on PR #33 if you want the cave-art PFP)

## Provenance

- Reported: operator deploy logs 2026-05-04 PT (Railway crash)
- Investigated: codex:codex-rescue Agent · ~4.2min wall · 35k tokens · cited line numbers verified
- Implemented + Dockerfile diff + persona.md verification: Claude Opus 4.7 paired with operator (zksoju)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · with Codex headless co-authoring