### PR TITLE
chore(docker): auto-include all `apps/character-*` · env-driven selection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,16 +8,17 @@ docs
 README.md
 *.md
 
-# Local dev artifacts
-.env
-.env.*
-!.env.example
-*.log
-.DS_Store
+# Local dev artifacts — depth-aware patterns since Dockerfile uses
+# wholesale `COPY apps` / `COPY packages` (.dockerignore is the security
+# boundary for accidental secret/cruft inclusion in the image).
+**/.env
+**/.env.*
+!**/.env.example
+**/*.log
+**/.DS_Store
 
 # Deps + build outputs (rebuilt in image)
-node_modules
-apps/bot/node_modules
+**/node_modules
 **/dist
 **/.bun
 **/.turbo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,42 @@
 # freeside-characters — Discord persona bot (Bun runtime)
 #
-# Builds a long-running bot service. Same image deploys to:
-#   - staging-ruggy   (project purupuru guild, ruggy bot account)
-#   - staging-satoshi (project purupuru guild, satoshi bot account)
+# Builds a long-running bot service. The image contains ALL characters;
+# per-service ENV selects which to instantiate at runtime via CHARACTERS
+# (comma-separated character ids). Adding a new character requires ZERO
+# Dockerfile edits — bun's workspace globs auto-discover it.
 #
-# Per-service ENV picks the character via CHARACTERS=<id> and which bot
-# account speaks via DISCORD_BOT_TOKEN. See docs/DEPLOY.md for full env
-# matrix per service.
+# Per-service ENV (set in Railway portal):
+#   CHARACTERS=ruggy            staging-ruggy service
+#   CHARACTERS=satoshi          staging-satoshi service
+#   CHARACTERS=mongolian        staging-mongolian service (V0.7-A.x cycle-3)
+#   CHARACTERS=ruggy,satoshi    multi-character service
+#   DISCORD_BOT_TOKEN=...       per-character bot account token
+#   DISCORD_CHANNEL_*=...       per-zone channel IDs
 #
 # Memory: discord.js + pg pool + claude-agent-sdk subprocess. Allocate
 # at least 512MB; 1GB headroom is comfortable.
 
-FROM oven/bun:1.3-alpine AS base
+FROM oven/bun:1.3-alpine
 
 WORKDIR /app
 
-# ─── workspace metadata first — keeps layer cache hot when source ─────
-# changes but deps don't. V0.6 monorepo has 6 workspaces:
-#   apps/bot · apps/character-ruggy · apps/character-satoshi
-#   apps/character-mongolian · packages/persona-engine · packages/protocol
-COPY package.json bun.lock ./
-COPY apps/bot/package.json ./apps/bot/
-COPY apps/character-ruggy/package.json ./apps/character-ruggy/
-COPY apps/character-satoshi/package.json ./apps/character-satoshi/
-COPY apps/character-mongolian/package.json ./apps/character-mongolian/
-COPY packages/persona-engine/package.json ./packages/persona-engine/
-COPY packages/protocol/package.json ./packages/protocol/
+# Monorepo workspace shape · root package.json declares:
+#   "workspaces": ["apps/*", "packages/*"]
+# so adding `apps/character-{slug}/` is auto-discovered by bun and
+# auto-included in the image. Single surface for character roster:
+# the CHARACTERS env at runtime. The Dockerfile is character-agnostic.
+COPY package.json bun.lock tsconfig.json ./
+COPY apps ./apps
+COPY packages ./packages
 
-# Install production deps only. claude-agent-sdk pulls a Claude Code
-# bundle (~25MB) — needed at runtime for the SDK subprocess.
+# claude-agent-sdk pulls a Claude Code bundle (~25MB) — runtime
+# requirement for the persona-engine SDK subprocess (e.g.
+# apps/bot/.claude/skills/arneson loaded via SDK settingSources).
 RUN bun install --frozen-lockfile --production
-
-# ─── source after deps ────────────────────────────────────────────────
-# substrate (system-agent layer)
-COPY packages/persona-engine ./packages/persona-engine
-COPY packages/protocol ./packages/protocol
-
-# bot runtime (loads characters, dispatches via substrate)
-# includes apps/bot/.claude/skills/arneson loaded via SDK settingSources
-COPY apps/bot ./apps/bot
-
-# character profiles — markdown + json. persona.md + exemplars/ + codex
-# anchors are read at runtime by persona-engine's loader. CHARACTERS env
-# selects which to load.
-COPY apps/character-ruggy ./apps/character-ruggy
-COPY apps/character-satoshi ./apps/character-satoshi
-COPY apps/character-mongolian ./apps/character-mongolian
-
-# tsconfig for Bun's TS resolution
-COPY tsconfig.json ./
 
 ENV NODE_ENV=production
 
-# Default command — run the bot's index.ts via Bun. The bot opens a
+# Default command — Bun runs the bot's index.ts directly. Bot opens a
 # Discord gateway connection + schedules cron + serves digest fires.
 # Logs go to stdout; Railway captures them.
-#
-# Per-service overrides via ENV (set in Railway portal):
-#   CHARACTERS=ruggy            (staging-ruggy service)
-#   CHARACTERS=satoshi          (staging-satoshi service)
-#   DISCORD_BOT_TOKEN=...       per-character bot account token
-#   DISCORD_CHANNEL_*=...       per-zone channel IDs (staging guild)
 CMD ["bun", "run", "apps/bot/src/index.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ WORKDIR /app
 # so adding `apps/character-{slug}/` is auto-discovered by bun and
 # auto-included in the image. Single surface for character roster:
 # the CHARACTERS env at runtime. The Dockerfile is character-agnostic.
+#
+# Security note: `.dockerignore` is the security boundary for these
+# wholesale copies — depth-aware patterns there exclude .env files,
+# node_modules, logs, IDE caches, etc from the build context.
 COPY package.json bun.lock tsconfig.json ./
 COPY apps ./apps
 COPY packages ./packages
@@ -32,7 +36,11 @@ COPY packages ./packages
 # claude-agent-sdk pulls a Claude Code bundle (~25MB) — runtime
 # requirement for the persona-engine SDK subprocess (e.g.
 # apps/bot/.claude/skills/arneson loaded via SDK settingSources).
-RUN bun install --frozen-lockfile --production
+# BuildKit cache mount preserves `~/.bun/install/cache` across rebuilds
+# so source-only changes don't re-download the SDK bundle (addresses
+# the deps-cache-invalidation trade-off documented in PR #38 review).
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --frozen-lockfile --production
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Operator ask

> *\"Can we make it easy so that it includes all character-*? and then we can simply have a single surface to include via env?\"*

Yes — collapse the per-character `COPY` lines into a wholesale `COPY apps ./apps` and rely on the **CHARACTERS env** (already wired) for runtime selection.

## Architecture

| Layer | Surface | Maintenance per new character |
|-------|---------|-------------------------------|
| Image | `COPY apps ./apps` (all character-*) | **zero** |
| Workspace deps | `package.json` declares `workspaces: [\"apps/*\", \"packages/*\"]` | **zero** (auto-globbed by bun) |
| Runtime selection | `CHARACTERS=...` env at `character-loader.ts:56` | per-Railway-service env update |

## Diff

Net: **-47 / +25 lines**. Single `apps/` + `packages/` copies replace 7 per-workspace COPY lines. Header doc + per-service ENV examples live in the file itself.

```diff
-COPY apps/bot/package.json ./apps/bot/
-COPY apps/character-ruggy/package.json ./apps/character-ruggy/
-COPY apps/character-satoshi/package.json ./apps/character-satoshi/
-COPY apps/character-mongolian/package.json ./apps/character-mongolian/
-...
-COPY apps/character-ruggy ./apps/character-ruggy
-COPY apps/character-satoshi ./apps/character-satoshi
-COPY apps/character-mongolian ./apps/character-mongolian
+COPY package.json bun.lock tsconfig.json ./
+COPY apps ./apps
+COPY packages ./packages
```

## Trade-off (called out in commit)

Old pattern copied per-workspace `package.json` files FIRST to preserve the `bun install` layer cache when only source changed. New shape invalidates the deps layer on any source change.

For bun's fast install (~5-10s for this monorepo) and Railway's build cadence: **acceptable**. If build perf becomes a concern later, drop in:

```dockerfile
RUN --mount=type=cache,target=/root/.bun/install/cache \
    bun install --frozen-lockfile --production
```

(BuildKit cache mount preserves `~/.bun/install/cache` across rebuilds — fast install even when the layer rebuilds.)

## Future-proofing

The cycle-3 mibera-as-npc instances (per `~/vault/wiki/concepts/mibera-as-npc.md` §6 cycle-3 plan) will spawn more character siblings beyond Munkh. This change keeps that path zero-friction — the curator authors `apps/character-{slug}/` and the Dockerfile picks it up automatically. Only the Railway service env needs `CHARACTERS=...` updated.

## Verified locally

- root `package.json` workspaces glob ✓
- `.dockerignore` preserves `persona.md` / `character.json` in subdirs (`*.md` matches root only by default) ✓
- `selectedCharacterIds()` at `character-loader.ts:56` reads `CHARACTERS` env (defaults to `['ruggy']`) ✓

## Test plan

- [ ] Railway rebuild on merge → image builds clean
- [ ] All 3 character services boot (`CHARACTERS=ruggy`, `=satoshi`, `=mongolian`)
- [ ] Build time observed (compare to pre-change baseline · sanity check on the cache trade-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)