### PR TITLE
fix(docker): add `id=` to BuildKit cache mount (Railway parser fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY packages ./packages
 # BuildKit cache mount preserves `~/.bun/install/cache` across rebuilds
 # so source-only changes don't re-download the SDK bundle (addresses
 # the deps-cache-invalidation trade-off documented in PR #38 review).
-RUN --mount=type=cache,target=/root/.bun/install/cache \
+RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
     bun install --frozen-lockfile --production
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Deploy hot-fix

PR #38 merged → Railway tried to build → rejected with:

```
dockerfile invalid: flag '--mount=type=cache,target=/root/.bun/install/cache'
is missing an id argument at Line 42
```

## Cause

Stock BuildKit treats the `id=` argument on `--mount=type=cache` as **optional** (defaults to a hash of the target path). Railway's BuildKit parser requires it explicit. The cache mount I added in the bridgebuilder fix commit was syntactically valid for stock BuildKit but rejected by Railway's stricter check.

## Fix

```diff
-RUN --mount=type=cache,target=/root/.bun/install/cache \
+RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
     bun install --frozen-lockfile --production
```

One line. Codex-rescue confirmed (resumed thread · gpt-5).

## Test plan

- [ ] Railway rebuilds → image builds clean
- [ ] All 3 character services boot

🤖 Generated with [Claude Code](https://claude.com/claude-code) · with Codex headless co-authoring