### PR TITLE
fix(docker): drop BuildKit cache mount (Railway parser fight #2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,16 @@ COPY packages ./packages
 # claude-agent-sdk pulls a Claude Code bundle (~25MB) — runtime
 # requirement for the persona-engine SDK subprocess (e.g.
 # apps/bot/.claude/skills/arneson loaded via SDK settingSources).
-# BuildKit cache mount preserves `~/.bun/install/cache` across rebuilds
-# so source-only changes don't re-download the SDK bundle (addresses
-# the deps-cache-invalidation trade-off documented in PR #38 review).
-RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
-    bun install --frozen-lockfile --production
+#
+# Note: a `--mount=type=cache,id=bun-cache,...` was tried in PRs #38/#39
+# to preserve `~/.bun/install/cache` across rebuilds, but Railway's
+# BuildKit parser requires a Railway-specific cacheKey prefix on the
+# `id` argument (undocumented format · errors with "missing the cacheKey
+# prefix from its id"). Dropped the cache mount entirely until the
+# Railway-correct syntax is clarified — bun install is fast enough on
+# cold builds for the current monorepo size that the cache optimization
+# is non-essential.
+RUN bun install --frozen-lockfile --production
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Second Railway rejection in a row

```
dockerfile invalid: flag '--mount=type=cache,id=bun-cache,target=/root/.bun/install/cache'
is missing the cacheKey prefix from its id at Line 42
```

PR #39 added explicit `id=bun-cache` to satisfy the **first** Railway rejection. Now Railway wants a **\"cacheKey prefix\" on the id** — an undocumented Railway/Railpack-specific extension.

## Decision: drop the cache mount entirely

Rather than guess the exact prefix shape (likely `id=s/<service-id>/<key>` based on Railpack patterns I've seen, but unconfirmed) and ship another broken deploy, simpler to **revert to plain `RUN bun install`**.

- Working deploy > fragile cache optimization
- Bun install is fast on cold builds for this monorepo size — the cache mount was never essential
- Original trade-off (bridgebuilder F1 in PR #38) returns: deps reinstall on source-only changes
- Comment in Dockerfile preserves the lesson for whoever revisits this

## Diff

```diff
-RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
-    bun install --frozen-lockfile --production
+RUN bun install --frozen-lockfile --production
```

Plus a 6-line comment block documenting the Railway parser issue so a future reader doesn't re-try the same syntax.

## Test plan

- [ ] Railway rebuilds clean
- [ ] All 3 character services boot

## When to revisit

If Railway/Railpack documents the exact cacheKey syntax, drop the cache mount back in with the correct prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)