### PR TITLE
fix(deps): regenerate bun.lock to include character-mongolian workspace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,10 @@
         "@freeside-characters/persona-engine": "workspace:*",
       },
     },
+    "apps/character-mongolian": {
+      "name": "@freeside-characters/character-mongolian",
+      "version": "0.1.0",
+    },
     "apps/character-ruggy": {
       "name": "@freeside-characters/character-ruggy",
       "version": "0.8.0",
@@ -84,6 +88,8 @@
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@freeside-characters/bot": ["@freeside-characters/bot@workspace:apps/bot"],
+
+    "@freeside-characters/character-mongolian": ["@freeside-characters/character-mongolian@workspace:apps/character-mongolian"],
 
     "@freeside-characters/character-ruggy": ["@freeside-characters/character-ruggy@workspace:apps/character-ruggy"],
 


### PR DESCRIPTION
## Railway build failure #4 on the Munkh-deploy chain

```
bun install v1.3.13
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

PR #33 added `apps/character-mongolian/` as a new bun workspace but didn't regenerate `bun.lock`. Now that the Dockerfile copies all of `apps/`, `bun install --frozen-lockfile` discovers the unregistered workspace and refuses.

## Diff

6-line addition to `bun.lock` registering the new workspace member. No actual new deps:

```diff
+    "apps/character-mongolian": {
+      "name": "@freeside-characters/character-mongolian",
+      "version": "0.1.0",
+    },
...
+    "@freeside-characters/character-mongolian": ["@freeside-characters/character-mongolian@workspace:apps/character-mongolian"],
```

Local verification: `bun install` reports `Checked 154 installs across 160 packages (no changes)` — confirming this is workspace-registration-only, not a dependency upgrade.

## Test plan

- [ ] Railway rebuilds → `bun install --frozen-lockfile` passes → bot starts → 3 characters live

## Deploy chain summary

| PR | What | Result |
|----|------|--------|
| #33 | Add character-mongolian (Munkh) | merged · forgot bun.lock + Dockerfile |
| #37 | Dockerfile COPY for character-mongolian | merged · unblocked load-character |
| #38 | Auto-include all character-* + cache mount | merged · cache mount syntax fight |
| #39 | Add `id=` to cache mount | merged · still rejected (cacheKey prefix) |
| #40 | Drop cache mount entirely | merged · revealed bun.lock issue |
| #41 (this) | Regenerate bun.lock | should be the final domino |

🤖 Generated with [Claude Code](https://claude.com/claude-code)