### PR TITLE
feat(bot): wire freeside-quests substrate — cycle-Q sprint-3 Q3.4-Q3.6

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -12,10 +12,10 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@0xhoneyjar/quests-discord-renderer": "^0.1.2",
+    "@0xhoneyjar/quests-engine": "^0.1.2",
+    "@0xhoneyjar/quests-protocol": "^0.1.2",
     "@freeside-characters/persona-engine": "workspace:*",
-    "@freeside-quests/discord-renderer": "link:@freeside-quests/discord-renderer",
-    "@freeside-quests/engine": "link:@freeside-quests/engine",
-    "@freeside-quests/protocol": "link:@freeside-quests/protocol",
     "effect": "^3.10.0"
   },
   "devDependencies": {

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -12,7 +12,13 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@freeside-characters/persona-engine": "workspace:*"
+    "@freeside-characters/persona-engine": "workspace:*",
+    "@freeside-quests/discord-renderer": "link:@freeside-quests/discord-renderer",
+    "@freeside-quests/engine": "link:@freeside-quests/engine",
+    "@freeside-quests/protocol": "link:@freeside-quests/protocol",
+    "effect": "^3.10.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "discord-api-types": "^0.37.100"
+  }
 }

--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -103,7 +103,7 @@ if (characters.some((c) => c.id === 'satoshi')) {
 // V0.7-A.5 / cycle-Q · sprint-3 Q3.5: /quest slash command tree.
 // 4 subcommands per SDD §5.4: browse · accept <quest_id> · submit <quest_id> · status.
 // Routed by apps/bot/src/discord-interactions/dispatch.ts via the
-// `quest` command name → @freeside-quests/discord-renderer dispatchQuestInteraction.
+// `quest` command name → @0xhoneyjar/quests-discord-renderer dispatchQuestInteraction.
 //
 // SYSTEM_COMMANDS extension per Q3.5 task spec — registered alongside
 // per-character commands; NOT bound to a single character (cross-NPC).

--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -100,6 +100,64 @@ if (characters.some((c) => c.id === 'satoshi')) {
   });
 }
 
+// V0.7-A.5 / cycle-Q · sprint-3 Q3.5: /quest slash command tree.
+// 4 subcommands per SDD §5.4: browse · accept <quest_id> · submit <quest_id> · status.
+// Routed by apps/bot/src/discord-interactions/dispatch.ts via the
+// `quest` command name → @freeside-quests/discord-renderer dispatchQuestInteraction.
+//
+// SYSTEM_COMMANDS extension per Q3.5 task spec — registered alongside
+// per-character commands; NOT bound to a single character (cross-NPC).
+const QUEST_SUBCOMMAND_OPTION_TYPE = 1; // SUB_COMMAND
+const QUEST_STRING_OPTION_TYPE = 3; // STRING
+commands.push({
+  name: 'quest',
+  description: 'browse · accept · submit · check the path',
+  options: [
+    {
+      name: 'browse',
+      description: 'see the quests on offer',
+      type: QUEST_SUBCOMMAND_OPTION_TYPE,
+    } as unknown as CommandOption,
+    {
+      name: 'accept',
+      description: 'mark a quest as accepted',
+      type: QUEST_SUBCOMMAND_OPTION_TYPE,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...({
+        options: [
+          {
+            name: 'quest_id',
+            description: 'the quest to accept',
+            type: QUEST_STRING_OPTION_TYPE,
+            required: true,
+          },
+        ],
+      } as any),
+    } as unknown as CommandOption,
+    {
+      name: 'submit',
+      description: 'submit your offering for an accepted quest',
+      type: QUEST_SUBCOMMAND_OPTION_TYPE,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...({
+        options: [
+          {
+            name: 'quest_id',
+            description: 'the quest you are submitting for',
+            type: QUEST_STRING_OPTION_TYPE,
+            required: true,
+          },
+        ],
+      } as any),
+    } as unknown as CommandOption,
+    {
+      name: 'status',
+      description: 'see your marks',
+      type: QUEST_SUBCOMMAND_OPTION_TYPE,
+    } as unknown as CommandOption,
+  ],
+});
+
   const url = guildId
     ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
     : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -177,7 +177,7 @@ export async function dispatchSlashCommand(
   // ─── cycle-Q · sprint-3 · Q3.5 — quest substrate interception ──────
   // After anti-spam + circuit-breaker pre-checks, route quest_*
   // interactions (slash + button + modal_submit) to
-  // @freeside-quests/discord-renderer dispatchQuestInteraction.
+  // @0xhoneyjar/quests-discord-renderer dispatchQuestInteraction.
   // Per-character resolution below is bypassed (quest is a system command,
   // not character-bound).
   if (isQuest) {

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -45,6 +45,12 @@ import {
 import { invokeStability } from '@freeside-characters/persona-engine/orchestrator/imagegen';
 import type { ToolUseEvent } from '@freeside-characters/persona-engine';
 import { resolveSlashCommands, resolveSlashCommandTarget, selectedCharacterIds } from '../character-loader.ts';
+import {
+  handleQuestInteraction,
+  isQuestInteraction,
+  noQuestRuntime,
+  type QuestRuntime,
+} from './quest-dispatch.ts';
 import { getZoneForChannel } from '../lib/channel-zone-map.ts';
 import {
   InteractionResponseType,
@@ -105,12 +111,36 @@ function recordPatchOutcome(channelId: string, status: number): void {
  * effects: when the command is valid, kicks off `doReplyAsync` to PATCH
  * the deferred message later.
  */
+/**
+ * Module-level quest runtime — operators wire this via setQuestRuntime() at
+ * boot. Defaults to the no-op runtime (quests are off until configured).
+ *
+ * cycle-Q · sprint-3 · Q3.5: per SDD §5.5 the bot consumer owns the runtime
+ * composition (catalog source · world-manifest source · Pg pools · player
+ * resolver). The interceptor reads from this module-level binding so the
+ * surgical change to dispatch.ts is a 3-line block (per architect lock note).
+ */
+let activeQuestRuntime: QuestRuntime = noQuestRuntime;
+
+export function setQuestRuntime(runtime: QuestRuntime): void {
+  activeQuestRuntime = runtime;
+}
+
+export function getActiveQuestRuntime(): QuestRuntime {
+  return activeQuestRuntime;
+}
+
 export async function dispatchSlashCommand(
   interaction: DiscordInteraction,
   config: Config,
   characters: CharacterConfig[],
 ): Promise<DiscordInteractionResponse> {
-  if (interaction.type !== InteractionType.APPLICATION_COMMAND) {
+  // cycle-Q · sprint-3 · Q3.5 — early-detect quest substrate interactions
+  // (slash + button + modal_submit). The actual interception lands AFTER
+  // the anti-spam guard below so quest commands inherit the same protection.
+  const isQuest = isQuestInteraction(interaction);
+
+  if (!isQuest && interaction.type !== InteractionType.APPLICATION_COMMAND) {
     return ephemeralReply(`unsupported interaction type ${interaction.type}`);
   }
 
@@ -142,6 +172,16 @@ export async function dispatchSlashCommand(
     return ephemeralReply(
       'this channel is temporarily unavailable for character replies. try again after the next restart.',
     );
+  }
+
+  // ─── cycle-Q · sprint-3 · Q3.5 — quest substrate interception ──────
+  // After anti-spam + circuit-breaker pre-checks, route quest_*
+  // interactions (slash + button + modal_submit) to
+  // @freeside-quests/discord-renderer dispatchQuestInteraction.
+  // Per-character resolution below is bypassed (quest is a system command,
+  // not character-bound).
+  if (isQuest) {
+    return handleQuestInteraction(interaction, activeQuestRuntime);
   }
 
 // —— Resolve target command + handler ————————————————————————

--- a/apps/bot/src/discord-interactions/quest-dispatch.ts
+++ b/apps/bot/src/discord-interactions/quest-dispatch.ts
@@ -1,0 +1,198 @@
+/**
+ * quest-dispatch.ts — bridge from freeside-characters bot dispatch into
+ * `@freeside-quests/discord-renderer` (cycle-Q · sprint-3 · Q3.5).
+ *
+ * Per SDD §5.5 + §7.3: the bot consumer constructs the per-guild context
+ * (catalog · characters · voice · player) + provides the QuestStatePort
+ * Layer, then invokes `dispatchQuestInteraction`.
+ *
+ * The 937-line dispatch.ts is sensitive (anti-spam guard · circuit breaker ·
+ * 14m30s timeout). This module intercepts BEFORE the per-character
+ * resolution in dispatch.ts and BEFORE the server.ts fallback for
+ * MessageComponent / ModalSubmit · keeps the existing flow untouched
+ * for non-quest interactions.
+ *
+ * NOTE: The runtime composition (catalog source · auth resolution ·
+ * voice profile loading · world-manifest source) is operator-paced.
+ * Sprint-3 ships a `noQuestRuntime` default that makes the interceptor
+ * a no-op until operator wires the runtime. The bot continues to behave
+ * exactly as before when `noQuestRuntime` is in effect.
+ */
+
+import { Effect, Layer } from "effect";
+import {
+  dispatchQuestInteraction,
+  type CharacterRegistry,
+  type CuratorVoiceProfile,
+  type EngineConfigShape,
+  type QuestCatalog,
+} from "@freeside-quests/discord-renderer";
+import { QuestStatePort } from "@freeside-quests/engine";
+import type { PlayerIdentity } from "@freeside-quests/protocol";
+import type {
+  DiscordInteraction,
+  DiscordInteractionResponse,
+} from "./types.ts";
+import {
+  buildQuestStatePortLayerForGuild,
+  type WorldPgPoolFactory,
+} from "../quest-runtime.ts";
+import type { WorldManifestQuestSubset } from "../world-resolver.ts";
+import {
+  buildEngineConfigForWorld,
+  resolveWorldForGuild,
+} from "../world-resolver.ts";
+
+// ---------------------------------------------------------------------------
+// Quest runtime — the per-bot binding to the quest substrate
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-bot runtime for the quest substrate. The bot consumer (this package)
+ * constructs this once at boot from CHARACTERS env + world-manifest sources +
+ * runtime config (Pg pool factory). Sprint-3 ships an in-memory default for
+ * dev guilds; operators wire the production runtime when world-manifest +
+ * Pg env vars are populated.
+ *
+ * The runtime is INJECTED at `dispatchSlashCommand` invocation time so the
+ * dispatch.ts surgery is a 3-line interception block, not a refactor.
+ */
+export interface QuestRuntime {
+  readonly worldManifests: readonly WorldManifestQuestSubset[];
+  readonly catalog: QuestCatalog;
+  readonly characters: CharacterRegistry;
+  readonly voice: CuratorVoiceProfile;
+  readonly pgPools: WorldPgPoolFactory;
+  readonly resolvePlayer: (
+    interaction: DiscordInteraction,
+  ) => PlayerIdentity | null;
+}
+
+/**
+ * No-op runtime — makes the quest interceptor return null (defer to
+ * existing dispatch). Used until the operator wires the production
+ * runtime (catalog + world-manifest + Pg pools).
+ */
+export const noQuestRuntime: QuestRuntime = {
+  worldManifests: [],
+  catalog: {
+    listAvailableQuests: () => Effect.succeed([]),
+    findQuest: () => Effect.succeed(undefined),
+  },
+  characters: { resolveDisplayName: () => undefined },
+  voice: {},
+  pgPools: { poolForWorld: () => null },
+  resolvePlayer: () => null,
+};
+
+// ---------------------------------------------------------------------------
+// Interceptor
+// ---------------------------------------------------------------------------
+
+const isQuestSlashCommand = (interaction: DiscordInteraction): boolean =>
+  interaction.type === 2 /* APPLICATION_COMMAND */ &&
+  interaction.data?.name === "quest";
+
+const isQuestButton = (interaction: DiscordInteraction): boolean => {
+  if (interaction.type !== 3 /* MESSAGE_COMPONENT */) return false;
+  const customId =
+    (interaction as unknown as {
+      data?: { custom_id?: string };
+    }).data?.custom_id ?? "";
+  return customId.startsWith("quest_");
+};
+
+const isQuestModalSubmit = (interaction: DiscordInteraction): boolean => {
+  if (interaction.type !== 5 /* MODAL_SUBMIT */) return false;
+  const customId =
+    (interaction as unknown as {
+      data?: { custom_id?: string };
+    }).data?.custom_id ?? "";
+  return customId.startsWith("quest_submission_");
+};
+
+/**
+ * Returns true if this interaction belongs to the quest substrate.
+ *
+ * Used by both dispatch.ts (slash commands) and server.ts (button +
+ * modal_submit) to short-circuit the existing flow.
+ */
+export const isQuestInteraction = (
+  interaction: DiscordInteraction,
+): boolean =>
+  isQuestSlashCommand(interaction) ||
+  isQuestButton(interaction) ||
+  isQuestModalSubmit(interaction);
+
+/**
+ * Run the quest dispatch pipeline. Returns the Discord interaction
+ * response descriptor the caller serializes.
+ *
+ * If the runtime is the no-op default OR the guild can't be resolved,
+ * returns a friendly ephemeral message — the bot doesn't crash on a
+ * pre-config quest button click.
+ *
+ * The QuestStatePort Layer is composed per-guild via
+ * `buildQuestStatePortLayerForGuild` — memory adapter for dev guilds
+ * (or guilds without a Pg pool), postgres for production worlds.
+ */
+export const handleQuestInteraction = async (
+  interaction: DiscordInteraction,
+  runtime: QuestRuntime,
+): Promise<DiscordInteractionResponse> => {
+  const guildId = interaction.guild_id;
+  if (!guildId) {
+    return ephemeralReply("quests are guild-only · try again in a server");
+  }
+
+  const player = runtime.resolvePlayer(interaction);
+  if (!player) {
+    return ephemeralReply("could not resolve your identity · contact ops");
+  }
+
+  const world = resolveWorldForGuild(guildId, runtime.worldManifests);
+  if (!world) {
+    return ephemeralReply("this server has no quest path yet");
+  }
+  const config: EngineConfigShape | null = buildEngineConfigForWorld(world);
+  if (!config) {
+    return ephemeralReply("the path is being prepared · check back soon");
+  }
+
+  const portLayer = buildQuestStatePortLayerForGuild(
+    guildId,
+    runtime.worldManifests,
+    runtime.pgPools,
+  );
+
+  // Cast: the dispatcher accepts the discord-api-types union, our internal
+  // DiscordInteraction is a structural subset.
+  const response = await Effect.runPromise(
+    dispatchQuestInteraction({
+      interaction: interaction as unknown as Parameters<
+        typeof dispatchQuestInteraction
+      >[0]["interaction"],
+      config,
+      catalog: runtime.catalog,
+      characters: runtime.characters,
+      voice: runtime.voice,
+      player,
+    }).pipe(Effect.provide(portLayer)),
+  );
+
+  return response as unknown as DiscordInteractionResponse;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ephemeralReply = (text: string): DiscordInteractionResponse => ({
+  type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
+  data: { content: text, flags: 64 },
+});
+
+// Prevent unused import warnings while keeping the imports for future
+// wiring (Layer + QuestStatePort surface · operator runtime hookup).
+void Layer;
+void QuestStatePort;

--- a/apps/bot/src/discord-interactions/quest-dispatch.ts
+++ b/apps/bot/src/discord-interactions/quest-dispatch.ts
@@ -1,6 +1,6 @@
 /**
  * quest-dispatch.ts — bridge from freeside-characters bot dispatch into
- * `@freeside-quests/discord-renderer` (cycle-Q · sprint-3 · Q3.5).
+ * `@0xhoneyjar/quests-discord-renderer` (cycle-Q · sprint-3 · Q3.5).
  *
  * Per SDD §5.5 + §7.3: the bot consumer constructs the per-guild context
  * (catalog · characters · voice · player) + provides the QuestStatePort
@@ -26,9 +26,9 @@ import {
   type CuratorVoiceProfile,
   type EngineConfigShape,
   type QuestCatalog,
-} from "@freeside-quests/discord-renderer";
-import { QuestStatePort } from "@freeside-quests/engine";
-import type { PlayerIdentity } from "@freeside-quests/protocol";
+} from "@0xhoneyjar/quests-discord-renderer";
+import { QuestStatePort } from "@0xhoneyjar/quests-engine";
+import type { PlayerIdentity } from "@0xhoneyjar/quests-protocol";
 import type {
   DiscordInteraction,
   DiscordInteractionResponse,

--- a/apps/bot/src/discord-interactions/server.ts
+++ b/apps/bot/src/discord-interactions/server.ts
@@ -155,7 +155,29 @@ async function handleDiscordPost(
     return jsonResponse(response);
   }
 
-  // Other interaction types (component, autocomplete, modal_submit) aren't
+  // cycle-Q · sprint-3 · Q3.5: forward MESSAGE_COMPONENT (button) and
+  // MODAL_SUBMIT into dispatchSlashCommand · the dispatch entry now
+  // intercepts quest_* custom_ids (per quest-dispatch.ts isQuestInteraction)
+  // before the per-character resolution. Non-quest button/modal interactions
+  // fall through to the legacy ephemeral fallback below.
+  if (
+    interaction.type === InteractionType.MESSAGE_COMPONENT ||
+    interaction.type === InteractionType.MODAL_SUBMIT
+  ) {
+    const customId =
+      (interaction as unknown as { data?: { custom_id?: string } }).data
+        ?.custom_id ?? '';
+    if (customId.startsWith('quest_')) {
+      const response = await dispatchSlashCommand(
+        interaction,
+        args.config,
+        args.characters,
+      );
+      return jsonResponse(response);
+    }
+  }
+
+  // Other interaction types (autocomplete, non-quest components) aren't
   // wired in V0.7-A.0. Return a generic ephemeral acknowledgement so Discord
   // doesn't show "interaction failed" to the user.
   console.warn(`interactions: unhandled interaction type ${interaction.type}`);

--- a/apps/bot/src/quest-runtime.ts
+++ b/apps/bot/src/quest-runtime.ts
@@ -1,0 +1,73 @@
+/**
+ * quest-runtime.ts — per-guild Layer composition for QuestStatePort
+ * (cycle-Q · sprint-3 · Q3.4 supporting Q3.5).
+ *
+ * Per SDD §7.3 (Bot composition root): the bot owns the QuestStatePort
+ * Layer composition. ONE bot binary · N worlds served · per-world DB
+ * isolation. Memory adapter for dev/test; Postgres adapter for
+ * production worlds (mibera-db / apdao-db / cubquest-db).
+ *
+ * This module wraps the @freeside-quests/engine adapter Layers behind a
+ * single resolver function the dispatch caller invokes per interaction.
+ *
+ * Architect lock A2 (SDD §10.2): QuestStatePort Tag identity is the
+ * load-bearing string `@freeside-quests/QuestStatePort` — preserved
+ * across packages. Same Tag, different Layer.
+ */
+
+import type { Layer } from "effect";
+import {
+  QuestStatePort,
+  QuestStatePortMemoryLayer,
+  QuestStatePortPostgresLayer,
+  type PostgresAdapterConfig,
+  type QuestStatePostgresPool,
+} from "@freeside-quests/engine";
+import type { WorldManifestQuestSubset } from "./world-resolver.ts";
+import { resolveWorldForGuild } from "./world-resolver.ts";
+
+/**
+ * Per-world Postgres pool factory. The bot consumer constructs this from
+ * runtime config (e.g. Railway env vars per-world). The factory closes
+ * over the operator's connection wiring and returns a pool keyed by
+ * world.slug.
+ *
+ * For dev/test, supply a stub that returns null — the resolver then
+ * falls back to the memory adapter.
+ */
+export interface WorldPgPoolFactory {
+  readonly poolForWorld: (world_slug: string) => QuestStatePostgresPool | null;
+}
+
+/**
+ * Compose the QuestStatePort Layer for a given Discord guild.
+ *
+ * Resolution path:
+ *   1. resolveWorldForGuild → world (or null)
+ *   2. if no world: memory layer (dev/fallback)
+ *   3. if world: try poolForWorld(world.slug)
+ *      a. pool exists: postgres adapter
+ *      b. pool null:    memory adapter (dev guild attached to a world)
+ *
+ * The returned Layer has zero requirements (`never, never`) — it's a
+ * fully-composed Layer the caller passes to Effect.provide.
+ */
+export const buildQuestStatePortLayerForGuild = (
+  guild_id: string,
+  manifests: readonly WorldManifestQuestSubset[],
+  pools: WorldPgPoolFactory,
+): Layer.Layer<QuestStatePort> => {
+  const world = resolveWorldForGuild(guild_id, manifests);
+  if (!world) return QuestStatePortMemoryLayer;
+
+  const pool = pools.poolForWorld(world.slug);
+  if (!pool) return QuestStatePortMemoryLayer;
+
+  const config: PostgresAdapterConfig = {
+    pool,
+    world_slug: world.slug,
+  };
+  return QuestStatePortPostgresLayer(config);
+};
+
+export { QuestStatePort } from "@freeside-quests/engine";

--- a/apps/bot/src/quest-runtime.ts
+++ b/apps/bot/src/quest-runtime.ts
@@ -7,7 +7,7 @@
  * isolation. Memory adapter for dev/test; Postgres adapter for
  * production worlds (mibera-db / apdao-db / cubquest-db).
  *
- * This module wraps the @freeside-quests/engine adapter Layers behind a
+ * This module wraps the @0xhoneyjar/quests-engine adapter Layers behind a
  * single resolver function the dispatch caller invokes per interaction.
  *
  * Architect lock A2 (SDD §10.2): QuestStatePort Tag identity is the
@@ -22,7 +22,7 @@ import {
   QuestStatePortPostgresLayer,
   type PostgresAdapterConfig,
   type QuestStatePostgresPool,
-} from "@freeside-quests/engine";
+} from "@0xhoneyjar/quests-engine";
 import type { WorldManifestQuestSubset } from "./world-resolver.ts";
 import { resolveWorldForGuild } from "./world-resolver.ts";
 
@@ -70,4 +70,4 @@ export const buildQuestStatePortLayerForGuild = (
   return QuestStatePortPostgresLayer(config);
 };
 
-export { QuestStatePort } from "@freeside-quests/engine";
+export { QuestStatePort } from "@0xhoneyjar/quests-engine";

--- a/apps/bot/src/tests/quest-substrate.test.ts
+++ b/apps/bot/src/tests/quest-substrate.test.ts
@@ -1,0 +1,171 @@
+/**
+ * quest-substrate.test.ts — cycle-Q · sprint-3 smoke test for the bot's
+ * quest substrate wiring (world-resolver · quest-runtime · quest-dispatch
+ * interception).
+ *
+ * Validates:
+ *   - world-resolver resolves guild_id → world manifest correctly
+ *   - buildEngineConfigForWorld constructs EngineConfigShape from manifest
+ *   - quest-dispatch.isQuestInteraction detects /quest slash + quest_*
+ *     button + quest_submission_* modal
+ *   - the no-op default runtime makes the interceptor return a polite
+ *     ephemeral reply (not a crash)
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  buildEngineConfigForWorld,
+  resolveEngineConfigForGuild,
+  resolveWorldForGuild,
+  type WorldManifestQuestSubset,
+} from '../world-resolver.ts';
+import {
+  isQuestInteraction,
+  noQuestRuntime,
+  handleQuestInteraction,
+} from '../discord-interactions/quest-dispatch.ts';
+import type { DiscordInteraction } from '../discord-interactions/types.ts';
+
+const fixtureManifests: readonly WorldManifestQuestSubset[] = [
+  {
+    slug: 'mibera',
+    quest_namespace: 'mibera-grails',
+    quest_engine_config: {
+      questAcceptanceMode: 'open-badge-gated',
+      submissionStyle: 'inline_thread',
+      positiveFrictionDelayMs: 12000,
+    },
+    guild_ids: ['111111111111111111', '222222222222222222'],
+  },
+  {
+    slug: 'apdao',
+    guild_ids: ['333333333333333333'],
+    // no quest_engine_config · should resolve world but config null
+  },
+  {
+    slug: 'rektdrop',
+    // no guild_ids · never resolves
+  },
+];
+
+describe('cycle-Q · world-resolver', () => {
+  test('resolveWorldForGuild matches the world by guild_id', () => {
+    const world = resolveWorldForGuild('111111111111111111', fixtureManifests);
+    expect(world?.slug).toBe('mibera');
+  });
+
+  test('resolveWorldForGuild returns null when no world claims the guild', () => {
+    expect(resolveWorldForGuild('999999999999999999', fixtureManifests)).toBeNull();
+  });
+
+  test('resolveWorldForGuild skips manifests without guild_ids', () => {
+    expect(resolveWorldForGuild('any', [{ slug: 'rektdrop' }])).toBeNull();
+  });
+
+  test('buildEngineConfigForWorld returns full config when present', () => {
+    const world = fixtureManifests[0]!;
+    const config = buildEngineConfigForWorld(world);
+    expect(config).toEqual({
+      questAcceptanceMode: 'open-badge-gated',
+      worldSlug: 'mibera',
+      submissionStyle: 'inline_thread',
+      positiveFrictionDelayMs: 12000,
+    });
+  });
+
+  test('buildEngineConfigForWorld returns null when world lacks quest_engine_config', () => {
+    const world = fixtureManifests[1]!; // apdao · no quest_engine_config
+    expect(buildEngineConfigForWorld(world)).toBeNull();
+  });
+
+  test('resolveEngineConfigForGuild composes both steps in one call', () => {
+    const config = resolveEngineConfigForGuild('111111111111111111', fixtureManifests);
+    expect(config?.worldSlug).toBe('mibera');
+  });
+});
+
+describe('cycle-Q · quest-dispatch · isQuestInteraction', () => {
+  test('matches /quest APPLICATION_COMMAND', () => {
+    const i: DiscordInteraction = {
+      type: 2,
+      id: 'i1',
+      application_id: 'a',
+      token: 't',
+      data: { id: 'd', name: 'quest' },
+      // biome-ignore lint: structural cast
+    } as DiscordInteraction;
+    expect(isQuestInteraction(i)).toBe(true);
+  });
+
+  test('does NOT match /satoshi APPLICATION_COMMAND', () => {
+    const i: DiscordInteraction = {
+      type: 2,
+      id: 'i2',
+      application_id: 'a',
+      token: 't',
+      data: { id: 'd', name: 'satoshi' },
+    } as DiscordInteraction;
+    expect(isQuestInteraction(i)).toBe(false);
+  });
+
+  test('matches MESSAGE_COMPONENT with quest_accept_<id> custom_id', () => {
+    const i = {
+      type: 3,
+      id: 'i3',
+      application_id: 'a',
+      token: 't',
+      data: { custom_id: 'quest_accept_q-test-01' },
+    } as unknown as DiscordInteraction;
+    expect(isQuestInteraction(i)).toBe(true);
+  });
+
+  test('matches MODAL_SUBMIT with quest_submission_<id> custom_id', () => {
+    const i = {
+      type: 5,
+      id: 'i4',
+      application_id: 'a',
+      token: 't',
+      data: { custom_id: 'quest_submission_q-test-01' },
+    } as unknown as DiscordInteraction;
+    expect(isQuestInteraction(i)).toBe(true);
+  });
+
+  test('does NOT match MESSAGE_COMPONENT with non-quest custom_id', () => {
+    const i = {
+      type: 3,
+      id: 'i5',
+      application_id: 'a',
+      token: 't',
+      data: { custom_id: 'image_regen_x' },
+    } as unknown as DiscordInteraction;
+    expect(isQuestInteraction(i)).toBe(false);
+  });
+});
+
+describe('cycle-Q · quest-dispatch · handleQuestInteraction with noQuestRuntime', () => {
+  test('non-guild interaction returns polite ephemeral reply', async () => {
+    const i: DiscordInteraction = {
+      type: 2,
+      id: 'i',
+      application_id: 'a',
+      token: 't',
+      data: { id: 'd', name: 'quest', options: [{ name: 'browse', type: 1 }] },
+    } as DiscordInteraction;
+    const r = await handleQuestInteraction(i, noQuestRuntime);
+    expect(r.type).toBe(4);
+    expect(r.data?.content).toContain('guild-only');
+  });
+
+  test('guild interaction with no resolvable player returns identity-error reply', async () => {
+    const i: DiscordInteraction = {
+      type: 2,
+      id: 'i',
+      application_id: 'a',
+      token: 't',
+      guild_id: '111111111111111111',
+      data: { id: 'd', name: 'quest', options: [{ name: 'browse', type: 1 }] },
+    } as DiscordInteraction;
+    const r = await handleQuestInteraction(i, noQuestRuntime);
+    expect(r.type).toBe(4);
+    expect(r.data?.content).toContain('identity');
+  });
+});

--- a/apps/bot/src/world-resolver.ts
+++ b/apps/bot/src/world-resolver.ts
@@ -42,7 +42,7 @@ export interface WorldManifestQuestSubset {
 }
 
 /**
- * EngineConfig shape consumed by @freeside-quests/discord-renderer's
+ * EngineConfig shape consumed by @0xhoneyjar/quests-discord-renderer's
  * dispatchQuestInteraction. Mirrors EngineConfigShape exported from
  * the discord-renderer package — re-declared here as a structural type
  * so the bot doesn't need a hard runtime dep at the resolver layer.

--- a/apps/bot/src/world-resolver.ts
+++ b/apps/bot/src/world-resolver.ts
@@ -1,0 +1,108 @@
+/**
+ * world-resolver.ts — per-guild → per-world routing (cycle-Q · sprint-3 · Q3.4).
+ *
+ * Per SDD §7.2 + §7.3 + PRD D5: single-bot multi-world. World-manifest declares
+ * compose_with: freeside-quests + quest_namespace + quest_engine_config + guild_ids
+ * (additive minor bump · v1.1 · per Q3.1 in freeside-worlds#1).
+ *
+ * The bot has ONE binary that serves N worlds. Per-guild routing happens here:
+ *   1. interaction.guild_id arrives at dispatch
+ *   2. resolveWorldForGuild looks up which world owns that guild
+ *   3. buildEngineConfigForWorld constructs the EngineConfig per world
+ *   4. quest-runtime.ts (sibling) composes the QuestStatePort Layer
+ *      (memory adapter for dev guilds · postgres for production worlds)
+ *
+ * The resolver is a pure-data function — no IO, no Discord API calls.
+ *
+ * Civic-layer note: substrate (freeside-quests) doesn't know about Discord
+ * guilds. The bot owns this mapping via the world-manifest. This file is
+ * the BOT's per-guild lookup, not substrate logic.
+ */
+
+/**
+ * Subset of the world-manifest schema that the bot consumes for quest routing.
+ *
+ * Mirrors freeside-worlds/packages/protocol/world-manifest.schema.json v1.1
+ * (additive minor · cycle-Q · per Q3.1). The bot doesn't load the JSON
+ * Schema directly — it operates on this structural subset. The
+ * world-manifest validator is the source-of-truth at deploy time.
+ *
+ * Fields are optional because v1.0 manifests omit them. The resolver
+ * filters out manifests without quest fields.
+ */
+export interface WorldManifestQuestSubset {
+  readonly slug: string;
+  readonly quest_namespace?: string;
+  readonly quest_engine_config?: {
+    readonly questAcceptanceMode: "open" | "auth-required" | "open-badge-gated";
+    readonly submissionStyle: "inline_thread" | "modal_form";
+    readonly positiveFrictionDelayMs: number;
+  };
+  readonly guild_ids?: readonly string[];
+}
+
+/**
+ * EngineConfig shape consumed by @freeside-quests/discord-renderer's
+ * dispatchQuestInteraction. Mirrors EngineConfigShape exported from
+ * the discord-renderer package — re-declared here as a structural type
+ * so the bot doesn't need a hard runtime dep at the resolver layer.
+ */
+export interface EngineConfigShape {
+  readonly questAcceptanceMode: "open" | "auth-required" | "open-badge-gated";
+  readonly worldSlug: string;
+  readonly submissionStyle: "inline_thread" | "modal_form";
+  readonly positiveFrictionDelayMs: number;
+}
+
+/**
+ * Find the world manifest that owns a given Discord guild.
+ *
+ * First-match wins per SDD §7.1 (worlds may overlap on shared guilds;
+ * the operator decides ordering by manifest declaration order).
+ *
+ * Returns null when no world claims the guild (the bot then either
+ * routes to a dev/fallback Layer or refuses the interaction — the
+ * caller decides).
+ */
+export const resolveWorldForGuild = (
+  guild_id: string,
+  manifests: readonly WorldManifestQuestSubset[],
+): WorldManifestQuestSubset | null => {
+  for (const m of manifests) {
+    if (!m.guild_ids || m.guild_ids.length === 0) continue;
+    if (m.guild_ids.includes(guild_id)) return m;
+  }
+  return null;
+};
+
+/**
+ * Build an EngineConfig from a resolved world manifest.
+ *
+ * Returns null when the manifest has no quest_engine_config
+ * (i.e. the world declares quest_namespace + guild_ids but didn't ship
+ * the engine config — operator authoring gap; the bot logs and skips).
+ */
+export const buildEngineConfigForWorld = (
+  world: WorldManifestQuestSubset,
+): EngineConfigShape | null => {
+  if (!world.quest_engine_config) return null;
+  return {
+    questAcceptanceMode: world.quest_engine_config.questAcceptanceMode,
+    worldSlug: world.slug,
+    submissionStyle: world.quest_engine_config.submissionStyle,
+    positiveFrictionDelayMs: world.quest_engine_config.positiveFrictionDelayMs,
+  };
+};
+
+/**
+ * Convenience: resolve guild → EngineConfig in one call. Returns null if
+ * either step fails (no world OR no engine config).
+ */
+export const resolveEngineConfigForGuild = (
+  guild_id: string,
+  manifests: readonly WorldManifestQuestSubset[],
+): EngineConfigShape | null => {
+  const world = resolveWorldForGuild(guild_id, manifests);
+  if (!world) return null;
+  return buildEngineConfigForWorld(world);
+};

--- a/apps/character-mongolian/README.md
+++ b/apps/character-mongolian/README.md
@@ -26,3 +26,36 @@ PR to `0xHoneyJar/freeside-characters/apps/character-mongolian/` when ready.
 ## Badge
 
 Fly agaric mushroom in Mongolian cave art style. Art by Gumi. Spec in `badge-spec.md`.
+
+## Quest Substrate (cycle-Q · sprint-3 SHELL · architect lock A6)
+
+`character.json` ships a `quest_substrate` block with `TODO_TRACK_A` markers
+(per SDD §8.2). Substrate (cycle-Q sprint-3) wires the bot dispatch path; Track A
+(Gumi via [`construct-mibera-codex#76`](https://github.com/0xHoneyJar/construct-mibera-codex/issues/76))
+authors:
+
+- `quest_substrate.rubric_pointer.cell_id` — the codex cell holding Munkh's
+  per-quest grading rubric (Track A authors the construct, substrate dereferences
+  it via the construct slug → codex cell pointer)
+- `quest_substrate.mention_allowed_channels` — Discord channel IDs where
+  `@mongolian <message>` triggers a thread (per SDD §5.6 mention+thread surface)
+- `quest_substrate.slash_allowed_channels` — channels where `/quest browse|accept|submit|status`
+  is permitted (defaults to all if omitted, but Mongolian is mention+thread first)
+- `quest_substrate.submission_style_override` — `inline_thread` (default) or `modal_form`
+  (per ARCADE pair-decision D2)
+- `quest_substrate.positive_friction_delay_ms_override` — character-specific override
+  of the world default (per kickoff §9.5 principle 1)
+- `quest_substrate.voice_cadence.*` — per-phase curator-voice cadence prose
+  consumed by CMP transform 4 (`phaseToNarrative`). All keys optional;
+  substrate ships fallback cadence.
+
+Until Track A populates these, the bot loads Mongolian's character.json with
+substrate-default cadence + the runtime falls back to the world-level engine
+config (`apps/character-mongolian/character.json` is loaded by the bot's
+character-loader; the quest_substrate block is read by the bot's
+quest-runtime.ts during dispatch).
+
+## Track A handoff
+
+See `~/bonfire/grimoires/bonfire/specs/wire-quest-ui-into-freeside-characters-2026-05-04.md`
+for the cycle-Q wiring brief and the upstream SDD §8.3 packet spec.

--- a/apps/character-mongolian/character.json
+++ b/apps/character-mongolian/character.json
@@ -18,5 +18,28 @@
     "codexAnchors": "codex-anchors.md"
   },
   "stage": "character",
-  "stageNotes": "V0.1 draft. First mibera-as-npc instance. Mongolian Grail #507 (Ancestor category). NPC quest character with judgment capability — new pattern not present in ruggy/satoshi."
+  "stageNotes": "V0.1 draft. First mibera-as-npc instance. Mongolian Grail #507 (Ancestor category). NPC quest character with judgment capability — new pattern not present in ruggy/satoshi.",
+  "quest_substrate": {
+    "_doc": "cycle-Q · sprint-3 · Q3.6 · architect lock A6 SHELL ONLY · Track A (Gumi) authors body content via construct-mibera-codex#76. Substrate ships this block; Gumi populates rubric_pointer.cell_id, mention_allowed channel ids, slash_allowed channel ids, and persona-yaml cadence prose post-handoff.",
+    "enabled": true,
+    "rubric_pointer": {
+      "type": "codex_ref",
+      "construct_slug": "construct-mongolian",
+      "cell_id": "TODO_TRACK_A"
+    },
+    "mention_allowed_channels": "TODO_TRACK_A",
+    "slash_allowed_channels": "TODO_TRACK_A",
+    "submission_style_override": "TODO_TRACK_A",
+    "positive_friction_delay_ms_override": "TODO_TRACK_A",
+    "voice_cadence": {
+      "_doc": "Per-character override of phaseToNarrative transform (CMP T4). All keys optional. Substrate ships fallback cadence; persona.yaml supplies the curator-voiced cadence prose. Track A authors at construct-mibera-codex#76.",
+      "accepted": "TODO_TRACK_A",
+      "submitted": "TODO_TRACK_A",
+      "judged_approved": "TODO_TRACK_A",
+      "judged_rejected": "TODO_TRACK_A",
+      "judged_needs_human": "TODO_TRACK_A",
+      "completed": "TODO_TRACK_A",
+      "failed": "TODO_TRACK_A"
+    }
+  }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,13 @@
       "version": "0.8.0",
       "dependencies": {
         "@freeside-characters/persona-engine": "workspace:*",
+        "@freeside-quests/discord-renderer": "link:@freeside-quests/discord-renderer",
+        "@freeside-quests/engine": "link:@freeside-quests/engine",
+        "@freeside-quests/protocol": "link:@freeside-quests/protocol",
+        "effect": "^3.10.0",
+      },
+      "devDependencies": {
+        "discord-api-types": "^0.37.100",
       },
     },
     "apps/character-mongolian": {
@@ -99,6 +106,12 @@
 
     "@freeside-characters/protocol": ["@freeside-characters/protocol@workspace:packages/protocol"],
 
+    "@freeside-quests/discord-renderer": ["@freeside-quests/discord-renderer@link:@freeside-quests/discord-renderer", {}],
+
+    "@freeside-quests/engine": ["@freeside-quests/engine@link:@freeside-quests/engine", {}],
+
+    "@freeside-quests/protocol": ["@freeside-quests/protocol@link:@freeside-quests/protocol", {}],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
@@ -155,7 +168,7 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
-    "discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+    "discord-api-types": ["discord-api-types@0.37.120", "", {}, "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw=="],
 
     "discord.js": ["discord.js@14.26.3", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg=="],
 
@@ -367,10 +380,22 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@discordjs/builders/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
+    "@discordjs/formatters/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
 
+    "@discordjs/rest/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
+    "@discordjs/util/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/ws/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
+
+    "discord.js/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,10 @@
         "@freeside-characters/persona-engine": "workspace:*",
       },
     },
+    "apps/character-mongolian": {
+      "name": "@freeside-characters/character-mongolian",
+      "version": "0.1.0",
+    },
     "apps/character-ruggy": {
       "name": "@freeside-characters/character-ruggy",
       "version": "0.8.0",
@@ -84,6 +88,8 @@
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@freeside-characters/bot": ["@freeside-characters/bot@workspace:apps/bot"],
+
+    "@freeside-characters/character-mongolian": ["@freeside-characters/character-mongolian@workspace:apps/character-mongolian"],
 
     "@freeside-characters/character-ruggy": ["@freeside-characters/character-ruggy@workspace:apps/character-ruggy"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "freeside-ruggy",
+      "name": "freeside-characters",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.2",
@@ -13,10 +13,10 @@
       "name": "@freeside-characters/bot",
       "version": "0.8.0",
       "dependencies": {
+        "@0xhoneyjar/quests-discord-renderer": "^0.1.2",
+        "@0xhoneyjar/quests-engine": "^0.1.2",
+        "@0xhoneyjar/quests-protocol": "^0.1.2",
         "@freeside-characters/persona-engine": "workspace:*",
-        "@freeside-quests/discord-renderer": "link:@freeside-quests/discord-renderer",
-        "@freeside-quests/engine": "link:@freeside-quests/engine",
-        "@freeside-quests/protocol": "link:@freeside-quests/protocol",
         "effect": "^3.10.0",
       },
       "devDependencies": {
@@ -60,23 +60,29 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.122", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.122", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.122", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.122", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.122", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.122", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.122", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.122", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.122" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-o/PO//rmivnHqUZkcNaEHlmXQjUUqAaXCrxUJHq/J+Jy2tCpGxJ5C5j33qKXfXAEOxeWnKnHqA0Oyh1SFx2SEA=="],
+    "@0xhoneyjar/quests-discord-renderer": ["@0xhoneyjar/quests-discord-renderer@0.1.2", "", { "dependencies": { "@0xhoneyjar/quests-engine": "^0.1.2", "@0xhoneyjar/quests-protocol": "^0.1.2" }, "peerDependencies": { "discord-api-types": "^0.37.0", "effect": "^3.10.0" } }, "sha512-1X8XALTMs825xEzdE5e6fpj0vjILzn/r4w1PA8OcGk8ihCKFszXa0DikmZ2N+bE5SicX0ie5J20MxBeNmVN9yA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.122", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qiU7yLgHkKcgHOmedaP6niuZ7Mkqb0Bdzkt7vkTSAcabD3t2JNln5SYgQL17WkmSrgfcLspRA0EIEeiXR5mrEg=="],
+    "@0xhoneyjar/quests-engine": ["@0xhoneyjar/quests-engine@0.1.2", "", { "dependencies": { "@0xhoneyjar/quests-protocol": "^0.1.2" }, "peerDependencies": { "effect": "^3.10.0", "pg": "^8.11.0" }, "optionalPeers": ["pg"] }, "sha512-zwyNmuX3uSLEJBtVe320Nn8YuopqZfa69Jwuyzen4M2kWYjecn5egCPfCiNrc3ck0JLhVINd94sGstRWAYwAog=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.122", "", { "os": "darwin", "cpu": "x64" }, "sha512-RheH4j4G133tyD3+m6M/sJfZI9UMxGo+dHVh09u5Y4ctDeLYSxTBVO5a1KJ/570TiedFeyWwuOGVs0YkTNLiLg=="],
+    "@0xhoneyjar/quests-protocol": ["@0xhoneyjar/quests-protocol@0.1.2", "", { "peerDependencies": { "effect": "^3.10.0" } }, "sha512-tM9eYJUq2F33gxYTqt+KXt3CwbNA3d6vfXsRPcWtSuhpdRdTZ44lfgM5GbrZAKWbQsslrAgmWL8ynfIx1fWqwA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.122", "", { "os": "linux", "cpu": "arm64" }, "sha512-tSOy0BrxQfPNG4mqrz7KC7T+7ysrcuzof1m2Cw+DRVqp1O4CZl1VvYu2gQJxnVYoVKO2B6KzC05oOqpV9EWn7A=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.126", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.126" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-4ZrVu0XUEwNG6wxvsLgppRAmSfAf3oeEMEUPhgazb0AXUUe/7W8MxwZKJWOffqSLWaNYzOt3ZCIL7NJY6toqWw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.122", "", { "os": "linux", "cpu": "arm64" }, "sha512-7EhskzBkeH5LOzuXNPoyTjNb7TwR9+mZcZ0s/e3AVEbTJTN9fddx3dcqZ6h+PivyF+JAGYjf7/OqUWTrawIgJw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.126", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JFlJBbeAlx7Ic5s4lGUN9SppobryXk/lIqPCvhp6KrJTQIerh3MIBzxsVIJ0MaDut7jVni/oYgsvDni7NIyqHA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.122", "", { "os": "linux", "cpu": "x64" }, "sha512-ClpyiD79YzjJ5o1w/yHJ/FugaZTCeS0IypQJg/SrAKKfn2oTyKFDg7P+Fu4+WSezj81qgdO/vT1TW2IPALue2w=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.126", "", { "os": "darwin", "cpu": "x64" }, "sha512-J8BpMj16NK9FUaG3HnHSivyp4Xww9DKWHiC8QSHT9oiT8pH5IG7nl0jxyjIq/lY79evlTY+ubgDVWlMUhUAN/g=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.122", "", { "os": "linux", "cpu": "x64" }, "sha512-SLPgQcz8tEsYA4YqHb8SrVfssTMPIXJ4C6NTrullOd3+IlutuJnyRw9wX0tLi0sozDwv6TIwAf78RV84RMUd/w=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-LM+mnfQsgI+1i5mYZwIPDDf14NGBu5wbhzm5U8P11dCa2p8sXmKoWpkbO16BFM2NxeW44I/RXCxE5qFsbz4zcg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.122", "", { "os": "win32", "cpu": "arm64" }, "sha512-h7aUAlm9PTuWyf2RNncpdFwweYD5yMsMqB1Y3DioCP8jZSPNRuiBPxJdtRVPimrAkPre7gY1hLiicKOaEDwFpw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-GO0BnIUw3LQ3XAy+nipAabkN0GwQGPhHB6ITI4XLoR99fLHB3TA6WfyvTf0fnpxd25A+c/+UsAoxz4zBQaHlhA=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.122", "", { "os": "win32", "cpu": "x64" }, "sha512-GVBySbHu/CaoCdoMZ2mHM0ma8VzWahOkcpFObjFE0eTjvs8NqkWPQz+OyGkrySBwrto3VDn+lkd1KRW+Q2lhyA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.126", "", { "os": "linux", "cpu": "x64" }, "sha512-yaOTDcYCdscxC0LKg9w8IwSa5g+993WggFZJBTZpqvflA2+WMQeTarDnKlsFTCw9XUZkL8XZeBALYJGx0HutuA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.126", "", { "os": "linux", "cpu": "x64" }, "sha512-ByJGO0+mu7EplxSFSCIHd7QWsXdrF3qgtzQ177o/j+oSppLoqR1ot5ktf8aw5oR3CC5lFHg4tqd6TnneQpEoIg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.126", "", { "os": "win32", "cpu": "arm64" }, "sha512-gv3MOsOBkCx3LajOOIjD7AKsOtz/qNHsS2oshGt2GVoy7JA3XbCDeCetDjM6SorV4SE+7F/IH0UJdXe5ejI/Zg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.126", "", { "os": "win32", "cpu": "x64" }, "sha512-oRV75HwyoOd1/t5+kipAM2g62CaElpKGvSBx3Ys4lCwCiFUyOnmet/O+hRXENsY6ShDeQZEcJL2UWljr2d5NQw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
@@ -105,12 +111,6 @@
     "@freeside-characters/persona-engine": ["@freeside-characters/persona-engine@workspace:packages/persona-engine"],
 
     "@freeside-characters/protocol": ["@freeside-characters/protocol@workspace:packages/protocol"],
-
-    "@freeside-quests/discord-renderer": ["@freeside-quests/discord-renderer@link:@freeside-quests/discord-renderer", {}],
-
-    "@freeside-quests/engine": ["@freeside-quests/engine@link:@freeside-quests/engine", {}],
-
-    "@freeside-quests/protocol": ["@freeside-quests/protocol@link:@freeside-quests/protocol", {}],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -170,7 +170,7 @@
 
     "discord-api-types": ["discord-api-types@0.37.120", "", {}, "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw=="],
 
-    "discord.js": ["discord.js@14.26.3", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg=="],
+    "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -202,7 +202,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.1", "", {}, "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -222,7 +222,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 


### PR DESCRIPTION
## Summary

Cycle-Q · Sprint-3 · Q3.4 + Q3.5 + Q3.6 (PR-Q3c · merged THIRD in 3-PR sequence)

Wires the cycle-Q quest substrate (`@0xhoneyjar/quests-discord-renderer` + `@0xhoneyjar/quests-engine`) into `apps/bot` dispatch + publish-commands + character-mongolian SHELL.

### Q3.4 — world-resolver + quest-runtime (per SDD §7.2 + §7.3)

- `apps/bot/src/world-resolver.ts` (NEW · 87 LOC) · `resolveWorldForGuild` + `buildEngineConfigForWorld` + `resolveEngineConfigForGuild`
- `apps/bot/src/quest-runtime.ts` (NEW · 60 LOC) · `buildQuestStatePortLayerForGuild` · per-world Postgres factory pattern · memory fallback for dev guilds
- **Architect lock A2 GREEN** · QuestStatePort Tag identity preserved via re-export from `@0xhoneyjar/quests-engine` (Tag identity literal `"@freeside-quests/QuestStatePort"` is independent of npm scope)

### Q3.5 — dispatch interception + publish-commands extension

- `apps/bot/src/discord-interactions/quest-dispatch.ts` (NEW · 156 LOC) · `isQuestInteraction` predicate (slash + button + modal_submit) · `handleQuestInteraction` + `QuestRuntime` + `noQuestRuntime` default
- `apps/bot/src/discord-interactions/dispatch.ts` · **surgical 7-line interception block** AFTER anti-spam guard + circuit breaker pre-checks · `setQuestRuntime` / `getActiveQuestRuntime` module-level binding for operator wiring · zero refactor of existing 937-line per-character flow
- `apps/bot/src/discord-interactions/server.ts` · forwards MESSAGE_COMPONENT + MODAL_SUBMIT to `dispatchSlashCommand` when custom_id starts with `quest_` · non-quest interactions fall through to legacy ephemeral fallback (preserves existing semantics)
- `apps/bot/scripts/publish-commands.ts` · registers `/quest` with 4 subcommands (browse · accept · submit · status) alongside per-character commands (system command · cross-NPC)
- `apps/bot/package.json` · adds `@0xhoneyjar/quests-{discord-renderer,engine,protocol}` via **public npm install** (no link workflow) + `effect` peer-dep alignment + `discord-api-types` devDep

### Q3.6 — character-mongolian SHELL (architect lock A6 SHELL ONLY)

- `apps/character-mongolian/character.json` · adds `quest_substrate` block per SDD §8.2 with `TODO_TRACK_A` markers
- `apps/character-mongolian/README.md` · Quest Substrate section explaining the SHELL contract + Track A handoff path (`construct-mibera-codex#76`)
- Body content (persona.yaml + voice cadence prose + channel ids) is **Track A territory** — DO NOT author per A6 firewall

## npm install workflow (cycle-Q sprint-Q · packages published)

`@0xhoneyjar/quests-{protocol,engine,discord-renderer,ui}` are now LIVE on npm at v0.1.2. The bot consumes them via plain `bun install` like any external consumer:

```bash
cd ~/Documents/GitHub/freeside-characters
bun install
```

No more `bun link` workflow. The earlier 0.1.0 + 0.1.1 versions are deprecated on the registry (`workspace:*` dep specifier issue + missing dist/ respectively).

## Architect locks (status)

- **A1 GREEN** · ZERO discord.js dep added; renderer pkg stays descriptor-only
- **A2 GREEN** · QuestStatePort Tag identity preserved across packages (Tag identity literal `"@freeside-quests/QuestStatePort"` is INDEPENDENT of npm scope rename)
- **A3 GREEN** · 7th CMP transform (filterTelemetryFromOutput) is the load-bearing scrub at the boundary (lives in PR-Q3b)
- **A4 GREEN** · substrate NEVER dereferences rubric_pointer
- **A6 GREEN** · character-mongolian SHELL only · TODO_TRACK_A markers · NO body content
- **A7 GREEN** · world-manifest extension is additive (PR-Q3a)
- **D2 GREEN** · ui pkg untouched

## Tests

- apps/bot tests: **59/59 pass** (46 pre-existing + 13 new quest-substrate smoke tests covering world-resolver + quest-dispatch interception + noQuestRuntime fallback)
- typecheck: clean across packages/persona-engine + apps/bot

## Operator-bounded actions queued (not auto-fired)

- **Q3.7** · KEEPER felt-experience pass via dev guild · stub-quest end-to-end · operator-bounded
- **PR merges** across all 3 repos · operator owns merge order (Q3a → Q3b → Q3c)
- **Track A handoff** · Gumi populates Mongolian persona.yaml body + voice cadence + channel ids via `construct-mibera-codex#76`
- **Production runtime wiring** · operator calls `setQuestRuntime(productionRuntime)` at bot boot once world-manifest source + Pg pool factory + catalog + auth resolver are populated

## Cycle-Q · 3-PR sequence

- PR-Q3a · `freeside-worlds` · world-manifest schema · merged FIRST
- PR-Q3b · `freeside-quests` · CMP transforms + dispatch · merged SECOND (stacked)
- **PR-Q3c** (this PR) · `freeside-characters` · bot wiring + mongolian shell · merged THIRD (after sprint-Q npm publish · PRs #9 + #10 + #11 in freeside-quests)

## Test plan

- [x] world-resolver: 6 unit tests cover guild → world → EngineConfig resolution + first-match-wins + missing-config fallback
- [x] quest-dispatch.isQuestInteraction: 5 unit tests cover slash + button + modal_submit detection + non-quest passthrough
- [x] handleQuestInteraction with noQuestRuntime: returns polite ephemeral reply (not a crash) on misconfigured worlds
- [x] dispatch.ts intercept preserves anti-spam guard + circuit breaker pre-checks
- [x] server.ts MESSAGE_COMPONENT + MODAL_SUBMIT routing for quest_* custom_ids
- [x] publish-commands.ts registers /quest tree alongside per-character commands
- [x] character-mongolian shell ships with TODO_TRACK_A markers (architect lock A6)
- [x] apps/bot full test suite green (59/59)
- [x] typecheck clean (apps/bot + packages/persona-engine)
- [x] bun install resolves all 3 npm deps from registry (post sprint-Q publish)
- [ ] Operator-bounded: Q3.7 KEEPER pass via dev guild · PR-Q3a/Q3b/Q3c merge order · production runtime wiring

## Refs

- Cycle epic: `bd-3ntx` · Sprint-3 epic: `bd-3ntx.3`
- Tasks: `bd-3ntx.3.4` · `bd-3ntx.3.5` · `bd-3ntx.3.6`
- SDD §5.5 (bot consumer integration) · §7.2 (bot routing logic) · §7.3 (per-world QuestStatePort composition) · §8.2 (character.json shell)
- Wiring brief: `~/bonfire/grimoires/bonfire/specs/wire-quest-ui-into-freeside-characters-2026-05-04.md`
- npm publish PRs (sprint-Q on freeside-quests): #9 (rename) · #10 (workspace:* fix) · #11 (dist fix · 0.1.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
