### PR TITLE
fix(munkh): populate webhookAvatarUrl + webhookUsername (canonical codex path)

### DIFF
--- a/apps/character-mongolian/character.json
+++ b/apps/character-mongolian/character.json
@@ -11,8 +11,8 @@
   "anchoredArchetypes": ["Ancient Witness", "Quest Keeper"],
   "mcps": ["codex", "freeside_auth"],
   "tool_invocation_style": "Use codex when a player asks about Mongolian lore, ancestors, or grail history — ground the answer in canon rather than improvising. Use freeside_auth to resolve wallet identity when a player's on-chain presence is relevant to quest progress. Default to voice; tools support, never lead.",
-  "webhookAvatarUrl": "",
-  "webhookUsername": "Munkh",
+  "webhookAvatarUrl": "https://assets.0xhoneyjar.xyz/Mibera/grails/mongolian.webp",
+  "webhookUsername": "Mongolian",
   "doc": {
     "creativeDirection": "creative-direction.md",
     "codexAnchors": "codex-anchors.md"


### PR DESCRIPTION
## Fast-follow on PR #33 — webhook fields were deferred to follow-up

Munkh is loading on Railway (CHARACTERS=ruggy,satoshi,mongolian) but webhook posts use the bot's default avatar because both fields were left empty in PR #33:

```diff
- "webhookAvatarUrl": "",
- "webhookUsername": "Munkh",
+ "webhookAvatarUrl": "https://assets.0xhoneyjar.xyz/Mibera/grails/mongolian.webp",
+ "webhookUsername": "Mongolian",
```

## Canonical via construct-mibera-codex

`grails/mongolian.md:11` references `/Mibera/grails/mongolian.webp` on the org CDN. Verified live `HTTP 200 · 122KB` · cave-art aesthetic matches the Munkh persona's visual register.

| field | value | provenance |
|---|---|---|
| `webhookAvatarUrl` | `https://assets.0xhoneyjar.xyz/Mibera/grails/mongolian.webp` | `construct-mibera-codex/grails/mongolian.md:11` (canonical) |
| `webhookUsername` | `Mongolian` (capitalized) | operator directive — Discord-facing handle |
| `displayName` | `Munkh` (unchanged) | preserved · curator's authored entity name |

## Pattern alignment

Mirror of PR #34 (satoshi canonical avatar swap · still open). Same pattern: mibera-derived characters resolve their PFP via codex `Mibera/grails/{slug}.webp` rather than a per-collection mirror.

## Test plan

- [ ] Railway picks up new image on merge → bot redeploys
- [ ] Operator runs `bun run apps/bot/scripts/publish-commands.ts` with `DISCORD_GUILD_ID=1135545260538339420` to register `/mongolian` slash command
- [ ] Discord render check: `/mongolian` in the guild → webhook post shows cave-art PFP + handle "Mongolian"

🤖 Generated with [Claude Code](https://claude.com/claude-code)