### PR TITLE
fix(error-ux): webhook-first error delivery · bare body on PATCH fallback

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -26,7 +26,7 @@
 
 import {
   appendToLedger,
-  composeErrorReply,
+  composeErrorBody,
   composeReplyWithEnrichment,
   composeToolUseStatusForCharacter,
   getBotClient,
@@ -335,7 +335,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
       console.error(
         `interactions: ${character.id}/chat TIMEOUT after ${Date.now() - t0}ms · channel=${channelId}`,
       );
-      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'timeout'));
+      await deliverError(interaction, config, character, channelId, ephemeral, 'timeout');
       return;
     }
 
@@ -343,7 +343,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
       console.warn(
         `interactions: ${character.id}/chat composeReply returned null · channel=${channelId}`,
       );
-      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'empty'));
+      await deliverError(interaction, config, character, channelId, ephemeral, 'empty');
       return;
     }
 
@@ -445,13 +445,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
       `interactions: ${character.id}/chat dispatch failed · channel=${channelId}`,
       err,
     );
-    try {
-      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'error'));
-    } catch (patchErr) {
-      // Already-failed PATCH attempt feeds the circuit breaker via
-      // recordPatchOutcome inside patchOriginal. No further recovery.
-      console.error(`interactions: PATCH-original after error also failed:`, patchErr);
-    }
+    await deliverError(interaction, config, character, channelId, ephemeral, 'error');
   }
 }
 
@@ -482,7 +476,7 @@ async function doReplyImagegen(args: AsyncWorkerArgs): Promise<void> {
       console.error(
         `interactions: ${character.id}/imagegen TIMEOUT after ${Date.now() - t0}ms · channel=${channelId}`,
       );
-      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'timeout'));
+      await deliverError(interaction, config, character, channelId, ephemeral, 'timeout');
       return;
     }
 
@@ -575,14 +569,7 @@ async function doReplyImagegen(args: AsyncWorkerArgs): Promise<void> {
           webhookErr,
         );
         invalidateWebhookCache(channelId);
-        try {
-          await patchOriginal(interaction, ephemeral, formatErrorReply(character, errKind));
-        } catch (patchErr) {
-          console.error(
-            `interactions: ${character.id}/imagegen error PATCH also failed:`,
-            patchErr,
-          );
-        }
+        await deliverError(interaction, config, character, channelId, ephemeral, errKind);
       }
     } else {
       // Placeholder mode (no real bytes): fall back to text-only via the
@@ -619,11 +606,7 @@ async function doReplyImagegen(args: AsyncWorkerArgs): Promise<void> {
       `interactions: ${character.id}/imagegen dispatch failed · channel=${channelId}`,
       err,
     );
-    try {
-      await patchOriginal(interaction, ephemeral, formatErrorReply(character, 'error'));
-    } catch (patchErr) {
-      console.error(`interactions: PATCH-original after imagegen error also failed:`, patchErr);
-    }
+    await deliverError(interaction, config, character, channelId, ephemeral, 'error');
   }
 }
 
@@ -812,18 +795,106 @@ function formatReply(
 }
 
 /**
- * Format the in-character error reply. V0.12 (kickoff §4.3) routes
- * through the substrate-side error register so ruggy and satoshi each
- * speak from their locked register at every error class. Bold-prefix
- * attribution stays here because it disambiguates shell-bot identity
- * for interaction PATCHes (per Gemini DR 2026-04-30).
+ * Format the error body without the bold-name prefix. Used for:
+ *   - Webhook delivery (Pattern B) — character avatar+username handle
+ *     attribution; bold-prefix would be redundant noise.
+ *   - Interaction PATCH fallback when the operator wants the bot to
+ *     speak as itself rather than puppeting the character name. The
+ *     Discord interaction header already shows "<user> used /<character>"
+ *     so context is preserved without the bold-prefix.
  */
-function formatErrorReply(
+function formatErrorBody(
   character: CharacterConfig,
   kind: ErrorClass,
 ): string {
-  const displayName = character.displayName ?? character.id;
-  return composeErrorReply(character.id, displayName, kind);
+  return composeErrorBody(character.id, kind);
+}
+
+/**
+ * Pattern B error delivery via channel webhook — the character speaks
+ * the error itself (avatar + username override), matching the success-
+ * reply UX. The deferred "thinking" PATCH placeholder is DELETEd once
+ * the webhook message lands so the timeline shows a single character
+ * post (mirrors `deliverViaWebhook`'s convention).
+ *
+ * Throws on any webhook failure so the caller can fall back to PATCH
+ * with bare body (no name prefix).
+ */
+async function deliverErrorViaWebhook(
+  interaction: DiscordInteraction,
+  config: Config,
+  character: CharacterConfig,
+  channelId: string,
+  kind: ErrorClass,
+): Promise<void> {
+  const client = await getBotClient(config);
+  if (!client) {
+    throw new Error('error webhook path: bot client unavailable');
+  }
+  const webhook = await getOrCreateChannelWebhook(client, channelId);
+  const body = formatErrorBody(character, kind);
+
+  await sendChatReplyViaWebhook(webhook, character, body);
+
+  // Clean up the deferred "thinking" placeholder (Pattern B convention).
+  void deleteOriginal(interaction).catch((err) => {
+    console.warn(
+      `interactions: ${character.id} error-webhook deleteOriginal best-effort failed:`,
+      err,
+    );
+  });
+}
+
+/**
+ * Unified error delivery — operator UX directive 2026-05-04:
+ *
+ *   1. Non-ephemeral: try Pattern B webhook (character avatar+username)
+ *      so the error reads as the character speaking, matching success
+ *      replies. Fall back to PATCH with bare body if webhook fails.
+ *   2. Ephemeral: PATCH only (webhooks aren't visible per-user). Bare
+ *      body — when loa speaks, drop the character-name prefix because
+ *      the Discord interaction header already shows which character
+ *      was invoked.
+ *
+ * Best-effort; logs + swallows PATCH failures (the circuit breaker
+ * inside patchOriginal records outcomes).
+ */
+async function deliverError(
+  interaction: DiscordInteraction,
+  config: Config,
+  character: CharacterConfig,
+  channelId: string,
+  ephemeral: boolean,
+  kind: ErrorClass,
+): Promise<void> {
+  if (ephemeral) {
+    await patchOriginal(interaction, true, formatErrorBody(character, kind)).catch(
+      (patchErr) => {
+        console.error(
+          `interactions: ${character.id} error PATCH (ephemeral) failed:`,
+          patchErr,
+        );
+      },
+    );
+    return;
+  }
+  try {
+    await deliverErrorViaWebhook(interaction, config, character, channelId, kind);
+  } catch (webhookErr) {
+    console.warn(
+      `interactions: ${character.id} error-webhook delivery failed · falling back to PATCH:`,
+      webhookErr,
+    );
+    invalidateWebhookCache(channelId);
+    await patchOriginal(interaction, false, formatErrorBody(character, kind)).catch(
+      (patchErr) => {
+        console.error(
+          `interactions: ${character.id} error PATCH after webhook fallback also failed:`,
+          patchErr,
+        );
+      },
+    );
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/packages/persona-engine/src/expression/error-register.test.ts
+++ b/packages/persona-engine/src/expression/error-register.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_ERROR_REGISTRY,
   getErrorTemplate,
   composeErrorReply,
+  composeErrorBody,
   type ErrorClass,
 } from "./error-register.ts";
 
@@ -127,6 +128,40 @@ describe("composeErrorReply · bold-prefix shape", () => {
     for (const banned of CORPORATE_BOT_BANNED) {
       expect(lower.includes(banned)).toBe(false);
     }
+  });
+});
+
+describe("composeErrorBody · bare-body shape (operator UX 2026-05-04)", () => {
+  // Per operator directive: webhook delivery (Pattern B · character speaks)
+  // and PATCH-fallback (loa speaks · drop the name) both use bare body.
+  // The bold-prefix is gone; webhook handles attribution via avatar+username,
+  // and the Discord interaction header already shows which character was
+  // invoked when loa speaks via PATCH.
+
+  test("returns just the body — no **DisplayName** prefix", () => {
+    const body = composeErrorBody("ruggy", "timeout");
+    expect(body.startsWith("**")).toBe(false);
+    expect(body).toBe(getErrorTemplate("ruggy", "timeout"));
+  });
+
+  test("body matches the registered template verbatim", () => {
+    const body = composeErrorBody("satoshi", "error");
+    expect(body).toBe(getErrorTemplate("satoshi", "error"));
+    expect(body).toBe("The channel between worlds slipped. Retry on the next.");
+  });
+
+  test("unknown character falls back to substrate-quiet generic (no prefix)", () => {
+    const body = composeErrorBody("stranger", "error");
+    expect(body).toBe("something broke. try again?");
+    expect(body.startsWith("**")).toBe(false);
+  });
+
+  test("composeErrorReply still works for legacy callers (deprecated path)", () => {
+    // Retained for any callers that haven't migrated; dispatch.ts no
+    // longer uses it but the export stays during deprecation window.
+    const reply = composeErrorReply("ruggy", "Ruggy", "timeout");
+    expect(reply.startsWith("**Ruggy**\n\n")).toBe(true);
+    expect(reply).toContain(composeErrorBody("ruggy", "timeout"));
   });
 });
 

--- a/packages/persona-engine/src/expression/error-register.ts
+++ b/packages/persona-engine/src/expression/error-register.ts
@@ -148,6 +148,14 @@ export function getErrorTemplate(
  *
  * `displayName` is the character's preferred attribution surface (falls
  * back to character.id at the call site).
+ *
+ * @deprecated 2026-05-04 — operator directive: when the bot (loa) speaks
+ * via interaction PATCH, it should NOT say the character's name (the
+ * Discord interaction header already shows "user used /character"). Use
+ * `composeErrorBody` for both webhook-delivered errors (Pattern B with
+ * character avatar/username override) and PATCH-fallback errors (bare
+ * body, no name prefix). Retained for any callers that haven't migrated
+ * yet — flag for cleanup once dispatch.ts migration confirmed.
  */
 export function composeErrorReply(
   characterId: string,
@@ -157,4 +165,29 @@ export function composeErrorReply(
   const body =
     getErrorTemplate(characterId, errorClass) ?? "something broke. try again?";
   return `**${displayName}**\n\n${body}`;
+}
+
+/**
+ * Compose just the error body (no character-name prefix). Use this for:
+ *
+ *   1. Webhook-delivered errors (Pattern B) — webhook avatar+username
+ *      handle attribution; bold-prefix would be redundant noise.
+ *   2. Interaction PATCH-fallback errors when the operator wants the bot
+ *      to speak without "puppeting" the character name (per operator
+ *      directive 2026-05-04: "if loa talks then don't have it say the
+ *      name"). The Discord interaction header already shows
+ *      "<user> used /<character>" so the user knows which character was
+ *      invoked even when the response is rendered as the shell-bot
+ *      identity (loa).
+ *
+ * Returns the substrate-quiet generic if no template registered for
+ * (characterId, errorClass).
+ */
+export function composeErrorBody(
+  characterId: string,
+  errorClass: ErrorClass,
+): string {
+  return (
+    getErrorTemplate(characterId, errorClass) ?? "something broke. try again?"
+  );
 }

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -129,6 +129,7 @@ export {
   DEFAULT_ERROR_REGISTRY,
   getErrorTemplate,
   composeErrorReply,
+  composeErrorBody,
 } from './expression/error-register.ts';
 export type {
   ErrorClass,


### PR DESCRIPTION
## Operator directive (Discord screenshot review · 2026-05-04)

> *\"I would like the webhook to spit this error not loa. if loa talks then don't have it say the name.\"*

Two pre-fix screenshots:

| Trigger | Pre-fix render |
|---------|---------------|
| `/mongolian prompt:\"henlo\"` (crashed at composeReply · pre PR #44) | **loa** says **Munkh** / something broke. try again? |
| `/satoshi-image prompt:\"...\"` (timeout) | **loa** says **Satoshi** / The channel between worlds slipped. Retry on the next. |

Both errors went through interaction PATCH with a bold-name prefix. The bot's shell identity (loa) appeared as the speaker even when Pattern B webhook was available.

## Architecture before vs after

```
BEFORE — every error path
─────────────────────────────────────────────
  compose throws → patchOriginal(`**Munkh**\n\nbody`)
                   → loa speaks · bold prefix puppets character

AFTER — unified deliverError helper
─────────────────────────────────────────────
  non-ephemeral:
    compose throws → deliverErrorViaWebhook (Pattern B · character speaks)
                     ↓ fail
                     PATCH(bare body) — loa speaks, no name prefix

  ephemeral:
    compose throws → PATCH(bare body) — loa speaks, no name prefix
                     (webhooks aren't visible per-user)
```

## Substrate change · `error-register.ts`

New `composeErrorBody(characterId, errorClass)` — body only, no prefix:

```typescript
// before: \"**Munkh**\\n\\nsomething broke. try again?\"
// after:  \"something broke. try again?\"
composeErrorBody(\"mongolian\", \"error\")
```

`composeErrorReply` (with prefix) marked `@deprecated`; retained during deprecation window for any external callers.

## Dispatch change · `dispatch.ts`

- New `deliverError(interaction, config, character, channelId, ephemeral, kind)` — unified helper, ~50 LOC.
- 6 `patchOriginal(..., formatErrorReply(...))` call sites collapsed to 6 `deliverError(...)` calls.
  - chat: timeout · empty · catch
  - imagegen: timeout · attachment-fail · catch
- `formatErrorReply` removed (was the last internal user of `composeErrorReply`).
- Webhook delivery uses existing `sendChatReplyViaWebhook` primitive (same path as success replies).

## Tests

```
✓ 19 existing tests still pass
✓ 4 new cases for composeErrorBody:
   - returns body, no ** prefix
   - matches registered template verbatim
   - unknown character → substrate-quiet generic (no prefix)
   - legacy composeErrorReply still works (deprecation window)
✓ 23/23 pass · 191 expect() calls · 81ms
```

Both packages typecheck clean.

## Test plan post-merge

- [ ] Railway redeploys → bot picks up new image
- [ ] Trigger an error (e.g. `/satoshi-image` with intentionally bad prompt or while imagegen is offline)
- [ ] Webhook post should appear with character avatar + username, error body without bold prefix
- [ ] If webhook fails (rare), PATCH fallback shows just the body — no \"**Munkh**\" / \"**Satoshi**\" prefix

## Future-proofing

- `composeErrorReply` cleanup: remove from `persona-engine/src/index.ts` exports once external usage confirmed zero.
- `formatReply` (success-path PATCH formatter at line 786) still uses bold-prefix — operator's directive applied to errors, but the success-PATCH-fallback case may also warrant it. Out of scope this PR; flag for separate review.
- Empty-reply edge case in `formatReply` (line 791) preserves bold-prefix; should also migrate to bare body for consistency. Same out-of-scope flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)