### PR TITLE
feat(bot): wire memory-mode QuestRuntime for QA dogfood (cycle-Q post-merge)

### DIFF
--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -81,23 +81,33 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // cycle-Q post-merge: env-gated quest runtime selection. Default disabled
-  // preserves backward-compat (V0.7-A.4 parity · /quest returns ephemeral
-  // "no quest path yet" via noQuestRuntime).
+  // === QUEST_RUNTIME · feature-flag selection · 3-mode ============
+  // Operator-authorized 2026-05-04 PM: testing in production server is OK.
+  // Runtime selection composes orthogonally to staging/production:
   //
-  //   QUEST_RUNTIME=disabled    (default · noQuestRuntime · pre-cycle-Q parity)
-  //   QUEST_RUNTIME=memory      memory adapter · in-process state · QA dogfood
-  //   QUEST_RUNTIME=production  operator-authored · NOT wired here · throws
+  //   QUEST_RUNTIME=disabled    backward-compat · noQuestRuntime · /quest = ephemeral
+  //   QUEST_RUNTIME=memory      in-process state · QA dogfood · works in prod or staging
+  //   QUEST_RUNTIME=production  real Pg pools + world-manifest source · operator-wired
+  //
+  // staging/production environment separation is a DIFFERENT axis (Railway
+  // service environment · bot binary · DISCORD_GUILD_ID values). Memory mode
+  // is environment-agnostic — works wherever the bot is deployed.
+  // =================================================================
+  //
+  // QUEST_GUILD_ID overrides if quest substrate runs in a different guild
+  // than the chat character substrate. Default: fall back to DISCORD_GUILD_ID
+  // (the canonical guild env var · already set on Railway production).
   const questRuntimeMode = (process.env.QUEST_RUNTIME ?? 'disabled').trim();
   if (questRuntimeMode === 'memory') {
-    const devGuildId = process.env.QUEST_DEV_GUILD_ID;
+    const guildId = process.env.QUEST_GUILD_ID ?? process.env.DISCORD_GUILD_ID;
     const runtime = buildMemoryDevQuestRuntime({
-      devGuildId,
+      guildId,
       characters,
     });
     setQuestRuntime(runtime);
+    const runtimeContext = `mode=memory world=mongolian guild=${guildId ?? 'unset'}`;
     console.log(
-      `quest-runtime:  memory · world=${'mongolian'} · dev_guild=${devGuildId ?? '(unset · /quest will return polite no-path reply)'}`,
+      `quest-runtime:  memory · world=${'mongolian'} · guild=${guildId ?? '(unset · /quest will return polite no-path reply)'} · ${runtimeContext}`,
     );
   } else if (questRuntimeMode === 'production') {
     // OPERATOR-AUTHORED: production runtime requires a real world-manifest

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -40,6 +40,8 @@ import {
   startInteractionServer,
   type InteractionServerHandle,
 } from './discord-interactions/server.ts';
+import { setQuestRuntime } from './discord-interactions/dispatch.ts';
+import { buildMemoryDevQuestRuntime } from './quest-runtime-bootstrap.ts';
 
 const banner = `─── freeside-characters bot · v0.6.0-A ────────────────────────`;
 
@@ -77,6 +79,38 @@ async function main(): Promise<void> {
   } catch (err) {
     console.error('persona/codex load failed:', err);
     process.exit(1);
+  }
+
+  // cycle-Q post-merge: env-gated quest runtime selection. Default disabled
+  // preserves backward-compat (V0.7-A.4 parity · /quest returns ephemeral
+  // "no quest path yet" via noQuestRuntime).
+  //
+  //   QUEST_RUNTIME=disabled    (default · noQuestRuntime · pre-cycle-Q parity)
+  //   QUEST_RUNTIME=memory      memory adapter · in-process state · QA dogfood
+  //   QUEST_RUNTIME=production  operator-authored · NOT wired here · throws
+  const questRuntimeMode = (process.env.QUEST_RUNTIME ?? 'disabled').trim();
+  if (questRuntimeMode === 'memory') {
+    const devGuildId = process.env.QUEST_DEV_GUILD_ID;
+    const runtime = buildMemoryDevQuestRuntime({
+      devGuildId,
+      characters,
+    });
+    setQuestRuntime(runtime);
+    console.log(
+      `quest-runtime:  memory · world=${'mongolian'} · dev_guild=${devGuildId ?? '(unset · /quest will return polite no-path reply)'}`,
+    );
+  } else if (questRuntimeMode === 'production') {
+    // OPERATOR-AUTHORED: production runtime requires a real world-manifest
+    // source + per-world Pg pools (mibera-db / apdao-db / cubquest-db).
+    // Out of scope for the QA bootstrap. Operator wires this when Q2.9
+    // DB migration lands + world-manifest source is published.
+    throw new Error(
+      'QUEST_RUNTIME=production not yet wired · use QUEST_RUNTIME=memory for QA',
+    );
+  } else {
+    console.log(
+      `quest-runtime:  disabled · /quest returns ephemeral (set QUEST_RUNTIME=memory for QA)`,
+    );
   }
 
   if (config.DISCORD_BOT_TOKEN) {

--- a/apps/bot/src/quest-runtime-bootstrap.ts
+++ b/apps/bot/src/quest-runtime-bootstrap.ts
@@ -86,13 +86,15 @@ const buildStubQuest = (): Quest =>
 
 export interface MemoryDevQuestRuntimeOptions {
   /**
-   * Discord guild ID the dev/QA server uses. The stub world manifest
-   * declares this as the only `guild_ids` entry so resolveWorldForGuild
-   * matches it. If undefined or empty string, the stub world manifest
-   * declares NO guild_ids · the resolver returns null for every guild
-   * · /quest returns the polite "no quest path yet" reply.
+   * Discord guild ID the bot runs in. The stub world manifest declares
+   * this as the only `guild_ids` entry so resolveWorldForGuild matches it.
+   * Applies whether testing on staging or production guild ·
+   * operator-acknowledged prod-test posture 2026-05-04. If undefined or
+   * empty string, the stub world manifest declares NO guild_ids · the
+   * resolver returns null for every guild · /quest returns the polite
+   * "no quest path yet" reply.
    */
-  readonly devGuildId?: string;
+  readonly guildId?: string;
   /**
    * Loaded characters (from character-loader). Used to construct the
    * CharacterRegistry · resolveDisplayName maps NpcId → displayName.
@@ -159,10 +161,10 @@ const buildResolvePlayer = (): ((
 // ---------------------------------------------------------------------------
 
 const buildWorldManifests = (
-  devGuildId: string | undefined,
+  guildId: string | undefined,
 ): readonly WorldManifestQuestSubset[] => {
   const guild_ids =
-    devGuildId && devGuildId.trim().length > 0 ? [devGuildId] : [];
+    guildId && guildId.trim().length > 0 ? [guildId] : [];
   return [
     {
       slug: STUB_WORLD_SLUG,
@@ -198,11 +200,16 @@ const emptyVoiceProfile: CuratorVoiceProfile = {};
 // ---------------------------------------------------------------------------
 
 /**
- * Build a memory-mode QuestRuntime suitable for Discord dev-guild QA.
+ * Build a memory-mode QuestRuntime suitable for Discord guild QA.
+ *
+ * The "Dev" in the name refers to the runtime *mode* (memory-dev-mode) ·
+ * NOT the deployment environment. Memory-mode runs cleanly in staging
+ * OR production guilds — operator-acknowledged prod-test posture
+ * 2026-05-04.
  *
  * Backed by:
  *   - in-memory catalog with one stub quest (`munkh-introduction-v1`)
- *   - one stub world manifest scoped to `devGuildId` (if provided)
+ *   - one stub world manifest scoped to `guildId` (if provided)
  *   - memory QuestStatePort (no Pg) · state lives in-process · resets on bot restart
  *   - anon-only player identity (per PRD D4 anon-allowed default)
  *   - empty voice profile · substrate cadence fallback
@@ -213,7 +220,7 @@ export const buildMemoryDevQuestRuntime = (
   opts: MemoryDevQuestRuntimeOptions,
 ): QuestRuntime => {
   return {
-    worldManifests: buildWorldManifests(opts.devGuildId),
+    worldManifests: buildWorldManifests(opts.guildId),
     catalog: buildMemoryCatalog(),
     characters: buildCharacterRegistry(opts.characters),
     voice: emptyVoiceProfile,

--- a/apps/bot/src/quest-runtime-bootstrap.ts
+++ b/apps/bot/src/quest-runtime-bootstrap.ts
@@ -1,0 +1,228 @@
+/**
+ * quest-runtime-bootstrap.ts — memory-mode QuestRuntime constructor for QA
+ * dogfood (cycle-Q post-merge).
+ *
+ * Per CLAUDE.md operator authorization 2026-05-04 PM ("/autonomous so I can
+ * QA test with mongolian"): unblocks Q3.7 KEEPER felt-pass via Discord
+ * without Q2.9 DB migration. Memory adapter only · production runtime
+ * stays operator-bounded (real world-manifest source + per-world Pg pools).
+ *
+ * Architect locks honored:
+ *   - A2: QuestStatePort Tag identity preserved (this module only constructs
+ *     QuestRuntime — does not touch the Tag string at all).
+ *   - A4: substrate does NOT dereference rubric_pointer · the catalog stub
+ *     ships a codex_ref pointer that the construct (LLM) would resolve at
+ *     judgment time · NOT here.
+ *   - A6: Munkh persona body is curator territory · this module ships
+ *     SUBSTRATE scaffolding only. voice_cadence stays empty · falls back
+ *     to phaseToNarrative substrate default until Track A populates.
+ */
+
+import { Effect } from "effect";
+import type {
+  CharacterRegistry,
+  CuratorVoiceProfile,
+  QuestCatalog,
+} from "@0xhoneyjar/quests-discord-renderer";
+import type {
+  Quest,
+  QuestId,
+  NpcId,
+  WorldSlug,
+  BadgeFamilyId,
+  PlayerIdentity,
+  DiscordId,
+} from "@0xhoneyjar/quests-protocol";
+import type { CharacterConfig } from "@freeside-characters/persona-engine";
+import type { QuestRuntime } from "./discord-interactions/quest-dispatch.ts";
+import type {
+  WorldPgPoolFactory,
+} from "./quest-runtime.ts";
+import type { WorldManifestQuestSubset } from "./world-resolver.ts";
+import type { DiscordInteraction } from "./discord-interactions/types.ts";
+
+// ---------------------------------------------------------------------------
+// Stub catalog content (cell_id is a placeholder · construct-mongolian
+// authoring lives at construct-mibera-codex#76 per Track A boundary)
+// ---------------------------------------------------------------------------
+
+const STUB_QUEST_ID = "munkh-introduction-v1";
+const STUB_WORLD_SLUG = "mongolian";
+const STUB_NPC_ID = "mongolian";
+
+/**
+ * Build the stub quest. The fields here are SUBSTRATE shapes — no curator
+ * voice. The construct (LLM-bound) dereferences rubric_pointer at judgment
+ * time per architect lock A4.
+ */
+const buildStubQuest = (): Quest =>
+  ({
+    quest_id: STUB_QUEST_ID as unknown as QuestId,
+    npc_pointer: STUB_NPC_ID as unknown as NpcId,
+    world_slug: STUB_WORLD_SLUG as unknown as WorldSlug,
+    title: "Why did you come?",
+    prompt:
+      "Share why you came · what brought you to the steppe today. A few lines is enough · the wind carries everything you do not say.",
+    rubric_pointer: {
+      type: "codex_ref",
+      construct_slug: "construct-mongolian",
+      cell_id: "stub-v1-munkh-quest",
+    },
+    badge_spec: {
+      family_id: "mongolian-petroglyph-stub" as unknown as BadgeFamilyId,
+      display_name: "First Mark on the Steppe",
+      prompt_seed:
+        "A simple petroglyph carved into weathered stone · the first mark a traveler leaves on Mongolian soil.",
+      format_hint: "webp",
+    },
+    published_at: new Date("2026-05-04T00:00:00Z").toISOString(),
+    step_count: 1,
+    contract_version: "1.0.0",
+  }) as Quest;
+
+// ---------------------------------------------------------------------------
+// Bootstrap options
+// ---------------------------------------------------------------------------
+
+export interface MemoryDevQuestRuntimeOptions {
+  /**
+   * Discord guild ID the dev/QA server uses. The stub world manifest
+   * declares this as the only `guild_ids` entry so resolveWorldForGuild
+   * matches it. If undefined or empty string, the stub world manifest
+   * declares NO guild_ids · the resolver returns null for every guild
+   * · /quest returns the polite "no quest path yet" reply.
+   */
+  readonly devGuildId?: string;
+  /**
+   * Loaded characters (from character-loader). Used to construct the
+   * CharacterRegistry · resolveDisplayName maps NpcId → displayName.
+   */
+  readonly characters: readonly CharacterConfig[];
+}
+
+// ---------------------------------------------------------------------------
+// CharacterRegistry · NpcId → displayName
+// ---------------------------------------------------------------------------
+
+const buildCharacterRegistry = (
+  characters: readonly CharacterConfig[],
+): CharacterRegistry => {
+  const map = new Map<string, string>();
+  for (const c of characters) {
+    if (c.displayName) map.set(c.id, c.displayName);
+  }
+  return {
+    resolveDisplayName: (npc_id: string) => map.get(npc_id),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// QuestCatalog · in-memory single-quest catalog scoped to STUB_WORLD_SLUG
+// ---------------------------------------------------------------------------
+
+const buildMemoryCatalog = (): QuestCatalog => {
+  const stub = buildStubQuest();
+  return {
+    listAvailableQuests: (worldSlug: string) =>
+      Effect.succeed(worldSlug === STUB_WORLD_SLUG ? [stub] : []),
+    findQuest: (worldSlug: string, quest_id: string) =>
+      Effect.succeed(
+        worldSlug === STUB_WORLD_SLUG && quest_id === STUB_QUEST_ID
+          ? stub
+          : undefined,
+      ),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// resolvePlayer · Discord interaction → PlayerIdentity (anon-default per D4)
+// ---------------------------------------------------------------------------
+
+const DISCORD_ID_PATTERN = /^\d{17,20}$/;
+
+const buildResolvePlayer = (): ((
+  interaction: DiscordInteraction,
+) => PlayerIdentity | null) => {
+  return (interaction: DiscordInteraction): PlayerIdentity | null => {
+    const userId = interaction.member?.user?.id ?? interaction.user?.id;
+    if (!userId) return null;
+    if (!DISCORD_ID_PATTERN.test(userId)) return null;
+    return {
+      type: "anon",
+      discord_id: userId as unknown as DiscordId,
+    };
+  };
+};
+
+// ---------------------------------------------------------------------------
+// World manifest stub
+// ---------------------------------------------------------------------------
+
+const buildWorldManifests = (
+  devGuildId: string | undefined,
+): readonly WorldManifestQuestSubset[] => {
+  const guild_ids =
+    devGuildId && devGuildId.trim().length > 0 ? [devGuildId] : [];
+  return [
+    {
+      slug: STUB_WORLD_SLUG,
+      quest_namespace: "mongolian-stub",
+      quest_engine_config: {
+        questAcceptanceMode: "open",
+        submissionStyle: "inline_thread",
+        positiveFrictionDelayMs: 12000,
+      },
+      guild_ids,
+    },
+  ];
+};
+
+// ---------------------------------------------------------------------------
+// Pg pool factory · always null (memory adapter only)
+// ---------------------------------------------------------------------------
+
+const memoryOnlyPgPools: WorldPgPoolFactory = {
+  poolForWorld: () => null,
+};
+
+// ---------------------------------------------------------------------------
+// Voice profile · empty stub. phaseToNarrative falls back to substrate
+// default cadence per CMP-boundary T4. Track A (Gumi) populates per-phase
+// cadence in persona.yaml/character.json voice_cadence post-handoff.
+// ---------------------------------------------------------------------------
+
+const emptyVoiceProfile: CuratorVoiceProfile = {};
+
+// ---------------------------------------------------------------------------
+// Public constructor
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a memory-mode QuestRuntime suitable for Discord dev-guild QA.
+ *
+ * Backed by:
+ *   - in-memory catalog with one stub quest (`munkh-introduction-v1`)
+ *   - one stub world manifest scoped to `devGuildId` (if provided)
+ *   - memory QuestStatePort (no Pg) · state lives in-process · resets on bot restart
+ *   - anon-only player identity (per PRD D4 anon-allowed default)
+ *   - empty voice profile · substrate cadence fallback
+ *
+ * Returns a QuestRuntime the bot wires via `setQuestRuntime` at boot.
+ */
+export const buildMemoryDevQuestRuntime = (
+  opts: MemoryDevQuestRuntimeOptions,
+): QuestRuntime => {
+  return {
+    worldManifests: buildWorldManifests(opts.devGuildId),
+    catalog: buildMemoryCatalog(),
+    characters: buildCharacterRegistry(opts.characters),
+    voice: emptyVoiceProfile,
+    pgPools: memoryOnlyPgPools,
+    resolvePlayer: buildResolvePlayer(),
+  };
+};
+
+// Re-export the stub identifiers for tests + observability.
+export const MEMORY_DEV_STUB_QUEST_ID = STUB_QUEST_ID;
+export const MEMORY_DEV_STUB_WORLD_SLUG = STUB_WORLD_SLUG;
+export const MEMORY_DEV_STUB_NPC_ID = STUB_NPC_ID;

--- a/apps/bot/src/tests/quest-runtime-bootstrap.test.ts
+++ b/apps/bot/src/tests/quest-runtime-bootstrap.test.ts
@@ -1,0 +1,181 @@
+/**
+ * quest-runtime-bootstrap.test.ts — smoke test for the memory-mode
+ * QuestRuntime constructor (cycle-Q post-merge QA bootstrap).
+ *
+ * Validates:
+ *   - buildMemoryDevQuestRuntime returns a fully-shaped QuestRuntime
+ *   - catalog.listAvailableQuests returns the stub quest scoped to
+ *     world="mongolian" · returns [] for any other world slug
+ *   - catalog.findQuest("mongolian", "munkh-introduction-v1") returns
+ *     the stub · returns undefined for any other (world, quest) pair
+ *   - resolvePlayer extracts user.id correctly from interaction.member.user
+ *     and returns null when no Discord user is present (per anon-default
+ *     PRD D4 with anon-only stub)
+ *   - worldManifests scope to QUEST_DEV_GUILD_ID exactly when provided
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Effect } from 'effect';
+import {
+  buildMemoryDevQuestRuntime,
+  MEMORY_DEV_STUB_QUEST_ID,
+  MEMORY_DEV_STUB_WORLD_SLUG,
+} from '../quest-runtime-bootstrap.ts';
+import type { CharacterConfig } from '@freeside-characters/persona-engine';
+import type { DiscordInteraction } from '../discord-interactions/types.ts';
+
+const stubCharacters: readonly CharacterConfig[] = [
+  {
+    id: 'mongolian',
+    displayName: 'Munkh',
+    personaPath: '/dev/null/persona.md',
+    exemplarsDir: undefined,
+    emojiAffinity: { primary: 'mibera', fallback: 'mibera' },
+  } as unknown as CharacterConfig,
+];
+
+describe('cycle-Q · quest-runtime-bootstrap · buildMemoryDevQuestRuntime shape', () => {
+  test('returns a fully-shaped QuestRuntime', () => {
+    const r = buildMemoryDevQuestRuntime({
+      devGuildId: '111111111111111111',
+      characters: stubCharacters,
+    });
+    expect(Array.isArray(r.worldManifests)).toBe(true);
+    expect(typeof r.catalog.listAvailableQuests).toBe('function');
+    expect(typeof r.catalog.findQuest).toBe('function');
+    expect(typeof r.characters.resolveDisplayName).toBe('function');
+    expect(typeof r.pgPools.poolForWorld).toBe('function');
+    expect(typeof r.resolvePlayer).toBe('function');
+  });
+
+  test('worldManifests scope to devGuildId exactly when provided', () => {
+    const r = buildMemoryDevQuestRuntime({
+      devGuildId: '999888777666555444',
+      characters: stubCharacters,
+    });
+    expect(r.worldManifests).toHaveLength(1);
+    expect(r.worldManifests[0]?.slug).toBe(MEMORY_DEV_STUB_WORLD_SLUG);
+    expect(r.worldManifests[0]?.guild_ids).toEqual(['999888777666555444']);
+  });
+
+  test('worldManifests have no guild_ids when devGuildId omitted', () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    expect(r.worldManifests).toHaveLength(1);
+    expect(r.worldManifests[0]?.guild_ids).toEqual([]);
+  });
+
+  test('CharacterRegistry resolves Munkh display name from loaded character', () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    expect(r.characters.resolveDisplayName('mongolian')).toBe('Munkh');
+    expect(r.characters.resolveDisplayName('unknown')).toBeUndefined();
+  });
+
+  test('pgPools.poolForWorld always returns null (memory adapter only)', () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    expect(r.pgPools.poolForWorld('mongolian')).toBeNull();
+    expect(r.pgPools.poolForWorld('mibera')).toBeNull();
+  });
+});
+
+describe('cycle-Q · quest-runtime-bootstrap · catalog', () => {
+  test('listAvailableQuests returns 1 stub quest for mongolian', async () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const quests = await Effect.runPromise(
+      r.catalog.listAvailableQuests(MEMORY_DEV_STUB_WORLD_SLUG),
+    );
+    expect(quests).toHaveLength(1);
+    expect(String(quests[0]?.quest_id)).toBe(MEMORY_DEV_STUB_QUEST_ID);
+    expect(String(quests[0]?.world_slug)).toBe(MEMORY_DEV_STUB_WORLD_SLUG);
+  });
+
+  test('listAvailableQuests returns [] for any other world', async () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const quests = await Effect.runPromise(
+      r.catalog.listAvailableQuests('mibera'),
+    );
+    expect(quests).toEqual([]);
+  });
+
+  test('findQuest returns stub for matching (world, id)', async () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const q = await Effect.runPromise(
+      r.catalog.findQuest(MEMORY_DEV_STUB_WORLD_SLUG, MEMORY_DEV_STUB_QUEST_ID),
+    );
+    expect(String(q?.quest_id)).toBe(MEMORY_DEV_STUB_QUEST_ID);
+    expect(q?.title).toBeTruthy();
+    expect(q?.prompt).toBeTruthy();
+    expect(q?.rubric_pointer.type).toBe('codex_ref');
+  });
+
+  test('findQuest returns undefined for unknown quest', async () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const q = await Effect.runPromise(
+      r.catalog.findQuest(MEMORY_DEV_STUB_WORLD_SLUG, 'no-such-quest'),
+    );
+    expect(q).toBeUndefined();
+  });
+
+  test('findQuest returns undefined for non-mongolian world', async () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const q = await Effect.runPromise(
+      r.catalog.findQuest('mibera', MEMORY_DEV_STUB_QUEST_ID),
+    );
+    expect(q).toBeUndefined();
+  });
+});
+
+describe('cycle-Q · quest-runtime-bootstrap · resolvePlayer', () => {
+  test('extracts anon PlayerIdentity from interaction.member.user.id', () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const interaction = {
+      type: 2,
+      id: 'i1',
+      application_id: 'a',
+      token: 't',
+      guild_id: '111111111111111111',
+      member: {
+        user: {
+          id: '12345678901234567', // 17-digit Discord ID
+          username: 'tester',
+        },
+      },
+      data: { id: 'd', name: 'quest' },
+    } as unknown as DiscordInteraction;
+    const player = r.resolvePlayer(interaction);
+    expect(player).not.toBeNull();
+    expect(player?.type).toBe('anon');
+    if (player?.type === 'anon') {
+      expect(String(player.discord_id)).toBe('12345678901234567');
+    }
+  });
+
+  test('returns null when interaction has no member.user', () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const interaction = {
+      type: 2,
+      id: 'i1',
+      application_id: 'a',
+      token: 't',
+      data: { id: 'd', name: 'quest' },
+    } as unknown as DiscordInteraction;
+    const player = r.resolvePlayer(interaction);
+    expect(player).toBeNull();
+  });
+
+  test('returns null when user.id fails Discord ID pattern', () => {
+    const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
+    const interaction = {
+      type: 2,
+      id: 'i1',
+      application_id: 'a',
+      token: 't',
+      guild_id: '111111111111111111',
+      member: {
+        user: { id: 'not-a-discord-id', username: 'tester' },
+      },
+      data: { id: 'd', name: 'quest' },
+    } as unknown as DiscordInteraction;
+    const player = r.resolvePlayer(interaction);
+    expect(player).toBeNull();
+  });
+});

--- a/apps/bot/src/tests/quest-runtime-bootstrap.test.ts
+++ b/apps/bot/src/tests/quest-runtime-bootstrap.test.ts
@@ -11,7 +11,7 @@
  *   - resolvePlayer extracts user.id correctly from interaction.member.user
  *     and returns null when no Discord user is present (per anon-default
  *     PRD D4 with anon-only stub)
- *   - worldManifests scope to QUEST_DEV_GUILD_ID exactly when provided
+ *   - worldManifests scope to guildId exactly when provided
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -37,7 +37,7 @@ const stubCharacters: readonly CharacterConfig[] = [
 describe('cycle-Q · quest-runtime-bootstrap · buildMemoryDevQuestRuntime shape', () => {
   test('returns a fully-shaped QuestRuntime', () => {
     const r = buildMemoryDevQuestRuntime({
-      devGuildId: '111111111111111111',
+      guildId: '111111111111111111',
       characters: stubCharacters,
     });
     expect(Array.isArray(r.worldManifests)).toBe(true);
@@ -48,9 +48,9 @@ describe('cycle-Q · quest-runtime-bootstrap · buildMemoryDevQuestRuntime shape
     expect(typeof r.resolvePlayer).toBe('function');
   });
 
-  test('worldManifests scope to devGuildId exactly when provided', () => {
+  test('worldManifests scope to guildId exactly when provided', () => {
     const r = buildMemoryDevQuestRuntime({
-      devGuildId: '999888777666555444',
+      guildId: '999888777666555444',
       characters: stubCharacters,
     });
     expect(r.worldManifests).toHaveLength(1);
@@ -58,7 +58,7 @@ describe('cycle-Q · quest-runtime-bootstrap · buildMemoryDevQuestRuntime shape
     expect(r.worldManifests[0]?.guild_ids).toEqual(['999888777666555444']);
   });
 
-  test('worldManifests have no guild_ids when devGuildId omitted', () => {
+  test('worldManifests have no guild_ids when guildId omitted', () => {
     const r = buildMemoryDevQuestRuntime({ characters: stubCharacters });
     expect(r.worldManifests).toHaveLength(1);
     expect(r.worldManifests[0]?.guild_ids).toEqual([]);

--- a/apps/character-mongolian/character.json
+++ b/apps/character-mongolian/character.json
@@ -20,17 +20,17 @@
   "stage": "character",
   "stageNotes": "V0.1 draft. First mibera-as-npc instance. Mongolian Grail #507 (Ancestor category). NPC quest character with judgment capability — new pattern not present in ruggy/satoshi.",
   "quest_substrate": {
-    "_doc": "cycle-Q · sprint-3 · Q3.6 · architect lock A6 SHELL ONLY · Track A (Gumi) authors body content via construct-mibera-codex#76. Substrate ships this block; Gumi populates rubric_pointer.cell_id, mention_allowed channel ids, slash_allowed channel ids, and persona-yaml cadence prose post-handoff.",
+    "_doc": "cycle-Q · sprint-3 · Q3.6 · architect lock A6 SHELL ONLY · Track A (Gumi) authors voice_cadence body content via construct-mibera-codex#76. Substrate scaffolds rubric_pointer.cell_id (catalog anchor) + submission_style + friction-delay defaults. Operator populates mention_allowed_channels + slash_allowed_channels with dev-guild channel IDs. Voice cadence stays TODO_TRACK_A until curator authoring lands.",
     "enabled": true,
     "rubric_pointer": {
       "type": "codex_ref",
       "construct_slug": "construct-mongolian",
-      "cell_id": "TODO_TRACK_A"
+      "cell_id": "stub-v1-munkh-quest"
     },
-    "mention_allowed_channels": "TODO_TRACK_A",
-    "slash_allowed_channels": "TODO_TRACK_A",
-    "submission_style_override": "TODO_TRACK_A",
-    "positive_friction_delay_ms_override": "TODO_TRACK_A",
+    "mention_allowed_channels": "TODO_OPERATOR_DEV_GUILD",
+    "slash_allowed_channels": "TODO_OPERATOR_DEV_GUILD",
+    "submission_style_override": "inline-thread",
+    "positive_friction_delay_ms_override": 12000,
     "voice_cadence": {
       "_doc": "Per-character override of phaseToNarrative transform (CMP T4). All keys optional. Substrate ships fallback cadence; persona.yaml supplies the curator-voiced cadence prose. Track A authors at construct-mibera-codex#76.",
       "accepted": "TODO_TRACK_A",


### PR DESCRIPTION
## Summary

Post-merge bootstrap so operator can fire Q3.7 KEEPER felt-pass via Discord without DB migration. Memory-mode runtime ships behind `QUEST_RUNTIME` env flag (default `disabled` · backward-compat).

## What ships

- `apps/bot/src/quest-runtime-bootstrap.ts` — `buildMemoryDevQuestRuntime` · stub world manifest + 1-quest catalog (`munkh-introduction-v1`) + `resolvePlayer` (anon-default per PRD D4)
- `apps/bot/src/index.ts` — env-gated runtime selection (`disabled`/`memory`/`production`); production mode throws (operator-bounded)
- `apps/bot/src/tests/quest-runtime-bootstrap.test.ts` — 13 smoke tests · runtime shape · catalog scoping · resolvePlayer extraction
- `apps/character-mongolian/character.json` — substrate-only `quest_substrate` stubs (cell_id `stub-v1-munkh-quest` · channels `TODO_OPERATOR_DEV_GUILD` · style `inline-thread` · friction 12000ms); `voice_cadence` stays `TODO_TRACK_A` per A6 curator boundary

## Beauvoir-lens audit fixes (commit 7247835)

- **F1+F2** · env var rename: `QUEST_DEV_GUILD_ID` → `QUEST_GUILD_ID` with `DISCORD_GUILD_ID` fallback (canonical guild env var · already set on Railway production · single source of truth)
- **F3** · bootstrap signature: `MemoryDevQuestRuntimeOptions.devGuildId` → `guildId`. JSDoc clarifies "Dev" in `buildMemoryDevQuestRuntime` refers to the runtime *mode* (memory-dev-mode) — NOT a deployment-tier marker. Memory mode runs cleanly in staging or production guild
- **F4** · staging/prod separation doctrine inlined as comment above QUEST_RUNTIME selection: runtime mode (`disabled`/`memory`/`production`) and env tier (Railway service environment) are orthogonal axes
- **F5** · tests updated to use `guildId` parameter · 13/13 pass

## QA test path

```bash
# Railway production (operator-authorized 2026-05-04 PM):
# QUEST_RUNTIME=memory  ← post-merge follow-up · sets memory mode
# DISCORD_GUILD_ID=1135545260538339420  ← already set · auto-falls-through

# /quest in production guild → catalog returns 1 stub quest "munkh-introduction-v1"
# /quest accept → state-machine transitions
# /quest submit → judgment dispatch (rubric stub)
# capture register/CMP-leak findings per Q3.7 KEEPER checklist
```

## Operator next (after merge)

1. Set `QUEST_RUNTIME=memory` on Railway production · auto-deploy on env change · bot restart inherits the runtime mode
2. Drop preferred channel IDs into `apps/character-mongolian/character.json` (replace `TODO_OPERATOR_DEV_GUILD`) OR leave permissive for first QA pass
3. Fire `/quest` in any allowed channel · expect: Munkh quest "Why did you come?" stub renders
4. Capture Q3.7 KEEPER pass observations
5. (parallel) Gumi populates `voice_cadence` per Munkh `persona.md` post-handoff (Track A)

## Staging/production separation

Runtime selection composes orthogonally to staging/production (different axis · Railway service environment · bot binary · `DISCORD_GUILD_ID` values). Memory mode is environment-agnostic — works wherever the bot is deployed.

| `QUEST_RUNTIME` | Behavior |
|---|---|
| `disabled` (default) | backward-compat · `noQuestRuntime` · `/quest` returns ephemeral "no quest path yet" |
| `memory` | in-process state · QA dogfood · works in prod or staging |
| `production` | real Pg pools + world-manifest source · operator-wired (throws until Q2.9 lands) |

## Architect locks

- A2 GREEN — QuestStatePort Tag identity strings preserved (this PR does NOT touch the Tag)
- A4 GREEN — substrate does NOT dereference `rubric_pointer`; catalog ships codex_ref pointer the construct (LLM) resolves at judgment time
- A6 GREEN — Munkh persona body untouched · `voice_cadence` stays `TODO_TRACK_A`

## Verification

- `bun run --cwd apps/bot typecheck` — clean
- `bun test apps/bot/src/tests/quest-runtime-bootstrap.test.ts` — 13/13 pass
- pre-existing `packages/persona-engine/src/expression/error-register.test.ts` typecheck error noted · separate follow-up · already on main