### PR TITLE
feat(bot): auto-publish slash commands on startup

### DIFF
--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -1,19 +1,8 @@
 /**
- * Publish slash commands to Discord (V0.7-A.1).
+ * Publish slash commands to Discord — CLI entry point.
  *
- * One-shot script — run after character set or command schema changes.
- * Registers `/ruggy`, `/satoshi`, and any additional characters loaded
- * via the standard CHARACTERS env mechanism.
-* Registers every command declared by every loaded character. Characters
- * Registers `/ruggy`, `/satoshi`, and any additional characters loaded
- * that don't declare `slash_commands` get the V0.7-A.0 default `/<id>
- * via the standard CHARACTERS env mechanism.
- * prompt:<text> ephemeral:<bool>` (chat handler).
- *
- * V0.7-A.1: characters can now declare divergent command sets in their
- * `character.json`. Eileen's framing: "commands are diff otherwise they'd
- * be reporting the same shit." E.g. /satoshi (chat) + /satoshi-image
- * (imagegen handler).
+ * The actual registration logic lives in `src/lib/publish-commands.ts` so
+ * it can be reused from `src/index.ts` (auto-publish on bot startup).
  *
  * Usage:
  *   # guild-only (immediate propagation in a single guild · use during dev):
@@ -24,35 +13,17 @@
  *   DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... \
  *     bun run apps/bot/scripts/publish-commands.ts
  *
- * Propagation gotcha (Gemini DR 2026-04-30): GLOBAL command sync can take
- * up to 1 HOUR to propagate · users may invoke OLD CACHED schemas during
- * the window, sending malformed payloads to the new backend. For breaking
- * changes, prefer guild-only registration during dev and stage carefully
- * for prod cutover.
- *
- * The script does NOT read DISCORD_APPLICATION_ID from the standard config
- * schema (it's a deploy-time concern, not a runtime one). The bot token
- * is the only secret in `.env` strictly required for this script.
+ * After 2026-05-04 the bot also auto-publishes on every startup (gated by
+ * AUTO_PUBLISH_COMMANDS env, default true). This CLI tool remains for
+ * ad-hoc registration during local dev or off-deploy fixes.
  */
 
-import { loadCharacters, resolveSlashCommands } from '../src/character-loader.ts';
-import type { SlashCommandOption, SlashCommandSpec } from '@freeside-characters/persona-engine';
-
-const DISCORD_API_BASE = 'https://discord.com/api/v10';
-
-interface CommandOption {
-  name: string;
-  description: string;
-  /** Discord application command option type. STRING=3, BOOLEAN=5. */
-  type: number;
-  required?: boolean;
-}
-
-interface CommandSchema {
-  name: string;
-  description: string;
-  options: CommandOption[];
-}
+import { loadCharacters } from '../src/character-loader.ts';
+import {
+  buildCommandSet,
+  fetchApplicationId,
+  publishCommands,
+} from '../src/lib/publish-commands.ts';
 
 async function main(): Promise<void> {
   const botToken = process.env.DISCORD_BOT_TOKEN;
@@ -77,142 +48,29 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const commands: CommandSchema[] = characters.map((c) => buildCommand(c.id, c.displayName ?? c.id));
-
-if (characters.some((c) => c.id === 'satoshi')) {
-  commands.push({
-    name: 'satoshi-image',
-    description: 'Ask Satoshi to generate an image',
-    options: [
-      {
-        name: 'prompt',
-        description: 'Describe the image you want Satoshi to generate',
-        type: 3,
-        required: true,
-      },
-      {
-        name: 'ephemeral',
-        description: 'only you see the reply',
-        type: 5,
-        required: false,
-      },
-    ],
-  });
-}
-
-// V0.7-A.5 / cycle-Q · sprint-3 Q3.5: /quest slash command tree.
-// 4 subcommands per SDD §5.4: browse · accept <quest_id> · submit <quest_id> · status.
-// Routed by apps/bot/src/discord-interactions/dispatch.ts via the
-// `quest` command name → @0xhoneyjar/quests-discord-renderer dispatchQuestInteraction.
-//
-// SYSTEM_COMMANDS extension per Q3.5 task spec — registered alongside
-// per-character commands; NOT bound to a single character (cross-NPC).
-const QUEST_SUBCOMMAND_OPTION_TYPE = 1; // SUB_COMMAND
-const QUEST_STRING_OPTION_TYPE = 3; // STRING
-commands.push({
-  name: 'quest',
-  description: 'browse · accept · submit · check the path',
-  options: [
-    {
-      name: 'browse',
-      description: 'see the quests on offer',
-      type: QUEST_SUBCOMMAND_OPTION_TYPE,
-    } as unknown as CommandOption,
-    {
-      name: 'accept',
-      description: 'mark a quest as accepted',
-      type: QUEST_SUBCOMMAND_OPTION_TYPE,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...({
-        options: [
-          {
-            name: 'quest_id',
-            description: 'the quest to accept',
-            type: QUEST_STRING_OPTION_TYPE,
-            required: true,
-          },
-        ],
-      } as any),
-    } as unknown as CommandOption,
-    {
-      name: 'submit',
-      description: 'submit your offering for an accepted quest',
-      type: QUEST_SUBCOMMAND_OPTION_TYPE,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...({
-        options: [
-          {
-            name: 'quest_id',
-            description: 'the quest you are submitting for',
-            type: QUEST_STRING_OPTION_TYPE,
-            required: true,
-          },
-        ],
-      } as any),
-    } as unknown as CommandOption,
-    {
-      name: 'status',
-      description: 'see your marks',
-      type: QUEST_SUBCOMMAND_OPTION_TYPE,
-    } as unknown as CommandOption,
-  ],
-});
-
-  const url = guildId
-    ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
-    : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
-
+  const commands = buildCommandSet(characters);
   const scope = guildId ? `guild ${guildId}` : 'GLOBAL (1-hour propagation)';
   console.log(`publish-commands: registering ${commands.length} commands → ${scope}`);
   for (const cmd of commands) {
     console.log(`  · /${cmd.name} — ${cmd.description}`);
   }
 
-  const response = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bot ${botToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(commands),
-  });
-
-  if (!response.ok) {
-    const txt = await response.text().catch(() => '<unreadable>');
-    console.error(`publish-commands: FAILED status=${response.status}`);
-    console.error(txt);
+  try {
+    const result = await publishCommands({
+      botToken,
+      applicationId,
+      guildId,
+      characters,
+    });
+    console.log(`publish-commands: registered ${result.registered} commands successfully`);
+    for (const r of result.commands) {
+      console.log(`  ✓ /${r.name} → id ${r.id}`);
+    }
+  } catch (err) {
+    console.error('publish-commands: FAILED');
+    console.error(err instanceof Error ? err.message : err);
     process.exit(1);
   }
-
-  const result = (await response.json()) as Array<{ id: string; name: string }>;
-  console.log(`publish-commands: registered ${result.length} commands successfully`);
-  for (const r of result) {
-    console.log(`  ✓ /${r.name} → id ${r.id}`);
-  }
-}
-
-function buildCommand(id: string, displayName: string): CommandSchema {
-  const lower = displayName.toLowerCase();
-  return {
-    name: id,
-    description: `talk to ${lower}`,
-    options: [
-      { name: 'prompt', description: `what to say to ${lower}`, type: 3, required: true },
-      { name: 'ephemeral', description: 'only you see the reply', type: 5, required: false },
-    ],
-  };
-}
-
-async function fetchApplicationId(botToken: string): Promise<string | undefined> {
-  const response = await fetch(`${DISCORD_API_BASE}/applications/@me`, {
-    headers: { Authorization: `Bot ${botToken}` },
-  });
-  if (!response.ok) {
-    console.warn(`publish-commands: could not fetch /applications/@me (status ${response.status})`);
-    return undefined;
-  }
-  const data = (await response.json()) as { id?: string };
-  return data.id;
 }
 
 main().catch((err) => {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from './discord-interactions/server.ts';
 import { setQuestRuntime } from './discord-interactions/dispatch.ts';
 import { buildMemoryDevQuestRuntime } from './quest-runtime-bootstrap.ts';
+import { publishCommands } from './lib/publish-commands.ts';
 
 const banner = `─── freeside-characters bot · v0.6.0-A ────────────────────────`;
 
@@ -170,6 +171,51 @@ async function main(): Promise<void> {
     }
   } else {
     console.log('grail-cache:    DISABLED (GRAIL_CACHE_ENABLED=false · live-fetch every call)');
+  }
+
+  // === AUTO-PUBLISH SLASH COMMANDS · on every bot start ============
+  // When the bot deploys (Railway env change · git push · etc), commands
+  // auto-sync with Discord. Each environment's bot syncs to its own guild
+  // via DISCORD_GUILD_ID. Disable with AUTO_PUBLISH_COMMANDS=false.
+  //
+  // Idempotent: Discord PUT /applications/{id}/guilds/{guild}/commands
+  // replaces the full set · no dupes · no leak.
+  //
+  // Failure mode: registration error logs but does NOT block bot startup.
+  // Bot still serves existing (cached) commands until next successful sync.
+  //
+  // Authorized 2026-05-04 PM via /autonomous · operator framing:
+  // "Can you make it so that merge code autopushes to discord?"
+  // =================================================================
+  const autoPublish = (process.env.AUTO_PUBLISH_COMMANDS ?? 'true').trim().toLowerCase();
+  if (autoPublish !== 'false' && autoPublish !== '0' && autoPublish !== 'no') {
+    try {
+      const botToken = process.env.DISCORD_BOT_TOKEN;
+      const applicationId = process.env.DISCORD_APPLICATION_ID;
+      const guildId = process.env.DISCORD_GUILD_ID;
+
+      if (!botToken) {
+        console.warn('auto-publish:   DISCORD_BOT_TOKEN not set · skipping command sync');
+      } else {
+        const result = await publishCommands({
+          botToken,
+          applicationId,
+          guildId,
+          characters,
+        });
+        console.log(
+          `auto-publish:   synced ${result.registered} commands · ` +
+            `${result.scope}=${result.guildId ?? '(global)'} · ` +
+            `[${result.commands.map((c) => `/${c.name}`).join(' ')}]`,
+        );
+      }
+    } catch (err) {
+      // Don't block bot startup on registration failure. Log and continue —
+      // bot still serves the previously cached command set until next sync.
+      console.error('auto-publish:   command sync failed (bot continues with cached commands):', err);
+    }
+  } else {
+    console.log('auto-publish:   disabled via AUTO_PUBLISH_COMMANDS · skipping');
   }
 
   console.log('────────────────────────────────────────────────────────────────\n');

--- a/apps/bot/src/lib/publish-commands.ts
+++ b/apps/bot/src/lib/publish-commands.ts
@@ -1,0 +1,234 @@
+/**
+ * publishCommands — register slash commands with Discord.
+ *
+ * Two consumers (2026-05-04):
+ *   1. Bot startup auto-publish (`apps/bot/src/index.ts`) — every deploy
+ *      auto-syncs commands so merge=Discord push.
+ *   2. CLI tool (`apps/bot/scripts/publish-commands.ts`) — ad-hoc
+ *      registration during local dev.
+ *
+ * Discord PUT replaces the full set per (application, guild) so calls are
+ * idempotent — duplicate calls don't leak.
+ *
+ * Propagation gotcha (Gemini DR 2026-04-30): GLOBAL command sync can take
+ * up to 1 HOUR to propagate · users may invoke OLD CACHED schemas during
+ * the window, sending malformed payloads to the new backend. For breaking
+ * changes, prefer guild-only registration during dev and stage carefully
+ * for prod cutover.
+ */
+
+import type { CharacterConfig } from '@freeside-characters/persona-engine';
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+
+// Discord application command option types (PARTIAL · only what we use).
+const SUB_COMMAND_OPTION_TYPE = 1;
+const STRING_OPTION_TYPE = 3;
+const BOOLEAN_OPTION_TYPE = 5;
+
+interface CommandOption {
+  name: string;
+  description: string;
+  /** Discord application command option type. STRING=3, BOOLEAN=5, SUB_COMMAND=1. */
+  type: number;
+  required?: boolean;
+}
+
+export interface CommandSchema {
+  name: string;
+  description: string;
+  options: CommandOption[];
+}
+
+// =====================================================================
+// Public API
+// =====================================================================
+
+export interface PublishCommandsOptions {
+  readonly botToken: string;
+  /** If absent, derived from `/applications/@me`. */
+  readonly applicationId?: string;
+  /** undefined = global registration (~1hr propagation). */
+  readonly guildId?: string;
+  readonly characters: readonly CharacterConfig[];
+}
+
+export interface PublishCommandsResult {
+  readonly registered: number;
+  readonly commands: ReadonlyArray<{ name: string; id: string }>;
+  readonly scope: 'guild' | 'global';
+  readonly guildId?: string;
+}
+
+/**
+ * Register slash commands with Discord. Idempotent — Discord PUT replaces
+ * the full set per (application, guild) so duplicate calls don't leak.
+ *
+ * @throws Error on missing/invalid auth, network failure, or non-2xx response.
+ */
+export async function publishCommands(
+  opts: PublishCommandsOptions,
+): Promise<PublishCommandsResult> {
+  if (!opts.botToken) {
+    throw new Error('publishCommands: botToken is required');
+  }
+
+  const applicationId =
+    opts.applicationId ?? (await fetchApplicationId(opts.botToken));
+  if (!applicationId) {
+    throw new Error(
+      'publishCommands: applicationId not provided and could not be derived from /applications/@me',
+    );
+  }
+
+  if (opts.characters.length === 0) {
+    throw new Error('publishCommands: no characters provided');
+  }
+
+  const commands = buildCommandSet(opts.characters);
+
+  const url = opts.guildId
+    ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${opts.guildId}/commands`
+    : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bot ${opts.botToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(commands),
+  });
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => '<unreadable>');
+    throw new Error(
+      `publishCommands: Discord PUT failed status=${response.status} body=${txt}`,
+    );
+  }
+
+  const result = (await response.json()) as Array<{ id: string; name: string }>;
+  return {
+    registered: result.length,
+    commands: result.map((r) => ({ name: r.name, id: r.id })),
+    scope: opts.guildId ? 'guild' : 'global',
+    guildId: opts.guildId,
+  };
+}
+
+/**
+ * Build the full command set for the loaded characters. Pure function —
+ * no I/O, deterministic given the same characters input.
+ *
+ * Exported so the CLI can preview the set before submitting.
+ */
+export function buildCommandSet(
+  characters: readonly CharacterConfig[],
+): CommandSchema[] {
+  const commands: CommandSchema[] = characters.map((c) =>
+    buildCommand(c.id, c.displayName ?? c.id),
+  );
+
+  if (characters.some((c) => c.id === 'satoshi')) {
+    commands.push({
+      name: 'satoshi-image',
+      description: 'Ask Satoshi to generate an image',
+      options: [
+        {
+          name: 'prompt',
+          description: 'Describe the image you want Satoshi to generate',
+          type: STRING_OPTION_TYPE,
+          required: true,
+        },
+        {
+          name: 'ephemeral',
+          description: 'only you see the reply',
+          type: BOOLEAN_OPTION_TYPE,
+          required: false,
+        },
+      ],
+    });
+  }
+
+  // V0.7-A.5 / cycle-Q · sprint-3 Q3.5: /quest slash command tree.
+  // 4 subcommands per SDD §5.4: browse · accept <quest_id> · submit <quest_id> · status.
+  // Routed by apps/bot/src/discord-interactions/dispatch.ts via the
+  // `quest` command name → @0xhoneyjar/quests-discord-renderer dispatchQuestInteraction.
+  //
+  // SYSTEM_COMMANDS extension per Q3.5 task spec — registered alongside
+  // per-character commands; NOT bound to a single character (cross-NPC).
+  commands.push({
+    name: 'quest',
+    description: 'browse · accept · submit · check the path',
+    options: [
+      {
+        name: 'browse',
+        description: 'see the quests on offer',
+        type: SUB_COMMAND_OPTION_TYPE,
+      } as unknown as CommandOption,
+      {
+        name: 'accept',
+        description: 'mark a quest as accepted',
+        type: SUB_COMMAND_OPTION_TYPE,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({
+          options: [
+            {
+              name: 'quest_id',
+              description: 'the quest to accept',
+              type: STRING_OPTION_TYPE,
+              required: true,
+            },
+          ],
+        } as any),
+      } as unknown as CommandOption,
+      {
+        name: 'submit',
+        description: 'submit your offering for an accepted quest',
+        type: SUB_COMMAND_OPTION_TYPE,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({
+          options: [
+            {
+              name: 'quest_id',
+              description: 'the quest you are submitting for',
+              type: STRING_OPTION_TYPE,
+              required: true,
+            },
+          ],
+        } as any),
+      } as unknown as CommandOption,
+      {
+        name: 'status',
+        description: 'see your marks',
+        type: SUB_COMMAND_OPTION_TYPE,
+      } as unknown as CommandOption,
+    ],
+  });
+
+  return commands;
+}
+
+function buildCommand(id: string, displayName: string): CommandSchema {
+  const lower = displayName.toLowerCase();
+  return {
+    name: id,
+    description: `talk to ${lower}`,
+    options: [
+      { name: 'prompt', description: `what to say to ${lower}`, type: STRING_OPTION_TYPE, required: true },
+      { name: 'ephemeral', description: 'only you see the reply', type: BOOLEAN_OPTION_TYPE, required: false },
+    ],
+  };
+}
+
+export async function fetchApplicationId(botToken: string): Promise<string | undefined> {
+  const response = await fetch(`${DISCORD_API_BASE}/applications/@me`, {
+    headers: { Authorization: `Bot ${botToken}` },
+  });
+  if (!response.ok) {
+    console.warn(`publish-commands: could not fetch /applications/@me (status ${response.status})`);
+    return undefined;
+  }
+  const data = (await response.json()) as { id?: string };
+  return data.id;
+}


### PR DESCRIPTION
## Summary

Removes the manual `publish-commands.ts` step from the deploy workflow. After this PR merges, every bot deploy auto-syncs Discord slash commands.

## Mechanic

1. Registration logic extracted to `apps/bot/src/lib/publish-commands.ts` — exports reusable `publishCommands(opts)` function.
2. `apps/bot/scripts/publish-commands.ts` becomes a thin CLI wrapper around the library function (backward compat preserved).
3. `apps/bot/src/index.ts` calls `publishCommands()` on startup (after grail-cache init, before interaction server).
4. Gated by `AUTO_PUBLISH_COMMANDS=true` (default true) · set false to disable.
5. Failure mode: log error, continue (bot serves cached commands).
6. Idempotent: Discord PUT replaces full command set · no dupes.

## Why src/lib/ instead of scripts/

`apps/bot/tsconfig.json` has `rootDir: src` so files in `scripts/` can't be imported from `src/`. Moving the library code into `src/lib/publish-commands.ts` satisfies the rootDir constraint while keeping the CLI entry point at `scripts/`.

## Staging/production separation

Each environment's bot reads its own `DISCORD_GUILD_ID` from env. Staging bot syncs to staging guild · prod bot syncs to prod guild. Zero coupling to deploy pipeline.

## How operator workflow changes

Before:
```
1. push code
2. wait for Railway redeploy
3. railway run bun run apps/bot/scripts/publish-commands.ts (manual)
4. test in Discord
```

After:
```
1. push code
2. wait for Railway redeploy
3. test in Discord (commands auto-synced during bot startup)
```

## Backward compat

The CLI script (`bun run apps/bot/scripts/publish-commands.ts`) still works for ad-hoc registration (e.g., development without Railway).

## Env flags

- `AUTO_PUBLISH_COMMANDS=true` (default): sync on every startup
- `AUTO_PUBLISH_COMMANDS=false` / `0` / `no`: disable auto-sync · use CLI script as needed
- `DISCORD_GUILD_ID`: which guild to sync to (unset = global, ~1hr propagation)
- `DISCORD_BOT_TOKEN`: required (auto-publish skipped with warning if absent)
- `DISCORD_APPLICATION_ID`: optional (derived from `/applications/@me` if absent)

## Test plan

- [x] `bun run --cwd apps/bot typecheck` clean
- [x] `bun test` 321/321 pass · 0 fail
- [x] CLI script still works (`bun run apps/bot/scripts/publish-commands.ts` with stub creds → graceful 401 + non-zero exit)
- [ ] After merge: Railway redeploys · bot startup logs `auto-publish: synced N commands` · `/quest` visible in Discord without manual step

## Authorization

Authorized 2026-05-04 PM via /autonomous · operator framing: "Can you make it so that merge code autopushes to discord?"