### PR TITLE
fix(cmp-boundary): wire voice-discipline strip into slash-command path (PR #48 fast-follow)

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -35,6 +35,7 @@ import {
   sendChatReplyViaWebhook,
   sendImageReplyViaWebhook,
   splitForDiscord,
+  stripVoiceDisciplineDrift,
   type CharacterConfig,
   type Config,
   type EnrichedFile,
@@ -406,6 +407,20 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
         `channel=${channelId}`,
     );
 
+    // Voice-discipline transforms applied per-chunk before delivery
+    // (cmp-boundary §9 · cycle-r sprint-1 fast-follow 2026-05-05). The
+    // digest path applies these via embed.ts/buildPostPayload, but the
+    // chat-mode reply path (slash commands → composeReplyWithEnrichment
+    // → sendChatReplyViaWebhook) bypasses buildPostPayload entirely.
+    // Sprint 1 originally wired only the digest path; this surface
+    // catches the slash-command output where Eileen flagged em-dashes
+    // 2026-05-04. Strip runs on chunks (bot output) only · the user's
+    // prompt quote-prepend in deliverViaWebhook is applied AFTER this
+    // transform so user text passes through unchanged.
+    const cleanedChunks = result.chunks.map((chunk) =>
+      stripVoiceDisciplineDrift(chunk),
+    );
+
     // Delivery routing:
     //   - ephemeral=true   → interaction PATCH (webhooks can't be ephemeral ·
     //                        invoker chose this · accepts shell identity)
@@ -419,7 +434,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
     //                        when payload.files is populated · PATCH fallback
     //                        if webhook delivery fails (without attachment).
     if (ephemeral) {
-      await deliverViaInteraction(interaction, character, result.chunks, true);
+      await deliverViaInteraction(interaction, character, cleanedChunks, true);
     } else {
       try {
         await deliverViaWebhook(
@@ -427,7 +442,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
           config,
           character,
           channelId,
-          result.chunks,
+          cleanedChunks,
           prompt,
           invoker.username,
           attachedFiles,
@@ -438,7 +453,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
           webhookErr,
         );
         invalidateWebhookCache(channelId);
-        await deliverViaInteraction(interaction, character, result.chunks, false);
+        await deliverViaInteraction(interaction, character, cleanedChunks, false);
       }
     }
 

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -103,6 +103,20 @@ export {
   extractAttachedUrls,
 } from './deliver/strip-image-urls.ts';
 
+// Cycle-R sprint-1 voice-discipline transforms (cmp-boundary §9 ·
+// 2026-05-04). Surfaces the runtime strip for chat-mode delivery paths
+// (slash-command replies via webhook · ephemeral PATCH fallback). The
+// digest path applies these via embed.ts internally; chat-mode callers
+// (apps/bot/src/discord-interactions/dispatch.ts) apply via this export.
+//
+// Refs: ~/vault/wiki/concepts/chat-medium-presentation-boundary.md §9 ·
+//       ~/vault/wiki/concepts/discord-native-register.md (2026-05-04 amend)
+export {
+  stripVoiceDisciplineDrift,
+  escapeDiscordMarkdown,
+} from './deliver/sanitize.ts';
+export type { VoiceDisciplineOpts } from './deliver/sanitize.ts';
+
 // Chat-mode routing helpers (V0.7-A.4 surface-completeness test surface)
 export { shouldUseOrchestrator, resolveChatProvider } from './compose/reply.ts';
 export type { ChatProvider } from './compose/reply.ts';


### PR DESCRIPTION
## Summary

Sprint 1 (PR #48) wired voice-discipline transforms into the **digest path** only (`embed.ts/buildPostPayload`). **Slash-command replies bypass that path entirely** — they flow `composeReplyWithEnrichment` → `result.chunks` → `sendChatReplyViaWebhook` (Pattern B), which means em-dashes, asterisk roleplay, and closing signoffs were leaking into production slash-command output despite the Sprint 1 ship.

Operator + Eileen reproduced 2026-05-04 22:02 PM PT — `/ruggy` and `/satoshi` slash output had multiple em-dashes per paragraph + multi-paragraph length violating cadence rules.

## Fix

- Export `stripVoiceDisciplineDrift` + `escapeDiscordMarkdown` from `@freeside-characters/persona-engine` public API (was internal to `deliver/sanitize.ts`)
- Apply per-chunk in `apps/bot/src/discord-interactions/dispatch.ts` after `composeReplyWithEnrichment` returns content but BEFORE routing to `deliverViaWebhook` or `deliverViaInteraction`
- User's prompt quote-prepend (`> @soju asked: ...` in `deliverViaWebhook`) runs AFTER the strip · user text passes through unchanged

Architectural lock A4 (universal · zero opt-out) now genuinely universal: all delivery paths (digest embed · chat-mode webhook · ephemeral PATCH) apply the strip.

## Test plan

- [x] 377/377 tests pass after rebase onto `origin/main` (sprint-1 baseline · zero regression)
- [x] Sprint 1 unit tests still green (sanitize.test.ts 29 cases + cmp-boundary regression guards 28 cases)
- [ ] **Operator-bounded post-deploy check**: redeploy bot · `/ruggy prompt:"give me a take on the chain"` → output should have NO em-dashes · reply ≤3 sentences for one-on-one shape
- [ ] **Operator-bounded KEEPER 100-message sweep**: validates G-1 KPI with this fix in production

## Note on deploy

The bot needs to be redeployed for this fix (and the merged Sprint 1) to take effect in production. Prior to redeploy, the running bot has neither the digest-path strip nor the chat-mode strip.

## Refs

- Sprint 1 PR: #48 (squash-merged ff5cbedb)
- Sprint 1 review/audit: `grimoires/loa/a2a/sprint-cmp-boundary-arch-1/`
- Doctrine: `~/vault/wiki/concepts/chat-medium-presentation-boundary.md` §9
- Reproduction: operator screenshot 2026-05-04 22:02 PM PT (em-dashes in /ruggy slash output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)