### PR TITLE
fix(cmp-boundary): strip em-dashes from shell-bot static templates (Loa identity)

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -326,7 +326,12 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
       // Resolve the moment to character expression. Returns null when the
       // substrate should stay quiet (unmapped tool, or intentional silence
       // for self-referential / V1-deferred tools like emojis/imagegen).
-      const status = composeToolUseStatusForCharacter(character, event.name);
+      // Voice-discipline strip applied as defense-in-depth (cmp-boundary §9):
+      // shell-bot status text bypasses the chat-mode strip in deliverViaWebhook,
+      // so apply here. Static templates are em-dash-clean today, but this
+      // catches future regressions.
+      const rawStatus = composeToolUseStatusForCharacter(character, event.name);
+      const status = rawStatus === null ? null : stripVoiceDisciplineDrift(rawStatus);
       console.log(
         `interactions: ${character.id}/chat tool_use · ${event.name} · status=${
           status === null ? 'null(skip)' : `"${status}"`
@@ -862,7 +867,10 @@ function formatErrorBody(
   character: CharacterConfig,
   kind: ErrorClass,
 ): string {
-  return composeErrorBody(character.id, kind);
+  // Defense-in-depth voice-discipline strip (cmp-boundary §9) on shell-bot
+  // error output. Static templates are em-dash-clean today; this catches
+  // future regressions per architect lock A4 (universal · zero opt-out).
+  return stripVoiceDisciplineDrift(composeErrorBody(character.id, kind));
 }
 
 /**

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -35,6 +35,7 @@ import {
   sendChatReplyViaWebhook,
   sendImageReplyViaWebhook,
   splitForDiscord,
+  stripVoiceDisciplineDrift,
   type CharacterConfig,
   type Config,
   type EnrichedFile,
@@ -406,6 +407,20 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
         `channel=${channelId}`,
     );
 
+    // Voice-discipline transforms applied per-chunk before delivery
+    // (cmp-boundary §9 · cycle-r sprint-1 fast-follow 2026-05-05). The
+    // digest path applies these via embed.ts/buildPostPayload, but the
+    // chat-mode reply path (slash commands → composeReplyWithEnrichment
+    // → sendChatReplyViaWebhook) bypasses buildPostPayload entirely.
+    // Sprint 1 originally wired only the digest path; this surface
+    // catches the slash-command output where Eileen flagged em-dashes
+    // 2026-05-04. Strip runs on chunks (bot output) only · the user's
+    // prompt quote-prepend in deliverViaWebhook is applied AFTER this
+    // transform so user text passes through unchanged.
+    const cleanedChunks = result.chunks.map((chunk) =>
+      stripVoiceDisciplineDrift(chunk),
+    );
+
     // Delivery routing:
     //   - ephemeral=true   → interaction PATCH (webhooks can't be ephemeral ·
     //                        invoker chose this · accepts shell identity)
@@ -419,7 +434,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
     //                        when payload.files is populated · PATCH fallback
     //                        if webhook delivery fails (without attachment).
     if (ephemeral) {
-      await deliverViaInteraction(interaction, character, result.chunks, true);
+      await deliverViaInteraction(interaction, character, cleanedChunks, true);
     } else {
       try {
         await deliverViaWebhook(
@@ -427,7 +442,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
           config,
           character,
           channelId,
-          result.chunks,
+          cleanedChunks,
           prompt,
           invoker.username,
           attachedFiles,
@@ -438,7 +453,7 @@ async function doReplyChat(args: AsyncWorkerArgs): Promise<void> {
           webhookErr,
         );
         invalidateWebhookCache(channelId);
-        await deliverViaInteraction(interaction, character, result.chunks, false);
+        await deliverViaInteraction(interaction, character, cleanedChunks, false);
       }
     }
 

--- a/packages/persona-engine/src/expression/error-register.ts
+++ b/packages/persona-engine/src/expression/error-register.ts
@@ -76,12 +76,12 @@ const TEMPLATES_RAW: Record<string, Record<ErrorClass, string>> = {
   // **Ruggy** prefix; the voice is unmistakably ruggy.
   ruggy: {
     timeout: "took longer than ruggy could hold the line for. wanna try that again?",
-    empty: "cables got crossed — nothing came back. try again?",
+    empty: "cables got crossed, nothing came back. try again?",
     error: "something snapped on ruggy's end. cool to retry?",
     "image-too-large":
       "the image came out too thicc for discord. try tightening the prompt?",
     "image-delivery-failed":
-      "image rendered but delivery hiccuped. same seed should reproduce — try again?",
+      "image rendered but delivery hiccuped. same seed should reproduce, try again?",
   },
 
   // SATOSHI — sentence case, gnomic, dense. "Signal between worlds" register.
@@ -94,7 +94,7 @@ const TEMPLATES_RAW: Record<string, Record<ErrorClass, string>> = {
     "image-too-large":
       "The image carried more weight than the channel allows. Try again with less.",
     "image-delivery-failed":
-      "The image surfaced but failed to cross. Retry — the seed remembers.",
+      "The image surfaced but failed to cross. Retry, the seed remembers.",
   },
 };
 

--- a/packages/persona-engine/src/expression/loading-status.test.ts
+++ b/packages/persona-engine/src/expression/loading-status.test.ts
@@ -127,7 +127,7 @@ describe("composeToolUseStatusForCharacter · satoshi plain-text register", () =
       satoshi,
       "mcp__score__get_zone_digest",
     );
-    expect(status).toBe("the ledger advances — one moment.");
+    expect(status).toBe("the ledger advances, one moment.");
     // Defense-in-depth: no Discord custom emoji syntax
     expect(status).not.toMatch(/<a?:[^:]+:\d+>/);
   });
@@ -137,7 +137,7 @@ describe("composeToolUseStatusForCharacter · satoshi plain-text register", () =
       satoshi,
       "mcp__codex__lookup_grail",
     );
-    expect(status).toBe("the ledger advances — one moment.");
+    expect(status).toBe("the ledger advances, one moment.");
   });
 
   test("rosenzu tool returns the same locked template", () => {
@@ -145,7 +145,7 @@ describe("composeToolUseStatusForCharacter · satoshi plain-text register", () =
       satoshi,
       "mcp__rosenzu__read_room",
     );
-    expect(status).toBe("the ledger advances — one moment.");
+    expect(status).toBe("the ledger advances, one moment.");
   });
 
   test("emojis MCP returns null (defense — satoshi's mcps[] omits emojis anyway)", () => {

--- a/packages/persona-engine/src/expression/loading-status.ts
+++ b/packages/persona-engine/src/expression/loading-status.ts
@@ -39,16 +39,21 @@ import { getMoodsForTool } from "./tool-mood-map.ts";
  * (today: satoshi · gumi-locked "no custom emoji" register).
  *
  * Per kickoff §3:
- *   satoshi → "the ledger advances — one moment." (NO custom emoji ·
+ *   satoshi → "the ledger advances, one moment." (NO custom emoji ·
  *             locked register · sentence case · gnomic)
  *
  * The map is keyed by character.id. New characters added without a
- * plain-text fallback resolve to null (substrate-shaped quiet — caller
+ * plain-text fallback resolve to null (substrate-shaped quiet · caller
  * skips the patch). This is intentional: a generic plain-text fallback
  * would re-introduce substrate-voice during a character moment.
+ *
+ * Voice discipline (cmp-boundary §9 · cycle R sprint 1): templates use
+ * plain punctuation only — no em-dashes (—) or en-dashes (–). The shell
+ * bot ("Loa" identity) renders these strings directly via patchOriginal
+ * which bypasses the chat-mode strip. Static templates must be clean.
  */
 const PLAIN_TEXT_LOADING_REGISTER: Readonly<Record<string, string>> = {
-  satoshi: "the ledger advances — one moment.",
+  satoshi: "the ledger advances, one moment.",
 };
 
 /**

--- a/packages/persona-engine/src/index.ts
+++ b/packages/persona-engine/src/index.ts
@@ -103,6 +103,20 @@ export {
   extractAttachedUrls,
 } from './deliver/strip-image-urls.ts';
 
+// Cycle-R sprint-1 voice-discipline transforms (cmp-boundary §9 ·
+// 2026-05-04). Surfaces the runtime strip for chat-mode delivery paths
+// (slash-command replies via webhook · ephemeral PATCH fallback). The
+// digest path applies these via embed.ts internally; chat-mode callers
+// (apps/bot/src/discord-interactions/dispatch.ts) apply via this export.
+//
+// Refs: ~/vault/wiki/concepts/chat-medium-presentation-boundary.md §9 ·
+//       ~/vault/wiki/concepts/discord-native-register.md (2026-05-04 amend)
+export {
+  stripVoiceDisciplineDrift,
+  escapeDiscordMarkdown,
+} from './deliver/sanitize.ts';
+export type { VoiceDisciplineOpts } from './deliver/sanitize.ts';
+
 // Chat-mode routing helpers (V0.7-A.4 surface-completeness test surface)
 export { shouldUseOrchestrator, resolveChatProvider } from './compose/reply.ts';
 export type { ChatProvider } from './compose/reply.ts';


### PR DESCRIPTION
## Summary

Operator surfaced 2026-05-05: the **Loa shell-bot identity** (the orchestrator Discord application that handles slash commands · posts via interaction PATCH not webhook) was still showing em-dashes despite PR #48 + PR #49 shipping voice-discipline strip on the chat-mode webhook path.

## Root cause

Shell-bot composers embed em-dashes in **static plain-text templates**. These render via `patchOriginal(interaction, ephemeral, status)` directly · bypassing both:
- The digest-path strip (PR #48 · `embed.ts/buildPostPayload`)
- The chat-mode webhook strip (PR #49 · `dispatch.ts` per-chunk strip)

## Fix

**Static template cleanup** (em-dash → comma per the strip's lowercase-next rule):
- `loading-status.ts:51` — satoshi plain-text register ("the ledger advances, one moment.")
- `error-register.ts:79` — ruggy `empty` error
- `error-register.ts:84` — ruggy `image-delivery-failed` error
- `error-register.ts:97` — satoshi `image-delivery-failed` error

**Defense-in-depth strip wiring** in `dispatch.ts`:
- Wrap `composeToolUseStatusForCharacter` output with `stripVoiceDisciplineDrift`
- Wrap `formatErrorBody` output with `stripVoiceDisciplineDrift`

This catches future regressions per architect lock A4 (universal · zero opt-out) — even if a future template adds an em-dash, the runtime strip catches it before delivery.

## Test plan

- [x] 377/377 tests pass · zero regression (3 loading-status.test.ts assertions updated for new template)
- [x] Static templates verified em-dash-free
- [ ] **Operator-bounded**: redeploy bot · trigger a tool-use status (e.g., `/satoshi prompt:"observe"` · should show "the ledger advances, one moment.") AND a forced error path · expect zero em-dashes from Loa shell-bot identity

## Coverage after this PR

| Delivery path | Identity | Strip coverage |
|---|---|---|
| Digest embed (`buildPostPayload`) | Character webhook | ✅ PR #48 |
| Chat-mode webhook (`sendChatReplyViaWebhook`) | Character webhook | ✅ PR #49 |
| Shell-bot interaction PATCH (`patchOriginal`) | Loa identity | ✅ THIS PR |
| Shell-bot error delivery | Loa identity / character webhook | ✅ THIS PR |

All three delivery paths now apply voice-discipline strip after this PR + redeploy.

## Note on emoji rendering

Operator also surfaced `:ruggy_cheers:` literal in slash output. The `translateEmojiShortcodes` function works correctly in unit tests AND on the exact production input (verified locally). Most likely cause: **Railway deploy is stale or Docker layer cache is holding pre-PR-32 code**. Re-confirm with explicit Railway redeploy after this PR merges to ensure the bot is running latest main.

## Refs

- Sprint 1 PR: #48 (squash ff5cbedb)
- Fast-follow PR: #49 (squash 9ddf7cc6)
- Doctrine: ~/vault/wiki/concepts/chat-medium-presentation-boundary.md §9

🤖 Generated with [Claude Code](https://claude.com/claude-code)