### PR TITLE
feat(R3.1-4 PR-C): persona-engine medium-aware composer/embed/sanitize (cycle R sprint 3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,10 +27,6 @@
       "name": "@freeside-characters/character-mongolian",
       "version": "0.1.0",
     },
-    "apps/character-mongolian": {
-      "name": "@freeside-characters/character-mongolian",
-      "version": "0.1.0",
-    },
     "apps/character-ruggy": {
       "name": "@freeside-characters/character-ruggy",
       "version": "0.8.0",
@@ -43,6 +39,7 @@
       "name": "@freeside-characters/persona-engine",
       "version": "0.8.0",
       "dependencies": {
+        "@0xhoneyjar/medium-registry": "^0.2.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.122",
         "discord.js": "^14.16.3",
         "effect": "^3.21.2",
@@ -64,6 +61,8 @@
     },
   },
   "packages": {
+    "@0xhoneyjar/medium-registry": ["@0xhoneyjar/medium-registry@0.2.0", "", { "peerDependencies": { "effect": "^3.10.0" } }, "sha512-A7Kpd8UjfymCzQ6Gdod8ZcGn2LvWmgaksYhiY8M3RpUWAziJ/0VSc0SBG7PLt5dCwtWdf0xiOLG3TPJ5qitIqw=="],
+
     "@0xhoneyjar/quests-discord-renderer": ["@0xhoneyjar/quests-discord-renderer@0.1.2", "", { "dependencies": { "@0xhoneyjar/quests-engine": "^0.1.2", "@0xhoneyjar/quests-protocol": "^0.1.2" }, "peerDependencies": { "discord-api-types": "^0.37.0", "effect": "^3.10.0" } }, "sha512-1X8XALTMs825xEzdE5e6fpj0vjILzn/r4w1PA8OcGk8ihCKFszXa0DikmZ2N+bE5SicX0ie5J20MxBeNmVN9yA=="],
 
     "@0xhoneyjar/quests-engine": ["@0xhoneyjar/quests-engine@0.1.2", "", { "dependencies": { "@0xhoneyjar/quests-protocol": "^0.1.2" }, "peerDependencies": { "effect": "^3.10.0", "pg": "^8.11.0" }, "optionalPeers": ["pg"] }, "sha512-zwyNmuX3uSLEJBtVe320Nn8YuopqZfa69Jwuyzen4M2kWYjecn5egCPfCiNrc3ck0JLhVINd94sGstRWAYwAog=="],

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -16,6 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@0xhoneyjar/medium-registry": "^0.2.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.122",
     "discord.js": "^14.16.3",
     "effect": "^3.21.2",

--- a/packages/persona-engine/src/compose/composer.ts
+++ b/packages/persona-engine/src/compose/composer.ts
@@ -16,6 +16,7 @@
  * touches the SDK or MCP layer.
  */
 
+import type { MediumCapability } from '@0xhoneyjar/medium-registry';
 import type { Config } from '../config.ts';
 import type { CharacterConfig } from '../types.ts';
 import { fetchZoneDigest } from '../score/client.ts';
@@ -41,11 +42,26 @@ export interface PostComposeResult {
   payload: DigestPayload;
 }
 
+/**
+ * Per-invocation opts for composeZonePost. Cycle R Sprint 3.
+ *
+ * `medium` defaults to DISCORD_WEBHOOK_DESCRIPTOR when omitted (Pattern B
+ * shell-bot · the persona-bot default). Pass DISCORD_INTERACTION_DESCRIPTOR
+ * for slash-command responses, CLI_DESCRIPTOR for cli-renderer fixtures,
+ * etc. The medium threads through buildPostPayload to gate embed shape on
+ * `hasCapability(medium, 'embed')` and through stripVoiceDisciplineDrift
+ * for CLI ANSI strip / future medium-specific prose adjustments.
+ */
+export interface ComposeZonePostOpts {
+  readonly medium?: MediumCapability;
+}
+
 export async function composeZonePost(
   config: Config,
   character: CharacterConfig,
   zone: ZoneId,
   postType: PostType = 'digest',
+  opts: ComposeZonePostOpts = {},
 ): Promise<PostComposeResult | null> {
   // Fetch a digest in parallel with the LLM call — the LLM gets its own
   // copy via mcp__score__get_zone_digest; this one is for embed metadata
@@ -104,7 +120,11 @@ export async function composeZonePost(
     voice = applyHeadlineLock(rawVoice, zone, postType, character.id);
   }
 
-  const payload = buildPostPayload(digest, voice, postType);
+  // Cycle R Sprint 3: thread the medium through to the payload builder.
+  // Default (omitted opts.medium) preserves Sprint-1/Sprint-2 callsite
+  // semantics — buildPostPayload internally falls back to
+  // DISCORD_WEBHOOK_DESCRIPTOR.
+  const payload = buildPostPayload(digest, voice, postType, { medium: opts.medium });
   return { zone, postType, digest, voice, payload };
 }
 

--- a/packages/persona-engine/src/deliver/embed-medium.test.ts
+++ b/packages/persona-engine/src/deliver/embed-medium.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Embed medium-aware tests — cycle R Sprint 3 R3.3.
+ *
+ * Verifies buildPostPayload threads opts.medium through the registry:
+ *   1. Default (omitted opts.medium) preserves Sprint 1/2 behavior
+ *      (uses DISCORD_WEBHOOK_DESCRIPTOR · embed=true · digest emits embed)
+ *   2. CLI_DESCRIPTOR (no embed capability) → digest emits plain content,
+ *      no embed
+ *   3. DISCORD_INTERACTION_DESCRIPTOR (full surface) behaves like webhook
+ *      for embed purposes (both have embed=true)
+ *   4. Output remains byte-identical to pre-Sprint-3 for default callers
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  CLI_DESCRIPTOR,
+  DISCORD_WEBHOOK_DESCRIPTOR,
+  DISCORD_INTERACTION_DESCRIPTOR,
+} from "@0xhoneyjar/medium-registry";
+import { buildPostPayload } from "./embed.ts";
+import type { ZoneDigest } from "../score/types.ts";
+
+const FIXTURE_DIGEST: ZoneDigest = {
+  zone: "owsley-lab",
+  computed_at: "2026-05-04T21:00:00Z",
+  raw_stats: {
+    spotlight: null,
+    factor_trends: [],
+    rank_changes: { climbed: [], dropped: [], unchanged: [] },
+    window_event_count: 5,
+  } as unknown as ZoneDigest["raw_stats"],
+  narrative: "the lab quiet",
+  narrative_error: null,
+} as unknown as ZoneDigest;
+
+describe("buildPostPayload — medium threading (cycle R sprint 3)", () => {
+  describe("Default (no opts.medium) — back-compat", () => {
+    it("digest emits embed when no medium specified (DISCORD_WEBHOOK default)", () => {
+      const payload = buildPostPayload(FIXTURE_DIGEST, "voice text", "digest");
+      expect(payload.embeds.length).toBe(1);
+      expect(payload.embeds[0]?.description).toContain("voice text");
+    });
+
+    it("micro emits plain content (no embed) regardless of medium", () => {
+      const payload = buildPostPayload(FIXTURE_DIGEST, "yo", "micro");
+      expect(payload.embeds.length).toBe(0);
+      expect(payload.content).toContain("yo");
+    });
+  });
+
+  describe("DISCORD_WEBHOOK_DESCRIPTOR (Pattern B shell-bot · the persona-bot default)", () => {
+    it("digest emits embed (webhook context · embed=true)", () => {
+      const payload = buildPostPayload(FIXTURE_DIGEST, "voice text", "digest", {
+        medium: DISCORD_WEBHOOK_DESCRIPTOR,
+      });
+      expect(payload.embeds.length).toBe(1);
+    });
+
+    it("output byte-identical to default (omitted) caller", () => {
+      const a = buildPostPayload(FIXTURE_DIGEST, "voice", "digest");
+      const b = buildPostPayload(FIXTURE_DIGEST, "voice", "digest", {
+        medium: DISCORD_WEBHOOK_DESCRIPTOR,
+      });
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe("DISCORD_INTERACTION_DESCRIPTOR (slash + button + modal flows)", () => {
+    it("digest emits embed (interaction context · embed=true)", () => {
+      const payload = buildPostPayload(FIXTURE_DIGEST, "voice text", "digest", {
+        medium: DISCORD_INTERACTION_DESCRIPTOR,
+      });
+      expect(payload.embeds.length).toBe(1);
+    });
+  });
+
+  describe("CLI_DESCRIPTOR (no embed capability)", () => {
+    it("digest emits PLAIN content when CLI medium (no embed cap)", () => {
+      const payload = buildPostPayload(FIXTURE_DIGEST, "voice text", "digest", {
+        medium: CLI_DESCRIPTOR,
+      });
+      expect(payload.embeds.length).toBe(0);
+      expect(payload.content).toContain("voice text");
+    });
+
+    it("CLI strips ANSI escapes from voice (mediumId threading)", () => {
+      const payload = buildPostPayload(
+        FIXTURE_DIGEST,
+        "hello\x1b[31mred\x1b[0m",
+        "digest",
+        { medium: CLI_DESCRIPTOR },
+      );
+      expect(payload.content).not.toContain("\x1b");
+      expect(payload.content).toContain("hello");
+    });
+
+    it("Discord media DOES NOT strip ANSI from voice (different threat model)", () => {
+      const payload = buildPostPayload(
+        FIXTURE_DIGEST,
+        "hello\x1b[31mred\x1b[0m",
+        "digest",
+        { medium: DISCORD_WEBHOOK_DESCRIPTOR },
+      );
+      // The voice goes into embed.description for digest type
+      expect(payload.embeds[0]?.description).toContain("\x1b");
+    });
+  });
+});

--- a/packages/persona-engine/src/deliver/embed.ts
+++ b/packages/persona-engine/src/deliver/embed.ts
@@ -6,14 +6,27 @@
  *
  * For embedded types: ALWAYS populate `message.content` as graceful
  * fallback for users with embeds disabled.
+ *
+ * Cycle R Sprint 3: opts.medium threads through @0xhoneyjar/medium-registry
+ * descriptors. Default is DISCORD_WEBHOOK_DESCRIPTOR (Pattern B shell-bot
+ * delivery) per architect lock A4 + the SKP-001 ctx-split. Future
+ * non-Discord consumers (cli-renderer, telegram-renderer cycles) pass
+ * their own descriptor.
  */
 
+import {
+  DISCORD_WEBHOOK_DESCRIPTOR,
+  hasCapability,
+  mediumIdOf,
+  type MediumCapability,
+} from '@0xhoneyjar/medium-registry';
 import type { ZoneDigest, ZoneId } from '../score/types.ts';
 import { ZONE_FLAVOR, DIMENSION_NAME } from '../score/types.ts';
 import { POST_TYPE_SPECS, type PostType } from '../compose/post-types.ts';
 import {
   escapeDiscordMarkdown,
   stripVoiceDisciplineDrift,
+  type VoiceMediumId,
 } from './sanitize.ts';
 
 const DIRECTION_COLORS = {
@@ -42,22 +55,43 @@ export interface DiscordEmbed {
   footer?: { text: string };
 }
 
+export interface BuildPostPayloadOpts {
+  /**
+   * Active medium descriptor. Cycle R Sprint 3 — defaults to
+   * DISCORD_WEBHOOK_DESCRIPTOR (Pattern B shell-bot · the persona-bot
+   * default). Pass DISCORD_INTERACTION_DESCRIPTOR for slash-command
+   * responses or CLI_DESCRIPTOR for cli-renderer pre-formatting.
+   */
+  readonly medium?: MediumCapability;
+}
+
 export function buildPostPayload(
   digest: ZoneDigest,
   voice: string,
   postType: PostType,
+  opts: BuildPostPayloadOpts = {},
 ): DigestPayload {
   const spec = POST_TYPE_SPECS[postType];
+  const medium = opts.medium ?? DISCORD_WEBHOOK_DESCRIPTOR;
+  const mediumId = mediumIdOf(medium) as VoiceMediumId;
+
   // Voice discipline runs BEFORE markdown escape: strip em-dashes,
   // asterisk roleplay, and (non-digest) closing signoffs. Digest is the
   // only post-type that retains "stay groovy 🐻"-style closings per
   // discord-native-register doctrine. Per cmp-boundary §9 voice-discipline
-  // drift class · cycle R cmp-boundary-architecture S1.
-  const voiceCleaned = stripVoiceDisciplineDrift(voice, { postType });
+  // drift class · cycle R cmp-boundary-architecture S1. Sprint 3 threads
+  // mediumId for CLI ANSI-strip + future medium-specific register tunes.
+  const voiceCleaned = stripVoiceDisciplineDrift(voice, { postType, mediumId });
   const sanitized = escapeDiscordMarkdown(voiceCleaned);
 
-  if (!spec.useEmbed) {
-    // Plain content for micro / lore_drop / question — lightweight
+  // Cycle R Sprint 3 — gate embed shape on registry capability. Most
+  // calls land DISCORD_WEBHOOK_DESCRIPTOR which has embed=true; the
+  // gate is a safety net for future non-Discord callers.
+  const useEmbed = spec.useEmbed && hasCapability(medium, 'embed');
+
+  if (!useEmbed) {
+    // Plain content for micro / lore_drop / question OR for any medium
+    // that doesn't render embeds (CLI · future Telegram).
     return {
       content: sanitized,
       embeds: [],

--- a/packages/persona-engine/src/deliver/sanitize-medium.test.ts
+++ b/packages/persona-engine/src/deliver/sanitize-medium.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Sanitize medium-aware extension tests — cycle R Sprint 3 R3.4.
+ *
+ * Verifies:
+ *   1. mediumId='cli' threading strips ANSI escape sequences (defense-in-depth)
+ *   2. mediumId='discord-webhook' / 'discord-interaction' / undefined → no extra
+ *      transforms (back-compat with Sprint 1 callers)
+ *   3. Universal voice-discipline transforms (em-dash, asterisk, closings)
+ *      remain UNCONDITIONAL across all mediumId values per architect lock A4
+ */
+
+import { describe, it, expect } from "bun:test";
+import { stripVoiceDisciplineDrift } from "./sanitize.ts";
+
+describe("stripVoiceDisciplineDrift — medium threading (cycle R sprint 3)", () => {
+  describe("CLI medium · ANSI strip", () => {
+    it("strips CSI sequences when mediumId='cli'", () => {
+      const dirty = "hello\x1b[31mred\x1b[0m world";
+      const out = stripVoiceDisciplineDrift(dirty, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      expect(out).not.toMatch(/\x1b/);
+      // Non-ANSI text content survives the strip
+      expect(out).toContain("hello");
+      expect(out).toContain("world");
+    });
+
+    it("strips OSC sequences (window title injection) when CLI", () => {
+      const dirty = "hello\x1b]0;PWNED\x07world";
+      const out = stripVoiceDisciplineDrift(dirty, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      expect(out).not.toMatch(/\x1b/);
+      expect(out).not.toContain("PWNED");
+    });
+
+    it("strips screen-clear escapes when CLI", () => {
+      const dirty = "hello\x1b[2Jworld";
+      const out = stripVoiceDisciplineDrift(dirty, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      expect(out).not.toContain("\x1b[2J");
+    });
+  });
+
+  describe("Discord medium · ANSI escapes preserved (different threat model)", () => {
+    it("does NOT strip ANSI when mediumId='discord-webhook'", () => {
+      // Discord renders ANSI as-text (no terminal interpretation), so the
+      // injection threat model doesn't apply. Persona-bots may quote
+      // `\x1b[31m` in code blocks intentionally.
+      const text = "see `\\x1b[31m` for SGR red";
+      const out = stripVoiceDisciplineDrift(text, {
+        postType: "micro",
+        mediumId: "discord-webhook",
+      });
+      // The text was NOT touched by ANSI strip (it had no real ANSI either)
+      expect(out).toContain("\\x1b[31m");
+    });
+
+    it("does NOT strip ANSI when mediumId='discord-interaction'", () => {
+      const dirty = "hello\x1b[31mred\x1b[0m";
+      const out = stripVoiceDisciplineDrift(dirty, {
+        postType: "micro",
+        mediumId: "discord-interaction",
+      });
+      // ANSI bytes pass through (Discord won't render them as colors)
+      expect(out).toContain("\x1b");
+    });
+
+    it("does NOT strip ANSI when mediumId is undefined (back-compat)", () => {
+      // Sprint 1 callers don't thread mediumId — preserve their behavior.
+      const dirty = "hello\x1b[31mred\x1b[0m";
+      const out = stripVoiceDisciplineDrift(dirty, { postType: "micro" });
+      expect(out).toContain("\x1b");
+    });
+  });
+
+  describe("Universal voice-discipline UNCHANGED across mediums (architect lock A4)", () => {
+    it("strips em-dash for CLI medium", () => {
+      const out = stripVoiceDisciplineDrift("yo — wild stuff", {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      expect(out).not.toMatch(/—/);
+    });
+
+    it("strips em-dash for Discord webhook medium", () => {
+      const out = stripVoiceDisciplineDrift("yo — wild stuff", {
+        postType: "micro",
+        mediumId: "discord-webhook",
+      });
+      expect(out).not.toMatch(/—/);
+    });
+
+    it("strips em-dash for Discord interaction medium", () => {
+      const out = stripVoiceDisciplineDrift("yo — wild stuff", {
+        postType: "micro",
+        mediumId: "discord-interaction",
+      });
+      expect(out).not.toMatch(/—/);
+    });
+
+    it("strips asterisk roleplay regardless of medium", () => {
+      const text = "*adjusts cabling* the score is up";
+      const cli = stripVoiceDisciplineDrift(text, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      const dw = stripVoiceDisciplineDrift(text, {
+        postType: "micro",
+        mediumId: "discord-webhook",
+      });
+      expect(cli).not.toMatch(/\*adjusts cabling\*/);
+      expect(dw).not.toMatch(/\*adjusts cabling\*/);
+    });
+
+    it("preserves digest closing across mediums", () => {
+      const text = "big week.\n\nstay groovy 🐻";
+      const cli = stripVoiceDisciplineDrift(text, {
+        postType: "digest",
+        mediumId: "cli",
+      });
+      const dw = stripVoiceDisciplineDrift(text, {
+        postType: "digest",
+        mediumId: "discord-webhook",
+      });
+      expect(cli).toMatch(/stay groovy/);
+      expect(dw).toMatch(/stay groovy/);
+    });
+
+    it("strips micro closing across mediums", () => {
+      const text = "thinking on it.\n\nstay groovy 🐻";
+      const cli = stripVoiceDisciplineDrift(text, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      const dw = stripVoiceDisciplineDrift(text, {
+        postType: "micro",
+        mediumId: "discord-webhook",
+      });
+      expect(cli).not.toMatch(/stay groovy/);
+      expect(dw).not.toMatch(/stay groovy/);
+    });
+  });
+
+  describe("Idempotency across medium threading", () => {
+    it("CLI medium is idempotent", () => {
+      const dirty = "hello\x1b[31mred\x1b[0m world — cool";
+      const once = stripVoiceDisciplineDrift(dirty, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      const twice = stripVoiceDisciplineDrift(once, {
+        postType: "micro",
+        mediumId: "cli",
+      });
+      expect(once).toBe(twice);
+    });
+  });
+});

--- a/packages/persona-engine/src/deliver/sanitize.ts
+++ b/packages/persona-engine/src/deliver/sanitize.ts
@@ -98,8 +98,30 @@ export function inlineCode(id: string): string {
 // =============================================================================
 
 /**
- * Options for stripVoiceDisciplineDrift. Sprint 3 will extend with `medium`
- * for medium-aware variant selection per `MediumCapability` registry.
+ * Medium identifier for voice-discipline opt threading (cycle R sprint 3).
+ *
+ * Matches `mediumIdOf(...)` from `@0xhoneyjar/medium-registry@0.2.0`.
+ * Stays as a string union (NOT a registry import) to avoid forcing
+ * persona-engine consumers to take a medium-registry dep just to pass
+ * post-type metadata. Composer wires the registry at the
+ * variant-selection layer (deliver/embed.ts).
+ *
+ * Universal voice discipline (architect lock A4) does NOT vary by medium —
+ * em-dashes, asterisk roleplay, default closings are stripped uniformly.
+ * The `mediumId` arg is reserved for FUTURE medium-specific prose
+ * register adjustments (Telegram has different conventions; CLI strips
+ * additional ANSI-confusing characters).
+ */
+export type VoiceMediumId = "discord-webhook" | "discord-interaction" | "cli" | "telegram-stub";
+
+/**
+ * Options for stripVoiceDisciplineDrift. Cycle R Sprint 3 extends with
+ * `mediumId` for medium-aware additional discipline (CLI strips
+ * ANSI-confusing characters; Discord retains current behavior).
+ *
+ * Universal voice transforms (em-dash · asterisk roleplay · closing
+ * signoff) are NOT gated by mediumId — architect lock A4 (universal ·
+ * zero opt-out · code-block-safe · idempotent).
  */
 export interface VoiceDisciplineOpts {
   /**
@@ -108,6 +130,20 @@ export interface VoiceDisciplineOpts {
    * discord-native-register doctrine. Default: undefined → strip closings.
    */
   postType?: string;
+
+  /**
+   * Active medium · cycle R Sprint 3 · enables medium-specific discipline
+   * additions BEYOND the universal transforms. Today:
+   *
+   *   - 'cli'                           → strip ANSI escape sequences
+   *                                       (defense-in-depth · cli-renderer
+   *                                       package also strips at render time)
+   *   - 'discord-webhook' / 'discord-interaction' / undefined → no extra
+   *
+   * Default: undefined → universal-only behavior (back-compat · matches
+   * Sprint 1 + Sprint 2 callers that don't yet thread the medium through).
+   */
+  mediumId?: VoiceMediumId;
 }
 
 /**
@@ -160,13 +196,55 @@ export function stripVoiceDisciplineDrift(
   const skipClosings = opts?.postType === 'digest';
   const closed = skipClosings ? transformed : stripTrailingClosings(transformed);
 
+  // Cycle R Sprint 3 — medium-specific discipline ADDITIONS beyond the
+  // universal transforms. CLI strips ANSI escape sequences as
+  // defense-in-depth (cli-renderer package also strips at render time;
+  // applying here means downstream renderers + telemetry sinks get safe
+  // text too).
+  const mediumDisciplined =
+    opts?.mediumId === 'cli' ? stripAnsiEscapes(closed) : closed;
+
   // FINAL cleanup at whole-text level:
   //  - Trim leading whitespace at start (artifact from stripped roleplay
   //    at sentence start). Per-line indentation preserved.
   //  - Trim trailing comma + whitespace (artifact from em-dash transform
   //    at end of text · em-dash followed by trailing whitespace becomes
   //    `, ` per the no-peek branch · meaningless at end of text).
-  return closed.replace(/^[ \t]+/, '').replace(/,?\s*$/, '');
+  return mediumDisciplined.replace(/^[ \t]+/, '').replace(/,?\s*$/, '');
+}
+
+/**
+ * ANSI escape sequence stripper for CLI medium.
+ *
+ * Defense-in-depth — `@0xhoneyjar/cli-renderer` ALSO strips at render
+ * time (per SKP-001 architectural fix in cycle R sprint 3). Applying
+ * here means:
+ *
+ *   1. Telemetry / logging sinks downstream of sanitize see safe text
+ *   2. If a future non-cli-renderer consumer renders to terminal directly,
+ *      they're protected
+ *   3. Two-layer strip catches accidental cli-renderer bypasses
+ *
+ * Pattern matches CSI (`ESC [ ... final-byte`), OSC (`ESC ] ... BEL/ST`),
+ * and single-char escapes (`ESC X`). Same shape as cli-renderer's
+ * sanitize-ansi.ts.
+ */
+function stripAnsiEscapes(text: string): string {
+  if (!text) return text;
+  return text.replace(
+    new RegExp(
+      [
+        // CSI sequences (most common: SGR colors, cursor moves)
+        '[\\x1b\\x9b][\\[]([0-9;<=>?]*)[\\x20-\\x2f]*[\\x40-\\x7e]',
+        // OSC sequences (window title, hyperlinks) — terminated by BEL or ST
+        '[\\x1b\\x9b][\\]][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)',
+        // Single-char escapes (DEC private modes, charset switches)
+        '[\\x1b][@-Z\\\\-_]',
+      ].join('|'),
+      'g',
+    ),
+    '',
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Sprint 3 PR-C — third in the 3-stack. Threads `@0xhoneyjar/medium-registry@^0.2.0` through composer + buildPostPayload + stripVoiceDisciplineDrift. Default medium is `DISCORD_WEBHOOK_DESCRIPTOR` (Pattern B shell-bot · the persona-bot delivery shape) per architect lock A4 + the SKP-001 ctx-split.

## Tasks shipped

### R3.1 dependency

Adds `@0xhoneyjar/medium-registry@^0.2.0` to `persona-engine/package.json`. PR-A's npm publish must complete before `bun install` resolves; for local dev pre-publish, use `bun link @0xhoneyjar/medium-registry` per cycle-Q convention.

### R3.2 composer.ts accepts opts.medium

\`\`\`ts
composeZonePost(config, character, zone, postType, { medium })
\`\`\`

When `opts.medium` is omitted, `buildPostPayload` internally falls back to `DISCORD_WEBHOOK_DESCRIPTOR` — preserves Sprint 1/2 callsite semantics. Existing call sites continue to work without any modification.

### R3.3 deliver/embed.ts gates embed shape on hasCapability

\`\`\`ts
const useEmbed = spec.useEmbed && hasCapability(medium, 'embed');
\`\`\`

Most calls land webhook (`embed=true`) so behavior preserves byte-identically. CLI medium (`embed=false`) emits plain content instead. Future Telegram cycle inherits the gate.

`mediumIdOf()` threads the active medium ID through to `stripVoiceDisciplineDrift` for medium-specific prose discipline.

### R3.4 sanitize.ts becomes medium-aware

Adds `VoiceMediumId` type union matching medium-registry `_tag` literals. `VoiceDisciplineOpts` gains optional `mediumId?: VoiceMediumId`.

- CLI medium → `stripAnsiEscapes()` (defense-in-depth · SKP-001 architectural fix)
- Discord/Telegram/undefined → no extra discipline beyond universal transforms

Universal voice-discipline transforms (em-dash · asterisk roleplay · default closing) remain UNCONDITIONAL across all mediumId values per architect lock A4.

## Tests

\`\`\`
398/398 pass (was 377, +21 new from Sprint 3 additions)
\`\`\`

NEW `packages/persona-engine/src/deliver/sanitize-medium.test.ts` (13 cases):
- CLI medium · ANSI strip · CSI/OSC/screen-clear sequences
- Discord medium · ANSI escapes preserved (different threat model)
- Universal voice-discipline UNCHANGED across mediums (architect lock A4)
- Idempotency across medium threading

NEW `packages/persona-engine/src/deliver/embed-medium.test.ts` (8 cases):
- Default (omitted opts.medium) preserves Sprint 1/2 behavior
- DISCORD_WEBHOOK_DESCRIPTOR digest emits embed
- DISCORD_INTERACTION_DESCRIPTOR digest emits embed
- CLI_DESCRIPTOR digest emits PLAIN content
- CLI strips ANSI escapes from voice
- Discord media DOES NOT strip ANSI from voice
- Output byte-identical for default vs explicit DISCORD_WEBHOOK callers

Zero functional regression in existing 377-test baseline.
typecheck: 2 pre-existing errors in `error-register.test.ts` (unrelated to this PR · same count on main).

## Stacked on

PR-A: https://github.com/0xHoneyJar/freeside-mediums/pull/1 (publishes 0.2.0)

After PR-A's npm publish completes, `bun install` will resolve `^0.2.0`. Until then, local dev uses `bun link`.

## Architectural context — webhook vs interaction

This PR (PR-C) uses `DISCORD_WEBHOOK_DESCRIPTOR` because persona-bots (ruggy/satoshi/munkh) deliver via Pattern B shell-bot — webhook with per-message avatar+username override. Webhook context means NO modal · NO ephemeral.

Sibling PR-B (freeside-quests#12 · discord-renderer) uses `DISCORD_INTERACTION_DESCRIPTOR` because the quest engine delivers via slash command + button + modal flows — full Discord interactive surface available.

Distinct contexts per the SKP-001 architectural split (PR-A's medium-registry@0.2.0).

## Test plan

- [ ] Wait for PR-A's npm publish ceremony
- [ ] Pull branch + `bun install` (resolves `@0xhoneyjar/medium-registry@^0.2.0`)
- [ ] `bun test` → 398/398 pass
- [ ] Verify zero regression: existing 377-test baseline still green
- [ ] Verify Discord output byte-identical to pre-Sprint-3 for default callers (test in `embed-medium.test.ts` confirms)
- [ ] `bun run typecheck` → only 2 pre-existing errors (same as main)

## Cycle context

- Cycle R · cmp-boundary-architecture-2026-05-04
- Sprint 3 PR-C (3 of 3 stacked PRs)
- Architect locks A1-A8 STABLE
- SDD source: `~/bonfire/grimoires/loa/sdd.md` §5.7 + §5.2 + §5.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)