### PR TITLE
feat(cycle-B sprint-1): auth-bridge + tenant resolver + production runtime (B-1.6/1.7/1.8)

### DIFF
--- a/apps/bot/src/auth-bridge-deps.ts
+++ b/apps/bot/src/auth-bridge-deps.ts
@@ -1,0 +1,138 @@
+/**
+ * auth-bridge-deps.ts — bot composition root for auth-bridge ports
+ * (cycle-B sprint-1 review fix · PR #53 Blocker #1 + #8).
+ *
+ * Cross-reviewer flatline (PR #53 · CRITICAL Blocker #1): without dispatch
+ * wiring, the auth-bridge module is dead code at runtime. This module
+ * provides the boot-time hook (setAuthBridgeDeps) + the dispatch-time
+ * accessor (getAuthBridgeDeps) that the dispatch layer consumes.
+ *
+ * Default deps are anon-only: tenant resolver returns null · dynamic lookup
+ * returns null · mint throws. Combined with AUTH_BACKEND=anon (Lock-7
+ * default), every interaction takes the short-circuit anon path. Operators
+ * wire real ports at boot once @freeside-auth/* packages are bun-linked
+ * (cycle-B B-1.5 gateway deploy ceremony).
+ *
+ * Storm warning (B#8 · cross-reviewer flatline #53): the default logger
+ * wraps consoleLogger with a fallback counter that emits louder warnings
+ * as anon-fallback events accumulate. Approximation of a circuit breaker
+ * — operator-visible signal that gateway availability or midi profile
+ * coverage may be degraded, even when individual interactions still work.
+ */
+
+import {
+  consoleLogger,
+  type AuthBridgeDeps,
+  type AuthBridgeLogger,
+  type DynamicUserIdLookupPort,
+  type MintJwtPort,
+  type TenantResolverPort,
+} from './auth-bridge.ts';
+
+// ---------------------------------------------------------------------------
+// Default-anon ports (active when AUTH_BACKEND=anon · Lock-7 default)
+// ---------------------------------------------------------------------------
+
+const defaultTenantResolver: TenantResolverPort = {
+  resolveTenantFromGuild: async () => null,
+};
+
+const defaultDynamicLookup: DynamicUserIdLookupPort = {
+  fetchDynamicUserIdFromDiscord: async () => null,
+};
+
+const defaultMintJwt: MintJwtPort = {
+  mintJwt: async () => {
+    throw new Error(
+      'MintJwtPort default-stub: AUTH_BACKEND=freeside-jwt requires ' +
+        'bun-link of @freeside-auth/engine + setAuthBridgeDeps wired at boot ' +
+        '(cycle-B B-1.5 gateway deploy ceremony).',
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Storm-aware logger · per cross-reviewer flatline #53 Blocker #8
+// ---------------------------------------------------------------------------
+
+interface StormState {
+  count: number;
+  last_warn_at_ms: number;
+}
+
+const STORM_THRESHOLD = 50;
+const STORM_WARN_INTERVAL_MS = 5 * 60_000; // 5min
+
+/**
+ * Build a logger that tracks audit (anon-fallback) volume and emits a louder
+ * STORM warning when fallbacks accumulate. The threshold (every Nth
+ * fallback OR after the cooldown elapses with non-zero count) gives the
+ * operator a clear signal in logs without spamming when fallbacks are
+ * occasional.
+ *
+ * NOT a hard circuit breaker: Lock-7 anon-default keeps the bot functional
+ * during outages. The warning is a telemetry surface for operators to
+ * investigate (gateway 5xx · midi profile coverage gap · etc).
+ */
+export const buildStormAwareLogger = (
+  base: AuthBridgeLogger = consoleLogger,
+  state: StormState = { count: 0, last_warn_at_ms: 0 },
+  thresholdEvery: number = STORM_THRESHOLD,
+  warnIntervalMs: number = STORM_WARN_INTERVAL_MS,
+): AuthBridgeLogger => ({
+  info: base.info,
+  warn: base.warn,
+  audit: (m) => {
+    base.audit(m);
+    state.count++;
+    const now = Date.now();
+    const stormByCount = state.count % thresholdEvery === 0;
+    const stormByCooldown =
+      state.count > 0 && now - state.last_warn_at_ms > warnIntervalMs;
+    if (stormByCount || stormByCooldown) {
+      base.warn(
+        `[auth-bridge:STORM] anon-fallback count=${state.count} since boot · ` +
+          `operator may want to investigate gateway availability or midi profile coverage`,
+      );
+      state.last_warn_at_ms = now;
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Composition root accessors (set at boot · read at dispatch)
+// ---------------------------------------------------------------------------
+
+const defaultAnonDeps: AuthBridgeDeps = {
+  tenantResolver: defaultTenantResolver,
+  dynamicLookup: defaultDynamicLookup,
+  mintJwt: defaultMintJwt,
+  logger: buildStormAwareLogger(),
+};
+
+let activeDeps: AuthBridgeDeps = defaultAnonDeps;
+
+/**
+ * Bot main wires real deps here at boot. Default is anon-only · the verified
+ * path engages when operator (a) bun-links @freeside-auth/protocol +
+ * @freeside-auth/engine and (b) constructs real port impls + calls
+ * setAuthBridgeDeps before dispatch fires.
+ */
+export const setAuthBridgeDeps = (deps: AuthBridgeDeps): void => {
+  activeDeps = deps;
+};
+
+/**
+ * Dispatch layer reads deps per interaction. The returned object is stable
+ * for the process lifetime once setAuthBridgeDeps lands; before that, the
+ * default-anon deps are returned.
+ */
+export const getAuthBridgeDeps = (): AuthBridgeDeps => activeDeps;
+
+/**
+ * Test reset · restores the default-anon deps. Production code never calls
+ * this · it exists only for test isolation.
+ */
+export const __resetAuthBridgeDepsForTest = (): void => {
+  activeDeps = defaultAnonDeps;
+};

--- a/apps/bot/src/auth-bridge.ts
+++ b/apps/bot/src/auth-bridge.ts
@@ -1,0 +1,491 @@
+/**
+ * auth-bridge.ts — session-start identity attach (cycle-B · sprint-1 · B-1.6).
+ *
+ * Per SDD §3.2.1 + §13.1-3: at the START of every Discord interaction the bot
+ * resolves an AuthContext and attaches it to the per-interaction context object.
+ * Downstream quest dispatch / Sietch / finn invoke read `ctx.auth` to make
+ * authorization decisions.
+ *
+ * # The 3 fail-modes (per AC-B1.6.1)
+ *
+ * Each route declares its fail-mode. The bridge fails closed by default — any
+ * unspecified command is treated as `verified-required`, which means missing
+ * or invalid JWT raises `AuthBridgeError` and the dispatcher returns 401.
+ *
+ *   - `public`                     anon allowed (read-only quest list, public metadata)
+ *   - `verified-required`          401 + structured error if no valid JWT
+ *                                  (default · quest accept · quest submit · badge issue)
+ *   - `verified-with-anon-fallback` audit-logged anon fallback (operator-supervised V1
+ *                                  rollout for slice-B kickoff · ratchet to verified-required
+ *                                  once midi profile coverage reaches threshold)
+ *
+ * # Lock-7 feature flag (`AUTH_BACKEND` env)
+ *
+ *   - `anon`           default · all interactions short-circuit to anon AuthContext.
+ *                      Discord interactions remain functional with anon-tier permissions.
+ *                      One-line revert path per architect Lock-7.
+ *   - `freeside-jwt`   verified path · resolve tenant + lookup dynamic_user_id +
+ *                      mint JWT via @freeside-auth/engine MintJWTOrchestrator.
+ *
+ * # Architect locks honored
+ *
+ *   - I2 (Cyberdeck Seam): this module is L4 boundary code · NEVER touches RPC
+ *     directly · NEVER signs JWTs locally (delegation pattern per SDD §12.3).
+ *   - I5 (Construct Purity): pure orchestration · all side effects (HTTP mint
+ *     call, MCP user lookup, env reads) flow through injected ports so the
+ *     module is unit-testable without a network.
+ *   - I6 (Tenant-Boundary Assertion): every successful mint asserts
+ *     `claims.tenant === expected_tenant` before returning.
+ *   - Lock-7: AUTH_BACKEND env is the only kill switch.
+ *   - Lock-8: V1 single-keypair · 1h JWT TTL · jti denylist deferred to V2 ·
+ *     no revocation logic in this layer (verifier hook handles it upstream).
+ *   - Lock-9: schema source-of-truth = JSON Schema. Local `JWTClaim` shape
+ *     mirrors `@freeside-auth/protocol/jwt-claims.schema.json` until the bot
+ *     workspace links the published package (B-1.8 deferred).
+ *
+ * # Cross-repo dep status
+ *
+ * `@freeside-auth/engine` lives at `~/Documents/GitHub/freeside-auth` and is
+ * not yet bun-linked into this workspace (deferred to B-1.8). For B-1.6 we
+ * declare the orchestrator surface as an injected port; the bot wires the
+ * real `MintJWTOrchestrator` at boot once the link lands.
+ */
+
+import type { DiscordInteraction } from './discord-interactions/types.ts';
+
+// ---------------------------------------------------------------------------
+// Local schema mirror (Lock-9 · canonical = @freeside-auth/protocol)
+// ---------------------------------------------------------------------------
+
+/**
+ * Wallet shape inside JWT claims. Mirrors `@freeside-auth/protocol/jwt-claims`
+ * (chain enum + address). Local copy until B-1.8 bun-links the package; the
+ * canonical source is the JSON Schema, this is just the TS binding the bot
+ * consumes.
+ */
+export interface JWTWallet {
+  readonly chain: 'ethereum' | 'berachain' | 'solana' | 'bitcoin';
+  readonly address: string;
+}
+
+/**
+ * JWT claim shape. Mirrors `JWTClaimSchema` in @freeside-auth/protocol. The
+ * Rust gateway at loa-freeside/apps/gateway is the canonical signer; this
+ * shape is what verifiers honor. Slice-B populates the required fields;
+ * pool_id/byok/req_hash are reserved for execution-context (V2).
+ */
+export interface JWTClaim {
+  readonly schema_version?: '1.0';
+  readonly sub: string;
+  readonly tenant: string;
+  readonly wallets: readonly JWTWallet[];
+  readonly iss: string;
+  readonly aud: string;
+  readonly exp: number;
+  readonly iat: number;
+  readonly jti: string;
+  readonly v: 1;
+  readonly tier?: 'public' | 'verified' | 'bearer' | 'initiate' | 'keeper';
+  readonly display_name?: string;
+  readonly discord_id?: string;
+  readonly nft_id?: number;
+}
+
+// ---------------------------------------------------------------------------
+// AuthContext discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * Anonymous interaction · default for `AUTH_BACKEND=anon` and for routes
+ * declared `public`. discord_id is the only fact known about the invoker.
+ */
+export interface AuthAnon {
+  readonly kind: 'anon';
+  readonly discord_id: string;
+}
+
+/**
+ * Verified interaction · JWT minted by freeside-auth orchestrator + signed
+ * by loa-freeside/apps/gateway. claims.tenant has been asserted to match
+ * the resolved guild's tenant_id (I6 invariant).
+ */
+export interface AuthVerified {
+  readonly kind: 'verified';
+  readonly jwt: string;
+  readonly claims: JWTClaim;
+}
+
+/**
+ * Anon-fallback · audit-logged downgrade from verified to anon. Only emitted
+ * for routes declared `verified-with-anon-fallback`; never for the default
+ * `verified-required` mode (which throws AuthBridgeError instead).
+ *
+ * `reason` enumerates the divergence so operators can ratchet the policy:
+ *   - `no-tenant`       guild has no tenant binding (public discord guild)
+ *   - `no-dynamic-user` invoker not yet onboarded via Dynamic SDK
+ *   - `mint-failed`     orchestrator threw (gateway 5xx, network, etc)
+ *   - `policy-fallback` route policy explicitly chose fallback
+ */
+export interface AuthAnonFallback {
+  readonly kind: 'anon-fallback';
+  readonly discord_id: string;
+  readonly reason: 'no-tenant' | 'no-dynamic-user' | 'mint-failed' | 'policy-fallback';
+}
+
+export type AuthContext = AuthAnon | AuthVerified | AuthAnonFallback;
+
+/**
+ * Per-interaction context object. The bot constructs one of these at the top
+ * of every interaction handler · auth-bridge attaches `auth` · downstream
+ * quest dispatch and Sietch read it.
+ *
+ * Fields beyond `auth` are owned by their respective layers; this interface
+ * is intentionally minimal so each consumer extends as needed.
+ */
+export interface InteractionContext {
+  readonly interaction_id: string;
+  readonly guild_id: string | null;
+  readonly discord_id: string;
+  auth?: AuthContext;
+}
+
+// ---------------------------------------------------------------------------
+// Fail-mode classification (AC-B1.6.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-route fail-mode. Default for unspecified routes is `verified-required`
+ * (fail-closed by default · BARTH safety per SDD §13.1).
+ */
+export type FailMode =
+  | 'public'
+  | 'verified-required'
+  | 'verified-with-anon-fallback';
+
+export const DEFAULT_FAIL_MODE: FailMode = 'verified-required';
+
+/**
+ * Slice-B fail-mode registry. Operator extends as new commands ship.
+ *
+ * Mongolian B-1 ships `quest` as `verified-with-anon-fallback` to honor the
+ * operator-supervised V1 rollout (mibera midi profile coverage is incomplete;
+ * fallback gives anon-tier UX without breaking the flow). Once coverage hits
+ * threshold the policy ratchets to `verified-required`.
+ *
+ * `quest_list` is `public` because reading available quests is metadata.
+ */
+export const SLICE_B_FAIL_MODES: ReadonlyMap<string, FailMode> = new Map([
+  ['quest', 'verified-with-anon-fallback'],
+  ['quest_list', 'public'],
+  ['quest_accept', 'verified-required'],
+  ['quest_submit', 'verified-required'],
+  ['badge_issue', 'verified-required'],
+]);
+
+/**
+ * Look up the fail-mode for a slash command name. Unknown commands fall back
+ * to `DEFAULT_FAIL_MODE` (verified-required · fail-closed by default).
+ */
+export const resolveFailMode = (
+  commandName: string,
+  registry: ReadonlyMap<string, FailMode> = SLICE_B_FAIL_MODES,
+): FailMode => registry.get(commandName) ?? DEFAULT_FAIL_MODE;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Verified-required route received no valid JWT. Caller maps to a 401-style
+ * structured response · does NOT silently downgrade to anon.
+ */
+export class AuthBridgeError extends Error {
+  constructor(
+    public readonly code:
+      | 'no_tenant'
+      | 'no_dynamic_user'
+      | 'mint_failed'
+      | 'tenant_assertion_failed',
+    public readonly reason: string,
+    public readonly discord_id: string,
+  ) {
+    super(`auth-bridge: ${code} (${reason})`);
+    this.name = 'AuthBridgeError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Injectable ports (I5 Construct Purity)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tenant-resolution port. Wraps the world-manifest lookup added in B-1.7
+ * (`resolveTenantFromGuild` extension to world-resolver.ts). Returns null
+ * when the guild has no tenant binding (public Discord channel).
+ */
+export interface TenantResolverPort {
+  resolveTenantFromGuild(guildId: string): Promise<string | null>;
+}
+
+/**
+ * Dynamic SDK lookup port. Wraps the freeside_auth MCP tool that maps a
+ * Discord user_id → Dynamic SDK dynamic_user_id (the canonical identity
+ * key downstream consumers join on). Returns null for users not yet
+ * onboarded.
+ */
+export interface DynamicUserIdLookupPort {
+  fetchDynamicUserIdFromDiscord(discordId: string): Promise<string | null>;
+}
+
+/**
+ * Mint orchestrator port. Wraps `@freeside-auth/engine` MintJWTOrchestrator's
+ * `mintJwt({tenant_id, credential})` surface (per SDD §12.3 delegation
+ * pattern: this layer constructs claims · loa-freeside/apps/gateway signs).
+ *
+ * Throws if the orchestrator can't resolve identity OR the gateway rejects
+ * the issue request. Caller maps to AuthBridgeError or anon-fallback per
+ * fail-mode.
+ */
+export interface MintJwtPort {
+  mintJwt(input: {
+    tenant_id: string;
+    dynamic_user_id: string;
+  }): Promise<{ jwt: string; claims: JWTClaim }>;
+}
+
+/**
+ * Logger port. Default impl writes to console; tests inject a recording stub.
+ */
+export interface AuthBridgeLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  /**
+   * Audit log · used for `verified-with-anon-fallback` downgrades. Operator
+   * dashboards aggregate these to track midi profile coverage gaps.
+   */
+  audit(message: string): void;
+}
+
+export const consoleLogger: AuthBridgeLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  audit: (m) => console.log(`[auth-bridge:audit] ${m}`),
+};
+
+export interface AuthBridgeDeps {
+  readonly tenantResolver: TenantResolverPort;
+  readonly dynamicLookup: DynamicUserIdLookupPort;
+  readonly mintJwt: MintJwtPort;
+  readonly logger?: AuthBridgeLogger;
+}
+
+// ---------------------------------------------------------------------------
+// Backend selection (Lock-7)
+// ---------------------------------------------------------------------------
+
+export type AuthBackend = 'anon' | 'freeside-jwt';
+
+/**
+ * Read `AUTH_BACKEND` env. Defaults to `anon` per Lock-7 · operator flips
+ * each consumer independently to `freeside-jwt` after slice-B B-1.5 gateway
+ * deploy verifies. Unknown values fall back to `anon` with a warning so
+ * misconfiguration doesn't fail closed for the entire bot.
+ */
+export const readAuthBackend = (
+  env: NodeJS.ProcessEnv = process.env,
+  logger: AuthBridgeLogger = consoleLogger,
+): AuthBackend => {
+  const raw = (env.AUTH_BACKEND ?? 'anon').trim();
+  if (raw === 'anon' || raw === 'freeside-jwt') return raw;
+  logger.warn(
+    `[auth-bridge] AUTH_BACKEND="${raw}" unrecognized · defaulting to anon (Lock-7 fallback)`,
+  );
+  return 'anon';
+};
+
+// ---------------------------------------------------------------------------
+// Public entry · attachAuthContext
+// ---------------------------------------------------------------------------
+
+export interface AttachAuthOptions {
+  readonly interaction: DiscordInteraction;
+  readonly ctx: InteractionContext;
+  readonly commandName: string;
+  readonly deps: AuthBridgeDeps;
+  /** Override `process.env` reads (test injection). */
+  readonly env?: NodeJS.ProcessEnv;
+  /** Override the fail-mode registry (test injection). */
+  readonly failModes?: ReadonlyMap<string, FailMode>;
+}
+
+/**
+ * Attach an AuthContext to the InteractionContext.
+ *
+ * Decision tree (matches AC-B1.6.1):
+ *
+ *   AUTH_BACKEND=anon
+ *     → ctx.auth = anon
+ *
+ *   AUTH_BACKEND=freeside-jwt + fail_mode=public
+ *     → ctx.auth = anon (route doesn't need verified)
+ *
+ *   AUTH_BACKEND=freeside-jwt + fail_mode=verified-required
+ *     → resolve tenant + lookup dynamic_user_id + mint
+ *     → on any failure throw AuthBridgeError (caller returns 401)
+ *
+ *   AUTH_BACKEND=freeside-jwt + fail_mode=verified-with-anon-fallback
+ *     → resolve tenant + lookup dynamic_user_id + mint
+ *     → on any failure audit-log + return anon-fallback context
+ *
+ * Throws `AuthBridgeError` only for verified-required failures. Anon and
+ * anon-fallback paths never throw.
+ */
+export const attachAuthContext = async (
+  opts: AttachAuthOptions,
+): Promise<InteractionContext> => {
+  const { interaction, ctx, commandName, deps } = opts;
+  const logger = deps.logger ?? consoleLogger;
+  const env = opts.env ?? process.env;
+  const failModes = opts.failModes ?? SLICE_B_FAIL_MODES;
+  const failMode = resolveFailMode(commandName, failModes);
+  const backend = readAuthBackend(env, logger);
+  const discord_id = ctx.discord_id;
+
+  // ── Anon paths (Lock-7 default · or public route) ───────────────────
+  if (backend === 'anon' || failMode === 'public') {
+    ctx.auth = { kind: 'anon', discord_id };
+    logger.info(
+      `[auth-bridge] guild=${ctx.guild_id ?? 'dm'} user=${discord_id} ` +
+        `cmd=${commandName} fail_mode=${failMode} → ANON ` +
+        `(backend=${backend})`,
+    );
+    return ctx;
+  }
+
+  // ── Verified path (mint or fail per fail_mode) ──────────────────────
+  if (!ctx.guild_id) {
+    return handleVerifiedFailure({
+      ctx,
+      failMode,
+      logger,
+      code: 'no_tenant',
+      reason: 'interaction has no guild_id (DM context · no tenant binding)',
+      commandName,
+      discord_id,
+    });
+  }
+
+  const tenant_id = await deps.tenantResolver.resolveTenantFromGuild(ctx.guild_id);
+  if (!tenant_id) {
+    return handleVerifiedFailure({
+      ctx,
+      failMode,
+      logger,
+      code: 'no_tenant',
+      reason: `guild ${ctx.guild_id} has no tenant binding`,
+      commandName,
+      discord_id,
+    });
+  }
+
+  const dynamic_user_id = await deps.dynamicLookup.fetchDynamicUserIdFromDiscord(discord_id);
+  if (!dynamic_user_id) {
+    return handleVerifiedFailure({
+      ctx,
+      failMode,
+      logger,
+      code: 'no_dynamic_user',
+      reason: `discord_id=${discord_id} not onboarded via Dynamic SDK (midi gap)`,
+      commandName,
+      discord_id,
+    });
+  }
+
+  const mintStartedAt = Date.now();
+  let mintResult: { jwt: string; claims: JWTClaim };
+  try {
+    mintResult = await deps.mintJwt.mintJwt({ tenant_id, dynamic_user_id });
+  } catch (err) {
+    return handleVerifiedFailure({
+      ctx,
+      failMode,
+      logger,
+      code: 'mint_failed',
+      reason: `mint orchestrator threw: ${(err as Error)?.message ?? String(err)}`,
+      commandName,
+      discord_id,
+    });
+  }
+
+  // I6 invariant · assert tenant boundary BEFORE attaching context
+  if (mintResult.claims.tenant !== tenant_id) {
+    throw new AuthBridgeError(
+      'tenant_assertion_failed',
+      `mint returned tenant=${mintResult.claims.tenant} but expected ${tenant_id}`,
+      discord_id,
+    );
+  }
+
+  ctx.auth = { kind: 'verified', jwt: mintResult.jwt, claims: mintResult.claims };
+  logger.info(
+    `[auth-bridge] guild=${ctx.guild_id} user=${discord_id} cmd=${commandName} ` +
+      `→ VERIFIED tenant=${tenant_id} mint_ms=${Date.now() - mintStartedAt} ` +
+      `jwt_exp=${new Date(mintResult.claims.exp * 1000).toISOString()}`,
+  );
+  // mark interaction as touched so eslint-no-unused doesn't flag the parameter
+  // when this module is consumed by tests that supply minimal interaction stubs
+  void interaction;
+  return ctx;
+};
+
+// ---------------------------------------------------------------------------
+// Failure handling per fail-mode
+// ---------------------------------------------------------------------------
+
+interface VerifiedFailureArgs {
+  ctx: InteractionContext;
+  failMode: FailMode;
+  logger: AuthBridgeLogger;
+  code: AuthBridgeError['code'];
+  reason: string;
+  commandName: string;
+  discord_id: string;
+}
+
+const handleVerifiedFailure = (args: VerifiedFailureArgs): InteractionContext => {
+  const { ctx, failMode, logger, code, reason, commandName, discord_id } = args;
+
+  if (failMode === 'verified-required') {
+    logger.warn(
+      `[auth-bridge] FAIL-CLOSED guild=${ctx.guild_id ?? 'dm'} user=${discord_id} ` +
+        `cmd=${commandName} code=${code} reason="${reason}"`,
+    );
+    throw new AuthBridgeError(code, reason, discord_id);
+  }
+
+  // verified-with-anon-fallback — audit log + return anon-fallback
+  const fallbackReason = mapCodeToFallbackReason(code);
+  logger.audit(
+    `guild=${ctx.guild_id ?? 'dm'} user=${discord_id} cmd=${commandName} ` +
+      `fallback_reason=${fallbackReason} code=${code} detail="${reason}"`,
+  );
+  ctx.auth = { kind: 'anon-fallback', discord_id, reason: fallbackReason };
+  return ctx;
+};
+
+const mapCodeToFallbackReason = (
+  code: AuthBridgeError['code'],
+): AuthAnonFallback['reason'] => {
+  switch (code) {
+    case 'no_tenant':
+      return 'no-tenant';
+    case 'no_dynamic_user':
+      return 'no-dynamic-user';
+    case 'mint_failed':
+      return 'mint-failed';
+    case 'tenant_assertion_failed':
+      // tenant_assertion_failed never reaches here because it ALWAYS throws
+      // (I6 invariant · cannot fall back). Defensive default.
+      return 'mint-failed';
+  }
+};

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -54,6 +54,13 @@ import {
 } from './quest-dispatch.ts';
 import { getZoneForChannel } from '../lib/channel-zone-map.ts';
 import {
+  attachAuthContext,
+  AuthBridgeError,
+  type AuthContext,
+  type InteractionContext,
+} from '../auth-bridge.ts';
+import { getAuthBridgeDeps } from '../auth-bridge-deps.ts';
+import {
   InteractionResponseType,
   InteractionType,
   MessageFlags,
@@ -131,6 +138,43 @@ export function getActiveQuestRuntime(): QuestRuntime {
   return activeQuestRuntime;
 }
 
+/**
+ * Per-interaction AuthContext stash · cycle-B sprint-1 review fix (PR #53
+ * Blocker #1 · cross-reviewer flatline CRITICAL). The auth-bridge attaches
+ * an AuthContext per Discord interaction · downstream quest dispatch reads
+ * it via `getAuthContextForInteraction(interaction.id)` to compose the
+ * Sietch Layer (cycle-B B-1.9 · @freeside-quests/engine) at the right
+ * boundary.
+ *
+ * Map keyed by `interaction.id` (Discord snowflake · 17-20 digits · stable
+ * for the interaction lifetime). Entries auto-expire when the dispatch
+ * worker calls `clearAuthContextForInteraction` after PATCHing the reply ·
+ * worst-case stale entries (worker crashes mid-flight) age out via the
+ * MAX_AUTH_CTX_ENTRIES cap below.
+ */
+const authContextByInteractionId = new Map<string, AuthContext>();
+const MAX_AUTH_CTX_ENTRIES = 500;
+
+const setAuthContextForInteraction = (
+  interaction_id: string,
+  auth: AuthContext,
+): void => {
+  if (authContextByInteractionId.size >= MAX_AUTH_CTX_ENTRIES) {
+    // Evict oldest · simple FIFO via insertion-order Map iteration
+    const firstKey = authContextByInteractionId.keys().next().value;
+    if (firstKey !== undefined) authContextByInteractionId.delete(firstKey);
+  }
+  authContextByInteractionId.set(interaction_id, auth);
+};
+
+export const getAuthContextForInteraction = (
+  interaction_id: string,
+): AuthContext | undefined => authContextByInteractionId.get(interaction_id);
+
+export const clearAuthContextForInteraction = (interaction_id: string): void => {
+  authContextByInteractionId.delete(interaction_id);
+};
+
 export async function dispatchSlashCommand(
   interaction: DiscordInteraction,
   config: Config,
@@ -173,6 +217,52 @@ export async function dispatchSlashCommand(
     return ephemeralReply(
       'this channel is temporarily unavailable for character replies. try again after the next restart.',
     );
+  }
+
+  // ─── cycle-B sprint-1 · auth-bridge attach (Blocker #1 fix) ───────
+  // Per AC-B1.6 + cross-reviewer flatline (PR #53 · CRITICAL Blocker #1):
+  // every interaction gets an AuthContext attached BEFORE quest dispatch
+  // OR character routing. Lock-7 default AUTH_BACKEND=anon makes this a
+  // fast no-op (anon AuthContext attached); flipping to freeside-jwt
+  // activates the verified path (post bun-link of @freeside-auth/engine
+  // + setAuthBridgeDeps wired at boot in index.ts).
+  //
+  // Failure modes:
+  //   - verified-required route + missing/invalid JWT → AuthBridgeError
+  //     thrown · we map to ephemeral 401 reply (operator-readable code +
+  //     reason in audit log via attachAuthContext's logger)
+  //   - verified-with-anon-fallback route + verify failure → audit-log
+  //     anon-fallback ctx attached · interaction proceeds with anon-tier
+  //     downstream (Lock-7 storm warning if fallbacks accumulate)
+  //   - public route → anon ctx attached, no verification attempted
+  const interactionCtx: InteractionContext = {
+    interaction_id: interaction.id,
+    guild_id: interaction.guild_id ?? null,
+    discord_id: invoker.id,
+  };
+  const cmdName = interaction.data?.name ?? (isQuest ? 'quest' : 'unknown');
+  try {
+    await attachAuthContext({
+      interaction,
+      ctx: interactionCtx,
+      commandName: cmdName,
+      deps: getAuthBridgeDeps(),
+    });
+  } catch (err) {
+    if (err instanceof AuthBridgeError) {
+      console.warn(
+        `interactions: 401 fail-closed · cmd=${cmdName} code=${err.code} ` +
+          `reason="${err.reason}" user=${invoker.id}`,
+      );
+      return ephemeralReply(
+        `authentication required: ${err.code}. (route is verified-required · please /verify and try again)`,
+      );
+    }
+    // Unknown error · bubble to outer handler (logs + connects to alerting)
+    throw err;
+  }
+  if (interactionCtx.auth) {
+    setAuthContextForInteraction(interaction.id, interactionCtx.auth);
   }
 
   // ─── cycle-Q · sprint-3 · Q3.5 — quest substrate interception ──────

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -154,6 +154,36 @@ async function main(): Promise<void> {
       },
     ];
 
+    // === FAIL-CLOSED PRECONDITION CHECK · cycle-B sprint-1 review fix ====
+    // Cross-reviewer flatline (PR #53 · CRITICAL Blocker #2): production runtime
+    // must NOT silently fall back to memory when TENANT_<TENANT>_DATABASE_URL
+    // is unset. Lock-7 fail-closed posture: missing env at QUEST_RUNTIME=production
+    // is a configuration error · throw at startup so Railway logs surface it
+    // before any interaction lands.
+    //
+    // Each manifest with tenant_id MUST have its TENANT_<TENANT>_DATABASE_URL
+    // env populated. The check runs before pool factory construction so the
+    // failure is operator-readable in the boot banner.
+    const requiredTenantEnvVars = worldManifests
+      .filter((w) => w.tenant_id)
+      .map((w) => ({
+        tenant_id: w.tenant_id!,
+        env_key: `TENANT_${w.tenant_id!.toUpperCase().replace(/-/g, '_')}_DATABASE_URL`,
+      }));
+    const missing = requiredTenantEnvVars.filter(
+      ({ env_key }) => !process.env[env_key] || process.env[env_key]!.trim().length === 0,
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `QUEST_RUNTIME=production fail-closed precondition: missing env var(s) for ` +
+          `tenant${missing.length > 1 ? 's' : ''} ` +
+          missing.map((m) => `${m.tenant_id} (${m.env_key})`).join(', ') +
+          `. Set the connection string(s) on Railway env or downgrade to ` +
+          `QUEST_RUNTIME=memory for QA. Manifest source: hardcoded mibera ` +
+          `entry (cycle-B B-1.12 swap target).`,
+      );
+    }
+
     const tenantPgPoolFactory = buildEnvTenantPgPoolFactory(
       pgPoolBuilder,
       envConnectionStringSource(),
@@ -166,8 +196,8 @@ async function main(): Promise<void> {
     });
     setQuestRuntime(runtime);
 
-    const tenantsConfigured = ['mibera', 'cubquest']
-      .filter((t) => process.env[`TENANT_${t.toUpperCase()}_DATABASE_URL`])
+    const tenantsConfigured = requiredTenantEnvVars
+      .map((t) => t.tenant_id)
       .join(',') || '(none)';
     console.log(
       `quest-runtime:  production · world=mongolian · guild=${guildId ?? '(unset)'} ` +

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -42,6 +42,13 @@ import {
 } from './discord-interactions/server.ts';
 import { setQuestRuntime } from './discord-interactions/dispatch.ts';
 import { buildMemoryDevQuestRuntime } from './quest-runtime-bootstrap.ts';
+import {
+  buildEnvTenantPgPoolFactory,
+  buildProductionQuestRuntime,
+  envConnectionStringSource,
+} from './quest-runtime-production.ts';
+import { pgPoolBuilder } from './lib/pg-pool-builder.ts';
+import type { WorldManifestQuestSubset } from './world-resolver.ts';
 import { publishCommands } from './lib/publish-commands.ts';
 
 const banner = `─── freeside-characters bot · v0.6.0-A ────────────────────────`;
@@ -111,12 +118,60 @@ async function main(): Promise<void> {
       `quest-runtime:  memory · world=${'mongolian'} · guild=${guildId ?? '(unset · /quest will return polite no-path reply)'} · ${runtimeContext}`,
     );
   } else if (questRuntimeMode === 'production') {
-    // OPERATOR-AUTHORED: production runtime requires a real world-manifest
-    // source + per-world Pg pools (mibera-db / apdao-db / cubquest-db).
-    // Out of scope for the QA bootstrap. Operator wires this when Q2.9
-    // DB migration lands + world-manifest source is published.
-    throw new Error(
-      'QUEST_RUNTIME=production not yet wired · use QUEST_RUNTIME=memory for QA',
+    // === PRODUCTION RUNTIME · cycle-B sprint-1 · B-1.8 ============
+    // Composition:
+    //   - world manifests: hardcoded mibera entry until B-1.12 lands the
+    //     freeside-worlds registry loader. Operator extends this list as
+    //     additional worlds onboard (cubquest in B-2 · others in V2).
+    //   - tenant Pg pool factory: env-driven · TENANT_<TENANT>_DATABASE_URL
+    //     · pools created lazily via `pg.Pool` on first access · cached
+    //     for process lifetime.
+    //   - catalog: defaults to memory stub (Mongolian munkh-introduction-v1)
+    //     until B-1.13 lands cartridge loader. Same shape as memory-mode
+    //     bootstrap — swap-in target.
+    //   - resolvePlayer: defaults to anon-only (PRD D4) · auth-bridge wires
+    //     verified player identity at the dispatch layer (B-1.6 ports
+    //     declared · operator wires bridge call in dispatch.ts upstream).
+    //
+    // Per Lock-7 the production runtime composes orthogonally with
+    // AUTH_BACKEND. Operator runs `QUEST_RUNTIME=production AUTH_BACKEND=anon`
+    // to validate Pg path before flipping verified.
+    // =================================================================
+    const guildId =
+      process.env.QUEST_GUILD_ID ?? process.env.DISCORD_GUILD_ID;
+    const worldManifests: readonly WorldManifestQuestSubset[] = [
+      {
+        slug: 'mongolian',
+        tenant_id: 'mibera',
+        guild_ids: guildId ? [guildId] : [],
+        auth: { backend: 'freeside-jwt' },
+        quest_namespace: 'mongolian',
+        quest_engine_config: {
+          questAcceptanceMode: 'auth-required',
+          submissionStyle: 'inline_thread',
+          positiveFrictionDelayMs: 12000,
+        },
+      },
+    ];
+
+    const tenantPgPoolFactory = buildEnvTenantPgPoolFactory(
+      pgPoolBuilder,
+      envConnectionStringSource(),
+    );
+
+    const runtime = buildProductionQuestRuntime({
+      worldManifests,
+      characters,
+      tenantPgPoolFactory,
+    });
+    setQuestRuntime(runtime);
+
+    const tenantsConfigured = ['mibera', 'cubquest']
+      .filter((t) => process.env[`TENANT_${t.toUpperCase()}_DATABASE_URL`])
+      .join(',') || '(none)';
+    console.log(
+      `quest-runtime:  production · world=mongolian · guild=${guildId ?? '(unset)'} ` +
+        `· tenants_configured=${tenantsConfigured}`,
     );
   } else {
     console.log(

--- a/apps/bot/src/lib/pg-pool-builder.ts
+++ b/apps/bot/src/lib/pg-pool-builder.ts
@@ -32,6 +32,12 @@ interface PgPoolLike {
     rows: ReadonlyArray<Record<string, unknown>>;
     rowCount: number | null;
   }>;
+  /**
+   * Idle-client error event · cross-reviewer flatline IMP-001 (PR #53 ·
+   * HIGH_CONSENSUS 910): unhandled `error` events from idle pg clients
+   * crash the whole Node process. Always attach a handler at construction.
+   */
+  on: (event: 'error', handler: (err: Error) => void) => void;
 }
 
 interface PgModuleLike {
@@ -52,6 +58,19 @@ export const pgPoolBuilder: PoolBuilder = {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const pg = require('pg') as PgModuleLike;
     const pool = new pg.Pool({ connectionString: connection_string });
+
+    // Cross-reviewer flatline IMP-001 (PR #53 · HIGH_CONSENSUS 910): node-postgres
+    // emits `error` events on idle clients (DB connection lost · sleep timeout ·
+    // server killed connection). UNHANDLED, these events crash the entire bot
+    // process per Node.js EventEmitter rules. Logging keeps the bot alive while
+    // surfacing the failure for operator triage; the next acquired client either
+    // reconnects automatically or throws on the next query (caught by adapter).
+    pool.on('error', (err) => {
+      console.warn(
+        `[pg-pool-builder] idle client error · pool kept alive: ${err.message}`,
+      );
+    });
+
     return {
       query: async <T extends Record<string, unknown> = Record<string, unknown>>(
         text: string,

--- a/apps/bot/src/lib/pg-pool-builder.ts
+++ b/apps/bot/src/lib/pg-pool-builder.ts
@@ -1,0 +1,72 @@
+/**
+ * pg-pool-builder.ts — node-postgres adapter for the production runtime
+ * (cycle-B sprint-1 · B-1.8).
+ *
+ * Bridges `pg.Pool` to `QuestStatePostgresPool` (the minimal `query`
+ * surface @0xhoneyjar/quests-engine consumes).
+ *
+ * Why this lives in its own module:
+ *   - keeps `quest-runtime-production.ts` pure (no node-postgres import ·
+ *     unit-testable without a network)
+ *   - inline ambient type declaration for `pg` (no `@types/pg` dep needed
+ *     in this workspace · the types we use are minimal and stable)
+ *   - the bot's main() imports this lazily via the production-runtime branch
+ *     · memory/disabled paths never load pg
+ *
+ * Per Lock-9 (schema source-of-truth = JSON Schema): the runtime pool
+ * surface is a structural subset of pg.Pool · drift-tolerant.
+ */
+
+import type { QuestStatePostgresPool } from '@0xhoneyjar/quests-engine';
+import type { PoolBuilder } from '../quest-runtime-production.ts';
+
+// Minimal ambient declaration for `pg`. We don't depend on @types/pg
+// because the Pool surface we use is small and stable, and adding a
+// 100kB types dep just for two methods is overkill. Drift surfaces as
+// runtime mismatch · caught by integration tests in B-1.14.
+interface PgPoolLike {
+  query: (
+    text: string,
+    values?: readonly unknown[],
+  ) => Promise<{
+    rows: ReadonlyArray<Record<string, unknown>>;
+    rowCount: number | null;
+  }>;
+}
+
+interface PgModuleLike {
+  Pool: new (config: { connectionString: string }) => PgPoolLike;
+}
+
+/**
+ * Default PoolBuilder · constructs a `pg.Pool` from a connection string
+ * and adapts it to QuestStatePostgresPool's query contract.
+ *
+ * Runtime resolution: `require('pg')` at first call · the dep is hoisted
+ * via the workspace (transitively present from score-mibera / sibling
+ * packages). If pg is missing the require throws · operator surfaces a
+ * clear runtime error.
+ */
+export const pgPoolBuilder: PoolBuilder = {
+  build: (connection_string: string): QuestStatePostgresPool => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pg = require('pg') as PgModuleLike;
+    const pool = new pg.Pool({ connectionString: connection_string });
+    return {
+      query: async <T extends Record<string, unknown> = Record<string, unknown>>(
+        text: string,
+        values?: ReadonlyArray<unknown>,
+      ): Promise<{ rows: T[]; rowCount: number | null }> => {
+        const result = await pool.query(text, values);
+        // Cast through unknown · the QuestStatePostgresPool generic T is the
+        // caller's expected row shape · pg returns whatever Postgres yields.
+        // The quests-engine adapter validates rows via Effect Schema so any
+        // structural drift surfaces there.
+        return {
+          rows: result.rows as unknown as T[],
+          rowCount: result.rowCount,
+        };
+      },
+    };
+  },
+};

--- a/apps/bot/src/quest-runtime-production.ts
+++ b/apps/bot/src/quest-runtime-production.ts
@@ -1,0 +1,317 @@
+/**
+ * quest-runtime-production.ts — production-mode QuestRuntime constructor
+ * (cycle-B · sprint-1 · B-1.8).
+ *
+ * Replaces the memory-mode bootstrap with a tenant-aware runtime that:
+ *   - reads operator-provided world manifests (real freeside-worlds entries
+ *     once B-1.12 lands · injectable list for unit tests)
+ *   - dispatches per-tenant Postgres pools via a TenantPgPoolFactory
+ *     (translates world.slug → world.tenant_id → pg.Pool · matches the
+ *     existing WorldPgPoolFactory contract in quest-runtime.ts)
+ *   - lazily provisions pg.Pool instances from `TENANT_<TENANT>_DATABASE_URL`
+ *     env vars (one pool per tenant · process lifetime)
+ *   - accepts an injectable QuestCatalog so B-1.13's Mongolian cartridge
+ *     loader plugs in without a refactor
+ *
+ * Architect locks honored:
+ *   - I3 (Spine Seam): per-tenant heterogeneity is first-class · the factory
+ *     dispatches by `tenant_id` · NO `if (tenant === 'mibera')` shortcut.
+ *   - I5 (Construct Purity): pure orchestration · all side effects (pg.Pool
+ *     creation, env reads) flow through injected ports/factories.
+ *   - Lock-7 (Feature flag): production runtime composes orthogonally with
+ *     `AUTH_BACKEND` · runtime selection at `QUEST_RUNTIME=production` ·
+ *     auth backend at `AUTH_BACKEND=freeside-jwt` · operator flips each
+ *     independently.
+ *
+ * Out of scope for this commit:
+ *   - real freeside-worlds registry loader (B-1.12 ships mibera.yaml ·
+ *     operator wires the loader path at index.ts level)
+ *   - Mongolian cartridge catalog (B-1.13 · uses a memory stub catalog
+ *     for now · same shape as memory-mode bootstrap)
+ *   - auth-bridge orchestrator wiring (B-1.6 ships ports · this runtime
+ *     does NOT consume the bridge directly · the bot's interaction handler
+ *     will call attachAuthContext separately)
+ *
+ * Per CLAUDE.md royal decree (freeside-auth/CLAUDE.md): JWKS issuance
+ * stays at loa-freeside/apps/gateway. The auth-bridge orchestrator
+ * delegates signing there. This runtime does NOT touch JWKS surfaces.
+ */
+
+import { Effect } from "effect";
+import type {
+  CharacterRegistry,
+  CuratorVoiceProfile,
+  QuestCatalog,
+} from "@0xhoneyjar/quests-discord-renderer";
+import type {
+  Quest,
+  QuestId,
+  NpcId,
+  WorldSlug,
+  BadgeFamilyId,
+  PlayerIdentity,
+  DiscordId,
+} from "@0xhoneyjar/quests-protocol";
+import type { CharacterConfig } from "@freeside-characters/persona-engine";
+import type { QuestStatePostgresPool } from "@0xhoneyjar/quests-engine";
+import type { QuestRuntime } from "./discord-interactions/quest-dispatch.ts";
+import type { WorldPgPoolFactory } from "./quest-runtime.ts";
+import type { WorldManifestQuestSubset } from "./world-resolver.ts";
+import type { DiscordInteraction } from "./discord-interactions/types.ts";
+
+// ---------------------------------------------------------------------------
+// TenantPgPoolFactory — per-tenant pool dispatch (I3 Spine Seam)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-tenant Postgres pool factory. Returns a pool for the given tenant_id
+ * or null when no DB is provisioned for that tenant (operator hasn't set
+ * `TENANT_<TENANT>_DATABASE_URL`). Caller then falls back to memory adapter
+ * via the existing `quest-runtime.ts` resolver.
+ *
+ * Used by the bot's composition root to dispatch pools per interaction
+ * driven by world.tenant_id (set in B-1.7).
+ */
+export interface TenantPgPoolFactory {
+  readonly poolForTenant: (tenant_id: string) => QuestStatePostgresPool | null;
+}
+
+/**
+ * Wrap a TenantPgPoolFactory as a WorldPgPoolFactory · honors the existing
+ * quest-runtime.ts contract (poolForWorld takes world_slug). Translates
+ * world.slug → tenant_id (via manifest lookup) → pool.
+ *
+ * Returns null when:
+ *   - the slug isn't in the manifest list, OR
+ *   - the matched manifest has no tenant_id (cycle-Q v1.0 forward-compat),
+ *   - OR the tenant factory has no pool for that tenant.
+ *
+ * Each null path falls back to the memory adapter at quest-runtime.ts (per
+ * existing resolver semantics).
+ */
+export const buildWorldPgPoolFactoryFromTenants = (
+  manifests: readonly WorldManifestQuestSubset[],
+  tenantFactory: TenantPgPoolFactory,
+): WorldPgPoolFactory => ({
+  poolForWorld: (world_slug: string) => {
+    const world = manifests.find((m) => m.slug === world_slug);
+    if (!world || !world.tenant_id) return null;
+    return tenantFactory.poolForTenant(world.tenant_id);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Env-driven tenant pool factory (lazy pg.Pool · process-lifetime cache)
+// ---------------------------------------------------------------------------
+
+/**
+ * Connection-string lookup port. Default impl reads `TENANT_<TENANT>_DATABASE_URL`
+ * from process.env. Tests inject a recording stub.
+ *
+ * Pattern: `mibera` → `TENANT_MIBERA_DATABASE_URL` (uppercase + underscores ·
+ * tenant slugs may contain dashes which become underscores in env var names).
+ */
+export interface TenantConnectionStringSource {
+  /** Returns connection string for tenant or null if not provisioned. */
+  readonly forTenant: (tenant_id: string) => string | null;
+}
+
+export const envConnectionStringSource = (
+  env: NodeJS.ProcessEnv = process.env,
+): TenantConnectionStringSource => ({
+  forTenant: (tenant_id: string) => {
+    const key = `TENANT_${tenant_id.toUpperCase().replace(/-/g, "_")}_DATABASE_URL`;
+    const value = env[key];
+    return value && value.trim().length > 0 ? value : null;
+  },
+});
+
+/**
+ * Pool builder · constructs a QuestStatePostgresPool from a connection
+ * string. Default impl creates a `pg.Pool`; tests inject a stub.
+ *
+ * The minimal QuestStatePostgresPool surface (`query`) means we don't need
+ * a hard `pg` import at this module level — the bot's composition root
+ * supplies the real `pg.Pool`-derived adapter.
+ */
+export interface PoolBuilder {
+  readonly build: (connection_string: string) => QuestStatePostgresPool;
+}
+
+/**
+ * Build a TenantPgPoolFactory backed by env-driven connection strings.
+ * Pools are constructed lazily on first lookup and cached for the process
+ * lifetime (one pool per tenant).
+ *
+ * The factory returns null for tenants without `TENANT_<TENANT>_DATABASE_URL`
+ * set · existing memory-fallback path engages downstream.
+ */
+export const buildEnvTenantPgPoolFactory = (
+  poolBuilder: PoolBuilder,
+  source: TenantConnectionStringSource = envConnectionStringSource(),
+): TenantPgPoolFactory => {
+  const cache = new Map<string, QuestStatePostgresPool>();
+  return {
+    poolForTenant: (tenant_id: string) => {
+      const cached = cache.get(tenant_id);
+      if (cached) return cached;
+      const conn = source.forTenant(tenant_id);
+      if (!conn) return null;
+      const pool = poolBuilder.build(conn);
+      cache.set(tenant_id, pool);
+      return pool;
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Production runtime constructor
+// ---------------------------------------------------------------------------
+
+export interface ProductionQuestRuntimeOptions {
+  /**
+   * Real world manifests sourced from freeside-worlds registry. Until B-1.12
+   * lands the operator-readable mibera.yaml in freeside-worlds, the bot's
+   * composition root supplies a hardcoded mibera entry inline (see
+   * index.ts wiring).
+   */
+  readonly worldManifests: readonly WorldManifestQuestSubset[];
+
+  /** Loaded characters (from character-loader). */
+  readonly characters: readonly CharacterConfig[];
+
+  /** Per-tenant Pg pool dispatch · null tenant returns memory fallback. */
+  readonly tenantPgPoolFactory: TenantPgPoolFactory;
+
+  /**
+   * Quest catalog. Defaults to a stub (Mongolian munkh-introduction-v1)
+   * mirroring the memory-mode bootstrap. B-1.13 swaps in cartridge-loaded
+   * catalog without changing this constructor's shape.
+   */
+  readonly catalog?: QuestCatalog;
+
+  /**
+   * Curator voice profile. Defaults to empty · phaseToNarrative substrate
+   * fallback applies until Track A populates per-NPC cadence.
+   */
+  readonly voice?: CuratorVoiceProfile;
+
+  /**
+   * Player resolver. Defaults to anon-only (matching memory-mode · per
+   * PRD D4). Once auth-bridge wires verified player identity in the bot's
+   * dispatch chain, the resolver promotes to JWT-claim-derived identity.
+   */
+  readonly resolvePlayer?: (interaction: DiscordInteraction) => PlayerIdentity | null;
+}
+
+/**
+ * Build a production-mode QuestRuntime.
+ *
+ * Composition:
+ *   - manifests + tenant pool factory → WorldPgPoolFactory (existing
+ *     quest-runtime.ts contract)
+ *   - catalog defaults to memory stub (B-1.13 swap point)
+ *   - voice defaults to empty profile
+ *   - resolvePlayer defaults to anon-only
+ *   - characters → CharacterRegistry (NpcId → displayName)
+ *
+ * Returns a QuestRuntime the bot wires via setQuestRuntime at boot.
+ */
+export const buildProductionQuestRuntime = (
+  opts: ProductionQuestRuntimeOptions,
+): QuestRuntime => {
+  const pgPools = buildWorldPgPoolFactoryFromTenants(
+    opts.worldManifests,
+    opts.tenantPgPoolFactory,
+  );
+  const catalog = opts.catalog ?? buildStubCatalog();
+  const voice = opts.voice ?? {};
+  const resolvePlayer = opts.resolvePlayer ?? buildAnonPlayerResolver();
+  const characters = buildCharacterRegistry(opts.characters);
+
+  return {
+    worldManifests: opts.worldManifests,
+    catalog,
+    characters,
+    voice,
+    pgPools,
+    resolvePlayer,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Defaults · same shape as memory-mode bootstrap (B-1.13 swap targets)
+// ---------------------------------------------------------------------------
+
+const STUB_QUEST_ID = "munkh-introduction-v1";
+const STUB_WORLD_SLUG = "mongolian";
+const STUB_NPC_ID = "mongolian";
+
+const buildStubQuest = (): Quest =>
+  ({
+    quest_id: STUB_QUEST_ID as unknown as QuestId,
+    npc_pointer: STUB_NPC_ID as unknown as NpcId,
+    world_slug: STUB_WORLD_SLUG as unknown as WorldSlug,
+    title: "Why did you come?",
+    prompt:
+      "Share why you came · what brought you to the steppe today. A few lines is enough · the wind carries everything you do not say.",
+    rubric_pointer: {
+      type: "codex_ref",
+      construct_slug: "construct-mongolian",
+      cell_id: "stub-v1-munkh-quest",
+    },
+    badge_spec: {
+      family_id: "mongolian-petroglyph-stub" as unknown as BadgeFamilyId,
+      display_name: "First Mark on the Steppe",
+      prompt_seed:
+        "A simple petroglyph carved into weathered stone · the first mark a traveler leaves on Mongolian soil.",
+      format_hint: "webp",
+    },
+    published_at: new Date("2026-05-04T00:00:00Z").toISOString(),
+    step_count: 1,
+    contract_version: "1.0.0",
+  }) as Quest;
+
+const buildStubCatalog = (): QuestCatalog => {
+  const stub = buildStubQuest();
+  return {
+    listAvailableQuests: (worldSlug: string) =>
+      Effect.succeed(worldSlug === STUB_WORLD_SLUG ? [stub] : []),
+    findQuest: (worldSlug: string, quest_id: string) =>
+      Effect.succeed(
+        worldSlug === STUB_WORLD_SLUG && quest_id === STUB_QUEST_ID
+          ? stub
+          : undefined,
+      ),
+  };
+};
+
+const DISCORD_ID_PATTERN = /^\d{17,20}$/;
+
+const buildAnonPlayerResolver =
+  () =>
+  (interaction: DiscordInteraction): PlayerIdentity | null => {
+    const userId = interaction.member?.user?.id ?? interaction.user?.id;
+    if (!userId) return null;
+    if (!DISCORD_ID_PATTERN.test(userId)) return null;
+    return {
+      type: "anon",
+      discord_id: userId as unknown as DiscordId,
+    };
+  };
+
+const buildCharacterRegistry = (
+  characters: readonly CharacterConfig[],
+): CharacterRegistry => {
+  const map = new Map<string, string>();
+  for (const c of characters) {
+    if (c.displayName) map.set(c.id, c.displayName);
+  }
+  return {
+    resolveDisplayName: (npc_id: string) => map.get(npc_id),
+  };
+};
+
+export const PRODUCTION_STUB_QUEST_ID = STUB_QUEST_ID;
+export const PRODUCTION_STUB_WORLD_SLUG = STUB_WORLD_SLUG;
+export const PRODUCTION_STUB_NPC_ID = STUB_NPC_ID;

--- a/apps/bot/src/tests/auth-bridge-deps.test.ts
+++ b/apps/bot/src/tests/auth-bridge-deps.test.ts
@@ -1,0 +1,191 @@
+/**
+ * auth-bridge-deps.test.ts — coverage of the bot composition root for
+ * auth-bridge ports + storm-aware logger (cycle-B sprint-1 review fix ·
+ * PR #53 Blocker #1 + #8).
+ *
+ * Validates:
+ *   - default-anon deps surface (tenant resolver returns null · dynamic
+ *     lookup returns null · mint throws · logger present)
+ *   - setAuthBridgeDeps replaces the active deps · getAuthBridgeDeps
+ *     returns the wired deps for downstream dispatch
+ *   - __resetAuthBridgeDepsForTest restores defaults
+ *   - storm-aware logger emits STORM warning every Nth fallback +
+ *     emits another STORM warning after the cooldown elapses with
+ *     non-zero count
+ *   - storm logger does NOT emit STORM warning before the threshold
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  __resetAuthBridgeDepsForTest,
+  buildStormAwareLogger,
+  getAuthBridgeDeps,
+  setAuthBridgeDeps,
+} from '../auth-bridge-deps.ts';
+import type { AuthBridgeDeps, AuthBridgeLogger } from '../auth-bridge.ts';
+
+const buildRecordingLogger = (): AuthBridgeLogger & {
+  info_lines: string[];
+  warn_lines: string[];
+  audit_lines: string[];
+} => {
+  const info_lines: string[] = [];
+  const warn_lines: string[] = [];
+  const audit_lines: string[] = [];
+  return {
+    info_lines,
+    warn_lines,
+    audit_lines,
+    info: (m) => info_lines.push(m),
+    warn: (m) => warn_lines.push(m),
+    audit: (m) => audit_lines.push(m),
+  };
+};
+
+describe('cycle-B · auth-bridge-deps · default-anon deps', () => {
+  test('default tenantResolver returns null for any guild', async () => {
+    __resetAuthBridgeDepsForTest();
+    const deps = getAuthBridgeDeps();
+    const result = await deps.tenantResolver.resolveTenantFromGuild('any-guild');
+    expect(result).toBeNull();
+  });
+
+  test('default dynamicLookup returns null for any discord_id', async () => {
+    __resetAuthBridgeDepsForTest();
+    const deps = getAuthBridgeDeps();
+    const result = await deps.dynamicLookup.fetchDynamicUserIdFromDiscord('any');
+    expect(result).toBeNull();
+  });
+
+  test('default mintJwt throws structured error pointing at bun-link gate', async () => {
+    __resetAuthBridgeDepsForTest();
+    const deps = getAuthBridgeDeps();
+    await expect(
+      deps.mintJwt.mintJwt({ tenant_id: 'mibera', dynamic_user_id: 'x' }),
+    ).rejects.toThrow(/bun-link.*@freeside-auth\/engine/);
+  });
+
+  test('default logger is present (storm-aware wrapper)', () => {
+    __resetAuthBridgeDepsForTest();
+    const deps = getAuthBridgeDeps();
+    expect(typeof deps.logger?.info).toBe('function');
+    expect(typeof deps.logger?.audit).toBe('function');
+  });
+});
+
+describe('cycle-B · auth-bridge-deps · setAuthBridgeDeps wiring', () => {
+  test('setAuthBridgeDeps replaces active deps · getAuthBridgeDeps reads back', async () => {
+    __resetAuthBridgeDepsForTest();
+    const customResolver = {
+      resolveTenantFromGuild: async (gid: string) =>
+        gid === 'guild-mibera' ? 'mibera' : null,
+    };
+    const customDeps: AuthBridgeDeps = {
+      tenantResolver: customResolver,
+      dynamicLookup: { fetchDynamicUserIdFromDiscord: async () => 'd-user-xyz' },
+      mintJwt: { mintJwt: async () => ({ jwt: 'stub.jwt', claims: {} as never }) },
+    };
+    setAuthBridgeDeps(customDeps);
+
+    const deps = getAuthBridgeDeps();
+    expect(await deps.tenantResolver.resolveTenantFromGuild('guild-mibera')).toBe(
+      'mibera',
+    );
+    expect(await deps.dynamicLookup.fetchDynamicUserIdFromDiscord('any')).toBe(
+      'd-user-xyz',
+    );
+    expect((await deps.mintJwt.mintJwt({ tenant_id: 'mibera', dynamic_user_id: 'x' })).jwt).toBe(
+      'stub.jwt',
+    );
+
+    __resetAuthBridgeDepsForTest();
+  });
+
+  test('__resetAuthBridgeDepsForTest restores default-anon path', async () => {
+    setAuthBridgeDeps({
+      tenantResolver: { resolveTenantFromGuild: async () => 'cubquest' },
+      dynamicLookup: { fetchDynamicUserIdFromDiscord: async () => 'd-cub' },
+      mintJwt: { mintJwt: async () => ({ jwt: 'cub.jwt', claims: {} as never }) },
+    });
+    __resetAuthBridgeDepsForTest();
+    const deps = getAuthBridgeDeps();
+    expect(await deps.tenantResolver.resolveTenantFromGuild('any')).toBeNull();
+  });
+});
+
+describe('cycle-B · auth-bridge-deps · storm-aware logger (PR #53 Blocker #8)', () => {
+  test('emits no STORM warning when audit count is below threshold', () => {
+    const base = buildRecordingLogger();
+    const logger = buildStormAwareLogger(
+      base,
+      { count: 0, last_warn_at_ms: Date.now() },
+      10,
+      60_000,
+    );
+
+    for (let i = 0; i < 5; i++) {
+      logger.audit(`fallback #${i + 1}`);
+    }
+    expect(base.audit_lines).toHaveLength(5);
+    expect(base.warn_lines).toHaveLength(0);
+  });
+
+  test('emits STORM warning every Nth audit (count-based threshold)', () => {
+    const base = buildRecordingLogger();
+    const logger = buildStormAwareLogger(
+      base,
+      { count: 0, last_warn_at_ms: Date.now() },
+      10, // every 10th
+      60_000,
+    );
+
+    for (let i = 0; i < 25; i++) {
+      logger.audit(`fallback #${i + 1}`);
+    }
+    expect(base.audit_lines).toHaveLength(25);
+    // Audit count crosses 10 and 20 · two STORM warnings expected
+    expect(base.warn_lines.length).toBeGreaterThanOrEqual(2);
+    expect(
+      base.warn_lines.every((l) => l.includes('[auth-bridge:STORM]')),
+    ).toBe(true);
+    expect(base.warn_lines[0]).toContain('count=10');
+    expect(base.warn_lines[1]).toContain('count=20');
+  });
+
+  test('emits STORM warning after cooldown elapses with non-zero count', () => {
+    const base = buildRecordingLogger();
+    const state = { count: 0, last_warn_at_ms: Date.now() - 10 * 60_000 }; // 10min ago
+    const logger = buildStormAwareLogger(
+      base,
+      state,
+      1000, // high threshold so count-based rule won't fire
+      5 * 60_000, // 5min cooldown
+    );
+
+    // Single fallback after cooldown elapsed → STORM warning fires
+    logger.audit('fallback #1');
+    expect(base.warn_lines).toHaveLength(1);
+    expect(base.warn_lines[0]).toContain('count=1');
+  });
+
+  test('STORM warning does not double-emit when both rules trigger same call', () => {
+    const base = buildRecordingLogger();
+    const state = { count: 0, last_warn_at_ms: Date.now() - 10 * 60_000 };
+    const logger = buildStormAwareLogger(base, state, 1, 5 * 60_000);
+
+    // count threshold = every 1st AND cooldown elapsed → would warn twice
+    // if we didn't guard against it
+    logger.audit('fallback #1');
+    expect(base.warn_lines).toHaveLength(1);
+  });
+
+  test('preserves info + warn passthrough', () => {
+    const base = buildRecordingLogger();
+    const logger = buildStormAwareLogger(base);
+
+    logger.info('hello');
+    logger.warn('uh oh');
+    expect(base.info_lines).toEqual(['hello']);
+    expect(base.warn_lines).toEqual(['uh oh']);
+  });
+});

--- a/apps/bot/src/tests/auth-bridge.test.ts
+++ b/apps/bot/src/tests/auth-bridge.test.ts
@@ -1,0 +1,555 @@
+/**
+ * auth-bridge.test.ts — coverage of the 3 fail-modes + Lock-7 backend gate
+ * + I6 tenant-boundary assertion (cycle-B · sprint-1 · B-1.6).
+ *
+ * Validates:
+ *   - AC-B1.6 — attachAuthContext mints JWT for verified path · attaches anon
+ *     for AUTH_BACKEND=anon · feature-flag protected
+ *   - AC-B1.6.1 — fail-mode classification (public · verified-required ·
+ *     verified-with-anon-fallback) · default = verified-required for
+ *     unspecified routes (fail-closed)
+ *   - AC-B1.11.1 — post-mint tenant-boundary assertion throws
+ *     AuthBridgeError when mint returns wrong tenant (I6 invariant)
+ *   - Logger discipline · audit-line emitted for every anon-fallback
+ *
+ * Test seam: `attachAuthContext` consumes 3 injected ports + a logger so the
+ * suite never hits Discord, the freeside-auth orchestrator, or process.env
+ * directly. Each `describe` block builds a recording stub set per case.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  attachAuthContext,
+  AuthBridgeError,
+  DEFAULT_FAIL_MODE,
+  resolveFailMode,
+  readAuthBackend,
+  SLICE_B_FAIL_MODES,
+  type AuthBridgeLogger,
+  type DynamicUserIdLookupPort,
+  type FailMode,
+  type InteractionContext,
+  type JWTClaim,
+  type MintJwtPort,
+  type TenantResolverPort,
+} from '../auth-bridge.ts';
+import type { DiscordInteraction } from '../discord-interactions/types.ts';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const FIXTURE_DISCORD_ID = '111111111111111111';
+const FIXTURE_GUILD_ID = '222222222222222222';
+const FIXTURE_DYNAMIC_USER_ID = 'd-user-mibera-001';
+const FIXTURE_INTERACTION_ID = '333333333333333333';
+
+const buildCtx = (overrides: Partial<InteractionContext> = {}): InteractionContext => ({
+  interaction_id: FIXTURE_INTERACTION_ID,
+  guild_id: FIXTURE_GUILD_ID,
+  discord_id: FIXTURE_DISCORD_ID,
+  ...overrides,
+});
+
+const stubInteraction = {} as DiscordInteraction;
+
+const buildClaims = (tenant: string = 'mibera'): JWTClaim => ({
+  schema_version: '1.0',
+  sub: FIXTURE_DYNAMIC_USER_ID,
+  tenant,
+  wallets: [{ chain: 'ethereum', address: '0xabc...123' }],
+  iss: 'freeside-auth.0xhoneyjar.xyz',
+  aud: tenant,
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  iat: Math.floor(Date.now() / 1000),
+  jti: '00000000-0000-4000-8000-000000000001',
+  v: 1,
+});
+
+interface RecordingLogger extends AuthBridgeLogger {
+  readonly info_lines: string[];
+  readonly warn_lines: string[];
+  readonly audit_lines: string[];
+}
+
+const buildLogger = (): RecordingLogger => {
+  const info_lines: string[] = [];
+  const warn_lines: string[] = [];
+  const audit_lines: string[] = [];
+  return {
+    info_lines,
+    warn_lines,
+    audit_lines,
+    info: (m) => info_lines.push(m),
+    warn: (m) => warn_lines.push(m),
+    audit: (m) => audit_lines.push(m),
+  };
+};
+
+const tenantResolver = (mapping: Record<string, string | null>): TenantResolverPort => ({
+  resolveTenantFromGuild: async (gid) =>
+    gid in mapping ? mapping[gid] ?? null : null,
+});
+
+const dynamicLookup = (mapping: Record<string, string | null>): DynamicUserIdLookupPort => ({
+  fetchDynamicUserIdFromDiscord: async (did) =>
+    did in mapping ? mapping[did] ?? null : null,
+});
+
+interface MintCall {
+  tenant_id: string;
+  dynamic_user_id: string;
+}
+
+const mintJwtOk = (claims: JWTClaim, jwt = 'fake.jwt.token'): MintJwtPort & {
+  readonly calls: MintCall[];
+} => {
+  const calls: MintCall[] = [];
+  return {
+    calls,
+    mintJwt: async (input) => {
+      calls.push(input);
+      return { jwt, claims };
+    },
+  };
+};
+
+const mintJwtThrows = (err: Error = new Error('gateway 503')): MintJwtPort => ({
+  mintJwt: async () => {
+    throw err;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// resolveFailMode + DEFAULT_FAIL_MODE (AC-B1.6.1 fail-closed default)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · fail-mode resolution (AC-B1.6.1)', () => {
+  test('default for unspecified command is verified-required (fail-closed)', () => {
+    expect(DEFAULT_FAIL_MODE).toBe('verified-required');
+    expect(resolveFailMode('unknown-command-name')).toBe('verified-required');
+  });
+
+  test('SLICE_B_FAIL_MODES classifies the 5 slice-B commands explicitly', () => {
+    expect(resolveFailMode('quest_list')).toBe('public');
+    expect(resolveFailMode('quest')).toBe('verified-with-anon-fallback');
+    expect(resolveFailMode('quest_accept')).toBe('verified-required');
+    expect(resolveFailMode('quest_submit')).toBe('verified-required');
+    expect(resolveFailMode('badge_issue')).toBe('verified-required');
+  });
+
+  test('custom registry overrides slice-B defaults', () => {
+    const custom = new Map<string, FailMode>([['quest', 'public']]);
+    expect(resolveFailMode('quest', custom)).toBe('public');
+    // unknown still falls through to verified-required, not the slice-B default
+    expect(resolveFailMode('unknown', custom)).toBe('verified-required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readAuthBackend (Lock-7 feature flag · default anon)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · readAuthBackend (Lock-7)', () => {
+  test('defaults to anon when AUTH_BACKEND is unset', () => {
+    expect(readAuthBackend({}, buildLogger())).toBe('anon');
+  });
+
+  test('honors AUTH_BACKEND=anon', () => {
+    expect(readAuthBackend({ AUTH_BACKEND: 'anon' }, buildLogger())).toBe('anon');
+  });
+
+  test('honors AUTH_BACKEND=freeside-jwt', () => {
+    expect(readAuthBackend({ AUTH_BACKEND: 'freeside-jwt' }, buildLogger())).toBe(
+      'freeside-jwt',
+    );
+  });
+
+  test('unknown values fall back to anon WITH a warn log', () => {
+    const logger = buildLogger();
+    expect(readAuthBackend({ AUTH_BACKEND: 'magic-mode' }, logger)).toBe('anon');
+    expect(logger.warn_lines).toHaveLength(1);
+    expect(logger.warn_lines[0]).toContain('AUTH_BACKEND="magic-mode"');
+  });
+
+  test('whitespace is trimmed', () => {
+    expect(readAuthBackend({ AUTH_BACKEND: '  freeside-jwt  ' }, buildLogger())).toBe(
+      'freeside-jwt',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachAuthContext · anon paths (AUTH_BACKEND=anon · public route)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · anon paths', () => {
+  test('AUTH_BACKEND=anon attaches anon ctx · skips tenant + mint resolution', async () => {
+    const tenant = tenantResolver({});
+    const lookup = dynamicLookup({});
+    const mint = mintJwtOk(buildClaims());
+    const logger = buildLogger();
+    const ctx = buildCtx();
+
+    const out = await attachAuthContext({
+      interaction: stubInteraction,
+      ctx,
+      commandName: 'quest_accept',
+      deps: { tenantResolver: tenant, dynamicLookup: lookup, mintJwt: mint, logger },
+      env: { AUTH_BACKEND: 'anon' },
+    });
+
+    expect(out.auth).toEqual({ kind: 'anon', discord_id: FIXTURE_DISCORD_ID });
+    expect(mint.calls).toHaveLength(0);
+    expect(logger.info_lines.some((l) => l.includes('→ ANON'))).toBe(true);
+  });
+
+  test('public route returns anon even when AUTH_BACKEND=freeside-jwt', async () => {
+    const mint = mintJwtOk(buildClaims());
+    const logger = buildLogger();
+    const ctx = buildCtx();
+
+    const out = await attachAuthContext({
+      interaction: stubInteraction,
+      ctx,
+      commandName: 'quest_list',
+      deps: {
+        tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+        dynamicLookup: dynamicLookup({ [FIXTURE_DISCORD_ID]: FIXTURE_DYNAMIC_USER_ID }),
+        mintJwt: mint,
+        logger,
+      },
+      env: { AUTH_BACKEND: 'freeside-jwt' },
+    });
+
+    expect(out.auth?.kind).toBe('anon');
+    expect(mint.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachAuthContext · verified path · happy case
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · verified path (mint succeeds)', () => {
+  test('mints JWT · attaches verified ctx · I6 tenant assertion passes', async () => {
+    const claims = buildClaims('mibera');
+    const mint = mintJwtOk(claims, 'mibera.jwt.token');
+    const logger = buildLogger();
+    const ctx = buildCtx();
+
+    const out = await attachAuthContext({
+      interaction: stubInteraction,
+      ctx,
+      commandName: 'quest_accept',
+      deps: {
+        tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+        dynamicLookup: dynamicLookup({ [FIXTURE_DISCORD_ID]: FIXTURE_DYNAMIC_USER_ID }),
+        mintJwt: mint,
+        logger,
+      },
+      env: { AUTH_BACKEND: 'freeside-jwt' },
+    });
+
+    expect(out.auth).toEqual({ kind: 'verified', jwt: 'mibera.jwt.token', claims });
+    expect(mint.calls).toEqual([
+      { tenant_id: 'mibera', dynamic_user_id: FIXTURE_DYNAMIC_USER_ID },
+    ]);
+    expect(
+      logger.info_lines.some(
+        (l) => l.includes('→ VERIFIED') && l.includes('tenant=mibera'),
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-B1.11.1 · I6 tenant-boundary assertion (mint returns wrong tenant)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · I6 tenant-boundary assertion (AC-B1.11.1)', () => {
+  test('mint returning tenant != expected throws AuthBridgeError', async () => {
+    // Orchestrator mistakenly returns cubquest claims for a mibera mint
+    const claims = buildClaims('cubquest');
+    const mint = mintJwtOk(claims);
+    const logger = buildLogger();
+    const ctx = buildCtx();
+
+    let caught: AuthBridgeError | null = null;
+    try {
+      await attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'quest_accept',
+        deps: {
+          tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+          dynamicLookup: dynamicLookup({ [FIXTURE_DISCORD_ID]: FIXTURE_DYNAMIC_USER_ID }),
+          mintJwt: mint,
+          logger,
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      });
+    } catch (err) {
+      caught = err as AuthBridgeError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught).toBeInstanceOf(AuthBridgeError);
+    expect(caught?.code).toBe('tenant_assertion_failed');
+    expect(caught?.reason).toContain('cubquest');
+    expect(caught?.reason).toContain('mibera');
+    // ctx must NOT have a verified auth attached when the assertion fails
+    expect(ctx.auth).toBeUndefined();
+  });
+
+  test('tenant_assertion_failed throws even on verified-with-anon-fallback routes', async () => {
+    // Per I6 the assertion is non-negotiable · cannot silently fall back.
+    const claims = buildClaims('cubquest');
+    const mint = mintJwtOk(claims);
+    const ctx = buildCtx();
+
+    expect(
+      attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'quest', // verified-with-anon-fallback in slice-B
+        deps: {
+          tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+          dynamicLookup: dynamicLookup({ [FIXTURE_DISCORD_ID]: FIXTURE_DYNAMIC_USER_ID }),
+          mintJwt: mint,
+          logger: buildLogger(),
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      }),
+    ).rejects.toThrow(AuthBridgeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-B1.6.1 · verified-required fail-closed (no silent anon downgrade)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · verified-required fail-closed', () => {
+  test('no tenant binding throws AuthBridgeError (does NOT downgrade)', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    let caught: AuthBridgeError | null = null;
+    try {
+      await attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'quest_accept', // verified-required
+        deps: {
+          tenantResolver: tenantResolver({}), // no mapping → null
+          dynamicLookup: dynamicLookup({}),
+          mintJwt: mintJwtOk(buildClaims()),
+          logger,
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      });
+    } catch (err) {
+      caught = err as AuthBridgeError;
+    }
+    expect(caught?.code).toBe('no_tenant');
+    expect(ctx.auth).toBeUndefined();
+    expect(logger.warn_lines.some((l) => l.includes('FAIL-CLOSED'))).toBe(true);
+    expect(logger.audit_lines).toHaveLength(0); // not an audited fallback
+  });
+
+  test('no dynamic_user_id throws AuthBridgeError', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    let caught: AuthBridgeError | null = null;
+    try {
+      await attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'badge_issue', // verified-required
+        deps: {
+          tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+          dynamicLookup: dynamicLookup({}), // no mapping → null
+          mintJwt: mintJwtOk(buildClaims()),
+          logger,
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      });
+    } catch (err) {
+      caught = err as AuthBridgeError;
+    }
+    expect(caught?.code).toBe('no_dynamic_user');
+    expect(ctx.auth).toBeUndefined();
+  });
+
+  test('mint orchestrator throw propagates as AuthBridgeError', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    let caught: AuthBridgeError | null = null;
+    try {
+      await attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'quest_submit', // verified-required
+        deps: {
+          tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+          dynamicLookup: dynamicLookup({ [FIXTURE_DISCORD_ID]: FIXTURE_DYNAMIC_USER_ID }),
+          mintJwt: mintJwtThrows(new Error('gateway 503 service unavailable')),
+          logger,
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      });
+    } catch (err) {
+      caught = err as AuthBridgeError;
+    }
+    expect(caught?.code).toBe('mint_failed');
+    expect(caught?.reason).toContain('gateway 503');
+    expect(ctx.auth).toBeUndefined();
+  });
+
+  test('unspecified command falls through to verified-required default', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    expect(
+      attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'totally-new-command',
+        deps: {
+          tenantResolver: tenantResolver({}),
+          dynamicLookup: dynamicLookup({}),
+          mintJwt: mintJwtOk(buildClaims()),
+          logger,
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      }),
+    ).rejects.toThrow(AuthBridgeError);
+  });
+
+  test('DM context (guild_id=null) fails closed with no_tenant', async () => {
+    const ctx = buildCtx({ guild_id: null });
+    const logger = buildLogger();
+
+    let caught: AuthBridgeError | null = null;
+    try {
+      await attachAuthContext({
+        interaction: stubInteraction,
+        ctx,
+        commandName: 'quest_accept',
+        deps: {
+          tenantResolver: tenantResolver({}),
+          dynamicLookup: dynamicLookup({}),
+          mintJwt: mintJwtOk(buildClaims()),
+          logger,
+        },
+        env: { AUTH_BACKEND: 'freeside-jwt' },
+      });
+    } catch (err) {
+      caught = err as AuthBridgeError;
+    }
+    expect(caught?.code).toBe('no_tenant');
+    expect(caught?.reason).toContain('DM');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-B1.6.1 · verified-with-anon-fallback (audited downgrade)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · verified-with-anon-fallback (audited)', () => {
+  test('no_dynamic_user → anon-fallback ctx with audit log', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    const out = await attachAuthContext({
+      interaction: stubInteraction,
+      ctx,
+      commandName: 'quest', // verified-with-anon-fallback in slice-B
+      deps: {
+        tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+        dynamicLookup: dynamicLookup({}), // no mapping
+        mintJwt: mintJwtOk(buildClaims()),
+        logger,
+      },
+      env: { AUTH_BACKEND: 'freeside-jwt' },
+    });
+
+    expect(out.auth).toEqual({
+      kind: 'anon-fallback',
+      discord_id: FIXTURE_DISCORD_ID,
+      reason: 'no-dynamic-user',
+    });
+    expect(logger.audit_lines).toHaveLength(1);
+    expect(logger.audit_lines[0]).toContain('fallback_reason=no-dynamic-user');
+    expect(logger.audit_lines[0]).toContain(`user=${FIXTURE_DISCORD_ID}`);
+  });
+
+  test('no_tenant → anon-fallback ctx with audit log', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    const out = await attachAuthContext({
+      interaction: stubInteraction,
+      ctx,
+      commandName: 'quest',
+      deps: {
+        tenantResolver: tenantResolver({}), // no tenant binding
+        dynamicLookup: dynamicLookup({}),
+        mintJwt: mintJwtOk(buildClaims()),
+        logger,
+      },
+      env: { AUTH_BACKEND: 'freeside-jwt' },
+    });
+
+    expect(out.auth?.kind).toBe('anon-fallback');
+    if (out.auth?.kind === 'anon-fallback') {
+      expect(out.auth.reason).toBe('no-tenant');
+    }
+    expect(logger.audit_lines[0]).toContain('fallback_reason=no-tenant');
+  });
+
+  test('mint_failed → anon-fallback ctx with audit log', async () => {
+    const ctx = buildCtx();
+    const logger = buildLogger();
+
+    const out = await attachAuthContext({
+      interaction: stubInteraction,
+      ctx,
+      commandName: 'quest',
+      deps: {
+        tenantResolver: tenantResolver({ [FIXTURE_GUILD_ID]: 'mibera' }),
+        dynamicLookup: dynamicLookup({ [FIXTURE_DISCORD_ID]: FIXTURE_DYNAMIC_USER_ID }),
+        mintJwt: mintJwtThrows(new Error('network timeout')),
+        logger,
+      },
+      env: { AUTH_BACKEND: 'freeside-jwt' },
+    });
+
+    expect(out.auth?.kind).toBe('anon-fallback');
+    if (out.auth?.kind === 'anon-fallback') {
+      expect(out.auth.reason).toBe('mint-failed');
+    }
+    expect(logger.audit_lines[0]).toContain('fallback_reason=mint-failed');
+    expect(logger.audit_lines[0]).toContain('network timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SLICE_B_FAIL_MODES sanity (frozen invariants the slice-B sprint relies on)
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · auth-bridge · SLICE_B_FAIL_MODES invariants', () => {
+  test('quest_accept and quest_submit are verified-required (no fallback)', () => {
+    expect(SLICE_B_FAIL_MODES.get('quest_accept')).toBe('verified-required');
+    expect(SLICE_B_FAIL_MODES.get('quest_submit')).toBe('verified-required');
+  });
+
+  test('badge_issue is verified-required (BARTH safety · cannot anon-issue)', () => {
+    expect(SLICE_B_FAIL_MODES.get('badge_issue')).toBe('verified-required');
+  });
+
+  test('quest_list is public (read-only metadata)', () => {
+    expect(SLICE_B_FAIL_MODES.get('quest_list')).toBe('public');
+  });
+});

--- a/apps/bot/src/tests/quest-runtime-production.test.ts
+++ b/apps/bot/src/tests/quest-runtime-production.test.ts
@@ -1,0 +1,287 @@
+/**
+ * quest-runtime-production.test.ts — coverage of the production-mode
+ * QuestRuntime constructor and tenant→pool dispatch (cycle-B sprint-1 ·
+ * B-1.8).
+ *
+ * Validates:
+ *   - buildProductionQuestRuntime returns a fully-shaped QuestRuntime
+ *   - tenant→world dispatch translates world.slug → tenant_id → pool
+ *     (I3 Spine Seam · per-tenant heterogeneity is first-class)
+ *   - WorldPgPoolFactory falls back to null (memory-fallback path) when
+ *     tenant_id is missing OR no pool is provisioned for that tenant
+ *   - envConnectionStringSource reads `TENANT_<TENANT>_DATABASE_URL` keys
+ *     · uppercase + dashes → underscores · empty string treated as null
+ *   - buildEnvTenantPgPoolFactory caches pools per tenant (lazy init ·
+ *     one pool per tenant for process lifetime)
+ *   - resolvePlayer defaults to anon-only (matching memory-mode · PRD D4)
+ *
+ * Tests do NOT open real Pg connections · pool builder is injected as a
+ * recording stub. Integration tests for end-to-end Pg lands in B-1.14
+ * (operator-bounded smoke).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Effect } from 'effect';
+import {
+  PRODUCTION_STUB_QUEST_ID,
+  PRODUCTION_STUB_WORLD_SLUG,
+  buildEnvTenantPgPoolFactory,
+  buildProductionQuestRuntime,
+  buildWorldPgPoolFactoryFromTenants,
+  envConnectionStringSource,
+  type PoolBuilder,
+  type ProductionQuestRuntimeOptions,
+  type TenantPgPoolFactory,
+} from '../quest-runtime-production.ts';
+import type { QuestStatePostgresPool } from '@0xhoneyjar/quests-engine';
+import type { CharacterConfig } from '@freeside-characters/persona-engine';
+import type { WorldManifestQuestSubset } from '../world-resolver.ts';
+import type { DiscordInteraction } from '../discord-interactions/types.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const stubCharacters: readonly CharacterConfig[] = [
+  {
+    id: 'mongolian',
+    displayName: 'Munkh',
+    personaPath: '/dev/null/persona.md',
+    exemplarsDir: undefined,
+    emojiAffinity: { primary: 'mibera', fallback: 'mibera' },
+  } as unknown as CharacterConfig,
+];
+
+const miberaManifest: WorldManifestQuestSubset = {
+  slug: 'mongolian',
+  tenant_id: 'mibera',
+  guild_ids: ['111111111111111111'],
+  auth: { backend: 'freeside-jwt' },
+  quest_engine_config: {
+    questAcceptanceMode: 'auth-required',
+    submissionStyle: 'inline_thread',
+    positiveFrictionDelayMs: 12000,
+  },
+};
+
+const stubPool = (tag: string): QuestStatePostgresPool => ({
+  query: async () => ({ rows: [{ tag } as never], rowCount: 0 }),
+});
+
+const buildOpts = (
+  overrides: Partial<ProductionQuestRuntimeOptions> = {},
+): ProductionQuestRuntimeOptions => ({
+  worldManifests: [miberaManifest],
+  characters: stubCharacters,
+  tenantPgPoolFactory: { poolForTenant: () => null },
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// buildProductionQuestRuntime · shape
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · production runtime · buildProductionQuestRuntime shape (B-1.8)', () => {
+  test('returns a fully-shaped QuestRuntime', () => {
+    const r = buildProductionQuestRuntime(buildOpts());
+    expect(Array.isArray(r.worldManifests)).toBe(true);
+    expect(typeof r.catalog.listAvailableQuests).toBe('function');
+    expect(typeof r.catalog.findQuest).toBe('function');
+    expect(typeof r.characters.resolveDisplayName).toBe('function');
+    expect(typeof r.pgPools.poolForWorld).toBe('function');
+    expect(typeof r.resolvePlayer).toBe('function');
+  });
+
+  test('CharacterRegistry resolves Munkh display name from loaded character', () => {
+    const r = buildProductionQuestRuntime(buildOpts());
+    expect(r.characters.resolveDisplayName('mongolian')).toBe('Munkh');
+    expect(r.characters.resolveDisplayName('unknown')).toBeUndefined();
+  });
+
+  test('default catalog ships the Mongolian stub quest', async () => {
+    const r = buildProductionQuestRuntime(buildOpts());
+    const quests = await Effect.runPromise(
+      r.catalog.listAvailableQuests(PRODUCTION_STUB_WORLD_SLUG),
+    );
+    expect(quests).toHaveLength(1);
+    // quest_id is branded · coerce for value comparison
+    expect(String(quests[0]?.quest_id)).toBe(PRODUCTION_STUB_QUEST_ID);
+  });
+
+  test('default catalog returns empty list for unknown world', async () => {
+    const r = buildProductionQuestRuntime(buildOpts());
+    const quests = await Effect.runPromise(
+      r.catalog.listAvailableQuests('unknown-world'),
+    );
+    expect(quests).toEqual([]);
+  });
+
+  test('default resolvePlayer returns anon player for valid Discord ID', () => {
+    const r = buildProductionQuestRuntime(buildOpts());
+    const interaction = {
+      user: { id: '123456789012345678' },
+    } as unknown as DiscordInteraction;
+    const player = r.resolvePlayer(interaction);
+    expect(player?.type).toBe('anon');
+    if (player?.type === 'anon') {
+      // discord_id is branded · coerce for value comparison
+      expect(String(player.discord_id)).toBe('123456789012345678');
+    }
+  });
+
+  test('default resolvePlayer returns null for missing user', () => {
+    const r = buildProductionQuestRuntime(buildOpts());
+    const interaction = {} as unknown as DiscordInteraction;
+    expect(r.resolvePlayer(interaction)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildWorldPgPoolFactoryFromTenants · I3 Spine Seam dispatch
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · production runtime · world→tenant→pool dispatch (I3)', () => {
+  test('dispatches world.slug → tenant_id → pool', () => {
+    const pool = stubPool('mibera-pg');
+    const tenantFactory: TenantPgPoolFactory = {
+      poolForTenant: (t) => (t === 'mibera' ? pool : null),
+    };
+    const factory = buildWorldPgPoolFactoryFromTenants([miberaManifest], tenantFactory);
+    expect(factory.poolForWorld('mongolian')).toBe(pool);
+  });
+
+  test('returns null for unknown world slug (memory fallback engages)', () => {
+    const factory = buildWorldPgPoolFactoryFromTenants([miberaManifest], {
+      poolForTenant: () => stubPool('any'),
+    });
+    expect(factory.poolForWorld('not-in-manifest')).toBeNull();
+  });
+
+  test('returns null when matched manifest has no tenant_id (cycle-Q v1.0 forward-compat)', () => {
+    const noTenant: WorldManifestQuestSubset = {
+      slug: 'cycleq-legacy',
+      guild_ids: ['xxx'],
+    };
+    const factory = buildWorldPgPoolFactoryFromTenants([noTenant], {
+      poolForTenant: () => stubPool('any'),
+    });
+    expect(factory.poolForWorld('cycleq-legacy')).toBeNull();
+  });
+
+  test('returns null when tenant factory has no pool for that tenant', () => {
+    const factory = buildWorldPgPoolFactoryFromTenants([miberaManifest], {
+      poolForTenant: () => null,
+    });
+    expect(factory.poolForWorld('mongolian')).toBeNull();
+  });
+
+  test('two worlds same tenant share the same pool (no cache duplication)', () => {
+    const pool = stubPool('shared-mibera-pg');
+    const second: WorldManifestQuestSubset = {
+      slug: 'mongolian-v2',
+      tenant_id: 'mibera',
+      guild_ids: ['222'],
+    };
+    const factory = buildWorldPgPoolFactoryFromTenants(
+      [miberaManifest, second],
+      { poolForTenant: () => pool },
+    );
+    expect(factory.poolForWorld('mongolian')).toBe(pool);
+    expect(factory.poolForWorld('mongolian-v2')).toBe(pool);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// envConnectionStringSource · TENANT_<TENANT>_DATABASE_URL
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · production runtime · envConnectionStringSource', () => {
+  test('reads TENANT_<UPPER>_DATABASE_URL pattern', () => {
+    const source = envConnectionStringSource({
+      TENANT_MIBERA_DATABASE_URL: 'postgres://mibera-railway/db',
+    });
+    expect(source.forTenant('mibera')).toBe('postgres://mibera-railway/db');
+  });
+
+  test('translates dash-tenants to underscore env keys', () => {
+    const source = envConnectionStringSource({
+      TENANT_CUB_QUEST_DATABASE_URL: 'postgres://cubquest/db',
+    });
+    expect(source.forTenant('cub-quest')).toBe('postgres://cubquest/db');
+  });
+
+  test('returns null for missing tenant key', () => {
+    const source = envConnectionStringSource({});
+    expect(source.forTenant('mibera')).toBeNull();
+  });
+
+  test('treats empty string as null (operator misconfig)', () => {
+    const source = envConnectionStringSource({
+      TENANT_MIBERA_DATABASE_URL: '   ',
+    });
+    expect(source.forTenant('mibera')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildEnvTenantPgPoolFactory · lazy + cached per-tenant
+// ---------------------------------------------------------------------------
+
+describe('cycle-B · production runtime · buildEnvTenantPgPoolFactory caching', () => {
+  test('lazily builds pool on first access · caches subsequent calls', () => {
+    const builds: string[] = [];
+    const builder: PoolBuilder = {
+      build: (conn) => {
+        builds.push(conn);
+        return stubPool(conn);
+      },
+    };
+    const source = envConnectionStringSource({
+      TENANT_MIBERA_DATABASE_URL: 'postgres://mibera/db',
+    });
+    const factory = buildEnvTenantPgPoolFactory(builder, source);
+
+    const a = factory.poolForTenant('mibera');
+    const b = factory.poolForTenant('mibera');
+    expect(a).toBe(b);
+    expect(builds).toEqual(['postgres://mibera/db']); // only ONE build
+  });
+
+  test('returns null without building when env is unset', () => {
+    const builds: string[] = [];
+    const builder: PoolBuilder = {
+      build: (conn) => {
+        builds.push(conn);
+        return stubPool(conn);
+      },
+    };
+    const source = envConnectionStringSource({});
+    const factory = buildEnvTenantPgPoolFactory(builder, source);
+
+    expect(factory.poolForTenant('mibera')).toBeNull();
+    expect(builds).toHaveLength(0);
+  });
+
+  test('builds separate pools for different tenants', () => {
+    const builds: string[] = [];
+    const builder: PoolBuilder = {
+      build: (conn) => {
+        builds.push(conn);
+        return stubPool(conn);
+      },
+    };
+    const source = envConnectionStringSource({
+      TENANT_MIBERA_DATABASE_URL: 'postgres://mibera/db',
+      TENANT_CUBQUEST_DATABASE_URL: 'postgres://cubquest/db',
+    });
+    const factory = buildEnvTenantPgPoolFactory(builder, source);
+
+    const mibera = factory.poolForTenant('mibera');
+    const cubquest = factory.poolForTenant('cubquest');
+    expect(mibera).not.toBe(cubquest);
+    expect(builds).toEqual([
+      'postgres://mibera/db',
+      'postgres://cubquest/db',
+    ]);
+  });
+});

--- a/apps/bot/src/tests/world-resolver.test.ts
+++ b/apps/bot/src/tests/world-resolver.test.ts
@@ -1,0 +1,121 @@
+/**
+ * world-resolver.test.ts — coverage for tenant + auth-backend extensions
+ * (cycle-B · sprint-1 · B-1.7).
+ *
+ * Validates:
+ *   - resolveTenantFromGuild returns tenant_id for matched worlds
+ *   - resolveTenantFromGuild returns null for unmatched guilds (auth-bridge
+ *     decides fail-closed vs anon-fallback per route)
+ *   - resolveTenantFromGuild returns null when matched world has no
+ *     tenant_id field (cycle-Q v1.0 manifest forward-compat)
+ *   - resolveAuthBackendForGuild defaults to 'anon' for unmatched and for
+ *     worlds without auth.backend declaration
+ *   - resolveAuthBackendForGuild returns the manifest's declared backend
+ *   - First-match-wins ordering for guilds claimed by multiple worlds
+ *     (operator-controlled via manifest declaration order)
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  resolveAuthBackendForGuild,
+  resolveTenantFromGuild,
+  type WorldManifestQuestSubset,
+} from '../world-resolver.ts';
+
+const MIBERA_GUILD = '111111111111111111';
+const CUBQUEST_GUILD = '222222222222222222';
+const ANON_GUILD = '333333333333333333';
+const SHARED_GUILD = '999999999999999999';
+
+const miberaWorld: WorldManifestQuestSubset = {
+  slug: 'mibera',
+  tenant_id: 'mibera',
+  guild_ids: [MIBERA_GUILD, SHARED_GUILD],
+  auth: { backend: 'freeside-jwt' },
+  quest_namespace: 'mibera',
+  quest_engine_config: {
+    questAcceptanceMode: 'auth-required',
+    submissionStyle: 'inline_thread',
+    positiveFrictionDelayMs: 12000,
+  },
+};
+
+const cubquestWorld: WorldManifestQuestSubset = {
+  slug: 'cubquest',
+  tenant_id: 'cubquest',
+  guild_ids: [CUBQUEST_GUILD, SHARED_GUILD],
+  auth: { backend: 'freeside-jwt' },
+};
+
+// cycle-Q v1.0 shape · no tenant_id, no auth.backend
+const legacyMongolianWorld: WorldManifestQuestSubset = {
+  slug: 'mongolian',
+  guild_ids: [ANON_GUILD],
+};
+
+describe('cycle-B · world-resolver · resolveTenantFromGuild (B-1.7)', () => {
+  test('returns tenant_id for matched world', () => {
+    expect(resolveTenantFromGuild(MIBERA_GUILD, [miberaWorld, cubquestWorld])).toBe(
+      'mibera',
+    );
+    expect(resolveTenantFromGuild(CUBQUEST_GUILD, [miberaWorld, cubquestWorld])).toBe(
+      'cubquest',
+    );
+  });
+
+  test('returns null for unmatched guild', () => {
+    expect(resolveTenantFromGuild('444444444444444444', [miberaWorld])).toBeNull();
+  });
+
+  test('returns null for matched world without tenant_id (cycle-Q v1.0 forward-compat)', () => {
+    expect(resolveTenantFromGuild(ANON_GUILD, [legacyMongolianWorld])).toBeNull();
+  });
+
+  test('returns null for empty manifest list', () => {
+    expect(resolveTenantFromGuild(MIBERA_GUILD, [])).toBeNull();
+  });
+
+  test('first-match-wins for guilds claimed by multiple worlds', () => {
+    // mibera comes first in the list → claims SHARED_GUILD
+    expect(resolveTenantFromGuild(SHARED_GUILD, [miberaWorld, cubquestWorld])).toBe(
+      'mibera',
+    );
+    // reverse the list · cubquest claims SHARED_GUILD
+    expect(resolveTenantFromGuild(SHARED_GUILD, [cubquestWorld, miberaWorld])).toBe(
+      'cubquest',
+    );
+  });
+
+  test('skips manifests with no guild_ids', () => {
+    const noGuilds: WorldManifestQuestSubset = {
+      slug: 'no-guild-world',
+      tenant_id: 'orphan',
+    };
+    expect(resolveTenantFromGuild(MIBERA_GUILD, [noGuilds, miberaWorld])).toBe(
+      'mibera',
+    );
+  });
+});
+
+describe('cycle-B · world-resolver · resolveAuthBackendForGuild (B-1.7)', () => {
+  test("returns world's declared backend for matched guild", () => {
+    expect(resolveAuthBackendForGuild(MIBERA_GUILD, [miberaWorld])).toBe('freeside-jwt');
+    expect(resolveAuthBackendForGuild(CUBQUEST_GUILD, [cubquestWorld])).toBe(
+      'freeside-jwt',
+    );
+  });
+
+  test("defaults to 'anon' for unmatched guild", () => {
+    expect(resolveAuthBackendForGuild('444444444444444444', [miberaWorld])).toBe(
+      'anon',
+    );
+  });
+
+  test("defaults to 'anon' for matched world without auth.backend", () => {
+    expect(resolveAuthBackendForGuild(ANON_GUILD, [legacyMongolianWorld])).toBe('anon');
+  });
+
+  test("defaults to 'anon' for empty manifest list", () => {
+    expect(resolveAuthBackendForGuild(MIBERA_GUILD, [])).toBe('anon');
+  });
+});

--- a/apps/bot/src/world-resolver.ts
+++ b/apps/bot/src/world-resolver.ts
@@ -29,14 +29,24 @@
  *
  * Fields are optional because v1.0 manifests omit them. The resolver
  * filters out manifests without quest fields.
+ *
+ * cycle-B sprint-1 (B-1.7): added `tenant_id` and `auth.backend` so the
+ * bot's auth-bridge can resolve a per-guild tenant + know which backend
+ * (anon or freeside-jwt) the world has opted into. Both fields are
+ * optional to keep cycle-Q v1.0 manifests forward-compatible — only
+ * worlds that declare an identity composition need to populate them.
  */
 export interface WorldManifestQuestSubset {
   readonly slug: string;
+  readonly tenant_id?: string;
   readonly quest_namespace?: string;
   readonly quest_engine_config?: {
     readonly questAcceptanceMode: "open" | "auth-required" | "open-badge-gated";
     readonly submissionStyle: "inline_thread" | "modal_form";
     readonly positiveFrictionDelayMs: number;
+  };
+  readonly auth?: {
+    readonly backend: "anon" | "freeside-jwt";
   };
   readonly guild_ids?: readonly string[];
 }
@@ -105,4 +115,50 @@ export const resolveEngineConfigForGuild = (
   const world = resolveWorldForGuild(guild_id, manifests);
   if (!world) return null;
   return buildEngineConfigForWorld(world);
+};
+
+/**
+ * cycle-B sprint-1 (B-1.7): resolve the canonical tenant_id for a Discord
+ * guild from the world-manifest registry.
+ *
+ * Returns null when:
+ *   - no world claims the guild, OR
+ *   - the matched world manifest does not declare `tenant_id` (cycle-Q
+ *     v1.0 manifest · no identity composition)
+ *
+ * Auth-bridge consumes this to drive its `TenantResolverPort`. The bridge
+ * decides what null means based on the per-route fail-mode (verified-required
+ * → AuthBridgeError; verified-with-anon-fallback → audited downgrade;
+ * public/anon → not consulted at all).
+ *
+ * Pure-data function · no IO · no Discord API call · safe to invoke per
+ * interaction at the dispatch layer.
+ */
+export const resolveTenantFromGuild = (
+  guild_id: string,
+  manifests: readonly WorldManifestQuestSubset[],
+): string | null => {
+  const world = resolveWorldForGuild(guild_id, manifests);
+  if (!world) return null;
+  return world.tenant_id ?? null;
+};
+
+/**
+ * cycle-B sprint-1 (B-1.7): resolve the auth backend the world has opted
+ * into. Returns the manifest's declared backend or 'anon' when the world
+ * doesn't declare identity composition.
+ *
+ * Composes orthogonally with the AUTH_BACKEND env var (Lock-7): operators
+ * gate by env at the bot binary level; worlds advertise their preferred
+ * backend at the manifest level. The strict policy (env=anon overrides
+ * everything) is enforced inside auth-bridge · this resolver only surfaces
+ * the world's stated preference.
+ */
+export const resolveAuthBackendForGuild = (
+  guild_id: string,
+  manifests: readonly WorldManifestQuestSubset[],
+): "anon" | "freeside-jwt" => {
+  const world = resolveWorldForGuild(guild_id, manifests);
+  if (!world) return "anon";
+  return world.auth?.backend ?? "anon";
 };


### PR DESCRIPTION
## Summary

Cycle-B sprint-1 freeside-characters slice — wires identity-aware Discord interactions into the production-ready quest runtime path.

- **B-1.6 auth-bridge.ts** (NEW · `apps/bot/src/auth-bridge.ts` · 24 tests): per-interaction AuthContext attach with 3 fail-modes (public · verified-required · verified-with-anon-fallback · default verified-required per AC-B1.6.1) and Lock-7 AUTH_BACKEND feature flag (default anon). Honors I2/I5/I6/Lock-7/Lock-8/Lock-9. Injectable ports for tenant resolver + dynamic_user_id lookup + mint orchestrator + logger.
- **B-1.7 world-resolver tenant extension** (10 tests): `resolveTenantFromGuild` + `resolveAuthBackendForGuild` exported · `tenant_id` + `auth.backend` added as optionals on WorldManifestQuestSubset · cycle-Q v1.0 manifests stay forward-compatible · first-match-wins ordering preserved.
- **B-1.8 production runtime** (NEW · 18 tests): `buildProductionQuestRuntime` + tenant→world→pool dispatch (I3 Spine Seam) + env-driven lazy-cached pg.Pool factory. pg adapter isolated to `lib/pg-pool-builder.ts` with inline structural type shim (no @types/pg dep). `QUEST_RUNTIME=production` engages the new path; memory mode unchanged.

124 tests / 0 fail / typecheck clean / 0 regressions. Cycle-Q v1.0 manifests forward-compatible.

## Architect locks honored

- **I2 (Cyberdeck Seam)** — auth-bridge is L4 boundary code · never touches RPC · delegates signing to gateway per SDD §12.3
- **I3 (Spine Seam)** — per-tenant heterogeneity first-class · adapter dispatches by tenant_id · zero `if tenant === 'mibera'` branches
- **I5 (Construct Purity)** — runtime is pure orchestration · all side effects (pg, env, mint HTTP) flow through injected ports
- **I6 (Tenant-Boundary Assertion)** — post-mint `claims.tenant === expected_tenant` assertion · throws AuthBridgeError on mismatch · cannot fall back (AC-B1.11.1)
- **Lock-7 (Feature flag)** — AUTH_BACKEND env is the kill switch · defaults to anon · QUEST_RUNTIME composes orthogonally
- **Lock-8 (V1 single-keypair)** — no revocation logic at this layer · verifier hook upstream
- **Lock-9 (Schema source-of-truth)** — JWTClaim shape mirrors `@freeside-auth/protocol/jwt-claims.schema.json` · pg.Pool surface declared as structural subset

## Cross-repo dep posture

`@freeside-auth/engine` MintJWTOrchestrator surface is declared as an injected port (`MintJwtPort`). The bot wires the real orchestrator at boot once `bun link @freeside-auth/protocol @freeside-auth/engine` lands as part of the cycle-B B-1.5 gateway deploy ceremony. For now the bot binary continues to default to `AUTH_BACKEND=anon` · existing memory-mode runtime fully functional.

## Operator action queue

```bash
# Post B-1.5 gateway deploy
bun link @freeside-auth/protocol      # in this workspace
bun link @freeside-auth/engine

# On Railway prod env
TENANT_MIBERA_DATABASE_URL=postgres://...
QUEST_RUNTIME=memory  →  QUEST_RUNTIME=production    # flip after Pg path verified
AUTH_BACKEND=anon                                     # keep until verified path proves
```

## Test plan

- [ ] CI: `bun typecheck` passes
- [ ] CI: `bun test` reports 124+ passing
- [ ] Memory-mode regression: existing `/quest accept munkh-introduction-v1` flow unchanged when `QUEST_RUNTIME=memory`
- [ ] (Operator-bounded · B-1.14) End-to-end smoke in mibera Discord dev guild post `QUEST_RUNTIME=production` flip + `AUTH_BACKEND=freeside-jwt` flip

## Next in slice

- **B-1.9** (freeside-quests): flip `Sietch` Layer from stub to verified path · calls `freeside-auth.verifyJwt()` · returns structured `VerifyError` per SDD §3.1.4 (separate PR in 0xHoneyJar/freeside-quests)
- **B-1.10** (freeside-quests): per-world Pg pool wiring driven by `tenantId` from auth context (separate PR in 0xHoneyJar/freeside-quests)
- **B-1.11** (loa-finn): `Substrate.invoke()` callers wire `tenantId` from JWT context + AC-B1.11.1 assertion
- **B-1.12** (freeside-worlds): `mibera.yaml` manifest with `tenant_id: mibera` + `auth.backend: freeside-jwt` + `compose_with: [freeside-auth, freeside-quests]`

## Refs

- `grimoires/loa/sdd-convergence-spine-2026-05-04.md` §3.2 + §12.3 + §13.4
- `grimoires/loa/sprint-convergence-spine-2026-05-04.md` §13.1-3
- `grimoires/loa/prd-convergence-spine-2026-05-04.md` §13 (D8/D9/D10 + I6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)