### PR TITLE
fix(cycle-003): bridgebuilder pass-4 follow-up — F1/F2/F7/F10/F22 correctness fixes

### DIFF
--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -424,6 +424,97 @@ deployment topology to an invariant.
 | **SKP-003 (770)** MCP failure handling underspecified | HIGH | **ACCEPT** | NFR-7 / NFR-8 / NFR-9 added. timeouts + retries + circuit breaker now contract. |
 | **SKP-004 (720)** unknown category_key behavior undefined | HIGH | **ACCEPT** | NFR-11 added — unknown class quarantine + cron metric surface. |
 
+## 9.2 · Known technical debt (tracked, not resolved)
+
+> Per Bridgebuilder pass-4 review F25 REFRAME · 2026-05-11. The singleton
+> invariant elevated under NFR-21–25 is operationally correct for current
+> scale but is **technical debt with a known migration cost**, not a
+> satisfied requirement. This section makes the debt explicit so future
+> scale-up decisions don't surprise.
+
+### TD-1 · Singleton-as-SPOF + zero-downtime deferral
+
+**Current state** (NFR-21–25):
+- Bot deploys as exactly ONE running process per environment
+- `.run/*.jsonl` files hold cursor, ledger, circuit-breaker state
+- `flock` (or POSIX append-atomicity) protects within-process integrity
+- NFR-25 promises fail-loud crash on second-instance attempt
+
+**The debt**:
+- Any node failure or rolling deploy causes ~30s of downtime
+- Blue/green deployment requires distributed state backend (Redis/Postgres)
+  before it can be enabled
+- A future HA requirement forces rewriting all `.run/*.jsonl` state
+  writers, plus the appendIfNoFire atomic primitive, plus the cursor
+  advance protocol
+
+**Migration path** (when the operational signal demands it):
+1. Introduce a single Service port for atomic state (`StateBackend.port.ts`)
+   abstracting cursor + ledger + circuit-breaker behind a single Effect
+   interface
+2. Add Redis adapter (`state-backend.redis.live.ts`) with atomic primitives
+   (SETNX for fire-locks, INCR for daily-cap counters, ZADD for ledger
+   ordering, LRANGE+ZRANGEBYSCORE for window queries)
+3. Or Postgres adapter (`state-backend.pg.live.ts`) using the existing
+   `lib/pg-pool-builder.ts` infrastructure — likely cheaper since the
+   bot already has a Pg pool for freeside-auth
+4. Toggle via env: `STATE_BACKEND=jsonl | redis | postgres`
+5. Migration script reads existing jsonl files + bulk-writes to chosen
+   backend
+
+**Estimated effort**: ~1 sprint to abstract + ~half-sprint per adapter.
+
+**Trigger for migration**: any of —
+- Operational requirement for zero-downtime deploys
+- More than one bot character requires its own runtime instance
+- Cross-region deployment for latency
+- Anything that breaks the "one process" assumption
+
+**Decision (2026-05-11)**: defer until trigger fires. Document in
+[NFR-21–25](#75--singleton-deployment-invariant-flatline-blocker-theme-α--operator-decided)
+that the invariant is **acceptable for current scale** but should not
+be treated as architecturally permanent.
+
+### TD-2 · Wallet-resolver invocation gap (S4.T1 dependency)
+
+**Current state**: `WalletResolverLive` is wired into `AmbientLayer` but
+no router/composer path actually CALLS it. The CLAUDE.md compliance
+("never cite raw `0x…` wallets without resolve_wallet") is structurally
+enforced only by S4.T1 chat-mode composer wiring — which is deferred.
+
+**The debt**: Until S4.T1 lands, ambient pop-ins (if/when score-mibera
+Phase 1 ships) could theoretically emit raw `0x…` wallets if a
+narration code path is added that bypasses the resolver.
+
+**Mitigation today**: `EVENT_HEARTBEAT_ENABLED=false` is the default
+deploy posture until S4.T1 + score-mibera Phase 1 both land. Stir
+cron does not fire pop-in narrations in this state.
+
+**Migration path**: S4.T1 chat-mode reply.ts injection (deferred S4
+task) — invoke `WalletResolver.resolve` before any narration that
+references a wallet field. Add CI grep guard for raw `0x…` patterns
+in narration test snapshots.
+
+### TD-3 · NFR-16 stir replay on restart (not implemented)
+
+**Current state**: SDD §6 claims stir vector rebuilds from `cursor - 6h`
+events on restart. The replay code does not exist. After restart, every
+zone's stir resets to `null` and pulseTick uses `emptyStir(now)` for
+the first tick.
+
+**The debt**: A bot restart causes a perceptible "stir reset" — the
+narration deliberation tilt that ambient events accumulated is lost.
+Half-life of 6h means recovery is bounded but real.
+
+**Mitigation today**: Stir loss is bounded by half-life decay; rave-feel
+recovers naturally within ~6h. Document the gap explicitly so it doesn't
+masquerade as correct behavior.
+
+**Migration path**: On `AmbientLayer` first tick after process start,
+query score-mcp `get_events_since(cursor - 6h)` and replay through
+`pulseTick` to seed stir. Persist stir to `.run/stir-state.jsonl` for
+faster recovery on subsequent restarts. Estimated 4-6h work.
+
 ## 10 · open questions
 
 none load-bearing for cycle start. all 24 D-decisions locked at

--- a/packages/persona-engine/src/ambient/live/pop-in-ledger.live.ts
+++ b/packages/persona-engine/src/ambient/live/pop-in-ledger.live.ts
@@ -81,6 +81,38 @@ function _checkMonthlyRotate(now: string): void {
   }
 }
 
+// BB pass-4 F22 closure: cache parsed ledger entries in-memory. Previously
+// every appendIfNoFire/getLastFire/readWindow call did a full disk scan
+// of every monthly archive file (O(N) JSON.parse per router decision).
+// After 6 months of ops, fire decisions would parse thousands of lines
+// every time. Now: load once on first access, invalidate on append.
+//
+// Cache keyed by-file so monthly rotation doesn't churn the whole set.
+const _entryCache: Map<string, ReadonlyArray<LedgerEntry>> = new Map();
+let _activeFileMtimeMs = 0;
+
+function _readWithCache(file: string): ReadonlyArray<LedgerEntry> {
+  // The active LEDGER_PATH file mutates on append; check mtime to detect
+  // out-of-band writes (rare under singleton invariant but defensive).
+  if (file === LEDGER_PATH) {
+    try {
+      const stat = fs.statSync(file);
+      if (stat.mtimeMs !== _activeFileMtimeMs) {
+        _entryCache.delete(file);
+        _activeFileMtimeMs = stat.mtimeMs;
+      }
+    } catch {
+      // file doesn't exist yet — skip mtime tracking
+    }
+  }
+  let cached = _entryCache.get(file);
+  if (!cached) {
+    cached = _readAllEntries(file);
+    _entryCache.set(file, cached);
+  }
+  return cached;
+}
+
 function _readAllAcrossArchives(): ReadonlyArray<LedgerEntry> {
   _ensureDir();
   const files = fs.readdirSync(LEDGER_DIR).filter((f) =>
@@ -88,9 +120,15 @@ function _readAllAcrossArchives(): ReadonlyArray<LedgerEntry> {
   );
   const all: Array<LedgerEntry> = [];
   for (const f of files) {
-    all.push(..._readAllEntries(path.join(LEDGER_DIR, f)));
+    all.push(..._readWithCache(path.join(LEDGER_DIR, f)));
   }
   return all;
+}
+
+/** Invalidate cache for the active ledger file after an append. */
+function _invalidateActiveCache(): void {
+  _entryCache.delete(LEDGER_PATH);
+  _activeFileMtimeMs = 0;
 }
 
 export const PopInLedgerLive = Layer.succeed(
@@ -100,6 +138,7 @@ export const PopInLedgerLive = Layer.succeed(
       Effect.sync(() => {
         _checkMonthlyRotate(entry.ts);
         _atomicAppend(entry);
+        _invalidateActiveCache();
       }),
 
     getLastFire: ({ zone, afterTs }) =>
@@ -147,11 +186,46 @@ export const PopInLedgerLive = Layer.succeed(
           if (!blocker || e.ts > blocker.ts) blocker = e;
         }
         if (blocker) {
-          // Lex-min comparison: if the proposing character is lex-LESS than
-          // the blocker, the proposer would have won a true race. We honor
-          // wall-clock-first-wins here since the blocker's entry is already
-          // persisted — but the proposing character still records a yield
-          // to make the race outcome auditable.
+          // BB pass-4 F7 closure: lex-min character_id wins on exact-tie
+          // wall-clock collisions per spec FR-3.18 + S3.T2a. The blocker's
+          // entry is already persisted on disk so we can't retroactively
+          // overwrite a prior wall-clock fire — but we DO honor lex-min
+          // when the timestamps are equal (same-millisecond race). In
+          // that case the lex-LESSER character_id was the rightful winner.
+          //
+          // Outcomes:
+          //   ts(blocker) <  ts(proposed)  → wall-clock-first wins (blocker)
+          //   ts(blocker) == ts(proposed)  → lex-min wins (compare character_ids)
+          //   ts(blocker) >  ts(proposed)  → already filtered above (we
+          //                                  only consider blockers with
+          //                                  ts ≤ proposed.ts)
+          const sameWallClock = blocker.ts === proposedEntry.ts;
+          const proposerLexLessThanBlocker =
+            proposedEntry.character_id < blocker.character_id;
+          const proposerWinsByLexMin =
+            sameWallClock && proposerLexLessThanBlocker;
+
+          if (proposerWinsByLexMin) {
+            // Proposer is lex-min on a true millisecond tie. Write the
+            // proposed entry alongside the blocker — both fires are
+            // recorded, but lex-min wins the "canonical" outcome flag.
+            // The router-level dedup at the digest layer should rank
+            // by (ts ASC, character_id ASC) and the proposer surfaces.
+            const winnerEntry: LedgerEntry = {
+              ...proposedEntry,
+              decision: proposedEntry.decision,
+              // Note the resolved race in the entry itself for audit:
+              yielded_to: null,
+            };
+            _checkMonthlyRotate(proposedEntry.ts);
+            _atomicAppend(winnerEntry);
+            _invalidateActiveCache();
+            return { writtenAsProposed: true, yieldedTo: null };
+          }
+
+          // Default path: proposer yields. Either the blocker fired
+          // strictly earlier in wall-clock, OR the timestamps tied but
+          // the proposer is lex-greater.
           const yieldEntry: LedgerEntry = {
             ...proposedEntry,
             decision: "yielded_to_character",
@@ -160,10 +234,12 @@ export const PopInLedgerLive = Layer.succeed(
           };
           _checkMonthlyRotate(proposedEntry.ts);
           _atomicAppend(yieldEntry);
+          _invalidateActiveCache();
           return { writtenAsProposed: false, yieldedTo: blocker.character_id };
         }
         _checkMonthlyRotate(proposedEntry.ts);
         _atomicAppend(proposedEntry);
+        _invalidateActiveCache();
         return { writtenAsProposed: true, yieldedTo: null };
       }),
   }),

--- a/packages/persona-engine/src/ambient/live/pop-in-ledger.live.ts
+++ b/packages/persona-engine/src/ambient/live/pop-in-ledger.live.ts
@@ -75,6 +75,9 @@ function _checkMonthlyRotate(now: string): void {
     const archive = _monthArchivePath(entries[0]!.ts);
     try {
       fs.renameSync(LEDGER_PATH, archive);
+      // BB pass-5 F2: rotation renames active file → archive name; old
+      // cache key is now stale. Flush ALL cache entries; cheapest correct.
+      _invalidateAllCache();
     } catch {
       // best-effort rotation
     }
@@ -131,6 +134,58 @@ function _invalidateActiveCache(): void {
   _activeFileMtimeMs = 0;
 }
 
+/** BB pass-5 F2 closure: flush ALL cache entries on monthly rotation.
+ * The active file gets renamed to its archive name; the old path key
+ * becomes stale. Cheapest correct response is to drop everything;
+ * cache rebuilds on next read. */
+function _invalidateAllCache(): void {
+  _entryCache.clear();
+  _activeFileMtimeMs = 0;
+}
+
+/** BB pass-5 F4 closure: test-only reset hook. The module globals
+ * (_entryCache, _activeFileMtimeMs) survive across tests that swap
+ * LEDGER_PATH/LEDGER_DIR in the same process. Export this so tests
+ * can isolate. NOT used in production paths. */
+export function __resetPopInLedgerLiveCacheForTests(): void {
+  _invalidateAllCache();
+}
+
+/** BB pass-5 F1 + F11 closure: read-side lex-min collapse for
+ * same-millisecond "fired" entries. When two characters write fired
+ * entries at the EXACT same ts (rare but possible under F7 lex-min
+ * tie-break), readers should treat only the lex-min character_id as
+ * the canonical fire. The others are superseded.
+ *
+ * Cap/cooldown counting relies on this — without it, a tie would
+ * double-count fires in the readWindow path and double-block in
+ * appendIfNoFire's blocker scan.
+ *
+ * Pure function; preserves entry array order otherwise.
+ */
+function _collapseSameTsLexMin(
+  entries: ReadonlyArray<LedgerEntry>,
+): ReadonlyArray<LedgerEntry> {
+  // Group fired/bypassed entries by (zone, ts). For each group, keep
+  // only the lex-min character_id as fired; mark the rest as
+  // logically-superseded by filtering them OUT of the returned array.
+  // Non-fire decisions (yielded/queued/etc.) pass through unchanged.
+  const fireKeyToLexMinCharId: Map<string, string> = new Map();
+  for (const e of entries) {
+    if (e.decision !== "fired" && e.decision !== "bypassed") continue;
+    const key = `${e.zone}|${e.ts}`;
+    const current = fireKeyToLexMinCharId.get(key);
+    if (!current || e.character_id < current) {
+      fireKeyToLexMinCharId.set(key, e.character_id);
+    }
+  }
+  return entries.filter((e) => {
+    if (e.decision !== "fired" && e.decision !== "bypassed") return true;
+    const key = `${e.zone}|${e.ts}`;
+    return fireKeyToLexMinCharId.get(key) === e.character_id;
+  });
+}
+
 export const PopInLedgerLive = Layer.succeed(
   PopInLedger,
   PopInLedger.of({
@@ -143,7 +198,9 @@ export const PopInLedgerLive = Layer.succeed(
 
     getLastFire: ({ zone, afterTs }) =>
       Effect.sync(() => {
-        const all = _readAllAcrossArchives();
+        // BB pass-5 F1: collapse same-ts duplicates to lex-min winner
+        // before scanning. Otherwise an F7 tie produces double-counting.
+        const all = _collapseSameTsLexMin(_readAllAcrossArchives());
         // S3.T2a: most recent "fired" entry for this zone, after afterTs
         let best: LedgerEntry | null = null;
         for (const e of all) {
@@ -157,7 +214,8 @@ export const PopInLedgerLive = Layer.succeed(
 
     readWindow: ({ zone, sinceTs, untilTs }) =>
       Effect.sync(() => {
-        const all = _readAllAcrossArchives();
+        // BB pass-5 F1: same-ts lex-min collapse applies here too.
+        const all = _collapseSameTsLexMin(_readAllAcrossArchives());
         return all.filter(
           (e) =>
             (!zone || e.zone === zone) &&
@@ -174,7 +232,10 @@ export const PopInLedgerLive = Layer.succeed(
      * crash at boot per NFR-25 before reaching here. */
     appendIfNoFire: ({ proposedEntry, afterTs }) =>
       Effect.sync(() => {
-        const all = _readAllAcrossArchives();
+        // BB pass-5 F1: collapse same-ts duplicates BEFORE scanning for
+        // blockers, so a previously-lex-min-resolved tie doesn't count
+        // both characters as blockers.
+        const all = _collapseSameTsLexMin(_readAllAcrossArchives());
         // Check: any character fired in (afterTs, proposedEntry.ts] for this zone?
         let blocker: LedgerEntry | null = null;
         for (const e of all) {

--- a/packages/persona-engine/src/ambient/mock/pop-in-ledger.mock.ts
+++ b/packages/persona-engine/src/ambient/mock/pop-in-ledger.mock.ts
@@ -4,6 +4,28 @@ import type { LedgerEntry } from "../domain/budgets.ts";
 
 const _entries: Array<LedgerEntry> = [];
 
+/** BB pass-5 F1 + F11: read-side lex-min collapse for same-ts fires.
+ * Live + mock must agree on resolution strategy or tests written against
+ * the mock won't catch the live duplicate-fire issue. */
+function _collapseSameTsLexMin(
+  entries: ReadonlyArray<LedgerEntry>,
+): ReadonlyArray<LedgerEntry> {
+  const fireKeyToLexMinCharId: Map<string, string> = new Map();
+  for (const e of entries) {
+    if (e.decision !== "fired" && e.decision !== "bypassed") continue;
+    const key = `${e.zone}|${e.ts}`;
+    const current = fireKeyToLexMinCharId.get(key);
+    if (!current || e.character_id < current) {
+      fireKeyToLexMinCharId.set(key, e.character_id);
+    }
+  }
+  return entries.filter((e) => {
+    if (e.decision !== "fired" && e.decision !== "bypassed") return true;
+    const key = `${e.zone}|${e.ts}`;
+    return fireKeyToLexMinCharId.get(key) === e.character_id;
+  });
+}
+
 export function getMockLedgerEntries(): ReadonlyArray<LedgerEntry> {
   return _entries;
 }
@@ -27,8 +49,9 @@ export const PopInLedgerMock = Layer.succeed(
 
     getLastFire: ({ zone, afterTs }) =>
       Effect.sync(() => {
+        const collapsed = _collapseSameTsLexMin(_entries);
         let best: LedgerEntry | null = null;
-        for (const e of _entries) {
+        for (const e of collapsed) {
           if (e.zone !== zone) continue;
           if (e.decision !== "fired") continue;
           if (e.ts < afterTs) continue;
@@ -39,7 +62,7 @@ export const PopInLedgerMock = Layer.succeed(
 
     readWindow: ({ zone, sinceTs, untilTs }) =>
       Effect.sync(() =>
-        _entries.filter(
+        _collapseSameTsLexMin(_entries).filter(
           (e) =>
             (!zone || e.zone === zone) &&
             e.ts >= sinceTs &&
@@ -49,8 +72,9 @@ export const PopInLedgerMock = Layer.succeed(
 
     appendIfNoFire: ({ proposedEntry, afterTs }) =>
       Effect.sync(() => {
+        const collapsed = _collapseSameTsLexMin(_entries);
         let blocker = null as typeof _entries[number] | null;
-        for (const e of _entries) {
+        for (const e of collapsed) {
           if (e.zone !== proposedEntry.zone) continue;
           if (e.decision !== "fired" && e.decision !== "bypassed") continue;
           if (e.ts <= afterTs) continue;

--- a/packages/persona-engine/src/ambient/mock/pop-in-ledger.mock.ts
+++ b/packages/persona-engine/src/ambient/mock/pop-in-ledger.mock.ts
@@ -59,6 +59,14 @@ export const PopInLedgerMock = Layer.succeed(
           if (!blocker || e.ts > blocker.ts) blocker = e;
         }
         if (blocker) {
+          // BB pass-4 F7: lex-min character_id wins on exact-millisecond ties.
+          const sameWallClock = blocker.ts === proposedEntry.ts;
+          const proposerLexLess =
+            proposedEntry.character_id < blocker.character_id;
+          if (sameWallClock && proposerLexLess) {
+            _entries.push({ ...proposedEntry, yielded_to: null });
+            return { writtenAsProposed: true, yieldedTo: null };
+          }
           _entries.push({
             ...proposedEntry,
             decision: "yielded_to_character",

--- a/packages/persona-engine/src/ambient/runtime.ts
+++ b/packages/persona-engine/src/ambient/runtime.ts
@@ -29,9 +29,31 @@ import {
 } from "./live/score-mcp-client.ts";
 import { loadConfig } from "../config.ts";
 
-// BB pass-3 F10 closure: validate MCP endpoint config at module load.
-// Strict in production (throw); lenient in dev/test (warn-and-continue
-// so STUB_MODE works without env vars set).
+// BB pass-3 F10 + pass-4 F10 closure: validate MCP endpoint config at
+// module load.
+//
+// Pass-3 made the prod path throw — which kills the entire bot (digest
+// cron + read-side + everything) when only the ambient stir tier should
+// be disabled. The throw cascades to anyone importing runtime.ts (the
+// scheduler's lazy import would crash too) — F10 = conflate "stir
+// misconfigured" with "process should refuse to start".
+//
+// Pass-4 fix: set an internal disable flag instead of throwing. Callers
+// (the scheduler stir-tier cron) check `isAmbientStirDisabled()` and
+// skip if true. Digest + read-side remain healthy.
+let _ambientStirDisabled = false;
+let _ambientStirDisabledReasons: ReadonlyArray<string> = [];
+
+/** True when boot-time MCP endpoint validation failed in production.
+ * Scheduler stir-tier checks this and no-ops. Digest cron is unaffected. */
+export function isAmbientStirDisabled(): boolean {
+  return _ambientStirDisabled;
+}
+
+export function getAmbientStirDisableReasons(): ReadonlyArray<string> {
+  return _ambientStirDisabledReasons;
+}
+
 function _bootstrapEndpointValidation(): void {
   if (process.env.EVENT_HEARTBEAT_ENABLED === "false") {
     // Stir tier disabled — skip endpoint validation entirely.
@@ -41,7 +63,6 @@ function _bootstrapEndpointValidation(): void {
   try {
     config = loadConfig();
   } catch {
-    // Config loader threw — likely missing required env. Bail to warning.
     console.warn(
       "ambient-runtime: skipping endpoint validation (config load failed)",
     );
@@ -53,15 +74,27 @@ function _bootstrapEndpointValidation(): void {
     "codex",
     "freeside-auth",
   ];
+  const reasons: Array<string> = [];
   for (const endpoint of endpoints) {
     const result = validateEndpointConfig(endpoint, config);
     if (!result.ok) {
       const msg = `ambient-runtime: endpoint validation failed [${endpoint}] — ${result.reason}`;
       if (isProd) {
-        throw new Error(msg);
+        console.error(msg);
+        reasons.push(`${endpoint}: ${result.reason}`);
+      } else {
+        console.warn(msg + " (dev mode — continuing)");
       }
-      console.warn(msg + " (dev mode — continuing)");
     }
+  }
+  if (isProd && reasons.length > 0) {
+    _ambientStirDisabled = true;
+    _ambientStirDisabledReasons = reasons;
+    console.error(
+      "ambient-runtime: AMBIENT STIR TIER DISABLED in production — " +
+        `${reasons.length} endpoint(s) misconfigured. Digest cron + ` +
+        "read-side continue normally. Resolve endpoint config to re-enable.",
+    );
   }
 }
 

--- a/packages/persona-engine/src/ambient/scheduler-task.ts
+++ b/packages/persona-engine/src/ambient/scheduler-task.ts
@@ -19,7 +19,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { EventFeed } from "./ports/event-source.port.ts";
 import { PulseSink } from "./ports/pulse-sink.port.ts";
-import { ambientRuntime } from "./runtime.ts";
+import {
+  ambientRuntime,
+  isAmbientStirDisabled,
+  getAmbientStirDisableReasons,
+} from "./runtime.ts";
 import { pulseTick } from "./pulse.system.ts";
 import type { ZoneId } from "./domain/event.ts";
 import type { EventCursor } from "./domain/cursor.ts";
@@ -116,8 +120,29 @@ export async function runStirTick(
   primitive: LynchPrimitive,
 ): Promise<StirTickResult> {
   const now = new Date().toISOString();
+
+  // BB pass-4 F10 closure: if boot-time endpoint validation disabled the
+  // stir tier (production with misconfigured codex/auth MCPs), no-op
+  // cleanly. Caller's NFR-10 error boundary already ensures digest cron
+  // is unaffected, but skipping here avoids hammering broken endpoints.
+  if (isAmbientStirDisabled()) {
+    return {
+      zone,
+      events_fetched: 0,
+      cursor_advanced: false,
+      quarantined: 0,
+      error: `ambient-stir disabled at boot: ${getAmbientStirDisableReasons().join("; ")}`,
+    };
+  }
+
   const cursor = _loadCursor(zone, now);
 
+  // BB pass-4 F1 closure: cursor write moves INSIDE the Effect.gen so the
+  // sequence (sink.write + cursor advance) commits as one unit. If
+  // sink.write throws, the cursor is not advanced. NFR-14 transactional
+  // semantics now hold within a single fiber (cross-process safety still
+  // depends on the singleton invariant — NFR-21 — until proper-lockfile
+  // installs).
   const program = Effect.gen(function* (_) {
     const feed = yield* _(EventFeed);
     const sink = yield* _(PulseSink);
@@ -131,7 +156,14 @@ export async function runStirTick(
     );
 
     if (fetched.events.length === 0 && previousStir === null) {
-      // First-tick + no-events no-op
+      // First-tick + no-events no-op. Touch cursor's updated_at only —
+      // event_time stays at the initial value so the next overlap-window
+      // fetch still queries from the original since_ts. (BB pass-4 F2.)
+      const idleCursor: EventCursor = {
+        ...cursor,
+        updated_at: now,
+      };
+      _saveCursor(idleCursor);
       return {
         events_fetched: 0,
         cursor_advanced: false,
@@ -149,13 +181,32 @@ export async function runStirTick(
       now,
     });
 
+    // F1 transactional commit: sink write FIRST, then cursor save. If
+    // sink.write throws, the Effect propagates the failure and the cursor
+    // is never advanced; the next tick reprocesses the same window.
     yield* _(sink.write(tickOutput.stir));
+
+    // BB pass-4 F2 closure: on idle ticks (zero events fetched), do NOT
+    // advance event_time. The 6h score-mibera ingestion ceiling means
+    // chain events with old `occurred_at` can arrive late in bronze;
+    // advancing event_time on idle would skip them at the next fetch.
+    // Only `updated_at` moves on idle. event_time advances only when real
+    // events were processed (using fetched.nextCursor from the score-mcp
+    // response).
+    if (fetched.events.length > 0) {
+      _saveCursor(fetched.nextCursor);
+    } else {
+      const idleCursor: EventCursor = {
+        ...cursor,
+        updated_at: now,
+      };
+      _saveCursor(idleCursor);
+    }
 
     return {
       events_fetched: fetched.events.length,
       cursor_advanced: fetched.events.length > 0,
       quarantined: fetched.quarantinedCount,
-      nextCursor: fetched.nextCursor,
     };
   });
 
@@ -164,25 +215,7 @@ export async function runStirTick(
       events_fetched: number;
       cursor_advanced: boolean;
       quarantined: number;
-      nextCursor?: EventCursor;
     };
-
-    // BB pass-3 F1 closure: advance the cursor to `now` on every successful
-    // tick, even when zero events landed. computeOverlapSince at the NEXT
-    // fetch call subtracts REPLAY_WINDOW_SECONDS to form `since_ts`, so
-    // we do NOT pre-subtract here. (The pass-2 fix did pre-subtract,
-    // resulting in only 60s of cursor advance per hourly tick — accumulating
-    // arbitrary drift over an idle window. Caught by BB pass-3.)
-    if (result.cursor_advanced && result.nextCursor) {
-      _saveCursor(result.nextCursor);
-    } else {
-      const idleCursor: EventCursor = {
-        ...cursor,
-        event_time: now,
-        updated_at: now,
-      };
-      _saveCursor(idleCursor);
-    }
     return {
       zone,
       events_fetched: result.events_fetched,

--- a/packages/persona-engine/src/ambient/scheduler-task.ts
+++ b/packages/persona-engine/src/ambient/scheduler-task.ts
@@ -211,6 +211,8 @@ export async function runStirTick(
   });
 
   try {
+    // BB pass-5 F8: cast type now matches the Effect return exactly
+    // (no dangling nextCursor since cursor save is internalized).
     const result = (await ambientRuntime.runPromise(program)) as {
       events_fetched: number;
       cursor_advanced: boolean;


### PR DESCRIPTION
Closes the 5 highest-leverage HIGH-severity findings from Bridgebuilder pass-4 self-review on PR #56 (which had visibility into framework files via the \`bridgebuilder:self-review\` label).

## Why this exists

BB pass-4 surfaced **22 findings · mean confidence 0.80 (highest yet)** — most about already-merged cycle-003 code. Pass-4 confidence was higher than passes 1–3 because the smaller diff in PR #56 gave the reviewer model more attention budget per finding.

This PR addresses the 5 highest-leverage items and explicitly tracks the remaining items as known tech debt in PRD §9.2.

## What changes

| BB ID | Severity | Issue | Fix |
|---|---|---|---|
| **F1** | HIGH | Cursor write not transactional with sink/ledger writes (NFR-14 violated) | Moved \`_saveCursor\` INSIDE \`Effect.gen\` in \`scheduler-task.ts\` — sink.write runs first; cursor commits only on success |
| **F2** | HIGH | Pass-3 idle-cursor fix was still wrong; advancing to \`now\` skipped late-arriving chain events | On idle ticks, only update \`updated_at\`; leave \`event_time\` at last real value so overlap window still catches late ingestion |
| **F7** | MEDIUM | Spec promised lex-min character_id tie-break; code implemented wall-clock-first | \`appendIfNoFire\` (live + mock) now lex-min-resolves exact-millisecond ties |
| **F10** | HIGH | \`validateEndpointConfig\` threw at module load in prod → killed entire bot when only stir tier should disable | Internal \`_ambientStirDisabled\` flag + \`isAmbientStirDisabled()\` export; scheduler skips runStirTick if flag set; digest cron + read-side unaffected |
| **F22** | MEDIUM | Pop-in-ledger O(n) disk scan per fire decision (months of archives parsed every call) | In-memory \`_entryCache\` keyed by file path; mtime-check on active file; invalidate on append |

Plus **PRD §9.2** new section: Known Technical Debt tracking per BB F25 REFRAME — singleton-as-SPOF, wallet-resolver invocation gap (S4.T1), NFR-16 stir replay. Each entry: current state · the debt · mitigation today · migration path · trigger for action.

## Verification

- \`bun tsc --noEmit\` returns ZERO errors in \`src/ambient/\`
- \`bun test packages/persona-engine\` returns **371/371 pass** · 954 expects · 216ms (no regressions from cycle-003 baseline)
- BB pass-4 fix regression smoke: 4/4 pass
  - pulseTick baseline still works
  - F7 lex-min wins on exact-millisecond tie (satoshi yields to ruggy)
  - F7 lex-min wins even if lex-greater fired first wall-clock
  - F10 \`isAmbientStirDisabled()\` callable + correctly defaults false in dev

## What's NOT in this PR (correctly deferred)

| BB ID | Severity | Why deferred |
|---|---|---|
| F3 | MED | No flock around appendFileSync — depends on \`proper-lockfile\` install (S2.T5) |
| F4 | MED | Cursor + circuit-breaker JSONL rotation — follow-up cycle (similar to ledger monthly rotation pattern) |
| F5 | MED | Seen-ring in-memory only — restart-safety; persist follow-up |
| F8 | MED | NFR-16 stir replay on restart — tracked as TD-3 in PRD §9.2 |
| F9 | MED | \`furnish_kansei\` dynamic-imports live pulse-sink — architecture conversation (port-based stir read) |
| F11 | MED | Empty MCP_ENDPOINT_ALLOWLIST permissive — security follow-up |
| F12 | HIGH | Wallet-resolver not invoked — S4.T1 dependency, tracked as TD-2 in PRD §9.2 |
| F13 | MED | Router decision-tree order divergent from spec — spec/code reconciliation task |
| F16 | MED | Timestamp = Schema.String accepts NaN — validation tightening |
| F19 | MED | EventClass boot-validation against \`list_event_classes\` — needs the FR-1.4 score-mcp tool to ship first |
| F20 | LOW | MCP_KEY fallback — security tightening |
| F25 | REFRAME | Singleton-as-SPOF — tracked as TD-1 in PRD §9.2 |
| F14/F15/F17/F18/F21/F26 | LOW/SPEC | Clock-skew · saturation · validation · path centralization · circuit-breaker rotation · stir-weight calibration |

## Test plan

- [ ] CI typecheck green
- [ ] \`bun test packages/persona-engine\` 371/371 pass on merge
- [ ] Post-merge: verify boot in prod with intentionally-misconfigured \`CODEX_MCP_URL\` → stir tier disabled, digest cron unaffected (F10 fail-loud-not-fatal behavior)
- [ ] Post-merge: with score-mibera Phase 1 in dev → verify idle ticks accumulate updated_at without skipping events that arrive late in bronze (F1 + F2)

🤖 Generated via Bridgebuilder pass-4 triage loop · 2026-05-11