### PR TITLE
feat(publish-commands): per-character publishGuilds for guild-isolated registration

### DIFF
--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -48,23 +48,35 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const commands = buildCommandSet(characters);
-  const scope = guildId ? `guild ${guildId}` : 'GLOBAL (1-hour propagation)';
-  console.log(`publish-commands: registering ${commands.length} commands → ${scope}`);
-  for (const cmd of commands) {
-    console.log(`  · /${cmd.name} — ${cmd.description}`);
+  const hasPublishGuilds = characters.some(
+    (c) => c.publishGuilds && c.publishGuilds.length > 0,
+  );
+  const fallbackScope = guildId ? `guild ${guildId}` : 'GLOBAL (1-hour propagation)';
+  if (hasPublishGuilds) {
+    console.log(
+      `publish-commands: ${characters.length} characters · routing per-character publishGuilds (fallback: ${fallbackScope})`,
+    );
+  } else {
+    const commands = buildCommandSet(characters);
+    console.log(`publish-commands: registering ${commands.length} commands → ${fallbackScope}`);
+    for (const cmd of commands) {
+      console.log(`  · /${cmd.name} — ${cmd.description}`);
+    }
   }
 
   try {
-    const result = await publishCommands({
+    const results = await publishCommands({
       botToken,
       applicationId,
       guildId,
       characters,
     });
-    console.log(`publish-commands: registered ${result.registered} commands successfully`);
-    for (const r of result.commands) {
-      console.log(`  ✓ /${r.name} → id ${r.id}`);
+    for (const result of results) {
+      const scope = result.guildId ? `guild ${result.guildId}` : 'GLOBAL';
+      console.log(`publish-commands: registered ${result.registered} commands → ${scope}`);
+      for (const r of result.commands) {
+        console.log(`  ✓ /${r.name} → id ${r.id}`);
+      }
     }
   } catch (err) {
     console.error('publish-commands: FAILED');

--- a/apps/bot/src/character-loader.ts
+++ b/apps/bot/src/character-loader.ts
@@ -84,6 +84,26 @@ export function loadCharacter(id: string): CharacterConfig {
       `character-loader: id mismatch — config says "${json.id}" but folder is "character-${id}"`,
     );
   }
+
+  // BB-59 F6: validate publishGuilds entries are Discord snowflake-shaped
+  // (17-20 digit strings). Catches operator typos (numbers vs strings,
+  // whitespace, truncated IDs) at load time with a clear character.json
+  // reference, instead of as a Discord 400 at publish time.
+  if (json.publishGuilds !== undefined) {
+    if (!Array.isArray(json.publishGuilds)) {
+      throw new Error(
+        `character-loader: ${configPath} · publishGuilds must be an array of strings, got ${typeof json.publishGuilds}`,
+      );
+    }
+    for (let i = 0; i < json.publishGuilds.length; i++) {
+      const v = json.publishGuilds[i];
+      if (typeof v !== 'string' || !/^\d{17,20}$/.test(v)) {
+        throw new Error(
+          `character-loader: ${configPath} · publishGuilds[${i}] is not a Discord snowflake (17-20 digit string): ${JSON.stringify(v)}`,
+        );
+      }
+    }
+  }
   return {
     id: json.id,
     displayName: json.displayName,

--- a/apps/bot/src/character-loader.ts
+++ b/apps/bot/src/character-loader.ts
@@ -49,10 +49,14 @@ interface CharacterJson {
   tool_invocation_style?: string;
   /** V0.7 (2026-05-12): per-character Discord guild IDs for slash command
    *  registration. When set, slash commands route only to listed guilds;
-   *  when omitted, falls back to publishCommands `guildId` arg (env
-   *  DISCORD_GUILD_ID in auto-publish). Eliminates cross-guild bleed at
-   *  the registration boundary. */
-  publishGuilds?: string[];
+   *  when omitted (or empty array), falls back to publishCommands `guildId`
+   *  arg (env DISCORD_GUILD_ID in auto-publish). Eliminates cross-guild
+   *  bleed at the registration boundary.
+   *
+   *  ReadonlyArray<string> matches CharacterConfig.publishGuilds — JSON
+   *  spreads accept readonly so this is type-compatible with declared
+   *  arrays in character.json. */
+  publishGuilds?: ReadonlyArray<string>;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/apps/bot/src/character-loader.ts
+++ b/apps/bot/src/character-loader.ts
@@ -47,6 +47,12 @@ interface CharacterJson {
    *  blueprints, no fences. Substituted into the environment-context
    *  block at compose time. Optional; omit for no guidance line. */
   tool_invocation_style?: string;
+  /** V0.7 (2026-05-12): per-character Discord guild IDs for slash command
+   *  registration. When set, slash commands route only to listed guilds;
+   *  when omitted, falls back to publishCommands `guildId` arg (env
+   *  DISCORD_GUILD_ID in auto-publish). Eliminates cross-guild bleed at
+   *  the registration boundary. */
+  publishGuilds?: string[];
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -86,6 +92,7 @@ export function loadCharacter(id: string): CharacterConfig {
     slash_commands: json.slash_commands,
     mcps: json.mcps,
     tool_invocation_style: json.tool_invocation_style,
+    publishGuilds: json.publishGuilds,
   };
 }
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -282,17 +282,19 @@ async function main(): Promise<void> {
       if (!botToken) {
         console.warn('auto-publish:   DISCORD_BOT_TOKEN not set · skipping command sync');
       } else {
-        const result = await publishCommands({
+        const results = await publishCommands({
           botToken,
           applicationId,
           guildId,
           characters,
         });
-        console.log(
-          `auto-publish:   synced ${result.registered} commands · ` +
-            `${result.scope}=${result.guildId ?? '(global)'} · ` +
-            `[${result.commands.map((c) => `/${c.name}`).join(' ')}]`,
-        );
+        for (const result of results) {
+          console.log(
+            `auto-publish:   synced ${result.registered} commands · ` +
+              `${result.scope}=${result.guildId ?? '(global)'} · ` +
+              `[${result.commands.map((c) => `/${c.name}`).join(' ')}]`,
+          );
+        }
       }
     } catch (err) {
       // Don't block bot startup on registration failure. Log and continue —

--- a/apps/bot/src/lib/publish-commands.ts
+++ b/apps/bot/src/lib/publish-commands.ts
@@ -64,11 +64,22 @@ export interface PublishCommandsResult {
  * Register slash commands with Discord. Idempotent — Discord PUT replaces
  * the full set per (application, guild) so duplicate calls don't leak.
  *
- * @throws Error on missing/invalid auth, network failure, or non-2xx response.
+ * Per-character guild routing (V0.7 · 2026-05-12): if any character has
+ * `publishGuilds` set, characters are grouped by their target guilds and
+ * each guild receives only its allowed characters. Characters without
+ * `publishGuilds` fall back to `opts.guildId` (which may be undefined for
+ * global publish — backward-compat with V0.6 single-guild model).
+ *
+ * Returns one PublishCommandsResult per guild published. For backward-
+ * compat callers that expected a single result, use `results[0]`.
+ *
+ * @throws Error on missing/invalid auth, network failure, or non-2xx response
+ *         FOR ANY guild publish. Earlier guilds may have succeeded before
+ *         the throwing call; check returned results array for what landed.
  */
 export async function publishCommands(
   opts: PublishCommandsOptions,
-): Promise<PublishCommandsResult> {
+): Promise<PublishCommandsResult[]> {
   if (!opts.botToken) {
     throw new Error('publishCommands: botToken is required');
   }
@@ -85,35 +96,59 @@ export async function publishCommands(
     throw new Error('publishCommands: no characters provided');
   }
 
-  const commands = buildCommandSet(opts.characters);
-
-  const url = opts.guildId
-    ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${opts.guildId}/commands`
-    : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
-
-  const response = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bot ${opts.botToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(commands),
-  });
-
-  if (!response.ok) {
-    const txt = await response.text().catch(() => '<unreadable>');
-    throw new Error(
-      `publishCommands: Discord PUT failed status=${response.status} body=${txt}`,
-    );
+  // Group characters by target guild. Characters with publishGuilds set
+  // route per-guild; characters without it fall back to opts.guildId
+  // (which may be undefined = global publish).
+  const byGuild = new Map<string | undefined, CharacterConfig[]>();
+  for (const char of opts.characters) {
+    const targets =
+      char.publishGuilds && char.publishGuilds.length > 0
+        ? Array.from(char.publishGuilds)
+        : [opts.guildId];
+    for (const guild of targets) {
+      const existing = byGuild.get(guild);
+      if (existing) {
+        existing.push(char);
+      } else {
+        byGuild.set(guild, [char]);
+      }
+    }
   }
 
-  const result = (await response.json()) as Array<{ id: string; name: string }>;
-  return {
-    registered: result.length,
-    commands: result.map((r) => ({ name: r.name, id: r.id })),
-    scope: opts.guildId ? 'guild' : 'global',
-    guildId: opts.guildId,
-  };
+  const results: PublishCommandsResult[] = [];
+  for (const [guildId, characters] of byGuild) {
+    const commands = buildCommandSet(characters);
+
+    const url = guildId
+      ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
+      : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bot ${opts.botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(commands),
+    });
+
+    if (!response.ok) {
+      const txt = await response.text().catch(() => '<unreadable>');
+      throw new Error(
+        `publishCommands: Discord PUT failed for guild=${guildId ?? '(global)'} status=${response.status} body=${txt}`,
+      );
+    }
+
+    const result = (await response.json()) as Array<{ id: string; name: string }>;
+    results.push({
+      registered: result.length,
+      commands: result.map((r) => ({ name: r.name, id: r.id })),
+      scope: guildId ? 'guild' : 'global',
+      guildId,
+    });
+  }
+
+  return results;
 }
 
 /**

--- a/apps/bot/src/lib/publish-commands.ts
+++ b/apps/bot/src/lib/publish-commands.ts
@@ -70,12 +70,24 @@ export interface PublishCommandsResult {
  * `publishGuilds` fall back to `opts.guildId` (which may be undefined for
  * global publish — backward-compat with V0.6 single-guild model).
  *
- * Returns one PublishCommandsResult per guild published. For backward-
- * compat callers that expected a single result, use `results[0]`.
+ * **Breaking change from V0.6**: return type is now PublishCommandsResult[]
+ * (one entry per guild published) instead of a single PublishCommandsResult.
+ * Callers MUST update to iterate the array. There is no single-result
+ * compat shim — the multi-guild routing model requires the per-guild
+ * outcome shape. Both in-tree callers (auto-publish in `apps/bot/src/index.ts`
+ * and the CLI script in `apps/bot/scripts/publish-commands.ts`) were
+ * updated in the same commit.
  *
- * @throws Error on missing/invalid auth, network failure, or non-2xx response
- *         FOR ANY guild publish. Earlier guilds may have succeeded before
- *         the throwing call; check returned results array for what landed.
+ * Partial-failure semantics (BB-59 closure): each guild publish is wrapped
+ * in try/catch. Failures are collected and logged per-guild as they happen,
+ * then the function throws AT END with an aggregate message listing
+ * succeeded/failed guilds + the first failure's message. The thrown error
+ * carries observability of partial-success state vs. the prior throw-mid-loop
+ * which abandoned remaining guilds silently.
+ *
+ * @throws Error if any guild publish failed. Succeeded guilds' results are
+ *         logged to console.error before the throw; check logs for which
+ *         guilds landed. Throw aggregate message names succeeded/failed sets.
  */
 export async function publishCommands(
   opts: PublishCommandsOptions,

--- a/apps/bot/src/lib/publish-commands.ts
+++ b/apps/bot/src/lib/publish-commands.ts
@@ -96,14 +96,40 @@ export async function publishCommands(
     throw new Error('publishCommands: no characters provided');
   }
 
+  // Mixed-config footgun guard (BB-59 global-fallback-when-mixed): if
+  // some chars have publishGuilds + some don't + opts.guildId is
+  // undefined, the chars without publishGuilds would silently publish
+  // globally. Warn loudly so operator catches an unset DISCORD_GUILD_ID
+  // before 1-hour global propagation makes it visible everywhere.
+  const charsWithGuilds = opts.characters.filter(
+    (c) => c.publishGuilds && c.publishGuilds.length > 0,
+  );
+  const charsWithoutGuilds = opts.characters.filter(
+    (c) => !c.publishGuilds || c.publishGuilds.length === 0,
+  );
+  if (
+    charsWithGuilds.length > 0 &&
+    charsWithoutGuilds.length > 0 &&
+    opts.guildId === undefined
+  ) {
+    console.warn(
+      `publishCommands: MIXED CONFIG — ${charsWithGuilds.length} chars have publishGuilds, ${charsWithoutGuilds.length} lack it, opts.guildId is undefined. ` +
+        `Chars without publishGuilds will publish GLOBALLY (1-hour propagation, visible in EVERY guild the bot is in). ` +
+        `This is likely unintended. Set publishGuilds on: [${charsWithoutGuilds.map((c) => c.id).join(', ')}] OR provide opts.guildId as fallback.`,
+    );
+  }
+
   // Group characters by target guild. Characters with publishGuilds set
-  // route per-guild; characters without it fall back to opts.guildId
-  // (which may be undefined = global publish).
+  // route per-guild; characters without it (or with empty array) fall
+  // back to opts.guildId (which may be undefined = global publish).
+  // BB-59 duplicate-guild-ids-dedup: dedupe via Set in case operator
+  // typo'd publishGuilds: ['G1', 'G1'] — would otherwise duplicate the
+  // character in G1's command set.
   const byGuild = new Map<string | undefined, CharacterConfig[]>();
   for (const char of opts.characters) {
     const targets =
       char.publishGuilds && char.publishGuilds.length > 0
-        ? Array.from(char.publishGuilds)
+        ? Array.from(new Set(char.publishGuilds))
         : [opts.guildId];
     for (const guild of targets) {
       const existing = byGuild.get(guild);
@@ -115,37 +141,65 @@ export async function publishCommands(
     }
   }
 
+  // BB-59 partial-failure-atomicity: iterate guilds, collect per-guild
+  // outcomes, log each. If any failed, throw AFTER the loop with an
+  // aggregate message — preserves observability of which guilds landed
+  // vs. which didn't (vs. the prior throw-mid-loop which abandoned
+  // remaining guilds silently).
   const results: PublishCommandsResult[] = [];
+  const failures: Array<{ guildId: string | undefined; error: Error }> = [];
+
   for (const [guildId, characters] of byGuild) {
-    const commands = buildCommandSet(characters);
+    try {
+      const commands = buildCommandSet(characters);
+      const url = guildId
+        ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
+        : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
 
-    const url = guildId
-      ? `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
-      : `${DISCORD_API_BASE}/applications/${applicationId}/commands`;
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bot ${opts.botToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(commands),
+      });
 
-    const response = await fetch(url, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bot ${opts.botToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(commands),
-    });
+      if (!response.ok) {
+        const txt = await response.text().catch(() => '<unreadable>');
+        throw new Error(
+          `Discord PUT failed for guild=${guildId ?? '(global)'} status=${response.status} body=${txt}`,
+        );
+      }
 
-    if (!response.ok) {
-      const txt = await response.text().catch(() => '<unreadable>');
-      throw new Error(
-        `publishCommands: Discord PUT failed for guild=${guildId ?? '(global)'} status=${response.status} body=${txt}`,
+      const result = (await response.json()) as Array<{ id: string; name: string }>;
+      results.push({
+        registered: result.length,
+        commands: result.map((r) => ({ name: r.name, id: r.id })),
+        scope: guildId ? 'guild' : 'global',
+        guildId,
+      });
+    } catch (err) {
+      const wrapped = err instanceof Error ? err : new Error(String(err));
+      failures.push({ guildId, error: wrapped });
+      console.error(
+        `publishCommands: guild=${guildId ?? '(global)'} FAILED: ${wrapped.message}`,
       );
     }
+  }
 
-    const result = (await response.json()) as Array<{ id: string; name: string }>;
-    results.push({
-      registered: result.length,
-      commands: result.map((r) => ({ name: r.name, id: r.id })),
-      scope: guildId ? 'guild' : 'global',
-      guildId,
-    });
+  if (failures.length > 0) {
+    const succeeded = results
+      .map((r) => r.guildId ?? '(global)')
+      .join(', ') || 'none';
+    const failed = failures
+      .map((f) => f.guildId ?? '(global)')
+      .join(', ');
+    throw new Error(
+      `publishCommands: ${failures.length}/${byGuild.size} guild publishes failed; ${results.length} succeeded. ` +
+        `succeeded=[${succeeded}] failed=[${failed}]. ` +
+        `First failure: guild=${failures[0].guildId ?? '(global)'} ${failures[0].error.message}`,
+    );
   }
 
   return results;

--- a/apps/character-akane/character.json
+++ b/apps/character-akane/character.json
@@ -13,6 +13,7 @@
   "webhookAvatarUrl": "",
   "webhookUsername": "akane",
   "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-akane/ + use raw.githubusercontent.com path; (b) point at world-purupuru CDN (caretaker-akane-pfp-fire-pastel.png). empty for now → discord default avatar.",
+  "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-kaori/character.json
+++ b/apps/character-kaori/character.json
@@ -13,6 +13,7 @@
   "webhookAvatarUrl": "",
   "webhookUsername": "kaori",
   "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send — a broken/placeholder URL gets cached and requires webhook recreation to update. options: (a) place avatar.png in apps/character-kaori/ and set webhookAvatarUrl to https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/main/apps/character-kaori/avatar.png matching ruggy's convention; (b) point at world-purupuru CDN once canonical URL is confirmed (caretaker-kaori-pfp-wood-pastel.png is in the asset registry). leaving empty for now → discord uses the bot's default avatar, which is fine for v1 voice iteration but should be resolved before broader announcement.",
+  "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-mongolian/character.json
+++ b/apps/character-mongolian/character.json
@@ -13,6 +13,7 @@
   "tool_invocation_style": "Use codex when a player asks about Mongolian lore, ancestors, or grail history — ground the answer in canon rather than improvising. Use freeside_auth to resolve wallet identity when a player's on-chain presence is relevant to quest progress. Default to voice; tools support, never lead.",
   "webhookAvatarUrl": "https://assets.0xhoneyjar.xyz/Mibera/grails/mongolian.webp",
   "webhookUsername": "Mongolian",
+  "publishGuilds": ["1135545260538339420"],
   "doc": {
     "creativeDirection": "creative-direction.md",
     "codexAnchors": "codex-anchors.md"

--- a/apps/character-nemu/character.json
+++ b/apps/character-nemu/character.json
@@ -13,6 +13,7 @@
   "webhookAvatarUrl": "",
   "webhookUsername": "nemu",
   "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-nemu/ + use raw.githubusercontent.com path matching ruggy's convention; (b) point at world-purupuru CDN once canonical URL is confirmed (caretaker-nemu-pfp-earth-pastel.png in asset registry). empty for now → discord default avatar.",
+  "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-ren/character.json
+++ b/apps/character-ren/character.json
@@ -13,6 +13,7 @@
   "webhookAvatarUrl": "",
   "webhookUsername": "ren",
   "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-ren/ + use raw.githubusercontent.com path; (b) point at world-purupuru CDN (caretaker-ren-pfp-metal-pastel.png). empty for now → discord default avatar.",
+  "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-ruan/character.json
+++ b/apps/character-ruan/character.json
@@ -13,6 +13,7 @@
   "webhookAvatarUrl": "",
   "webhookUsername": "ruan",
   "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-ruan/ + use raw.githubusercontent.com path; (b) point at world-purupuru CDN (caretaker-ruan-pfp-water-pastel.png). empty for now → discord default avatar.",
+  "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-ruggy/character.json
+++ b/apps/character-ruggy/character.json
@@ -14,6 +14,7 @@
   "webhookAvatarUrl": "https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/staging/apps/character-ruggy/avatar.png",
   "webhookUsername": "ruggy",
   "webhookAvatarTarget": "https://assets.0xhoneyjar.xyz/freeside-characters/ruggy/avatar.png — canonical target per SDD §0.2 per-world URL contract; bridge URL above points at the staging branch's avatar.png (operator-uploaded 2026-04-30); swap to canonical when assets.0xhoneyjar.xyz CDN cycle reaches /freeside-characters/",
+  "publishGuilds": ["1135545260538339420"],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-satoshi/character.json
+++ b/apps/character-satoshi/character.json
@@ -14,6 +14,7 @@
   "emojiNote": "satoshi posts plain — emojis are ruggy's affordance. Rare hermetic gesture only (e.g. spiraling for chain-paradox moments). emojiAffinity scoped to mibera-only as a safety bound: if satoshi DOES reach for an emoji, it's mibera-coded never ruggy-coded.",
   "webhookAvatarUrl": "https://assets.0xhoneyjar.xyz/Mibera/grails/satoshi-as-hermes.webp",
   "webhookUsername": "Satoshi as Hermes",
+  "publishGuilds": ["1135545260538339420"],
   "slash_commands": [
     {
       "name": "satoshi",

--- a/docs/PURUPURU-DEPLOY.md
+++ b/docs/PURUPURU-DEPLOY.md
@@ -99,7 +99,7 @@ steps:
    - auto-publish reads each character's `publishGuilds`, groups by guild, PUTs each guild its own command set
    - THJ guild receives: `/ruggy /satoshi /satoshi-image /mongolian /quest` (5 commands)
    - purupuru guild receives: `/kaori /nemu /akane /ren /ruan` (5 commands)
-   - any caretakers that previously leaked into THJ via global/single-guild publish → automatically deregistered by the PUT replace on next sync
+   - **Discord PUT replace semantics** (be precise): PUT replaces the command set WITHIN a single (application, guild) scope. for caretakers previously registered guild-scoped to THJ (the current state in this repo's deploy as of 2026-05-12), the new PUT-to-THJ with `[ruggy, satoshi, mongolian, satoshi-image, quest]` replaces and removes them automatically. **HOWEVER** if any character was ever registered GLOBALLY (e.g., `DISCORD_GUILD_ID` env was unset at a prior publish time), the global registration persists until a separate global publish or per-command DELETE clears it — guild-scoped PUTs do NOT touch globals. if you see commands leftover after this rollout, check: `gh api applications/$APP_ID/commands` to see globals, then issue `PUT /applications/$APP_ID/commands` with an empty array OR per-command DELETE to clear.
 
 4. **(ad-hoc) one-off publish via CLI** if needed:
    ```bash

--- a/docs/PURUPURU-DEPLOY.md
+++ b/docs/PURUPURU-DEPLOY.md
@@ -51,54 +51,67 @@ per `world-purupuru/sites/world/src/lib/daemon/voice.ts` doctrine: **all voice i
 
 ## deploy paths (operator chooses)
 
-### path A · single bot, two guilds, GUILD-SCOPED publish (recommended for v1)
+### path A · single bot, two guilds, PER-CHARACTER GUILD ROUTING (recommended)
 
-ONE bot process. gateway-connects to the bot user (already invited to both THJ and purupuru). NEW caretaker commands are published **guild-scoped, not global** — purupuru guild gets only its own character set, eliminating cross-guild bleed AT THE REGISTRATION BOUNDARY for the new commands (not at non-deterministic LLM-runtime persona-compliance).
+ONE bot process. gateway-connects to the bot user (already invited to both THJ and purupuru). slash commands route to specific guilds based on each character.json's `publishGuilds` field — enforced at the REGISTRATION BOUNDARY, not at LLM-runtime persona compliance.
 
-**target end-state**:
-- THJ guild · gets `/ruggy` · `/satoshi`
-- purupuru guild · gets `/kaori` `/nemu` `/akane` `/ren` `/ruan`
+**configuration** (V0.7 · 2026-05-12):
+- `apps/character-{ruggy,satoshi,mongolian}/character.json` · `publishGuilds: ["1135545260538339420"]` (THJ)
+- `apps/character-{kaori,nemu,akane,ren,ruan}/character.json` · `publishGuilds: ["1495534680617910396"]` (purupuru)
 
-**honest about the transition**: if `/ruggy` and `/satoshi` were previously published GLOBALLY (the prior default), they will continue to appear in purupuru guild until migrated. publishing caretaker commands guild-scoped to purupuru does NOT remove prior global registrations. there are two sub-paths to handle this:
+**how publish flows**:
+1. bot starts with `CHARACTERS=ruggy,satoshi,mongolian,kaori,nemu,akane,ren,ruan` env (all 8 loaded so each can handle invocations)
+2. auto-publish reads each character's `publishGuilds`, groups by guild
+3. THJ receives PUT with ruggy/satoshi/mongolian commands (+ /satoshi-image · /quest since mongolian is present)
+4. purupuru receives PUT with kaori/nemu/akane/ren/ruan commands
+5. Discord PUT replaces the full set per (application, guild) → previously-leaked caretakers in THJ get **deregistered** automatically on the next sync
 
-- **A.1 fast** · accept that `/ruggy` + `/satoshi` remain visible in purupuru (their personas decline purupuru-context but the commands appear in the slash menu). caretaker iteration begins immediately. ruggy/satoshi migration deferred.
-- **A.2 clean** · ALSO migrate ruggy/satoshi to THJ-guild-scoped registration AND deregister the prior global commands. fully isolates command surfaces per guild. requires running two publishes + a deregister-globals pass (operator owns sequencing). cleaner long-term posture; slightly more work now.
+**end-state**:
+- THJ guild slash menu: `/ruggy` `/satoshi` `/satoshi-image` `/mongolian` `/quest`
+- purupuru guild slash menu: `/kaori` `/nemu` `/akane` `/ren` `/ruan`
+- no cross-guild bleed in either direction
+- changing a character's target guilds is a single character.json edit + bot restart
+
+**backward compat**: characters without `publishGuilds` fall back to the env `DISCORD_GUILD_ID` (V0.6 single-guild model). New characters can opt into per-character routing without breaking existing.
+
+**field reference**: `CharacterConfig.publishGuilds?: ReadonlyArray<string>` per `packages/persona-engine/src/types.ts`.
 
 steps:
+
+0. **confirm per-character `publishGuilds` is set** (this PR's feature). each `apps/character-<id>/character.json` should have a `publishGuilds` array matching its target guild(s). default-shipped state: THJ characters → `["1135545260538339420"]` · purupuru caretakers → `["1495534680617910396"]`. if you want to add/remove a character from a guild, edit its `publishGuilds` and restart the bot — auto-publish syncs on startup.
 
 1. **PRE-PUBLISH avatar checklist** (Discord caches webhook avatars at first send; broken or empty URLs at first-send cache the default → requires webhook recreation to swap later):
    - [ ] **v1 voice-iteration default** (currently shipped): all 5 caretaker `webhookAvatarUrl` fields are empty → Discord uses bot's default avatar. **this is intentional**: voice-only deploy explicitly prioritizes zero-friction iteration with gumi over polish at publish time (per operator framing "before any score mechanism · gumi iterates voice freely"). bridgebuilder F9 flagged this as a sticky-cache hazard; the operator-aligned response is **document the cost, ship, recreate webhooks when art lands**.
    - [ ] **if you want real avatars before first send**: confirm `apps/character-{kaori,nemu,akane,ren,ruan}/avatar.png` exists in each character dir (matching `apps/character-ruggy/avatar.png` convention), then set `webhookAvatarUrl` to `https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/main/apps/character-<name>/avatar.png`. OR point at world-purupuru CDN once canonical URL is confirmed (asset registry has `caretaker-<name>-pfp-<element>-pastel.png`).
    - [ ] **webhook recreation cost when swapping avatars later**: delete the channel webhook in Discord settings (or via `gh api` / discord.js), then re-invoke any caretaker so the bot recreates the webhook with the new avatar URL. operationally: ~30 seconds per channel-webhook swap. acceptable for v1 voice iteration.
 
-2. **env** (railway service for caretakers OR same service with merged CHARACTERS — see note below):
+2. **env** (railway service):
    ```
-   CHARACTERS=ruggy,satoshi,kaori,nemu,akane,ren,ruan
+   CHARACTERS=ruggy,satoshi,mongolian,kaori,nemu,akane,ren,ruan
    DISCORD_BOT_TOKEN=<existing token>
    ANTHROPIC_API_KEY=sk-...
    LLM_PROVIDER=anthropic
+   # DISCORD_GUILD_ID is now OPTIONAL · per-character publishGuilds takes precedence ·
+   # only used as fallback for characters that lack publishGuilds (backward compat)
    ```
 
-3. **publish caretaker commands GUILD-SCOPED to purupuru**:
+3. **restart railway service** OR `bun run start` locally
+   - auto-publish reads each character's `publishGuilds`, groups by guild, PUTs each guild its own command set
+   - THJ guild receives: `/ruggy /satoshi /satoshi-image /mongolian /quest` (5 commands)
+   - purupuru guild receives: `/kaori /nemu /akane /ren /ruan` (5 commands)
+   - any caretakers that previously leaked into THJ via global/single-guild publish → automatically deregistered by the PUT replace on next sync
+
+4. **(ad-hoc) one-off publish via CLI** if needed:
    ```bash
-   DISCORD_GUILD_ID=1495534680617910396 \
-   CHARACTERS=kaori,nemu,akane,ren,ruan \
-     bun run apps/bot/scripts/publish-commands.ts
+   bun run apps/bot/scripts/publish-commands.ts
    ```
-   → only `/kaori` `/nemu` `/akane` `/ren` `/ruan` register in purupuru guild · instant (no global propagation lag) · zero THJ visibility
+   reads `CHARACTERS` env, routes per-character via `publishGuilds`. for selective publish (e.g., one guild only):
+   ```bash
+   CHARACTERS=kaori,nemu,akane,ren,ruan bun run apps/bot/scripts/publish-commands.ts
+   # only caretakers loaded · their publishGuilds → only purupuru registered
+   ```
 
-4. **(no-op for THJ ruggy/satoshi)** — if `/ruggy` + `/satoshi` were previously published globally, they remain global · the guild-scoped publish in step 3 doesn't replace them
-   - if you want to MIGRATE ruggy/satoshi to THJ-guild-scoped too (cleanest separation):
-     ```bash
-     DISCORD_GUILD_ID=<THJ-guild-id> \
-     CHARACTERS=ruggy,satoshi \
-       bun run apps/bot/scripts/publish-commands.ts
-     ```
-     then run a deregister-globals pass — operator decides whether to do this now or defer
-
-5. **restart**: railway redeploy OR local `bun run start`
-
-6. **gumi invokes**: `/kaori prompt:"..."` (or any caretaker) in purupuru channels. iteration begins.
+5. **gumi invokes**: `/kaori prompt:"..."` (or any caretaker) in purupuru channels. iteration begins.
 
 ### path B · two bot processes (only if hard isolation needed)
 

--- a/packages/persona-engine/src/types.ts
+++ b/packages/persona-engine/src/types.ts
@@ -64,6 +64,11 @@ export interface CharacterConfig {
    * Discord guilds — eliminating cross-guild bleed at the registration
    * boundary (vs. relying on LLM persona-compliance at dispatch time).
    *
+   * **Empty-array semantics**: `publishGuilds: []` is equivalent to omitting
+   * the field — both fall back to the env-supplied `guildId`. There is no
+   * "publish to nowhere" state by design; to disable a character entirely,
+   * remove it from the `CHARACTERS` env instead.
+   *
    * When empty/missing, falls back to the publishCommands `guildId` arg
    * (sourced from `DISCORD_GUILD_ID` env in auto-publish) — backward
    * compatible with the V0.6 single-guild model.

--- a/packages/persona-engine/src/types.ts
+++ b/packages/persona-engine/src/types.ts
@@ -56,6 +56,31 @@ export interface CharacterConfig {
   displayName?: string;
   webhookAvatarUrl?: string;
   webhookUsername?: string;
+
+  /**
+   * V0.7 (2026-05-12) per-character guild routing for slash command registration.
+   *
+   * When set, slash commands for this character are PUT only to the listed
+   * Discord guilds — eliminating cross-guild bleed at the registration
+   * boundary (vs. relying on LLM persona-compliance at dispatch time).
+   *
+   * When empty/missing, falls back to the publishCommands `guildId` arg
+   * (sourced from `DISCORD_GUILD_ID` env in auto-publish) — backward
+   * compatible with the V0.6 single-guild model.
+   *
+   * Built-in/system commands (/satoshi-image, /quest) are routed alongside
+   * their parent character — /satoshi-image goes wherever satoshi goes,
+   * /quest goes wherever mongolian (quest-bound) goes. This is enforced
+   * by buildCommandSet's conditional add (only included if the parent
+   * character is in the guild's character subset).
+   *
+   * Examples:
+   *   ruggy/satoshi/mongolian → ["1135545260538339420"]  // THJ only
+   *   kaori/nemu/akane/ren/ruan → ["1495534680617910396"]  // purupuru only
+   *
+   * @see apps/bot/src/lib/publish-commands.ts
+   */
+  publishGuilds?: ReadonlyArray<string>;
   /**
    * V0.6-D voice/v4: anchored archetypes per character — the 1-2 cabal
    * archetypes that genuinely map to who the character IS (NOT rotating


### PR DESCRIPTION
## Summary

Adds \`CharacterConfig.publishGuilds?: ReadonlyArray<string>\` — when set, slash commands for that character route ONLY to listed Discord guilds at PUT time. Eliminates cross-guild bleed at the registration boundary instead of relying on non-deterministic LLM persona-compliance at dispatch time.

**The problem this solves**: prior single-\`DISCORD_GUILD_ID\` model forced either global publish (bleed both ways) OR guild-scoped to one guild (caretakers leak into THJ when CHARACTERS env includes both rosters). Per-character routing is the clean fix — each \`character.json\` declares its target guilds, \`publishCommands\` groups by guild and PUTs each guild its own subset.

**Backward compat preserved**: characters without \`publishGuilds\` fall back to the env-supplied \`guildId\` (V0.6 behavior).

## What lands

- \`packages/persona-engine/src/types.ts\` · \`CharacterConfig.publishGuilds?\`
- \`apps/bot/src/character-loader.ts\` · \`CharacterJson\` + mapper pass-through
- \`apps/bot/src/lib/publish-commands.ts\` · refactor publishCommands to group-by-guild + return \`PublishCommandsResult[]\`
- \`apps/bot/src/index.ts\` · auto-publish loops over results array
- \`apps/bot/scripts/publish-commands.ts\` · CLI handles array results
- \`apps/character-{ruggy,satoshi,mongolian}/character.json\` · \`publishGuilds: [\"1135545260538339420\"]\` (THJ)
- \`apps/character-{kaori,nemu,akane,ren,ruan}/character.json\` · \`publishGuilds: [\"1495534680617910396\"]\` (purupuru)
- \`docs/PURUPURU-DEPLOY.md\` · rewritten

## After this lands + bot restart

- THJ guild: \`/ruggy /satoshi /satoshi-image /mongolian /quest\`
- purupuru guild: \`/kaori /nemu /akane /ren /ruan\`
- prior caretaker registrations in THJ → **automatically deregistered** by the Discord PUT replace semantic on next auto-publish

## Test plan

- [ ] type-check passes for \`apps/bot\` (pre-existing errors in \`packages/persona-engine/src/expression/error-register.test.ts:144,149\` are unrelated — null vs string in test assertions)
- [ ] auto-publish on bot restart logs TWO \"synced N commands\" lines (one per guild)
- [ ] THJ slash menu shows mibera commands only (no caretakers)
- [ ] purupuru slash menu shows caretakers only (no mibera commands)
- [ ] backward-compat: removing \`publishGuilds\` from a character.json → falls back to env DISCORD_GUILD_ID
- [ ] gumi can \`/kaori prompt:\"...\"\` in purupuru and gets clean voice-only response

🤖 Generated with [Claude Code](https://claude.com/claude-code)