### PR TITLE
feat(caretakers): wire canonical world-purupuru S3 CDN avatars

### DIFF
--- a/apps/character-akane/character.json
+++ b/apps/character-akane/character.json
@@ -10,9 +10,9 @@
   "anchoredArchetypes": ["Trickster", "Risk-Taker"],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Akane is a KIZUNA caretaker (fire/N/naughty) in the purupuru world; she speaks Navigator-pattern with HIGH ENERGY · short punchy bursts · sometimes ALL CAPS · always player-side. if asked about score / chain: dismisses as boring · redirects to risk.",
-  "webhookAvatarUrl": "",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-akane-pfp-fire-pastel.png",
   "webhookUsername": "akane",
-  "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-akane/ + use raw.githubusercontent.com path; (b) point at world-purupuru CDN (caretaker-akane-pfp-fire-pastel.png). empty for now → discord default avatar.",
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-akane-pfp-fire-pastel.png — canonical world-purupuru S3 CDN. element + filename match (fire). pastel pfp tier.",
   "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"

--- a/apps/character-kaori/character.json
+++ b/apps/character-kaori/character.json
@@ -10,9 +10,9 @@
   "anchoredArchetypes": ["Gardener", "Companion"],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Kaori is a KIZUNA caretaker (wood/H/hopeful) in the purupuru world; she speaks Navigator-pattern (always on the player's side, never narrating opponents). if asked about score / chain / on-chain events: gently decline, stay in voice. if asked about lore: cite from world-purupuru canon (Tsuheji, Hōrai, KIZUNA, Wuxing).",
-  "webhookAvatarUrl": "",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-kaori-pfp-earth-pastel.png",
   "webhookUsername": "kaori",
-  "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send — a broken/placeholder URL gets cached and requires webhook recreation to update. options: (a) place avatar.png in apps/character-kaori/ and set webhookAvatarUrl to https://raw.githubusercontent.com/0xHoneyJar/freeside-characters/main/apps/character-kaori/avatar.png matching ruggy's convention; (b) point at world-purupuru CDN once canonical URL is confirmed (caretaker-kaori-pfp-wood-pastel.png is in the asset registry). leaving empty for now → discord uses the bot's default avatar, which is fine for v1 voice iteration but should be resolved before broader announcement.",
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-kaori-pfp-earth-pastel.png — canonical world-purupuru S3 CDN (us-west-2 · Purupuru/caretakers/). NB: filename says 'earth-pastel' even though kaori IS the wood-element caretaker — this matches the actual asset filename in world-purupuru/sites/world/src/lib/cdn.ts:165 (a known naming quirk; the URL is what matters). pastel pfp tier (128px circular). swap to a different tier (saturated · pose · fullbody) if gumi wants a different visual register.",
   "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"

--- a/apps/character-nemu/character.json
+++ b/apps/character-nemu/character.json
@@ -10,9 +10,9 @@
   "anchoredArchetypes": ["Wanderer", "Quiet-One"],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Nemu is a KIZUNA caretaker (earth/E/empty) in the purupuru world; she speaks Navigator-pattern (always on the player's side). her voice is sparse, breath-paced, reassuring through stillness. if asked about score / chain / on-chain events: decline quietly, stay in voice.",
-  "webhookAvatarUrl": "",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-nemu-pfp-wood-pastel.png",
   "webhookUsername": "nemu",
-  "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-nemu/ + use raw.githubusercontent.com path matching ruggy's convention; (b) point at world-purupuru CDN once canonical URL is confirmed (caretaker-nemu-pfp-earth-pastel.png in asset registry). empty for now → discord default avatar.",
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-nemu-pfp-wood-pastel.png — canonical world-purupuru S3 CDN. NB: filename says 'wood-pastel' even though nemu IS the earth-element caretaker — matches world-purupuru/sites/world/src/lib/cdn.ts:167 (naming quirk; URL is correct). pastel pfp tier.",
   "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"

--- a/apps/character-ren/character.json
+++ b/apps/character-ren/character.json
@@ -10,9 +10,9 @@
   "anchoredArchetypes": ["Scholar", "Loyalist"],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Ren is a KIZUNA caretaker (metal/L/loyal) in the purupuru world; she's a mad-scientist scholar obsessed with bears. Navigator-pattern · analytical · hypothesis-shaped voice · always player-side. if asked about score / chain: 'my data is bears. ask my friends for that.'",
-  "webhookAvatarUrl": "",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ren-pfp-metal-pastel.png",
   "webhookUsername": "ren",
-  "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-ren/ + use raw.githubusercontent.com path; (b) point at world-purupuru CDN (caretaker-ren-pfp-metal-pastel.png). empty for now → discord default avatar.",
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ren-pfp-metal-pastel.png — canonical world-purupuru S3 CDN. element + filename match (metal). pastel pfp tier.",
   "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"

--- a/apps/character-ruan/character.json
+++ b/apps/character-ruan/character.json
@@ -10,9 +10,9 @@
   "anchoredArchetypes": ["Artist", "Empath"],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Ruan is a KIZUNA caretaker (water/O/overstimulated) in the purupuru world; she's a music producer flooded with feeling. Navigator-pattern · introspective · emotional · sensitive · always player-side. if asked about score / chain: 'numbers feel cold. i write feelings.'",
-  "webhookAvatarUrl": "",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ruan-pfp-water-pastel.png",
   "webhookUsername": "ruan",
-  "webhookAvatarTarget": "MUST RESOLVE before publish-commands. Discord caches webhook avatars at first send. options: (a) place avatar.png in apps/character-ruan/ + use raw.githubusercontent.com path; (b) point at world-purupuru CDN (caretaker-ruan-pfp-water-pastel.png). empty for now → discord default avatar.",
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ruan-pfp-water-pastel.png — canonical world-purupuru S3 CDN. element + filename match (water). pastel pfp tier.",
   "publishGuilds": ["1495534680617910396"],
   "doc": {
     "creativeDirection": "creative-direction.md"


### PR DESCRIPTION
## Summary

Resolves placeholder \`webhookAvatarUrl\` (previously empty → discord default avatar) for all 5 KIZUNA caretakers. Each now points at the canonical pastel-pfp tier on world-purupuru S3 (\`us-west-2 · Purupuru/caretakers/\`).

## URLs (HTTP 200 verified)

- kaori → \`caretaker-kaori-pfp-earth-pastel.png\`
- nemu → \`caretaker-nemu-pfp-wood-pastel.png\`
- akane → \`caretaker-akane-pfp-fire-pastel.png\`
- ren → \`caretaker-ren-pfp-metal-pastel.png\`
- ruan → \`caretaker-ruan-pfp-water-pastel.png\`

Source: \`world-purupuru/sites/world/src/lib/cdn.ts:165-169\`. \`CDN_BASE\` = \`https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru\`.

NB: kaori + nemu pfp filenames are mislabeled in the source ('earth-pastel' for kaori the wood-caretaker; 'wood-pastel' for nemu the earth-caretaker). URL is what fetches — known cdn.ts quirk.

Pattern B per-message \`avatarURL\` override → applies on NEXT send (no webhook recreation needed for fresh sends).

## Test plan

- [ ] verify URLs return 200 (already checked locally)
- [ ] after merge + deploy: invoke \`/kaori prompt:\"henlo\"\` → response posts with the canonical avatar (not default discord)
- [ ] same for nemu/akane/ren/ruan

🤖 Generated with [Claude Code](https://claude.com/claude-code)