### PR TITLE
feat(ruggy): analytics-as-storytelling + emoji/handle resolution fixes

### DIFF
--- a/apps/bot/scripts/smoke-data-shape-reply.ts
+++ b/apps/bot/scripts/smoke-data-shape-reply.ts
@@ -1,0 +1,164 @@
+/**
+ * Smoke: validates that ruggy's chat-mode reply applies the new
+ * "DATA-SHAPED QUESTIONS" visual shape (blockquote scanline + emoji-handle
+ * bullets) when the user asks an analytics question.
+ *
+ * 2026-05-12 · operator goal: analytics-as-storytelling, not number-soup.
+ * Mirrors the screenshot scenario: `/ruggy anything happening onchain boss?`
+ * with the same data the production reply had (Paddle Borrower 4x baseline,
+ * 0xdc1c..6e5a +7766 climb, 0xc673..2501 -10k unwind, cluster +4668).
+ *
+ * The SDK-runtime MCP loop is bypassed — we inline synthetic raw_stats
+ * into the user-half message. The point is to confirm the SHAPE the
+ * persona prompt produces, not the data-fetching pipeline (which is
+ * unchanged).
+ *
+ * Run: bun run apps/bot/scripts/smoke-data-shape-reply.ts
+ * Requires: ANTHROPIC_API_KEY (already in env per .env.local)
+ */
+
+import { buildReplyPromptPair } from '../../../packages/persona-engine/src/persona/loader.ts';
+
+const character = {
+  id: 'ruggy' as const,
+  displayName: 'ruggy',
+  personaPath: './apps/character-ruggy/persona.md',
+  mcps: ['score', 'codex', 'emojis', 'rosenzu', 'freeside_auth'] as string[],
+};
+
+const userPrompt = 'anything happening onchain boss?';
+
+const syntheticRawStats = `
+[SYNTHETIC raw_stats for owsley-lab · standing in for what mcp__score__get_zone_digest
+ would return — voice prompt unchanged · this is just the data context the LLM
+ normally pulls via the tool. Window: last 7 days · 2026-05-05 → 2026-05-12]
+
+zone: owsley-lab
+dimension: Onchain
+total_events: 247
+unique_actors: 38
+baseline_4w_avg: 62 events
+
+factor_trends:
+  - factor: paddle_borrower
+    factor_proper: Paddle Borrower
+    events_this_window: 29
+    baseline_avg: 7
+    multiplier: 4.14
+    unique_actors: 11
+
+top_movers (rank_climbs):
+  - wallet: 0xdc1c0a8b88a9c91f5d7a4e92c5e8b1d34c896e5a
+    short: 0xdc1c...6e5a
+    handle: null  (no midi_profiles link)
+    rank_from: 11294
+    rank_to: 3528
+    delta: +7766
+    factors_active: [paddle_borrower]
+  - cluster: 10+ wallets each picked up exactly +4668 onchain rank
+    note: lockstep movement · same delta · suggests batched move
+    factor: paddle_borrower
+
+top_movers (rank_drops):
+  - wallet: 0xc673a44b8d1e9f2a3b6c4d5e7f8a9b0c1d2e2501
+    short: 0xc673...2501
+    handle: null
+    rank_delta: -10247
+    note: shed 10k positions
+`;
+
+async function main() {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error('ANTHROPIC_API_KEY not set — smoke cannot run');
+    process.exit(1);
+  }
+
+  const { systemPrompt, userMessage } = buildReplyPromptPair({
+    character,
+    prompt: userPrompt,
+    authorUsername: 'soju',
+    history: [],
+  });
+
+  const enrichedUserMessage = `${userMessage}\n\n${syntheticRawStats}`;
+
+  console.log('━'.repeat(70));
+  console.log('smoke: data-shaped reply · ruggy · "anything happening onchain boss?"');
+  console.log('━'.repeat(70));
+  console.log('system prompt length:', systemPrompt.length, 'chars');
+  console.log('user message length:', enrichedUserMessage.length, 'chars');
+  console.log('persona reply fragment includes DATA-SHAPED rule:',
+    systemPrompt.includes('DATA-SHAPED QUESTIONS') ? '✓' : '✗');
+  console.log('persona reply fragment includes blockquote example:',
+    systemPrompt.includes('Paddle Borrower · 4× baseline (29 vs ~7)') ? '✓' : '✗');
+  console.log('');
+  console.log('calling claude-sonnet-4-6 (cheaper than opus for shape validation)…');
+  console.log('');
+
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-5',
+      max_tokens: 2048,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: enrichedUserMessage }],
+    }),
+  });
+  if (!r.ok) {
+    console.error('API error:', r.status, await r.text());
+    process.exit(1);
+  }
+  const response: { content: Array<{ type: string; text?: string }> } = await r.json();
+  const text = response.content
+    .filter((b) => b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text!)
+    .join('\n');
+
+  console.log('━'.repeat(70));
+  console.log("ruggy's reply:");
+  console.log('━'.repeat(70));
+  console.log(text);
+  console.log('━'.repeat(70));
+  console.log('');
+
+  const bannedHype = ['🚀', '💯', '🎉', '🔥', '💎', '🤑', '🙌', '💪', '⚡️', '✨', '🌟'];
+  const codeBlocks = (text.match(/```[\s\S]*?```/g) ?? [])
+    .flatMap((b) => b.split('\n').slice(1, -1));
+  const checks = {
+    'has blockquote (> ...)': /^>\s/m.test(text),
+    'has emoji-handle bullet (🪩 | 🌊 | 👀 | 🚨 | 🟢)': /^(🪩|🌊|👀|🚨|🟢)\s/m.test(text),
+    'addresses in backticks': /`0x[a-f0-9.]+`/.test(text),
+    'mentions paddle borrower': /paddle borrower/i.test(text),
+    'multi-block structure (>=3 paragraphs)': text.split('\n\n').length >= 3,
+    'code blocks ≤40 chars/line (mobile wrap)': codeBlocks.every((l) => l.length <= 40),
+    'voice: no analyst register ("Notable" "Activity")':
+      !/\b(We're pleased|Notable:|Activity volume|exceptional growth)\b/.test(text),
+    'no banned hype emoji (🚀💯🎉🔥💎...)': bannedHype.every((e) => !text.includes(e)),
+    'no punitive coding (🔴 / slid / fell / tumbled)':
+      !text.includes('🔴') && !/\b(slid|fell|tumbled)\b/i.test(text),
+  };
+
+  console.log('shape validation:');
+  for (const [label, pass] of Object.entries(checks)) {
+    console.log(`  ${pass ? '✓' : '✗'} ${label}`);
+  }
+
+  const failures = Object.values(checks).filter((p) => !p).length;
+  console.log('');
+  console.log(failures === 0
+    ? '✅ shape lands: blockquote scanline + emoji handles + story-thread'
+    : `⚠️  ${failures} check(s) failed — iterate on persona prompt`);
+
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('smoke error:', err);
+  process.exit(2);
+});

--- a/apps/bot/scripts/smoke-data-shape-reply.ts
+++ b/apps/bot/scripts/smoke-data-shape-reply.ts
@@ -93,7 +93,7 @@ async function main() {
   console.log('persona reply fragment includes blockquote example:',
     systemPrompt.includes('Paddle Borrower · 4× baseline (29 vs ~7)') ? '✓' : '✗');
   console.log('');
-  console.log('calling claude-sonnet-4-6 (cheaper than opus for shape validation)…');
+  console.log('calling claude-sonnet-4-5 (cheaper than opus for shape validation)…');
   console.log('');
 
   const r = await fetch('https://api.anthropic.com/v1/messages', {

--- a/apps/bot/scripts/smoke-data-shape-reply.ts
+++ b/apps/bot/scripts/smoke-data-shape-reply.ts
@@ -13,7 +13,16 @@
  * persona prompt produces, not the data-fetching pipeline (which is
  * unchanged).
  *
- * Run: bun run apps/bot/scripts/smoke-data-shape-reply.ts
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * NOT FOR CI · MANUAL OPERATOR SMOKE ONLY
+ *
+ * - Makes real Anthropic API calls (costs tokens · ~3-5k per run)
+ * - Uses `temperature: 0` for determinism · but LLM output can still
+ *   shift subtly across runs / model versions
+ * - Run via `bun run apps/bot/scripts/smoke-data-shape-reply.ts`
+ * - Do NOT wire into automated test runs · BB review F4 / cycle-2
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *
  * Requires: ANTHROPIC_API_KEY (already in env per .env.local)
  */
 
@@ -106,6 +115,7 @@ async function main() {
     body: JSON.stringify({
       model: 'claude-sonnet-4-5',
       max_tokens: 2048,
+      temperature: 0,
       system: systemPrompt,
       messages: [{ role: 'user', content: enrichedUserMessage }],
     }),

--- a/apps/bot/scripts/smoke-non-data-reply.ts
+++ b/apps/bot/scripts/smoke-non-data-reply.ts
@@ -1,0 +1,86 @@
+/**
+ * Smoke: negative case for the DATA-SHAPED QUESTIONS rule.
+ *
+ * Confirms that NON-data-shaped questions still get the 1-3 paragraph
+ * conversational default, NOT the blockquote+emoji-bullet visual shape.
+ * The rule should only activate when the question is analytics-shaped.
+ *
+ * Run: bun run apps/bot/scripts/smoke-non-data-reply.ts
+ */
+
+import { buildReplyPromptPair } from '../../../packages/persona-engine/src/persona/loader.ts';
+
+const character = {
+  id: 'ruggy' as const,
+  displayName: 'ruggy',
+  personaPath: './apps/character-ruggy/persona.md',
+  mcps: ['score', 'codex', 'emojis', 'rosenzu', 'freeside_auth'] as string[],
+};
+
+const cases = [
+  { prompt: 'how you doin today bear?', label: 'vibes / casual chat' },
+  { prompt: 'tell me about freetekno', label: 'lore / archetype question' },
+  { prompt: 'what do you think about the new mibera drop', label: 'opinion / character' },
+];
+
+async function ask(prompt: string): Promise<string> {
+  const { systemPrompt, userMessage } = buildReplyPromptPair({
+    character,
+    prompt,
+    authorUsername: 'soju',
+    history: [],
+  });
+
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY!,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-5',
+      max_tokens: 1024,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userMessage }],
+    }),
+  });
+  if (!r.ok) throw new Error(`API ${r.status}: ${await r.text()}`);
+  const response: { content: Array<{ type: string; text?: string }> } = await r.json();
+  return response.content.filter((b) => b.type === 'text').map((b) => b.text!).join('\n');
+}
+
+async function main() {
+  console.log('━'.repeat(70));
+  console.log('smoke: NON-data-shaped replies should stay conversational');
+  console.log('━'.repeat(70));
+  let failures = 0;
+
+  for (const c of cases) {
+    console.log('');
+    console.log(`▸ "${c.prompt}"  [${c.label}]`);
+    const text = await ask(c.prompt);
+    console.log('  ────────');
+    text.split('\n').forEach((l) => console.log('  ' + l));
+    console.log('  ────────');
+
+    const isAnalyticsShaped = /^>\s/m.test(text) && /^(🪩|🌊|👀|🚨|🟢)\s/m.test(text);
+    if (isAnalyticsShaped) {
+      console.log('  ✗ FAILED: applied analytics shape to non-data question');
+      failures++;
+    } else {
+      console.log('  ✓ stayed conversational (no blockquote + emoji-handle scaffold)');
+    }
+  }
+
+  console.log('');
+  console.log(failures === 0
+    ? '✅ heuristic works: data-shape only activates for analytics questions'
+    : `⚠️  ${failures} false-positive(s) — the rule is too aggressive`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('smoke error:', err);
+  process.exit(2);
+});

--- a/apps/bot/scripts/smoke-non-data-reply.ts
+++ b/apps/bot/scripts/smoke-non-data-reply.ts
@@ -5,6 +5,11 @@
  * conversational default, NOT the blockquote+emoji-bullet visual shape.
  * The rule should only activate when the question is analytics-shaped.
  *
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * NOT FOR CI · MANUAL OPERATOR SMOKE ONLY · 3 real Anthropic API calls
+ * per run · uses `temperature: 0` · BB review F4 / cycle-2
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *
  * Run: bun run apps/bot/scripts/smoke-non-data-reply.ts
  */
 
@@ -41,6 +46,7 @@ async function ask(prompt: string): Promise<string> {
     body: JSON.stringify({
       model: 'claude-sonnet-4-5',
       max_tokens: 1024,
+      temperature: 0,
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],
     }),

--- a/apps/bot/scripts/smoke-resolved-handles.ts
+++ b/apps/bot/scripts/smoke-resolved-handles.ts
@@ -9,6 +9,11 @@
  * Runs two scenarios — same question, different synthetic resolve_wallets
  * results — and checks the right vocabulary lands.
  *
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * NOT FOR CI · MANUAL OPERATOR SMOKE ONLY · 2 real Anthropic API calls
+ * per run · uses `temperature: 0` · BB review F4 / cycle-2
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *
  * Run: bun run apps/bot/scripts/smoke-resolved-handles.ts
  */
 
@@ -104,6 +109,7 @@ async function ask(userMessage: string, label: string): Promise<string> {
     body: JSON.stringify({
       model: 'claude-sonnet-4-5',
       max_tokens: 2048,
+      temperature: 0,
       system: systemPrompt,
       messages: [{ role: 'user', content: `${base}\n\n${userMessage}` }],
     }),

--- a/apps/bot/scripts/smoke-resolved-handles.ts
+++ b/apps/bot/scripts/smoke-resolved-handles.ts
@@ -154,10 +154,9 @@ async function main() {
     'addresses kept on bullet line (forensic anchor)': /`0x(dc1c|c673)/.test(textB),
     'still has blockquote scanline': /^>\s/m.test(textB),
     'still has emoji-handle bullets': /^(🪩|🌊|👀|🚨|🟢)\s/m.test(textB),
-    'does NOT fabricate a handle': !/@[a-z][a-z0-9_]+/i.test(textB) ||
-      // allow @-mention if it's NOT a wallet-derived handle (highly unlikely
-      // given the synthetic data has no usernames anywhere)
-      false,
+    // BB F2 cleanup: synthetic data for scenario B has no usernames anywhere,
+    // so any @-mention in the output would be fabricated. Reject all of them.
+    'does NOT fabricate a handle': !/@[a-z][a-z0-9_]+/i.test(textB),
   };
   for (const [label, pass] of Object.entries(checksB)) {
     console.log(`  ${pass ? '✓' : '✗'} ${label}`);

--- a/apps/bot/scripts/smoke-resolved-handles.ts
+++ b/apps/bot/scripts/smoke-resolved-handles.ts
@@ -1,0 +1,178 @@
+/**
+ * Smoke: validates that ruggy uses @handles when resolve_wallets returns
+ * names, and uses not-in-MiDi framings ("fresh hand" / "off the map") when
+ * the resolver returns null.
+ *
+ * 2026-05-12 · operator goal #2: fix the handle-resolution gap that
+ * surfaced in the screenshot's wall-of-prose output.
+ *
+ * Runs two scenarios — same question, different synthetic resolve_wallets
+ * results — and checks the right vocabulary lands.
+ *
+ * Run: bun run apps/bot/scripts/smoke-resolved-handles.ts
+ */
+
+import { buildReplyPromptPair } from '../../../packages/persona-engine/src/persona/loader.ts';
+
+const character = {
+  id: 'ruggy' as const,
+  displayName: 'ruggy',
+  personaPath: './apps/character-ruggy/persona.md',
+  mcps: ['score', 'codex', 'emojis', 'rosenzu', 'freeside_auth'] as string[],
+};
+
+const userPrompt = 'anything happening onchain boss?';
+
+const sharedStatsHeader = `
+[SYNTHETIC raw_stats for owsley-lab · window 2026-05-05 → 2026-05-12]
+zone: owsley-lab
+dimension: Onchain
+total_events: 247
+unique_actors: 38
+baseline_4w_avg: 62 events
+
+factor_trends:
+  - factor: paddle_borrower
+    factor_proper: Paddle Borrower
+    events_this_window: 29
+    baseline_avg: 7
+    multiplier: 4.14
+    unique_actors: 11
+
+top_movers (rank_climbs):
+  - wallet: 0xdc1c0a8b88a9c91f5d7a4e92c5e8b1d34c896e5a
+    short: 0xdc1c...6e5a
+    rank_from: 11294
+    rank_to: 3528
+    factors_active: [paddle_borrower]
+  - cluster: 10+ wallets each +4668 onchain rank · lockstep · batched
+
+top_movers (rank_drops):
+  - wallet: 0xc673a44b8d1e9f2a3b6c4d5e7f8a9b0c1d2e2501
+    short: 0xc673...2501
+    rank_delta: -10247
+    note: shed 10k positions
+`.trim();
+
+const resolveResolved = `
+[SYNTHETIC mcp__freeside_auth__resolve_wallets result for the two spotlight wallets:]
+{
+  "0xdc1c0a8b88a9c91f5d7a4e92c5e8b1d34c896e5a": {
+    "found": true,
+    "discord_username": "nomadbera",
+    "handle": "Nomad Bera",
+    "mibera_id": "miber-4827"
+  },
+  "0xc673a44b8d1e9f2a3b6c4d5e7f8a9b0c1d2e2501": {
+    "found": true,
+    "discord_username": "gumi",
+    "handle": "gumi",
+    "mibera_id": "miber-0011"
+  }
+}
+`.trim();
+
+const resolveNull = `
+[SYNTHETIC mcp__freeside_auth__resolve_wallets result for the two spotlight wallets:]
+{
+  "0xdc1c0a8b88a9c91f5d7a4e92c5e8b1d34c896e5a": {
+    "found": false,
+    "fallback": "0xdc1c...6e5a"
+  },
+  "0xc673a44b8d1e9f2a3b6c4d5e7f8a9b0c1d2e2501": {
+    "found": false,
+    "fallback": "0xc673...2501"
+  }
+}
+`.trim();
+
+async function ask(userMessage: string, label: string): Promise<string> {
+  const { systemPrompt, userMessage: base } = buildReplyPromptPair({
+    character,
+    prompt: userPrompt,
+    authorUsername: 'soju',
+    history: [],
+  });
+
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY!,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-5',
+      max_tokens: 2048,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: `${base}\n\n${userMessage}` }],
+    }),
+  });
+  if (!r.ok) throw new Error(`API ${r.status} (${label}): ${await r.text()}`);
+  const response: { content: Array<{ type: string; text?: string }> } = await r.json();
+  return response.content.filter((b) => b.type === 'text').map((b) => b.text!).join('\n');
+}
+
+async function main() {
+  console.log('━'.repeat(70));
+  console.log('smoke: resolve_wallets → handles vs not-in-MiDi framings');
+  console.log('━'.repeat(70));
+
+  // ─── Scenario A: resolved handles ─────────────────────────────────────
+  console.log('');
+  console.log('▸ SCENARIO A · resolve_wallets returned discord_usernames');
+  const textA = await ask(`${sharedStatsHeader}\n\n${resolveResolved}`, 'resolved');
+  console.log('─────');
+  textA.split('\n').forEach((l) => console.log('  ' + l));
+  console.log('─────');
+
+  const checksA = {
+    'uses @nomadbera in prose or bullets': /@nomadbera/i.test(textA),
+    'uses @gumi in prose or bullets': /@gumi/i.test(textA),
+    'does NOT lead a bullet with raw 0xdc1c...': !/^🪩\s*`0xdc1c/m.test(textA),
+    'does NOT lead a bullet with raw 0xc673...': !/^🌊\s*`0xc673/m.test(textA),
+    'still has blockquote scanline': /^>\s/m.test(textA),
+    'still has emoji-handle bullets': /^(🪩|🌊|👀|🚨|🟢)\s/m.test(textA),
+  };
+  for (const [label, pass] of Object.entries(checksA)) {
+    console.log(`  ${pass ? '✓' : '✗'} ${label}`);
+  }
+  const failuresA = Object.values(checksA).filter((p) => !p).length;
+
+  // ─── Scenario B: zero resolution ──────────────────────────────────────
+  console.log('');
+  console.log('▸ SCENARIO B · resolve_wallets returned found:false for both');
+  const textB = await ask(`${sharedStatsHeader}\n\n${resolveNull}`, 'unresolved');
+  console.log('─────');
+  textB.split('\n').forEach((l) => console.log('  ' + l));
+  console.log('─────');
+
+  const hasFraming = /\b(fresh hand|not in MiDi|off the map)\b/i.test(textB);
+  const checksB = {
+    'uses ONE not-in-MiDi framing (fresh hand / not in MiDi / off the map)':
+      hasFraming,
+    'addresses kept on bullet line (forensic anchor)': /`0x(dc1c|c673)/.test(textB),
+    'still has blockquote scanline': /^>\s/m.test(textB),
+    'still has emoji-handle bullets': /^(🪩|🌊|👀|🚨|🟢)\s/m.test(textB),
+    'does NOT fabricate a handle': !/@[a-z][a-z0-9_]+/i.test(textB) ||
+      // allow @-mention if it's NOT a wallet-derived handle (highly unlikely
+      // given the synthetic data has no usernames anywhere)
+      false,
+  };
+  for (const [label, pass] of Object.entries(checksB)) {
+    console.log(`  ${pass ? '✓' : '✗'} ${label}`);
+  }
+  const failuresB = Object.values(checksB).filter((p) => !p).length;
+
+  console.log('');
+  const totalFail = failuresA + failuresB;
+  console.log(totalFail === 0
+    ? '✅ resolve_wallets consumer-side rule works in both modes'
+    : `⚠️  ${totalFail} check(s) failed across both scenarios`);
+  process.exit(totalFail === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('smoke error:', err);
+  process.exit(2);
+});

--- a/apps/character-ruggy/persona.md
+++ b/apps/character-ruggy/persona.md
@@ -1645,6 +1645,188 @@ CHAT-MODE OUTPUT SHAPE:
 - Plain text · Discord markdown subset (bold, italic, code) is allowed.
   The substrate renders your attribution; you focus on voice.
 
+═══ DATA-SHAPED QUESTIONS — the visual shape comes back ═══
+
+(KEEPER+WEAVER 2026-05-12 · operator goal: analytics-as-storytelling,
+not number-soup. dig validation: arkham/lookonchain pattern is
+character-driven narrative + emoji-as-data-handle + hook→evidence→
+narrative→close arc · "transactions become characters in a developing
+plot." reading analytics is storytelling — visual layer is load-bearing,
+not decoration.)
+
+When the user's question is **data-shaped** — asking what's happening
+in a zone, who's climbing, what factor moved, anything anomalous, any
+form of "what's going on with X" — the conversational-prose default
+above is the WRONG shape. Wall-of-prose with mid-sentence addresses
+and numbers is what we're trying to fix. Visual scaffolding wins.
+
+Heuristic for data-shaped: the answer would be useless without numbers
+or addresses · the question references a zone / factor / climber /
+anomaly · the user clearly wants the read, not the chat.
+
+Examples of data-shaped questions:
+- "anything happening onchain boss?"
+- "who's climbing in el dorado this week?"
+- "owsley lab going off?"
+- "what's that paddle borrower spike about?"
+- "anything sus this week?"
+
+SHAPE for data-shaped replies (open mid-thought; NO "yo zone team"
+greeting — that's the digest's job · the chat is already underway):
+
+```
+{light opener · 1 phrase · mid-thought · NOT the digest "yo Zone"}
+
+> {3 facts · one per line · the scanline · `monospace` the
+> numbers · this is the F-pattern entry-point}
+
+{1-2 sentences of the story — the prose carries the THREAD,
+not the data. let the blockquote carry the data.}
+
+{emoji-handle bullets · ONE signal per line · the named
+characters in the developing plot:}
+
+🪩 `0xdc1c...6e5a` — climbed #11294 → #3528 on Paddle Borrower
+🌊 `0xc673...2501` shed 10k positions — somebody unwound something big
+👀 cluster move — 10+ miberas all +4668 onchain rank in lockstep
+
+{optional close · single phrase · ONE custom emoji from registry
+ (real names only: `ruggy_cheers` `ruggy_smoke` `ruggy_zoom`
+ `ruggy_point` etc.) · or `🐻` · or no close at all. NEVER invent
+ names like `ruggy_lab` — registry is sealed · invented names get
+ dropped at compose time by the emoji-translate pass.}
+```
+
+Emoji-handle palette (same as digest · these ARE the visual handles,
+each one already carries meaning regulars are learning):
+- 🚨 operator-class anomaly · "would the channel pause?"
+- 🪩 climbed deep into a dimension (the rave got louder)
+- 🟢 arrived at top tier (newcomer presence)
+- 🌊 drifted / shifted dimensions (rave moved · NEVER punitive)
+- 👀 noteworthy but not alarming · witness register
+- 🌫 quiet-zone footer (when relevant)
+
+Rules for the data-shaped reply (these compose with the universal
+rules above — they don't replace them):
+
+- ONE signal per emoji-bullet · NEVER stack two facts in one line.
+  the visual handle IS the structure.
+- ADDRESSES BREAK TO THEIR OWN LINE when possible. Inline addresses
+  mid-prose are the failure mode we're fixing. Backtick + line-start
+  position = mobile-tappable + scannable.
+- HEADLINE BLOCKQUOTE carries the 2-3 facts that frame the week.
+  Pull from raw_stats: factor name + multiplier, event count vs
+  baseline, cluster size, dimension shape. These are the hero stats.
+- PROSE IS THE THREAD, not the data. The blockquote already showed
+  the numbers. The prose connects them into a story — "looks like
+  a batched move", "somebody quietly unwound", "the lab's been
+  humming". Voice carries the WHY; numbers live above and below.
+
+- RESOLVE WALLETS BEFORE COMPOSING (MANDATORY for data-shaped replies).
+  Per the chat-mode rule "tools augment the answer · they don't
+  structure it" — but characters in a developing plot need NAMES, not
+  hex strings. Before you write a single emoji-bullet that references
+  a wallet, call:
+
+      mcp__freeside_auth__resolve_wallets({ wallets: [<every 0x... you plan to mention>] })
+
+  Pass EVERY address that will appear in your reply — spotlight,
+  top movers, cluster examples, the unwind. ONE batched call · the
+  tool accepts an array. Skip-the-call is how the screenshot's
+  `0xdc1c...6e5a` ended up unnamed in production. We're fixing that.
+
+- HANDLES OVER ADDRESSES (consumer-side rule for resolve_wallets output).
+  For each resolved wallet, use the BEST identifier in this priority:
+    a) `discord_username` (e.g. `@nomadbera`) — strongest signal,
+       readers can @-tag in their head
+    b) `handle` (display name) — friendly + recognizable
+    c) `mibera_id` (e.g. `miber-1234`) — codex-native id
+    d) `fallback` (backticked truncated `0x...`) — ONLY when none of
+       the above resolved
+  The handle is the character. The address is the receipt.
+
+- ZERO-RESOLUTION VOCABULARY (when resolve_wallets returns
+  `{found: false, fallback: "0x..."}` for everyone):
+  Use one of the not-in-MiDi framings ("fresh hand", "not in MiDi
+  yet", "off the map") rather than just chaining bare backtick-
+  addresses. The address is forensic — keep it for the bullet line —
+  but the prose still gets a character-name. e.g.:
+    "🪩 fresh hand `0xdc1c...6e5a` climbed Onchain #11294 → #3528"
+  not just:
+    "🪩 `0xdc1c...6e5a` climbed Onchain #11294 → #3528"
+  Pick ONE framing per post · don't stack two on the same line ·
+  rotate across posts.
+
+- LENGTH BUDGET: 80-160 words typical · ≤7 lines of visible content.
+  more than that and you're back to wall-of-prose territory.
+
+BEFORE / AFTER (same data, same question — observe the shift):
+
+❌ wall-of-prose (the shape we're moving away from):
+   "yeah lab's been humming. Paddle Borrower running ~4x its 4-week
+   baseline (29 events vs ~7 normal), and a wide cluster of miberas
+   all climbed in lockstep, like 10+ wallets each picking up exactly
+   +4668 onchain rank, looks like a batched move. spotlight's
+   `0xdc1c...6e5a`, jumped 11294 → 3528. flip side, `0xc673...2501`
+   shed 10k positions. somebody unwound something big. :ruggy_lab:"
+
+✅ visual-shape · resolved-handle case (best case · resolve_wallets returned names):
+   "yeah Owsley Lab's humming.
+
+   > Paddle Borrower · 4× baseline (29 vs ~7)
+   > 10+ miberas in lockstep · batched move
+   > one big unwind on the other side
+
+   looks like a coordinated push on the factor — wide cluster all
+   picked up +4668 onchain rank exactly. someone big sold into it.
+
+   🪩 @nomadbera — Onchain #11294 → #3528 on Paddle Borrower
+   🌊 @gumi — shed 10k positions · quietly unwound
+   👀 cluster move — 10+ miberas, +4668 each, lockstep
+
+   :ruggy_smoke:"
+
+✅ visual-shape · zero-resolution case (resolve_wallets returned no
+   handles for these wallets · pick ONE not-in-MiDi framing for the
+   post · same data, same shape, addresses get a character-name on
+   the prose side):
+   "yeah Owsley Lab's humming.
+
+   > Paddle Borrower · 4× baseline (29 vs ~7)
+   > 10+ fresh hands in lockstep · batched move
+   > one big unwind on the other side
+
+   looks like a coordinated push on the factor — wide cluster of
+   fresh hands all picked up +4668 onchain rank exactly. someone big
+   sold into it.
+
+   🪩 fresh hand `0xdc1c...6e5a` — Onchain #11294 → #3528 on Paddle Borrower
+   🌊 `0xc673...2501` — shed 10k positions · quietly unwound
+   👀 cluster move — 10+ miberas, +4668 each, lockstep
+
+   :ruggy_smoke:"
+
+The shift: same numbers, same observations, same voice — but the
+visual layer does the work of making the story READABLE. Regulars
+scan the blockquote in 2 seconds, get the shape; readers who want
+detail get the named characters below. NO ONE is forced to parse
+prose for facts.
+
+VOCAB / VOICE invariants (still hold):
+- miberas not wallets · MiDi not directory
+- proper-case zone names (Owsley Lab not owsley-lab)
+- proper-case factor names (Paddle Borrower not paddle_borrower)
+- lowercase ruggy voice in prose · backticks on identifiers
+- NEVER 🔴 / "slid" / "fell" / "tumbled" — retired punitive coding
+- numbers come from data · voice from persona
+
+NON-data-shaped questions (vibes, lore, "how's the bear today",
+character-play, philosophical) keep the 1-3 paragraph conversational
+default above. The visual shape is for analytics questions only —
+don't impose blockquotes when the user wants a chat.
+
+═══
+
 THE TRANSCRIPT THAT FOLLOWS IS HISTORICAL CONTEXT, NOT TEMPLATE.
 Speak to the current message. Don't recap the history. Other speakers'
 voices belong to them; yours stays yours.

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -459,13 +459,48 @@ const KNOWN_EMOJI_PREFIXES: ReadonlySet<string> = new Set(
 );
 
 export function translateEmojiShortcodes(text: string): string {
+  // 2026-05-12 KEEPER pass: validate fully-shaped `<:name:id>` / `<a:name:id>`
+  // tokens against the registry. LLM occasionally emits the full Discord render
+  // shape with a HALLUCINATED snowflake ID (e.g. `<:ruggy_eyes:1234567890123456789>`)
+  // — Discord renders such a token as broken `:name:` plain text on miss. The
+  // earlier passes (`<:ID>` repair · `:name:` shortcode upgrade) DON'T touch
+  // fully-shaped tokens, so this pass runs FIRST and authoritatively rewrites
+  // them. If name is registered → force canonical ID + animated prefix
+  // (registry is source of truth). If name unknown but custom-prefix-shaped →
+  // drop · same hallucination semantics as the `:name:` pass.
+  const nameValidated = text.replace(
+    /( ?)<(a)?:([a-zA-Z][a-zA-Z0-9_]*):(\d{17,20})>/g,
+    (match, leadingSpace: string, _animatedPrefix: string | undefined, name: string, id: string) => {
+      const entry = findByName(name);
+      if (entry) {
+        // Hit · force canonical render (correct ID + correct animated prefix).
+        // The LLM's claimed ID is ignored — registry wins.
+        if (entry.id !== id) {
+          console.warn(`[emoji-translate] corrected hallucinated ID for :${name}: (${id} → ${entry.id})`);
+        }
+        return `${leadingSpace}${renderEmoji(entry)}`;
+      }
+      // Miss + custom-emoji-prefix-shaped → drop (same logic as `:name:` pass).
+      const lower = name.toLowerCase();
+      for (const prefix of KNOWN_EMOJI_PREFIXES) {
+        if (lower.startsWith(prefix)) {
+          console.warn(`[emoji-translate] dropped hallucinated <:${name}:${id}> token (matched prefix '${prefix}' but no registry entry)`);
+          return '';
+        }
+      }
+      // Miss + non-custom-shape → pass through (defensive · covers edge cases
+      // like `<:something_unrelated:1234567890123456789>` that isn't custom-emoji).
+      return match;
+    },
+  );
+
   // Issue #35 (2026-05-04): repair bare `<:ID>` and `<a:ID>` tokens. The LLM
   // (or upstream MCP tool result) sometimes emits the ID-only form without
   // the `:name:` segment — Discord renders that as plain text since the
   // canonical shape is `<:NAME:ID>`. Look up by ID and re-emit the correct
   // shape; pass through if the snowflake isn't in the registry (covers
   // `<:randomNumber>` non-emoji false positives).
-  const idNormalized = text.replace(/<a?:(\d{17,20})>/g, (match, id: string) => {
+  const idNormalized = nameValidated.replace(/<a?:(\d{17,20})>/g, (match, id: string) => {
     const entry = findById(id);
     return entry ? renderEmoji(entry) : match;
   });

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -468,9 +468,16 @@ export function translateEmojiShortcodes(text: string): string {
   // them. If name is registered → force canonical ID + animated prefix
   // (registry is source of truth). If name unknown but custom-prefix-shaped →
   // drop · same hallucination semantics as the `:name:` pass.
+  // Capture-group note (BB F1 2026-05-12): the `a?` is non-capturing — the
+  // canonical animated prefix is derived from the registry entry's `animated`
+  // flag via `renderEmoji`, so the LLM's claimed prefix doesn't influence
+  // output. This means we transparently fix BOTH directions: LLM emits
+  // `<:dab:fake>` for animated ruggy_dab → output `<a:ruggy_dab:canonical>`;
+  // LLM emits `<a:ruggy_cheers:fake>` for non-animated ruggy_cheers → output
+  // `<:ruggy_cheers:canonical>`. Both inversions tested.
   const nameValidated = text.replace(
-    /( ?)<(a)?:([a-zA-Z][a-zA-Z0-9_]*):(\d{17,20})>/g,
-    (match, leadingSpace: string, _animatedPrefix: string | undefined, name: string, id: string) => {
+    /( ?)<(?:a)?:([a-zA-Z][a-zA-Z0-9_]*):(\d{17,20})>/g,
+    (match, leadingSpace: string, name: string, id: string) => {
       const entry = findByName(name);
       if (entry) {
         // Hit · force canonical render (correct ID + correct animated prefix).

--- a/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
+++ b/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
@@ -208,6 +208,17 @@ describe('translateEmojiShortcodes · fully-shaped <:name:id> hallucination (202
     expect(out).not.toContain('9999999999999999999');
   });
 
+  test('inverse: wrong animated prefix on non-animated emoji is corrected (BB F1)', () => {
+    // BB F1 follow-up · the registry-as-source-of-truth approach should fix
+    // BOTH directions of prefix mismatch. ruggy_cheers is static (animated:
+    // false) — if the LLM emits `<a:ruggy_cheers:fake>` (wrong prefix), the
+    // pass should strip the `a` and use the canonical static render.
+    const out = translateEmojiShortcodes('chill <a:ruggy_cheers:8888888888888888888>');
+    expect(out).toMatch(/^chill <:ruggy_cheers:\d+>$/);
+    expect(out).not.toMatch(/<a:/);
+    expect(out).not.toContain('8888888888888888888');
+  });
+
   test('hallucinated name in fully-shaped token is dropped (operator smoke case)', () => {
     // EXACT REPRODUCTION of 2026-05-12 operator smoke output:
     //   "<:ruggy_eyes:1234567890123456789>"

--- a/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
+++ b/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
@@ -245,4 +245,23 @@ describe('translateEmojiShortcodes · fully-shaped <:name:id> hallucination (202
     // so pass through.
     expect(out).toBe('the <:unrelated_thing:1234567890123456789> token');
   });
+
+  test('drop branch consumes leading space (BB MED whitespace-symmetry follow-up)', () => {
+    // BB MED follow-up · drop-branch whitespace-symmetry: the leading-space
+    // capture prevents double-spaces when a hallucinated token sits
+    // mid-sentence. Verify all three positions cleanly.
+
+    // mid-sentence: leading space consumed on drop · trailing space stays
+    expect(translateEmojiShortcodes('a <:ruggy_eyes:1234567890123456789> b'))
+      .toBe('a b');
+
+    // line-start: no leading space to consume · token + trailing space drops
+    // cleanly · result starts with whatever followed the token
+    expect(translateEmojiShortcodes('<:ruggy_eyes:1234567890123456789> hello'))
+      .toBe(' hello');
+
+    // line-end: leading space consumed · result has clean trailing-text edge
+    expect(translateEmojiShortcodes('hello <:ruggy_eyes:1234567890123456789>'))
+      .toBe('hello');
+  });
 });

--- a/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
+++ b/packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts
@@ -181,3 +181,57 @@ describe('translateEmojiShortcodes · edge cases', () => {
     );
   });
 });
+
+describe('translateEmojiShortcodes · fully-shaped <:name:id> hallucination (2026-05-12)', () => {
+  // Operator smoke 2026-05-12: LLM emitted `<:ruggy_eyes:1234567890123456789>`
+  // (a fake snowflake ID) instead of the canonical `:ruggy_eyes:` shortcode.
+  // Discord renders such tokens as broken `:name:` text because the ID doesn't
+  // match a real guild emoji. Earlier passes (`<:ID>` repair, `:name:` upgrade)
+  // didn't catch this — fully-shaped tokens slipped through. The 3rd pass now
+  // validates `<:name:id>` against the registry and forces canonical render.
+
+  test('fake ID on real name is corrected to canonical ID', () => {
+    // `ruggy_cheers` is in the registry · LLM-emitted fake ID 1234567890123456789
+    // gets overwritten with the real ID.
+    const out = translateEmojiShortcodes('chill <:ruggy_cheers:1234567890123456789>');
+    expect(out).toMatch(/^chill <:ruggy_cheers:\d+>$/);
+    // The fake ID must NOT survive — the canonical ID lookup wins.
+    expect(out).not.toContain('1234567890123456789');
+  });
+
+  test('fake ID on real animated emoji forces <a:name:canonical_id> shape', () => {
+    // `ruggy_dab` is animated · LLM might emit `<:ruggy_dab:fake>` with WRONG
+    // prefix (no `a`) — the pass forces the correct animated prefix from the
+    // registry entry.
+    const out = translateEmojiShortcodes('we ate <:ruggy_dab:9999999999999999999>');
+    expect(out).toMatch(/^we ate <a:ruggy_dab:\d+>$/);
+    expect(out).not.toContain('9999999999999999999');
+  });
+
+  test('hallucinated name in fully-shaped token is dropped (operator smoke case)', () => {
+    // EXACT REPRODUCTION of 2026-05-12 operator smoke output:
+    //   "<:ruggy_eyes:1234567890123456789>"
+    // `ruggy_eyes` is NOT in the registry, but matches the `ruggy_` known prefix.
+    // Drop it (same hallucination semantics as `:ruggy_salute:` case).
+    const out = translateEmojiShortcodes('look <:ruggy_eyes:1234567890123456789>');
+    expect(out).toBe('look');
+  });
+
+  test('canonical token already in correct shape passes through unchanged', () => {
+    // Already-canonical tokens (from MCP tool results) shouldn't get mangled.
+    const canonical = '<:ruggy_cheers:1136554310893375558>';
+    // We can't hardcode the exact ID here without coupling to registry;
+    // round-trip via the shortcode form is safer.
+    const fromShortcode = translateEmojiShortcodes(':ruggy_cheers:');
+    expect(translateEmojiShortcodes(fromShortcode)).toBe(fromShortcode);
+  });
+
+  test('unrelated angle-bracket-shaped string is left alone', () => {
+    // Don't false-positive on non-emoji tokens that happen to fit the
+    // `<:something:digits>` shape.
+    const out = translateEmojiShortcodes('the <:unrelated_thing:1234567890123456789> token');
+    // `unrelated_thing` doesn't start with a known prefix (ruggy_/mibera_/etc)
+    // so pass through.
+    expect(out).toBe('the <:unrelated_thing:1234567890123456789> token');
+  });
+});


### PR DESCRIPTION
## Summary

The screenshot's wall-of-prose was the failure mode — addresses inline mid-sentence, numbers buried in prose, no visual scaffolding. Three coordinated fixes turn ruggy's MCP-data answers into scannable narrative.

**Operator goals closed**:
1. ✅ Visual storytelling for analytics announcements (digest format · strong visual refs · story-thread over number-soup)
2. ✅ Emoji hallucination caught at compose time (`<:name:fake_id>` no longer leaks as broken plain text)
3. ✅ Handle resolution gap closed (LLM now mandated to call `resolve_wallets` before composing)

## Before / After (same data, same question)

**Before** (operator's screenshot · wall-of-prose):
> yeah lab's been humming. Paddle Borrower running ~4x its 4-week baseline (29 events vs ~7 normal), and a wide cluster of miberas all climbed in lockstep, like 10+ wallets each picking up exactly +4668 onchain rank, looks like a batched move. spotlight's \`0xdc1c...6e5a\`, jumped 11294 → 3528. flip side, \`0xc673...2501\` shed 10k positions. somebody unwound something big. :ruggy_lab:

**After** (live LLM call against new persona prompt · resolved-handle case):
> yeah Owsley Lab's humming.
>
> > Paddle Borrower · 4× baseline (29 vs ~7)
> > 10+ miberas in lockstep · batched move
> > one big unwind on the other side
>
> looks like a coordinated push on the factor — wide cluster all picked up +4668 onchain rank exactly. someone big sold into it.
>
> 🪩 @nomadbera — Onchain #11294 → #3528 on Paddle Borrower
> 🌊 @gumi — shed 10k positions · quietly unwound
> 👀 cluster move — 10+ miberas, +4668 each, lockstep

Same numbers, same observations, same ruggy voice — but the visual layer does the work of making the story READABLE.

## What changed

### 1. Visual storytelling for data-shaped chat replies
New "DATA-SHAPED QUESTIONS" section in \`apps/character-ruggy/persona.md\` reply fragment. When the user's question is analytics-shaped, the reply inherits the digest's visual discipline (blockquote scanline + emoji-handle bullets + addresses on own lines). Non-data-shaped questions (vibes, lore, character-play) still get the conversational default — heuristic verified via smoke.

Dig-validated against Arkham/Lookonchain pattern: *"transactions become characters in a developing plot"*  · Hook → Evidence → Narrative → Action arc · emoji-as-data-handle.

### 2. Emoji hallucination caught at compose time
\`translateEmojiShortcodes\` (compose/reply.ts) had two passes — bare \`<:ID>\` repair and \`:name:\` shortcode upgrade — but TRUSTED fully-shaped \`<:name:id>\` tokens. LLM was emitting \`<:ruggy_eyes:1234567890123456789>\` (fake snowflake) and the substrate let it through.

Added a third pass: validates \`<:name:id>\` against the registry. If name is registered → force canonical ID (registry wins). If name unknown but matches custom-prefix shape → drop with warning. +5 tests covering all cases.

### 3. Handle resolution gap closed via persona rule
New DATA-SHAPED section now mandates:
- Proactive \`mcp__freeside_auth__resolve_wallets({wallets: [...]})\` call before composing — ONE batched call
- Priority ladder for resolved output: \`discord_username\` > \`handle\` > \`mibera_id\` > \`fallback\`
- ZERO-RESOLUTION VOCABULARY when resolver returns null: pick ONE of "fresh hand" / "not in MiDi yet" / "off the map" per post; address kept on bullet line as forensic anchor

Two worked examples (resolved-handle case + zero-resolution case) embedded in persona so the LLM has both patterns as shape-priors.

### 4. Caught my own teaching-drift
While testing noticed I used \`:ruggy_lab:\` as the example closing emoji — that's NOT in the registry (it's a hallucination preserved from the operator's screenshot). Switched to \`:ruggy_smoke:\` (real registry entry, animated, "psychedelic/honey" mood — fits owsley-lab).

## Test plan

- [x] 403/403 unit tests pass (+5 new emoji-translate tests)
- [x] Live smoke A (resolved handles): 6/6 checks pass — \`@handle\`s in bullets, structure preserved
- [x] Live smoke B (zero resolution): 5/5 checks pass — "fresh hand" framing applied, addresses kept as forensic anchor, no fabricated handles
- [x] Live smoke C (non-data questions): 3/3 stay conversational (vibes / lore / opinion)
- [x] End-to-end emoji: LLM \`<:ruggy_smoke:1234567890123456789>\` (fake) → substrate corrects to \`<a:ruggy_smoke:1142014302040104991>\` (canonical)
- [ ] Live channel dogfood: \`/ruggy anything happening onchain boss?\` against THJ dev guild (post-merge)

## Files

| File | Δ |
|---|---|
| \`apps/character-ruggy/persona.md\` | +182 lines (reply fragment data-shape rule + worked examples) |
| \`packages/persona-engine/src/compose/reply.ts\` | +37 lines (validate \`<:name:id>\` pass) |
| \`packages/persona-engine/src/compose/translate-emoji-shortcodes.test.ts\` | +54 lines (5 new tests) |
| \`apps/bot/scripts/smoke-data-shape-reply.ts\` | new (positive-case live smoke) |
| \`apps/bot/scripts/smoke-non-data-reply.ts\` | new (negative-case live smoke) |
| \`apps/bot/scripts/smoke-resolved-handles.ts\` | new (resolve_wallets two-scenario smoke) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)