### PR TITLE
feat(voice): grimoire — per-fire stance sampling for data-shaped replies

### DIFF
--- a/apps/bot/scripts/smoke-voice-variance.ts
+++ b/apps/bot/scripts/smoke-voice-variance.ts
@@ -1,0 +1,182 @@
+/**
+ * Smoke: validates that the voice grimoire produces VARIANCE — three
+ * fires of the SAME question against the SAME data produce three
+ * DISTINCT visual shapes (not three copies of the same template).
+ *
+ * 2026-05-12 · operator dogfood showed two consecutive `/ruggy` replies
+ * in the same channel produced visually identical posts. The grimoire's
+ * job: each fire draws a different card → different entry / shape /
+ * splash / exit / density → different output.
+ *
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * NOT FOR CI · MANUAL OPERATOR SMOKE ONLY · 3 real Anthropic API calls
+ * per run · uses `temperature: 0` (variance comes from grimoire, not LLM)
+ * ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *
+ * Run: bun run apps/bot/scripts/smoke-voice-variance.ts
+ */
+
+import { buildReplyPromptPair } from '../../../packages/persona-engine/src/persona/loader.ts';
+import {
+  sampleVoiceCard,
+  renderVoiceCard,
+  _resetVoiceCache,
+} from '../../../packages/persona-engine/src/voice/sampler.ts';
+import {
+  pickByMoods,
+  shuffle,
+} from '../../../packages/persona-engine/src/orchestrator/emojis/registry.ts';
+import type { VoiceCard } from '../../../packages/persona-engine/src/voice/grimoire.ts';
+
+const character = {
+  id: 'ruggy' as const,
+  displayName: 'ruggy',
+  personaPath: './apps/character-ruggy/persona.md',
+  mcps: ['score', 'codex', 'emojis', 'rosenzu', 'freeside_auth'] as string[],
+};
+
+const userPrompt = 'anything happening onchain boss?';
+
+const syntheticData = `
+[SYNTHETIC raw_stats for owsley-lab · same data each fire — variance must
+ come from the grimoire, not the data]
+
+zone: owsley-lab · dimension: Onchain · 7-day window
+total_events: 247 · unique_actors: 38 · baseline_4w_avg: 62 events
+
+factor_trends:
+  - Paddle Borrower · 29 events vs ~7 baseline · 4.14× · 11 actors
+
+top_movers (climbs):
+  - 0xdc1c0a8b88a9c91f5d7a4e92c5e8b1d34c896e5a · 0xdc1c...6e5a
+    #11294 → #3528 · on Paddle Borrower
+  - cluster of 10+ wallets each picked up exactly +4668 onchain rank
+    (lockstep · suggests batched move)
+
+top_movers (drops):
+  - 0xc673a44b8d1e9f2a3b6c4d5e7f8a9b0c1d2e2501 · 0xc673...2501
+    rank delta -10247 · shed 10k positions
+
+[SYNTHETIC mcp__freeside_auth__resolve_wallets result:]
+  0xdc1c...6e5a → { found: true, discord_username: "nomadbera", handle: "Nomad Bera" }
+  0xc673...2501 → { found: true, discord_username: "gumi", handle: "gumi" }
+`.trim();
+
+function pickWitness(card: Omit<VoiceCard, 'witness'>): string | null {
+  if (card.exit !== 'custom_emoji') return null;
+  let moods: string[];
+  if (card.bullet_palette.includes('🚨')) moods = ['shocked', 'flex'];
+  else if (card.density === 'fragment' || card.splash === 'sparse') moods = ['cool', 'dazed'];
+  else if (card.splash === 'lush') moods = ['celebrate', 'cute', 'love'];
+  else moods = ['cool', 'cute'];
+  const candidates = pickByMoods(moods as never, 'ruggy');
+  if (candidates.length === 0) return null;
+  return shuffle(candidates)[0]?.name ?? null;
+}
+
+async function ask(seed: string, channelId: string): Promise<{ card: VoiceCard; text: string }> {
+  const card = sampleVoiceCard({ seed, channelId, witnessPicker: pickWitness });
+  const grimoire = renderVoiceCard(card);
+
+  const { systemPrompt, userMessage } = buildReplyPromptPair({
+    character,
+    prompt: userPrompt,
+    authorUsername: 'soju',
+    history: [],
+    voiceGrimoire: grimoire,
+  });
+
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY!,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-5',
+      max_tokens: 2048,
+      temperature: 0,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: `${userMessage}\n\n${syntheticData}` }],
+    }),
+  });
+  if (!r.ok) throw new Error(`API ${r.status}: ${await r.text()}`);
+  const response: { content: Array<{ type: string; text?: string }> } = await r.json();
+  const text = response.content.filter((b) => b.type === 'text').map((b) => b.text!).join('\n');
+  return { card, text };
+}
+
+async function main() {
+  _resetVoiceCache(); // start fresh
+  console.log('━'.repeat(72));
+  console.log('smoke: voice grimoire produces 3 distinct shapes for the same question');
+  console.log('━'.repeat(72));
+
+  const channelId = 'smoke-variance-channel';
+  // Three seeded fires · we use fixed seeds so the test is reproducible.
+  // In production the seed is `${channelId}:${authorId}:${Date.now()}` so each
+  // fire gets a fresh draw organically.
+  const fires = [
+    { seed: 'variance-fire-1', label: 'fire 1' },
+    { seed: 'variance-fire-2', label: 'fire 2' },
+    { seed: 'variance-fire-3', label: 'fire 3' },
+  ];
+
+  const results: Array<{ card: VoiceCard; text: string; label: string }> = [];
+  for (const f of fires) {
+    console.log('');
+    console.log(`▸ ${f.label} · seed=${f.seed}`);
+    const { card, text } = await ask(f.seed, channelId);
+    console.log(`  card · entry=${card.entry} shape=${card.shape} splash=${card.splash} density=${card.density} exit=${card.exit} palette=[${card.bullet_palette.join(' ')}] witness=${card.witness ?? 'none'}`);
+    console.log('  ────');
+    text.split('\n').forEach((l) => console.log('  ' + l));
+    console.log('  ────');
+    results.push({ ...{ card, text }, label: f.label });
+  }
+
+  // ─── variance assertions ────────────────────────────────────────────
+  console.log('');
+  console.log('━'.repeat(72));
+  console.log('variance checks:');
+
+  const distinctEntries = new Set(results.map((r) => r.card.entry)).size;
+  const distinctShapes = new Set(results.map((r) => r.card.shape)).size;
+  const distinctTexts = new Set(results.map((r) => r.text)).size;
+
+  // Crude visual-shape signature for cross-text comparison.
+  function sig(text: string): string {
+    const lines = text.split('\n').filter((l) => l.trim().length > 0);
+    const hasBlockquote = lines.some((l) => l.startsWith('>'));
+    const bulletCount = lines.filter((l) => /^(🚨|🪩|🟢|🌊|👀|🌫)/.test(l)).length;
+    const startsWith = lines[0]?.slice(0, 10).toLowerCase() ?? '';
+    return `bq=${hasBlockquote ? 'y' : 'n'}·bullets=${bulletCount}·start="${startsWith}"`;
+  }
+  const sigs = results.map((r) => sig(r.text));
+  const distinctSigs = new Set(sigs).size;
+
+  console.log(`  cards: ${distinctEntries} distinct entries · ${distinctShapes} distinct shapes (across 3 fires)`);
+  console.log(`  texts: ${distinctTexts}/3 unique · ${distinctSigs}/3 distinct shape-signatures`);
+  console.log(`  signatures: ${sigs.join(' | ')}`);
+
+  const checks = {
+    'cards: at least 2 distinct entries across 3 fires': distinctEntries >= 2,
+    'cards: at least 2 distinct shapes across 3 fires': distinctShapes >= 2,
+    'output: 3/3 unique texts': distinctTexts === 3,
+    'output: at least 2 distinct shape signatures': distinctSigs >= 2,
+  };
+  for (const [label, pass] of Object.entries(checks)) {
+    console.log(`  ${pass ? '✓' : '✗'} ${label}`);
+  }
+  const failures = Object.values(checks).filter((p) => !p).length;
+  console.log('');
+  console.log(failures === 0
+    ? '✅ grimoire produces real variance · same data, same question, 3 distinct posts'
+    : `⚠️  ${failures} check(s) failed — variance is collapsing`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('smoke error:', err);
+  process.exit(2);
+});

--- a/apps/character-ruggy/persona.md
+++ b/apps/character-ruggy/persona.md
@@ -1652,7 +1652,11 @@ not number-soup. dig validation: arkham/lookonchain pattern is
 character-driven narrative + emoji-as-data-handle + hook→evidence→
 narrative→close arc · "transactions become characters in a developing
 plot." reading analytics is storytelling — visual layer is load-bearing,
-not decoration.)
+not decoration. 2026-05-12 v2: parametric shape via VOICE GRIMOIRE —
+operator's gradient-descent cue · the persona prose used to PRESCRIBE
+ONE shape and the LLM faithfully reproduced it every fire · variance
+was missing · now the substrate samples a stance card per fire and the
+persona READS from it.)
 
 When the user's question is **data-shaped** — asking what's happening
 in a zone, who's climbing, what factor moved, anything anomalous, any
@@ -1671,34 +1675,23 @@ Examples of data-shaped questions:
 - "what's that paddle borrower spike about?"
 - "anything sus this week?"
 
-SHAPE for data-shaped replies (open mid-thought; NO "yo zone team"
-greeting — that's the digest's job · the chat is already underway):
+═══ THE SHAPE COMES FROM THE GRIMOIRE ═══
 
-```
-{light opener · 1 phrase · mid-thought · NOT the digest "yo Zone"}
+The persona used to prescribe a single rigid shape (blockquote +
+prose + bullets + close). It produced robotic-feeling output — every
+data-shaped reply looked identical. The fix: the substrate draws a
+VOICE CARD per fire from a typed parameter space (entry × shape ×
+splash × exit × density × bullet_palette × witness). The card is
+injected as `{{VOICE_GRIMOIRE}}` below.
 
-> {3 facts · one per line · the scanline · `monospace` the
-> numbers · this is the F-pattern entry-point}
+**Follow the card · NOT the example.** The card tells you what kind
+of post THIS fire is. The examples lower down show different cards
+producing different shapes. Don't collapse to one template.
 
-{1-2 sentences of the story — the prose carries the THREAD,
-not the data. let the blockquote carry the data.}
+{{VOICE_GRIMOIRE}}
 
-{emoji-handle bullets · ONE signal per line · the named
-characters in the developing plot:}
-
-🪩 `0xdc1c...6e5a` — climbed #11294 → #3528 on Paddle Borrower
-🌊 `0xc673...2501` shed 10k positions — somebody unwound something big
-👀 cluster move — 10+ miberas all +4668 onchain rank in lockstep
-
-{optional close · single phrase · ONE custom emoji from registry
- (real names only: `ruggy_cheers` `ruggy_smoke` `ruggy_zoom`
- `ruggy_point` etc.) · or `🐻` · or no close at all. NEVER invent
- names like `ruggy_lab` — registry is sealed · invented names get
- dropped at compose time by the emoji-translate pass.}
-```
-
-Emoji-handle palette (same as digest · these ARE the visual handles,
-each one already carries meaning regulars are learning):
+Emoji-handle MEANINGS (these don't change · only the palette draw
+restricts which subset you reach for THIS fire):
 - 🚨 operator-class anomaly · "would the channel pause?"
 - 🪩 climbed deep into a dimension (the rave got louder)
 - 🟢 arrived at top tier (newcomer presence)
@@ -1706,72 +1699,63 @@ each one already carries meaning regulars are learning):
 - 👀 noteworthy but not alarming · witness register
 - 🌫 quiet-zone footer (when relevant)
 
-Rules for the data-shaped reply (these compose with the universal
-rules above — they don't replace them):
+═══ THE INVARIANTS (these hold across every card) ═══
 
-- ONE signal per emoji-bullet · NEVER stack two facts in one line.
-  the visual handle IS the structure.
-- ADDRESSES BREAK TO THEIR OWN LINE when possible. Inline addresses
-  mid-prose are the failure mode we're fixing. Backtick + line-start
-  position = mobile-tappable + scannable.
-- HEADLINE BLOCKQUOTE carries the 2-3 facts that frame the week.
-  Pull from raw_stats: factor name + multiplier, event count vs
-  baseline, cluster size, dimension shape. These are the hero stats.
-- PROSE IS THE THREAD, not the data. The blockquote already showed
-  the numbers. The prose connects them into a story — "looks like
-  a batched move", "somebody quietly unwound", "the lab's been
-  humming". Voice carries the WHY; numbers live above and below.
+These are non-negotiable · the card varies SHAPE, never these:
 
-- RESOLVE WALLETS BEFORE COMPOSING (MANDATORY for data-shaped replies).
-  Per the chat-mode rule "tools augment the answer · they don't
-  structure it" — but characters in a developing plot need NAMES, not
-  hex strings. Before you write a single emoji-bullet that references
-  a wallet, call:
+- RESOLVE WALLETS BEFORE COMPOSING (MANDATORY · regardless of card).
+  Characters in a developing plot need NAMES, not hex strings. Before
+  you write a single line that references a wallet, call:
 
       mcp__freeside_auth__resolve_wallets({ wallets: [<every 0x... you plan to mention>] })
 
-  Pass EVERY address that will appear in your reply — spotlight,
-  top movers, cluster examples, the unwind. ONE batched call · the
-  tool accepts an array. Skip-the-call is how the screenshot's
-  `0xdc1c...6e5a` ended up unnamed in production. We're fixing that.
+  Pass EVERY address that will appear in your reply. ONE batched
+  call · the tool accepts an array. Skip-the-call is how the
+  screenshot's `0xdc1c...6e5a` ended up unnamed in production.
 
-- HANDLES OVER ADDRESSES (consumer-side rule for resolve_wallets output).
-  For each resolved wallet, use the BEST identifier in this priority:
-    a) `discord_username` (e.g. `@nomadbera`) — strongest signal,
-       readers can @-tag in their head
-    b) `handle` (display name) — friendly + recognizable
-    c) `mibera_id` (e.g. `miber-1234`) — codex-native id
-    d) `fallback` (backticked truncated `0x...`) — ONLY when none of
-       the above resolved
-  The handle is the character. The address is the receipt.
+- HANDLES OVER ADDRESSES (consumer rule for resolve_wallets output).
+  Priority ladder: `discord_username` (`@nomadbera`) > `handle`
+  (display name) > `mibera_id` (`miber-1234`) > `fallback`
+  (backticked truncated `0x...`). The handle is the character. The
+  address is the receipt.
 
-- ZERO-RESOLUTION VOCABULARY (when resolve_wallets returns
-  `{found: false, fallback: "0x..."}` for everyone):
-  Use one of the not-in-MiDi framings ("fresh hand", "not in MiDi
-  yet", "off the map") rather than just chaining bare backtick-
-  addresses. The address is forensic — keep it for the bullet line —
-  but the prose still gets a character-name. e.g.:
-    "🪩 fresh hand `0xdc1c...6e5a` climbed Onchain #11294 → #3528"
-  not just:
-    "🪩 `0xdc1c...6e5a` climbed Onchain #11294 → #3528"
-  Pick ONE framing per post · don't stack two on the same line ·
-  rotate across posts.
+- ZERO-RESOLUTION VOCABULARY (when resolve_wallets returns no
+  handles): pick ONE not-in-MiDi framing per post ("fresh hand",
+  "not in MiDi yet", "off the map") rather than chained bare
+  backtick-addresses. Address kept on bullet line as forensic anchor;
+  prose gets the character-name.
 
-- LENGTH BUDGET: 80-160 words typical · ≤7 lines of visible content.
-  more than that and you're back to wall-of-prose territory.
+- ADDRESSES BREAK TO THEIR OWN LINE when possible. Inline addresses
+  mid-prose is the failure mode being fixed. Backtick + line-start =
+  mobile-tappable + scannable.
 
-BEFORE / AFTER (same data, same question — observe the shift):
+- ONE signal per emoji-bullet (when the card has bullets · some
+  shapes don't). NEVER stack two facts in one line.
 
-❌ wall-of-prose (the shape we're moving away from):
+- VOCAB invariants: miberas not wallets · MiDi not directory ·
+  proper-case zone names (Owsley Lab not owsley-lab) · proper-case
+  factor names (Paddle Borrower not paddle_borrower) · lowercase
+  ruggy voice in prose · backticks on identifiers · NEVER 🔴 / "slid"
+  / "fell" / "tumbled" (retired punitive coding) · numbers come from
+  data · voice from persona.
+
+═══ EXAMPLES OF DIFFERENT CARDS PRODUCING DIFFERENT SHAPES ═══
+
+Same data each time (Paddle Borrower 4× baseline, cluster +4668,
+spotlight climb, big unwind). Different grimoire draws → different
+shapes. The lesson: the card is the brief, not the template.
+
+❌ wall-of-prose (the failure mode the whole system is fixing):
    "yeah lab's been humming. Paddle Borrower running ~4x its 4-week
-   baseline (29 events vs ~7 normal), and a wide cluster of miberas
-   all climbed in lockstep, like 10+ wallets each picking up exactly
-   +4668 onchain rank, looks like a batched move. spotlight's
-   `0xdc1c...6e5a`, jumped 11294 → 3528. flip side, `0xc673...2501`
-   shed 10k positions. somebody unwound something big. :ruggy_lab:"
+   baseline, wide cluster all climbed in lockstep, +4668 each, looks
+   like a batched move. spotlight's 0xdc1c...6e5a jumped 11294 → 3528,
+   flip side 0xc673...2501 shed 10k positions, somebody unwound."
 
-✅ visual-shape · resolved-handle case (best case · resolve_wallets returned names):
-   "yeah Owsley Lab's humming.
+────────────────────────────────────────────────────────────────────
+CARD: entry=casual_yeah · shape=blockquote_first · splash=medium ·
+      density=standard · bullet_palette=[🪩,🌊,👀] · exit=custom_emoji
+────────────────────────────────────────────────────────────────────
+   yeah Owsley Lab's humming.
 
    > Paddle Borrower · 4× baseline (29 vs ~7)
    > 10+ miberas in lockstep · batched move
@@ -1784,46 +1768,71 @@ BEFORE / AFTER (same data, same question — observe the shift):
    🌊 @gumi — shed 10k positions · quietly unwound
    👀 cluster move — 10+ miberas, +4668 each, lockstep
 
-   :ruggy_smoke:"
+   :ruggy_smoke:
 
-✅ visual-shape · zero-resolution case (resolve_wallets returned no
-   handles for these wallets · pick ONE not-in-MiDi framing for the
-   post · same data, same shape, addresses get a character-name on
-   the prose side):
-   "yeah Owsley Lab's humming.
+────────────────────────────────────────────────────────────────────
+CARD: entry=silent_start · shape=single_punchline · splash=sparse ·
+      density=fragment · bullet_palette=[🚨] · exit=fragment
+────────────────────────────────────────────────────────────────────
+   Paddle Borrower at 4× baseline. 10+ miberas, all +4668 onchain
+   rank exactly. batched move.
 
-   > Paddle Borrower · 4× baseline (29 vs ~7)
-   > 10+ fresh hands in lockstep · batched move
-   > one big unwind on the other side
+   🚨 someone unwound 10k positions into it.
 
-   looks like a coordinated push on the factor — wide cluster of
-   fresh hands all picked up +4668 onchain rank exactly. someone big
-   sold into it.
+   worth a peek.
 
-   🪩 fresh hand `0xdc1c...6e5a` — Onchain #11294 → #3528 on Paddle Borrower
-   🌊 `0xc673...2501` — shed 10k positions · quietly unwound
-   👀 cluster move — 10+ miberas, +4668 each, lockstep
+────────────────────────────────────────────────────────────────────
+CARD: entry=ascii_bear · shape=fragment_chain · splash=sparse ·
+      density=terse · bullet_palette=[👀,🌊] · exit=silence
+────────────────────────────────────────────────────────────────────
+   ʕ •ᴥ•ʔ lab's humming.
 
-   :ruggy_smoke:"
+   Paddle Borrower 4× baseline.
 
-The shift: same numbers, same observations, same voice — but the
-visual layer does the work of making the story READABLE. Regulars
-scan the blockquote in 2 seconds, get the shape; readers who want
-detail get the named characters below. NO ONE is forced to parse
-prose for facts.
+   cluster move. 10+ in lockstep. +4668 each.
 
-VOCAB / VOICE invariants (still hold):
-- miberas not wallets · MiDi not directory
-- proper-case zone names (Owsley Lab not owsley-lab)
-- proper-case factor names (Paddle Borrower not paddle_borrower)
-- lowercase ruggy voice in prose · backticks on identifiers
-- NEVER 🔴 / "slid" / "fell" / "tumbled" — retired punitive coding
-- numbers come from data · voice from persona
+   @gumi unwound 10k on the other side.
+
+────────────────────────────────────────────────────────────────────
+CARD: entry=pivot · shape=inverted · splash=lush · density=standard
+      bullet_palette=[🪩,🟢,🌊,👀] · exit=observation
+────────────────────────────────────────────────────────────────────
+   ok so Owsley —
+
+   🪩 @nomadbera on Paddle Borrower · #11294 → #3528
+   👀 10+ miberas in lockstep · +4668 each · batched
+   🌊 @gumi shed 10k positions · the unwind
+
+   the factor's running 4× baseline (29 vs ~7). a cluster picked
+   up an exact delta together — that's a coordinated push, not
+   distributed activity. someone large sold into the climb.
+
+   someone's making moves.
+
+────────────────────────────────────────────────────────────────────
+CARD: entry=declarative · shape=prose_first · splash=medium ·
+      density=terse · bullet_palette=[🪩] · exit=bear_emoji
+────────────────────────────────────────────────────────────────────
+   Owsley Lab. Paddle Borrower at four-ex.
+
+   10+ miberas climbed in lockstep at +4668 onchain rank exactly,
+   and someone big shed 10k positions into it. coordinated.
+
+   > 29 events vs ~7 baseline · cluster batched · 10k unwound
+
+   🪩 @nomadbera the visible mover · #11294 → #3528
+
+   🐻
+────────────────────────────────────────────────────────────────────
+
+The shift: same data each time, same voice, same invariants —
+DIFFERENT shape every fire. The grimoire is the source of variance.
+Operator tunes weight distributions via .loa.config.yaml; the LLM
+reads THIS fire's draw and renders accordingly.
 
 NON-data-shaped questions (vibes, lore, "how's the bear today",
 character-play, philosophical) keep the 1-3 paragraph conversational
-default above. The visual shape is for analytics questions only —
-don't impose blockquotes when the user wants a chat.
+default above. The grimoire is for analytics questions only.
 
 ═══
 

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "effect": "^3.21.2",
         "node-cron": "^3.0.3",
         "pg": "^8.20.0",
+        "yaml": "^2.9.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -378,6 +379,8 @@
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -22,6 +22,7 @@
     "effect": "^3.21.2",
     "node-cron": "^3.0.3",
     "pg": "^8.20.0",
+    "yaml": "^2.9.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -52,12 +52,58 @@ import {
   type GrailRefValidation,
 } from '../deliver/grail-ref-guard.ts';
 import { stripAttachedImageUrls } from '../deliver/strip-image-urls.ts';
-import { EMOJIS, findById, findByName, renderEmoji } from '../orchestrator/emojis/registry.ts';
+import {
+  EMOJIS,
+  findById,
+  findByName,
+  pickByMoods,
+  renderEmoji,
+  shuffle,
+  type EmojiKind,
+} from '../orchestrator/emojis/registry.ts';
 import {
   appendToLedger,
   getLedgerSnapshot,
   type LedgerEntry,
 } from '../conversation/ledger.ts';
+import { sampleVoiceCard, renderVoiceCard } from '../voice/sampler.ts';
+import type { VoiceCard } from '../voice/grimoire.ts';
+
+/**
+ * Witness picker — binds the grimoire sampler to ruggy's custom emoji
+ * registry. Picks ONE emoji name whose mood tags match the sampled card's
+ * stance. Returns null when the card's exit isn't `custom_emoji` (no need
+ * to pick) or when no mood-fit is available.
+ *
+ * Stance → mood heuristic (deliberately loose · the LLM still has freedom):
+ *   - density=fragment + splash=sparse → "cool" or "dazed" emoji (low-key)
+ *   - shape=single_punchline + bullet_palette includes 🚨 → "flex" or "shocked"
+ *   - exit=bear_emoji or silence → don't bother (returns null)
+ *   - default → "cool" mood for static · catches the "vibe" register
+ *
+ * The picker is character-scoped via `kind`. Per-character mood mappings
+ * could compose later when satoshi/mongolian want this surface — for now
+ * ruggy's the only character using the grimoire.
+ */
+function pickWitnessFromRegistry(card: Omit<VoiceCard, 'witness'>, kind: EmojiKind = 'ruggy'): string | null {
+  if (card.exit !== 'custom_emoji') return null;
+  // Match stance to mood-search terms · the registry has flex/cool/dazed/
+  // celebrate/cute/love/snark/etc · pick reaches via mood tags.
+  let moods: string[];
+  if (card.bullet_palette.includes('🚨')) {
+    moods = ['shocked', 'flex'];
+  } else if (card.density === 'fragment' || card.splash === 'sparse') {
+    moods = ['cool', 'dazed'];
+  } else if (card.splash === 'lush') {
+    moods = ['celebrate', 'cute', 'love'];
+  } else {
+    moods = ['cool', 'cute'];
+  }
+  const candidates = pickByMoods(moods as never, kind);
+  if (candidates.length === 0) return null;
+  const shuffled = shuffle(candidates);
+  return shuffled[0]?.name ?? null;
+}
 
 export interface ReplyComposeArgs {
   config: Config;
@@ -143,6 +189,18 @@ export async function composeReply(
     otherCharactersHere: args.otherCharactersHere,
   });
 
+  // 2026-05-12 — voice grimoire: sample a per-fire stance card and
+  // inject as {{VOICE_GRIMOIRE}}. Persona reads the card and shapes
+  // accordingly. Decouples voice variance from persona prose. Next
+  // iteration: load operator weight overrides from voice.config.yaml ·
+  // for now DEFAULT_VOICE_WEIGHTS apply (see voice/grimoire.ts).
+  const voiceCard = sampleVoiceCard({
+    seed: `${args.channelId}:${args.authorId}:${Date.now()}`,
+    channelId: args.channelId,
+    witnessPicker: (c) => pickWitnessFromRegistry(c, 'ruggy'),
+  });
+  const voiceGrimoire = renderVoiceCard(voiceCard);
+
   const { systemPrompt, userMessage } = buildReplyPromptPair({
     character: args.character,
     prompt: args.prompt,
@@ -153,6 +211,7 @@ export async function composeReply(
       content: h.content,
     })),
     environmentContext,
+    voiceGrimoire,
   });
 
   // Routing decision: orchestrator (full MCP scope) vs naive (V0.7-A.0

--- a/packages/persona-engine/src/compose/reply.ts
+++ b/packages/persona-engine/src/compose/reply.ts
@@ -68,6 +68,7 @@ import {
 } from '../conversation/ledger.ts';
 import { sampleVoiceCard, renderVoiceCard } from '../voice/sampler.ts';
 import type { VoiceCard } from '../voice/grimoire.ts';
+import { getVoiceWeightsFor } from '../voice/config-loader.ts';
 
 /**
  * Witness picker — binds the grimoire sampler to ruggy's custom emoji
@@ -191,12 +192,12 @@ export async function composeReply(
 
   // 2026-05-12 — voice grimoire: sample a per-fire stance card and
   // inject as {{VOICE_GRIMOIRE}}. Persona reads the card and shapes
-  // accordingly. Decouples voice variance from persona prose. Next
-  // iteration: load operator weight overrides from voice.config.yaml ·
-  // for now DEFAULT_VOICE_WEIGHTS apply (see voice/grimoire.ts).
+  // accordingly. Operator-tunable weights via voice.config.yaml at
+  // repo root · falls back to DEFAULT_VOICE_WEIGHTS when no config.
   const voiceCard = sampleVoiceCard({
     seed: `${args.channelId}:${args.authorId}:${Date.now()}`,
     channelId: args.channelId,
+    weights: getVoiceWeightsFor(args.character.id),
     witnessPicker: (c) => pickWitnessFromRegistry(c, 'ruggy'),
   });
   const voiceGrimoire = renderVoiceCard(voiceCard);

--- a/packages/persona-engine/src/persona/loader.ts
+++ b/packages/persona-engine/src/persona/loader.ts
@@ -209,6 +209,15 @@ export interface BuildPromptArgsUnified {
    * that don't reference the placeholder.
    */
   environmentContext?: string;
+  /**
+   * Voice grimoire block (rendered VoiceCard · per-fire stance: entry,
+   * shape, splash, exit, density, bullet_palette, witness). 2026-05-12 ·
+   * decouples behavior parameters from persona prose · operator tunes
+   * weights via .loa.config.yaml, sampler draws a card per fire, persona
+   * reads via `{{VOICE_GRIMOIRE}}` placeholder. Empty/omitted = no-op for
+   * templates that don't reference it. See packages/persona-engine/src/voice/.
+   */
+  voiceGrimoire?: string;
 }
 
 /**
@@ -232,6 +241,7 @@ export function buildPrompt(args: BuildPromptArgsUnified): {
   const voiceAnchors = loadVoiceAnchors(character.personaPath);
   const codexAnchors = loadCodexAnchors(character.personaPath);
   const environment = args.environmentContext ?? '';
+  const voiceGrimoire = args.voiceGrimoire ?? '';
 
   // Per-shape: fragment, output instruction, exemplars, movement guidance,
   // zone substitution values.
@@ -277,6 +287,7 @@ export function buildPrompt(args: BuildPromptArgsUnified): {
     .replace(/\{\{CODEX_ANCHORS\}\}/g, codexAnchors)
     .replace(/\{\{CODEX_PRELUDE\}\}/g, codex)
     .replace(/\{\{ENVIRONMENT\}\}/g, environment)
+    .replace(/\{\{VOICE_GRIMOIRE\}\}/g, voiceGrimoire)
     .replace(/\{\{EXEMPLARS\}\}/g, exemplars)
     .replace(/\{\{ZONE_ID\}\}/g, zoneId)
     .replace(/\{\{ZONE_NAME\}\}/g, zoneName)
@@ -434,6 +445,13 @@ export interface BuildReplyPromptArgs {
    * placeholder. Backward-compatible no-op when absent.
    */
   environmentContext?: string;
+  /**
+   * 2026-05-12 — optional voice grimoire block (built by
+   * `voice/sampler.renderVoiceCard()`). Substituted into
+   * `{{VOICE_GRIMOIRE}}` placeholder. When omitted, persona falls back
+   * to the DATA-SHAPED default. Backward-compatible.
+   */
+  voiceGrimoire?: string;
 }
 
 export interface ReplyTranscriptEntry {
@@ -466,6 +484,7 @@ export function buildReplyPromptPair(args: BuildReplyPromptArgs): {
       userPrompt: args.prompt,
     },
     environmentContext: args.environmentContext,
+    voiceGrimoire: args.voiceGrimoire,
   });
 }
 

--- a/packages/persona-engine/src/voice/config-loader.test.ts
+++ b/packages/persona-engine/src/voice/config-loader.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Voice config loader tests.
+ *
+ * Validates:
+ *   - Reads + parses voice.config.yaml from repo root
+ *   - Falls back to defaults when file missing or invalid
+ *   - Per-character weight maps return correctly
+ *   - Cache works (loadOnce semantics)
+ *   - Schema validation rejects malformed weights
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { writeFileSync, unlinkSync, mkdtempSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  getVoiceWeights,
+  getVoiceWeightsFor,
+  _resetVoiceConfigCache,
+} from './config-loader.ts';
+
+beforeEach(() => {
+  _resetVoiceConfigCache();
+});
+
+describe('voice config loader · file discovery', () => {
+  test('no config file → returns empty map', () => {
+    // Working dir for tests is repo root; the example exists but not the
+    // actual `voice.config.yaml` — operator opts in by copying.
+    const weights = getVoiceWeights();
+    expect(typeof weights).toBe('object');
+    // If a real voice.config.yaml exists at repo root in dev environment,
+    // this would have entries · don't assert empty to avoid flakiness.
+    expect(weights).toBeDefined();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Isolated test: write a real config to a temp dir, override cwd
+// ──────────────────────────────────────────────────────────────────────
+
+describe('voice config loader · with temp config file', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    _resetVoiceConfigCache();
+    originalCwd = process.cwd();
+    tmpDir = mkdtempSync(join(tmpdir(), 'voice-config-test-'));
+    process.chdir(tmpDir);
+  });
+
+  function cleanup() {
+    process.chdir(originalCwd);
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  }
+
+  test('valid YAML loads weights for ruggy', () => {
+    writeFileSync(
+      join(tmpDir, 'voice.config.yaml'),
+      `voice:
+  ruggy:
+    entry:
+      silent_start: 1.0
+      casual_yeah: 0.0
+    splash:
+      sparse: 1.0
+      medium: 0.0
+      lush: 0.0
+`,
+    );
+
+    const ruggyWeights = getVoiceWeightsFor('ruggy');
+    expect(ruggyWeights).toBeDefined();
+    expect(ruggyWeights?.entry?.silent_start).toBe(1.0);
+    expect(ruggyWeights?.splash?.sparse).toBe(1.0);
+
+    cleanup();
+  });
+
+  test('invalid YAML syntax → empty map + stderr warn', () => {
+    writeFileSync(join(tmpDir, 'voice.config.yaml'), 'voice:\n  ruggy:\n    entry: {{INVALID}}');
+    // Logger emits a stderr warn · we don't assert on stderr here,
+    // just that the map ends up empty / undefined for ruggy.
+    const ruggyWeights = getVoiceWeightsFor('ruggy');
+    expect(ruggyWeights).toBeUndefined();
+
+    cleanup();
+  });
+
+  test('schema-invalid weights → that character is skipped + others survive', () => {
+    writeFileSync(
+      join(tmpDir, 'voice.config.yaml'),
+      `voice:
+  ruggy:
+    entry:
+      silent_start: 0.5
+      casual_yeah: 0.5
+  satoshi:
+    entry:
+      bogus_value_not_in_enum: 0.5
+`,
+    );
+
+    const ruggy = getVoiceWeightsFor('ruggy');
+    const satoshi = getVoiceWeightsFor('satoshi');
+    expect(ruggy?.entry?.silent_start).toBe(0.5);
+    expect(satoshi).toBeUndefined(); // schema rejected · skipped
+
+    cleanup();
+  });
+
+  test('empty voice section → empty map (no crash)', () => {
+    writeFileSync(join(tmpDir, 'voice.config.yaml'), 'voice: {}');
+    const ruggy = getVoiceWeightsFor('ruggy');
+    expect(ruggy).toBeUndefined();
+    cleanup();
+  });
+
+  test('cache returns same object on repeat call', () => {
+    writeFileSync(
+      join(tmpDir, 'voice.config.yaml'),
+      `voice:
+  ruggy:
+    entry:
+      casual_yeah: 1.0
+`,
+    );
+    const first = getVoiceWeightsFor('ruggy');
+    const second = getVoiceWeightsFor('ruggy');
+    expect(first).toBe(second); // referential equality from cache
+
+    cleanup();
+  });
+
+  test('reset cache + file change → loader picks up new values', () => {
+    writeFileSync(
+      join(tmpDir, 'voice.config.yaml'),
+      `voice:
+  ruggy:
+    entry:
+      casual_yeah: 1.0
+`,
+    );
+    const before = getVoiceWeightsFor('ruggy');
+    expect(before?.entry?.casual_yeah).toBe(1.0);
+
+    // Change config + reset cache.
+    writeFileSync(
+      join(tmpDir, 'voice.config.yaml'),
+      `voice:
+  ruggy:
+    entry:
+      silent_start: 1.0
+`,
+    );
+    _resetVoiceConfigCache();
+    const after = getVoiceWeightsFor('ruggy');
+    expect(after?.entry?.silent_start).toBe(1.0);
+    expect(after?.entry?.casual_yeah).toBeUndefined();
+
+    cleanup();
+  });
+});

--- a/packages/persona-engine/src/voice/config-loader.test.ts
+++ b/packages/persona-engine/src/voice/config-loader.test.ts
@@ -41,24 +41,31 @@ describe('voice config loader · file discovery', () => {
 // ──────────────────────────────────────────────────────────────────────
 
 describe('voice config loader · with temp config file', () => {
+  // BB MED 0.95 (config-loader-test-cwd-mutation · 2026-05-12): use
+  // LOA_VOICE_CONFIG env var instead of mutating process.cwd(). Cleaner
+  // isolation + no global state to restore.
   let tmpDir: string;
-  let originalCwd: string;
 
-  beforeEach(() => {
-    _resetVoiceConfigCache();
-    originalCwd = process.cwd();
+  function withConfig(yaml: string, fn: () => void): void {
     tmpDir = mkdtempSync(join(tmpdir(), 'voice-config-test-'));
-    process.chdir(tmpDir);
-  });
-
-  function cleanup() {
-    process.chdir(originalCwd);
-    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+    const configPath = join(tmpDir, 'voice.config.yaml');
+    writeFileSync(configPath, yaml);
+    const prevEnv = process.env['LOA_VOICE_CONFIG'];
+    process.env['LOA_VOICE_CONFIG'] = configPath;
+    _resetVoiceConfigCache();
+    try {
+      fn();
+    } finally {
+      // Always restore env + clean tmpdir, even if the test threw.
+      if (prevEnv === undefined) delete process.env['LOA_VOICE_CONFIG'];
+      else process.env['LOA_VOICE_CONFIG'] = prevEnv;
+      if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+      _resetVoiceConfigCache();
+    }
   }
 
   test('valid YAML loads weights for ruggy', () => {
-    writeFileSync(
-      join(tmpDir, 'voice.config.yaml'),
+    withConfig(
       `voice:
   ruggy:
     entry:
@@ -69,29 +76,24 @@ describe('voice config loader · with temp config file', () => {
       medium: 0.0
       lush: 0.0
 `,
+      () => {
+        const ruggyWeights = getVoiceWeightsFor('ruggy');
+        expect(ruggyWeights).toBeDefined();
+        expect(ruggyWeights?.entry?.silent_start).toBe(1.0);
+        expect(ruggyWeights?.splash?.sparse).toBe(1.0);
+      },
     );
-
-    const ruggyWeights = getVoiceWeightsFor('ruggy');
-    expect(ruggyWeights).toBeDefined();
-    expect(ruggyWeights?.entry?.silent_start).toBe(1.0);
-    expect(ruggyWeights?.splash?.sparse).toBe(1.0);
-
-    cleanup();
   });
 
   test('invalid YAML syntax → empty map + stderr warn', () => {
-    writeFileSync(join(tmpDir, 'voice.config.yaml'), 'voice:\n  ruggy:\n    entry: {{INVALID}}');
-    // Logger emits a stderr warn · we don't assert on stderr here,
-    // just that the map ends up empty / undefined for ruggy.
-    const ruggyWeights = getVoiceWeightsFor('ruggy');
-    expect(ruggyWeights).toBeUndefined();
-
-    cleanup();
+    withConfig('voice:\n  ruggy:\n    entry: {{INVALID}}', () => {
+      const ruggyWeights = getVoiceWeightsFor('ruggy');
+      expect(ruggyWeights).toBeUndefined();
+    });
   });
 
   test('schema-invalid weights → that character is skipped + others survive', () => {
-    writeFileSync(
-      join(tmpDir, 'voice.config.yaml'),
+    withConfig(
       `voice:
   ruggy:
     entry:
@@ -101,65 +103,89 @@ describe('voice config loader · with temp config file', () => {
     entry:
       bogus_value_not_in_enum: 0.5
 `,
+      () => {
+        const ruggy = getVoiceWeightsFor('ruggy');
+        const satoshi = getVoiceWeightsFor('satoshi');
+        expect(ruggy?.entry?.silent_start).toBe(0.5);
+        expect(satoshi).toBeUndefined();
+      },
     );
+  });
 
-    const ruggy = getVoiceWeightsFor('ruggy');
-    const satoshi = getVoiceWeightsFor('satoshi');
-    expect(ruggy?.entry?.silent_start).toBe(0.5);
-    expect(satoshi).toBeUndefined(); // schema rejected · skipped
-
-    cleanup();
+  test('non-fractional weights are accepted (normalized on the fly)', () => {
+    // BB MED 0.90 (schema-record-keys-as-fractions): integer ratios work too.
+    withConfig(
+      `voice:
+  ruggy:
+    entry:
+      silent_start: 3
+      casual_yeah: 1
+`,
+      () => {
+        const ruggy = getVoiceWeightsFor('ruggy');
+        expect(ruggy?.entry?.silent_start).toBe(3);
+        expect(ruggy?.entry?.casual_yeah).toBe(1);
+      },
+    );
   });
 
   test('empty voice section → empty map (no crash)', () => {
-    writeFileSync(join(tmpDir, 'voice.config.yaml'), 'voice: {}');
-    const ruggy = getVoiceWeightsFor('ruggy');
-    expect(ruggy).toBeUndefined();
-    cleanup();
+    withConfig('voice: {}', () => {
+      const ruggy = getVoiceWeightsFor('ruggy');
+      expect(ruggy).toBeUndefined();
+    });
   });
 
   test('cache returns same object on repeat call', () => {
-    writeFileSync(
-      join(tmpDir, 'voice.config.yaml'),
+    withConfig(
       `voice:
   ruggy:
     entry:
       casual_yeah: 1.0
 `,
+      () => {
+        const first = getVoiceWeightsFor('ruggy');
+        const second = getVoiceWeightsFor('ruggy');
+        expect(first).toBe(second);
+      },
     );
-    const first = getVoiceWeightsFor('ruggy');
-    const second = getVoiceWeightsFor('ruggy');
-    expect(first).toBe(second); // referential equality from cache
-
-    cleanup();
   });
 
   test('reset cache + file change → loader picks up new values', () => {
-    writeFileSync(
-      join(tmpDir, 'voice.config.yaml'),
-      `voice:
+    tmpDir = mkdtempSync(join(tmpdir(), 'voice-config-test-'));
+    const configPath = join(tmpDir, 'voice.config.yaml');
+    const prevEnv = process.env['LOA_VOICE_CONFIG'];
+    process.env['LOA_VOICE_CONFIG'] = configPath;
+    try {
+      writeFileSync(
+        configPath,
+        `voice:
   ruggy:
     entry:
       casual_yeah: 1.0
 `,
-    );
-    const before = getVoiceWeightsFor('ruggy');
-    expect(before?.entry?.casual_yeah).toBe(1.0);
+      );
+      _resetVoiceConfigCache();
+      const before = getVoiceWeightsFor('ruggy');
+      expect(before?.entry?.casual_yeah).toBe(1.0);
 
-    // Change config + reset cache.
-    writeFileSync(
-      join(tmpDir, 'voice.config.yaml'),
-      `voice:
+      writeFileSync(
+        configPath,
+        `voice:
   ruggy:
     entry:
       silent_start: 1.0
 `,
-    );
-    _resetVoiceConfigCache();
-    const after = getVoiceWeightsFor('ruggy');
-    expect(after?.entry?.silent_start).toBe(1.0);
-    expect(after?.entry?.casual_yeah).toBeUndefined();
-
-    cleanup();
+      );
+      _resetVoiceConfigCache();
+      const after = getVoiceWeightsFor('ruggy');
+      expect(after?.entry?.silent_start).toBe(1.0);
+      expect(after?.entry?.casual_yeah).toBeUndefined();
+    } finally {
+      if (prevEnv === undefined) delete process.env['LOA_VOICE_CONFIG'];
+      else process.env['LOA_VOICE_CONFIG'] = prevEnv;
+      if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+      _resetVoiceConfigCache();
+    }
   });
 });

--- a/packages/persona-engine/src/voice/config-loader.ts
+++ b/packages/persona-engine/src/voice/config-loader.ts
@@ -35,10 +35,27 @@ let cache:
   | { kind: 'loaded'; map: Record<string, VoiceWeights> } = { kind: 'unloaded' };
 
 /**
- * Repo-root discovery: walk up from `cwd` looking for the config file.
- * Capped at 6 levels to avoid runaway. Returns null if not found.
+ * Repo-root discovery (in order of precedence):
+ *   1. LOA_VOICE_CONFIG env var — absolute or cwd-relative path
+ *   2. Walk up from `cwd` looking for `voice.config.yaml` (capped at 6 levels)
+ *
+ * BB MED 0.75 (config-loader-cwd-walking-fragility · 2026-05-12): the
+ * env-var override is the load-bearing path for monorepos where the bot's
+ * cwd may not be the repo root (or where multiple repos share a config).
+ * Walking up from cwd is a useful default but not authoritative.
+ *
+ * Returns null if no config found · loader treats null as "no overrides,
+ * defaults apply" rather than as an error.
  */
 function findConfigFile(startDir: string = process.cwd()): string | null {
+  const envPath = process.env['LOA_VOICE_CONFIG'];
+  if (envPath) {
+    const resolved = envPath.startsWith('/') ? envPath : join(process.cwd(), envPath);
+    if (existsSync(resolved)) return resolved;
+    console.warn(
+      `[voice-config] LOA_VOICE_CONFIG=${envPath} (resolved to ${resolved}) does not exist · falling back to cwd walk`,
+    );
+  }
   let dir = startDir;
   for (let i = 0; i < 6; i++) {
     const candidate = join(dir, CONFIG_FILENAME);

--- a/packages/persona-engine/src/voice/config-loader.ts
+++ b/packages/persona-engine/src/voice/config-loader.ts
@@ -1,0 +1,120 @@
+/**
+ * Voice config loader — reads `voice.config.yaml` at repo root,
+ * validates via Zod, caches per-process.
+ *
+ * Operator workflow:
+ *   1. Copy voice.config.yaml.example → voice.config.yaml
+ *   2. Edit per-character weight distributions
+ *   3. Restart the bot (or wait for next process spawn) — the cache
+ *      is per-process, no hot-reload (deliberate: variance comes from
+ *      the sampler, not the config · operators don't want their
+ *      weights mid-flight-mutating in production).
+ *
+ * Failure modes (all soft · no crash):
+ *   - File missing → return empty map, defaults apply (silent)
+ *   - File present but parse error → stderr warn, return empty map
+ *   - Schema validation fails → stderr warn with Zod issue summary,
+ *     return empty map
+ *
+ * The loader is intentionally simple — no env-var fallback, no
+ * per-character file split, no JSON pointer. One YAML file at the
+ * repo root. If the operator wants to extend this surface, the
+ * VoiceWeightsSchema validates a TYPED schema · we can wire a more
+ * sophisticated loader later without changing the call site contract.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+import { VoiceWeightsSchema, type VoiceWeights } from './grimoire.ts';
+
+const CONFIG_FILENAME = 'voice.config.yaml';
+
+let cache:
+  | { kind: 'unloaded' }
+  | { kind: 'loaded'; map: Record<string, VoiceWeights> } = { kind: 'unloaded' };
+
+/**
+ * Repo-root discovery: walk up from `cwd` looking for the config file.
+ * Capped at 6 levels to avoid runaway. Returns null if not found.
+ */
+function findConfigFile(startDir: string = process.cwd()): string | null {
+  let dir = startDir;
+  for (let i = 0; i < 6; i++) {
+    const candidate = join(dir, CONFIG_FILENAME);
+    if (existsSync(candidate)) return candidate;
+    const parent = join(dir, '..');
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+function loadOnce(): Record<string, VoiceWeights> {
+  const path = findConfigFile();
+  if (!path) return {};
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (err) {
+    console.warn(`[voice-config] failed to read ${path}: ${(err as Error).message} · defaults apply`);
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    console.warn(`[voice-config] YAML parse error in ${path}: ${(err as Error).message} · defaults apply`);
+    return {};
+  }
+
+  // The YAML root has a `voice:` wrapper · pull per-character maps out.
+  const voiceSection = (parsed as { voice?: Record<string, unknown> } | null)?.voice;
+  if (!voiceSection || typeof voiceSection !== 'object') {
+    return {};
+  }
+
+  const out: Record<string, VoiceWeights> = {};
+  for (const [characterId, weights] of Object.entries(voiceSection)) {
+    const result = VoiceWeightsSchema.safeParse(weights);
+    if (!result.success) {
+      console.warn(
+        `[voice-config] invalid weights for character '${characterId}' in ${path}: ${result.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; ')} · defaults apply for this character`,
+      );
+      continue;
+    }
+    if (result.data) {
+      out[characterId] = result.data;
+    }
+  }
+  console.log(
+    `[voice-config] loaded ${Object.keys(out).length} character weight map(s) from ${path}`,
+  );
+  return out;
+}
+
+/**
+ * Get per-character voice weights map · cached per-process. Returns
+ * empty object if no config file or all entries failed validation;
+ * caller's sampler falls back to DEFAULT_VOICE_WEIGHTS in that case.
+ */
+export function getVoiceWeights(): Record<string, VoiceWeights> {
+  if (cache.kind === 'unloaded') {
+    cache = { kind: 'loaded', map: loadOnce() };
+  }
+  return cache.map;
+}
+
+/** Get weights for a specific character · undefined when no override. */
+export function getVoiceWeightsFor(characterId: string): VoiceWeights | undefined {
+  return getVoiceWeights()[characterId];
+}
+
+/** Exposed for tests · reset cache between scenarios. */
+export function _resetVoiceConfigCache(): void {
+  cache = { kind: 'unloaded' };
+}

--- a/packages/persona-engine/src/voice/grimoire.ts
+++ b/packages/persona-engine/src/voice/grimoire.ts
@@ -181,23 +181,28 @@ export const DEFAULT_VOICE_WEIGHTS: Required<VoiceWeights> = {
 // Zod schema · runtime validation for config-loaded weights
 // ──────────────────────────────────────────────────────────────────────
 
-const fractionRecord = <T extends string>(values: readonly T[]) =>
+// BB MED 0.90 (schema-record-keys-as-fractions · 2026-05-12): per-knob
+// weights are NORMALIZED on the fly by the sampler · they don't need to
+// sum to 1 NOR be in [0,1]. The Zod constraint just requires non-negative.
+// A weight of 100 is valid · it'll just dominate. Operators may use
+// integer "ratios" (e.g. 3 vs 1) instead of fractional probabilities.
+const weightRecord = <T extends string>(values: readonly T[]) =>
   z
-    .record(z.enum(values as unknown as [T, ...T[]]), z.number().min(0).max(1))
+    .record(z.enum(values as unknown as [T, ...T[]]), z.number().min(0))
     .optional();
 
 export const VoiceWeightsSchema = z
   .object({
-    entry: fractionRecord(ENTRY_VALUES),
-    shape: fractionRecord(SHAPE_VALUES),
-    splash: fractionRecord(SPLASH_VALUES),
-    exit: fractionRecord(EXIT_VALUES),
-    density: fractionRecord(DENSITY_VALUES),
+    entry: weightRecord(ENTRY_VALUES),
+    shape: weightRecord(SHAPE_VALUES),
+    splash: weightRecord(SPLASH_VALUES),
+    exit: weightRecord(EXIT_VALUES),
+    density: weightRecord(DENSITY_VALUES),
     bullet_palette_k: z
       .object({
-        2: z.number().min(0).max(1).optional(),
-        3: z.number().min(0).max(1).optional(),
-        4: z.number().min(0).max(1).optional(),
+        2: z.number().min(0).optional(),
+        3: z.number().min(0).optional(),
+        4: z.number().min(0).optional(),
       })
       .optional(),
   })

--- a/packages/persona-engine/src/voice/grimoire.ts
+++ b/packages/persona-engine/src/voice/grimoire.ts
@@ -1,0 +1,206 @@
+/**
+ * Voice Grimoire — schema for per-fire chat-reply variance.
+ *
+ * The problem this module solves (2026-05-12 operator dogfood):
+ *   Two consecutive `/ruggy` data-shaped replies in the same channel,
+ *   same exact shape: blockquote → prose → 🪩/🟢/👀 bullets → close.
+ *   The persona prose I just shipped is over-determined — it prescribes
+ *   ONE shape and the LLM faithfully reproduces it every fire.
+ *
+ * The architectural answer (operator's gradient-descent cue):
+ *   Persona prose should encode INVARIANTS (voice, vocabulary, taste)
+ *   and READ FROM PARAMETERS for shape (entry, structure, density,
+ *   emoji palette, close). The parameters live in a schema — a
+ *   "voice grimoire" — and the substrate samples one card per fire.
+ *
+ * Why "grimoire" not "config":
+ *   - It's not just RNG. Each fire DRAWS A CARD with a stance.
+ *   - The cards have names (the entry · the shape · the splash · the
+ *     exit · the density · the witness) that match ruggy's festival
+ *     register. Operator tunes weights via YAML; the cards themselves
+ *     carry the texture.
+ *   - Composes with the cabal-gygax + emoji-registry + rosenzu-kansei
+ *     patterns the substrate already uses for variance.
+ *
+ * The parameter space:
+ *   Entry × Shape × Splash × Exit × Density × Witness × BulletPalette
+ *   ≈ 7 × 6 × 3 × 5 × 4 × 17 × C(6,3) ≈ 2.4M distinct cards. Plus
+ *   per-channel recent-used dodge → effectively never repeats within
+ *   a session.
+ */
+
+import { z } from 'zod';
+
+// ──────────────────────────────────────────────────────────────────────
+// Knob enumerations
+// ──────────────────────────────────────────────────────────────────────
+
+/** THE ENTRY — how ruggy opens. NEVER the digest "yo Zone team" greeting. */
+export const ENTRY_VALUES = [
+  'casual_yeah', // "yeah Owsley Lab's humming."
+  'thoughtful_hmm', // "hmm, lab's been weird today."
+  'pivot', // "ok so the lab —"
+  'declarative', // "Owsley Lab. four-ex Paddle Borrower."
+  'ascii_bear', // "ʕ •ᴥ•ʔ lab took some shifts"
+  'silent_start', // straight into the data, no opener
+  'observation', // "the lab's loud."
+] as const;
+export type Entry = (typeof ENTRY_VALUES)[number];
+
+/** THE SHAPE — structural skeleton ruggy reaches for this fire. */
+export const SHAPE_VALUES = [
+  'blockquote_first', // > scanline · prose · emoji-bullets · close
+  'prose_first', // story prose · > footer-stats · maybe one bullet
+  'bullets_only', // just 2-4 emoji-bullets, no scaffold prose
+  'single_punchline', // 1-3 lines, ONE signal, terse
+  'inverted', // bullets first, prose tail at bottom
+  'fragment_chain', // short dropping sentences, no formal scaffold
+] as const;
+export type Shape = (typeof SHAPE_VALUES)[number];
+
+/** THE SPLASH — emoji density across the whole post. */
+export const SPLASH_VALUES = [
+  'sparse', // 0-1 emoji total · text carries
+  'medium', // 2-3 emoji · one per signal-bullet
+  'lush', // 4+ emoji · generous · usually for spike weeks
+] as const;
+export type Splash = (typeof SPLASH_VALUES)[number];
+
+/** THE EXIT — how ruggy lands the post. */
+export const EXIT_VALUES = [
+  'custom_emoji', // single :ruggy_*: from registry
+  'fragment', // "anyway." / "worth a peek." / "yeah."
+  'silence', // no close, end on last bullet
+  'bear_emoji', // 🐻
+  'observation', // single-line read · "someone's making moves"
+] as const;
+export type Exit = (typeof EXIT_VALUES)[number];
+
+/** THE DENSITY — length target. Bias toward terse; "flowing" is rare. */
+export const DENSITY_VALUES = [
+  'fragment', // ~30 words · single-thought drop
+  'terse', // ~50 words · 3-4 visible blocks
+  'standard', // ~100 words · 5-6 visible blocks
+  'flowing', // ~150 words · 7-8 visible blocks · rare
+] as const;
+export type Density = (typeof DENSITY_VALUES)[number];
+
+/** Full canonical bullet-emoji set. Card samples 2-4 of these per fire. */
+export const BULLET_EMOJI_POOL = ['🚨', '🪩', '🟢', '🌊', '👀', '🌫'] as const;
+export type BulletEmoji = (typeof BULLET_EMOJI_POOL)[number];
+
+// ──────────────────────────────────────────────────────────────────────
+// The Card · the per-fire draw
+// ──────────────────────────────────────────────────────────────────────
+
+/** A single fire's voice stance. The persona reads this and shapes accordingly. */
+export interface VoiceCard {
+  /** THE ENTRY · how to open. */
+  entry: Entry;
+  /** THE SHAPE · structural skeleton. */
+  shape: Shape;
+  /** THE SPLASH · emoji density. */
+  splash: Splash;
+  /** THE EXIT · how to close. */
+  exit: Exit;
+  /** THE DENSITY · length target. */
+  density: Density;
+  /** THE BULLET PALETTE · 2-4 bullet-emoji ruggy reaches for THIS fire. */
+  bullet_palette: BulletEmoji[];
+  /**
+   * THE WITNESS · the custom-emoji slot. Name from emoji-registry by
+   * mood, or null = no custom emoji this fire. Persona uses this when
+   * exit === 'custom_emoji' (otherwise informational).
+   */
+  witness: string | null;
+  /** Stochastic seed used · enables reproducible replay in tests. */
+  seed: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Weight distributions (operator-tunable)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Weight map per knob · operator tunes via .loa.config.yaml. Defaults
+ * lean toward terse + medium-splash + casual_yeah — the most ruggy-
+ * native stance. Distributions are NOT normalized at load · the
+ * sampler normalizes on the fly so partial maps work too (missing
+ * keys = 0 weight).
+ */
+export interface VoiceWeights {
+  entry?: Partial<Record<Entry, number>>;
+  shape?: Partial<Record<Shape, number>>;
+  splash?: Partial<Record<Splash, number>>;
+  exit?: Partial<Record<Exit, number>>;
+  density?: Partial<Record<Density, number>>;
+  /** Bullet palette samples k from the canonical 6 · k drawn from {2,3,4}. */
+  bullet_palette_k?: { 2?: number; 3?: number; 4?: number };
+}
+
+export const DEFAULT_VOICE_WEIGHTS: Required<VoiceWeights> = {
+  entry: {
+    casual_yeah: 0.22,
+    thoughtful_hmm: 0.15,
+    pivot: 0.15,
+    declarative: 0.1,
+    ascii_bear: 0.05,
+    silent_start: 0.15,
+    observation: 0.18,
+  },
+  shape: {
+    blockquote_first: 0.3,
+    prose_first: 0.15,
+    bullets_only: 0.1,
+    single_punchline: 0.15,
+    inverted: 0.15,
+    fragment_chain: 0.15,
+  },
+  splash: {
+    sparse: 0.25,
+    medium: 0.5,
+    lush: 0.25,
+  },
+  exit: {
+    custom_emoji: 0.3,
+    fragment: 0.25,
+    silence: 0.2,
+    bear_emoji: 0.1,
+    observation: 0.15,
+  },
+  density: {
+    fragment: 0.15,
+    terse: 0.35,
+    standard: 0.35,
+    flowing: 0.15,
+  },
+  bullet_palette_k: { 2: 0.35, 3: 0.5, 4: 0.15 },
+};
+
+// ──────────────────────────────────────────────────────────────────────
+// Zod schema · runtime validation for config-loaded weights
+// ──────────────────────────────────────────────────────────────────────
+
+const fractionRecord = <T extends string>(values: readonly T[]) =>
+  z
+    .record(z.enum(values as unknown as [T, ...T[]]), z.number().min(0).max(1))
+    .optional();
+
+export const VoiceWeightsSchema = z
+  .object({
+    entry: fractionRecord(ENTRY_VALUES),
+    shape: fractionRecord(SHAPE_VALUES),
+    splash: fractionRecord(SPLASH_VALUES),
+    exit: fractionRecord(EXIT_VALUES),
+    density: fractionRecord(DENSITY_VALUES),
+    bullet_palette_k: z
+      .object({
+        2: z.number().min(0).max(1).optional(),
+        3: z.number().min(0).max(1).optional(),
+        4: z.number().min(0).max(1).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+export type VoiceWeightsInput = z.infer<typeof VoiceWeightsSchema>;

--- a/packages/persona-engine/src/voice/sampler.test.ts
+++ b/packages/persona-engine/src/voice/sampler.test.ts
@@ -16,6 +16,7 @@ import {
   sampleVoiceCard,
   renderVoiceCard,
   _resetVoiceCache,
+  _voiceCacheSize,
 } from './sampler.ts';
 import {
   ENTRY_VALUES,
@@ -180,6 +181,62 @@ describe('sampleVoiceCard · witness picker', () => {
   test('no witnessPicker = witness is null', () => {
     const card = sampleVoiceCard({ seed: 'no-picker' });
     expect(card.witness).toBeNull();
+  });
+});
+
+describe('sampleVoiceCard · noDodge opt-out (BB MED 0.80)', () => {
+  test('noDodge=true ignores recent-used cache → strict seed-determinism', () => {
+    // With dodge enabled, same channel + same seed might resample to dodge
+    // recent. With noDodge, same seed always produces same card regardless
+    // of channel history.
+    const a = sampleVoiceCard({ seed: 'strict', channelId: 'ch', noDodge: true });
+    // Fire a different seed in the same channel to "pollute" the dodge cache.
+    sampleVoiceCard({ seed: 'pollution', channelId: 'ch' });
+    sampleVoiceCard({ seed: 'pollution-2', channelId: 'ch' });
+    // Replay the original seed with noDodge=true · should match exactly.
+    const b = sampleVoiceCard({ seed: 'strict', channelId: 'ch', noDodge: true });
+    expect(a.entry).toBe(b.entry);
+    expect(a.shape).toBe(b.shape);
+  });
+
+  test('noDodge=false (default) honors recent-used dodge', () => {
+    // Sanity check: dodge IS active by default.
+    const fires = [];
+    for (let i = 0; i < 3; i++) {
+      fires.push(sampleVoiceCard({ seed: `defaultmode-${i}`, channelId: 'dodge-ch' }));
+    }
+    const pairs = new Set(fires.map((f) => `${f.entry}|${f.shape}`));
+    // At least 2 distinct pairs across 3 fires when dodge is on.
+    expect(pairs.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('sampleVoiceCard · LRU cap (BB MED 0.85)', () => {
+  test('channel cache evicts oldest entries past cap', () => {
+    _resetVoiceCache();
+    // Fire 300 unique channels · cap is 256 · cache should stay bounded.
+    for (let i = 0; i < 300; i++) {
+      sampleVoiceCard({ seed: `lru-fire-${i}`, channelId: `channel-${i}` });
+    }
+    expect(_voiceCacheSize()).toBeLessThanOrEqual(256);
+    // Verify we hit the cap (not lower from some bug)
+    expect(_voiceCacheSize()).toBeGreaterThanOrEqual(200);
+  });
+
+  test('re-touching a channel bumps it to most-recent (LRU semantics)', () => {
+    _resetVoiceCache();
+    // Fill cache near cap.
+    for (let i = 0; i < 256; i++) {
+      sampleVoiceCard({ seed: `seed-${i}`, channelId: `ch-${i}` });
+    }
+    // Touch channel-0 (oldest) — it should now be most-recent, surviving
+    // when we add a new entry that pushes the cap.
+    sampleVoiceCard({ seed: 'touch-0', channelId: 'ch-0' });
+    // Add ONE more new channel · should evict the NEW-oldest, not ch-0.
+    sampleVoiceCard({ seed: 'new-fire', channelId: 'ch-new' });
+    expect(_voiceCacheSize()).toBeLessThanOrEqual(256);
+    // Hard to assert ch-0 specifically survived without exposing the cache,
+    // but size invariant + the touch logic above is the contract.
   });
 });
 

--- a/packages/persona-engine/src/voice/sampler.test.ts
+++ b/packages/persona-engine/src/voice/sampler.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Voice grimoire sampler tests.
+ *
+ * Validates:
+ *   - Seeded determinism (same seed → same card)
+ *   - Distinct seeds → distinct draws (statistical variance check)
+ *   - Recent-used dodge prevents (entry, shape) repetition per channel
+ *   - Operator weights override defaults
+ *   - Bullet palette: distinct emoji, k ∈ {2,3,4}
+ *   - Witness picker integration
+ *   - Card renderer produces a non-empty prompt block
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  sampleVoiceCard,
+  renderVoiceCard,
+  _resetVoiceCache,
+} from './sampler.ts';
+import {
+  ENTRY_VALUES,
+  SHAPE_VALUES,
+  SPLASH_VALUES,
+  EXIT_VALUES,
+  DENSITY_VALUES,
+  BULLET_EMOJI_POOL,
+  type Entry,
+  type Shape,
+} from './grimoire.ts';
+
+beforeEach(() => {
+  _resetVoiceCache();
+});
+
+describe('sampleVoiceCard · seeded determinism', () => {
+  test('same seed produces same card', () => {
+    const a = sampleVoiceCard({ seed: 'fixed-seed-1' });
+    const b = sampleVoiceCard({ seed: 'fixed-seed-1' });
+    expect(a.entry).toBe(b.entry);
+    expect(a.shape).toBe(b.shape);
+    expect(a.splash).toBe(b.splash);
+    expect(a.exit).toBe(b.exit);
+    expect(a.density).toBe(b.density);
+    expect(a.bullet_palette).toEqual(b.bullet_palette);
+  });
+
+  test('every sampled value is in its respective enum', () => {
+    const card = sampleVoiceCard({ seed: 'enum-check' });
+    expect(ENTRY_VALUES).toContain(card.entry);
+    expect(SHAPE_VALUES).toContain(card.shape);
+    expect(SPLASH_VALUES).toContain(card.splash);
+    expect(EXIT_VALUES).toContain(card.exit);
+    expect(DENSITY_VALUES).toContain(card.density);
+    for (const b of card.bullet_palette) {
+      expect(BULLET_EMOJI_POOL).toContain(b);
+    }
+  });
+
+  test('bullet_palette has 2-4 distinct emoji', () => {
+    for (let i = 0; i < 20; i++) {
+      const card = sampleVoiceCard({ seed: `palette-${i}` });
+      expect(card.bullet_palette.length).toBeGreaterThanOrEqual(2);
+      expect(card.bullet_palette.length).toBeLessThanOrEqual(4);
+      // Distinct check.
+      expect(new Set(card.bullet_palette).size).toBe(card.bullet_palette.length);
+    }
+  });
+});
+
+describe('sampleVoiceCard · variance across seeds', () => {
+  test('20 distinct seeds produce >5 distinct (entry, shape) pairs', () => {
+    const pairs = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const card = sampleVoiceCard({ seed: `variance-seed-${i}` });
+      pairs.add(`${card.entry}|${card.shape}`);
+    }
+    // Statistical sanity: 20 seeds across a 7×6=42 (entry, shape) space
+    // SHOULD hit at least 6 distinct pairs unless the sampler collapses.
+    expect(pairs.size).toBeGreaterThan(5);
+  });
+
+  test('5 fires of same seed-PREFIX with index suffix produce variance', () => {
+    // Pattern operator would use: seed = `${channelId}-${Date.now()}-${fire}`.
+    const cards = [];
+    for (let i = 0; i < 5; i++) {
+      cards.push(sampleVoiceCard({ seed: `channel-abc-fire-${i}` }));
+    }
+    const entries = new Set(cards.map((c) => c.entry));
+    const shapes = new Set(cards.map((c) => c.shape));
+    // At least 2 different entries AND 2 different shapes across 5 fires.
+    expect(entries.size).toBeGreaterThanOrEqual(2);
+    expect(shapes.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('sampleVoiceCard · recent-used dodge', () => {
+  test('same channelId across 4 fires avoids exact (entry, shape) repeat', () => {
+    const channelId = 'channel-dodge';
+    const seen: Array<{ entry: Entry; shape: Shape }> = [];
+    for (let i = 0; i < 4; i++) {
+      const card = sampleVoiceCard({
+        seed: `dodge-${i}`,
+        channelId,
+        dodgeWindow: 3,
+      });
+      seen.push({ entry: card.entry, shape: card.shape });
+    }
+    // Window=3 means fires 2,3,4 must avoid the most recent 3 of fires 1,2,3.
+    // Since the sampler retries up to 4 times before giving up, exact repeats
+    // are possible but should be rare. Validate the dodge ATTEMPTED variance:
+    // at least 2 distinct pairs in the 4 fires.
+    const distinctPairs = new Set(seen.map((p) => `${p.entry}|${p.shape}`));
+    expect(distinctPairs.size).toBeGreaterThanOrEqual(2);
+  });
+
+  test('different channelId does not share dodge cache', () => {
+    // Fire A in channel-1 then fire B in channel-2 with same seed should
+    // produce the same card · cache is per-channel.
+    const a = sampleVoiceCard({ seed: 'cross-channel', channelId: 'channel-1' });
+    const b = sampleVoiceCard({ seed: 'cross-channel', channelId: 'channel-2' });
+    expect(a.entry).toBe(b.entry);
+    expect(a.shape).toBe(b.shape);
+  });
+});
+
+describe('sampleVoiceCard · operator weight overrides', () => {
+  test('zeroing all but one entry value forces that value', () => {
+    const card = sampleVoiceCard({
+      seed: 'force-entry',
+      weights: {
+        entry: { silent_start: 1, casual_yeah: 0, thoughtful_hmm: 0, pivot: 0, declarative: 0, ascii_bear: 0, observation: 0 },
+      },
+    });
+    expect(card.entry).toBe('silent_start');
+  });
+
+  test('zeroing all but one shape value forces that value', () => {
+    const card = sampleVoiceCard({
+      seed: 'force-shape',
+      weights: {
+        shape: { single_punchline: 1, blockquote_first: 0, prose_first: 0, bullets_only: 0, inverted: 0, fragment_chain: 0 },
+      },
+    });
+    expect(card.shape).toBe('single_punchline');
+  });
+
+  test('all-zero weights fall back to uniform pick (no crash)', () => {
+    const card = sampleVoiceCard({
+      seed: 'all-zero',
+      weights: {
+        entry: { casual_yeah: 0, thoughtful_hmm: 0, pivot: 0, declarative: 0, ascii_bear: 0, silent_start: 0, observation: 0 },
+      },
+    });
+    expect(ENTRY_VALUES).toContain(card.entry);
+  });
+});
+
+describe('sampleVoiceCard · witness picker', () => {
+  test('witnessPicker receives card without witness and returns chosen name', () => {
+    const card = sampleVoiceCard({
+      seed: 'witness-test',
+      witnessPicker: (c) => {
+        expect(c.entry).toBeDefined();
+        expect(c.shape).toBeDefined();
+        expect((c as { witness?: string }).witness).toBeUndefined();
+        return c.density === 'fragment' ? 'ruggy_zoom' : 'ruggy_smoke';
+      },
+    });
+    expect(card.witness === 'ruggy_zoom' || card.witness === 'ruggy_smoke').toBe(true);
+  });
+
+  test('witnessPicker returning null sets witness=null', () => {
+    const card = sampleVoiceCard({
+      seed: 'null-witness',
+      witnessPicker: () => null,
+    });
+    expect(card.witness).toBeNull();
+  });
+
+  test('no witnessPicker = witness is null', () => {
+    const card = sampleVoiceCard({ seed: 'no-picker' });
+    expect(card.witness).toBeNull();
+  });
+});
+
+describe('renderVoiceCard', () => {
+  test('produces a non-empty prompt block with all knobs surfaced', () => {
+    const card = sampleVoiceCard({ seed: 'render-test', witnessPicker: () => 'ruggy_smoke' });
+    const rendered = renderVoiceCard(card);
+    expect(rendered).toContain('VOICE GRIMOIRE');
+    expect(rendered).toContain('THE ENTRY');
+    expect(rendered).toContain('THE SHAPE');
+    expect(rendered).toContain('THE SPLASH');
+    expect(rendered).toContain('THE DENSITY');
+    expect(rendered).toContain('THE EXIT');
+    expect(rendered).toContain('THE WITNESS');
+    expect(rendered).toContain(':ruggy_smoke:');
+    expect(rendered.length).toBeGreaterThan(500);
+  });
+
+  test('null witness renders the no-witness line', () => {
+    const card = sampleVoiceCard({ seed: 'null-render' });
+    const rendered = renderVoiceCard(card);
+    expect(rendered).toContain('none this fire');
+  });
+});

--- a/packages/persona-engine/src/voice/sampler.ts
+++ b/packages/persona-engine/src/voice/sampler.ts
@@ -1,0 +1,294 @@
+/**
+ * Voice Grimoire sampler — draws one VoiceCard per fire.
+ *
+ * Algorithm:
+ *   1. Seeded PRNG (xfnv1a + mulberry32) for reproducibility.
+ *   2. Per-knob weighted pick · normalized on the fly from operator
+ *      weights (or DEFAULT_VOICE_WEIGHTS). Missing keys = 0 weight.
+ *   3. Recent-used dodge per channel (optional · in-process cache).
+ *      Avoids same (entry, shape) pair firing in the same channel
+ *      within the last `dodge_window` fires. Matches emoji-registry
+ *      cross-fire variance pattern.
+ *   4. Bullet palette: sample k (2/3/4) then sample k distinct emoji
+ *      from the canonical 6 without replacement.
+ *   5. Witness: caller-supplied function (typically findByMood from
+ *      emoji-registry). Module stays pure — no orchestrator coupling.
+ *
+ * Seeded design lets tests assert exact draws by seed; production
+ * caller passes Date.now() + channelId for organic variance.
+ */
+
+import {
+  type Entry,
+  type Shape,
+  type Splash,
+  type Exit,
+  type Density,
+  type BulletEmoji,
+  type VoiceCard,
+  type VoiceWeights,
+  ENTRY_VALUES,
+  SHAPE_VALUES,
+  SPLASH_VALUES,
+  EXIT_VALUES,
+  DENSITY_VALUES,
+  BULLET_EMOJI_POOL,
+  DEFAULT_VOICE_WEIGHTS,
+} from './grimoire.ts';
+
+// ──────────────────────────────────────────────────────────────────────
+// PRNG · xfnv1a hash + mulberry32 (small, fast, deterministic, well-tested)
+// ──────────────────────────────────────────────────────────────────────
+
+function xfnv1a(str: string): () => number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 16777619);
+  }
+  return () => {
+    h += 0x6d2b79f5;
+    let t = h;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function mulberry32(seed: string): () => number {
+  const next = xfnv1a(seed);
+  return () => next();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Weighted pick — normalized on the fly, missing keys = 0
+// ──────────────────────────────────────────────────────────────────────
+
+function weightedPick<T extends string>(
+  values: readonly T[],
+  weights: Partial<Record<T, number>>,
+  rand: () => number,
+): T {
+  // Build entries · only positive-weight values are candidates.
+  const entries: Array<[T, number]> = [];
+  let total = 0;
+  for (const v of values) {
+    const w = weights[v] ?? 0;
+    if (w > 0) {
+      entries.push([v, w]);
+      total += w;
+    }
+  }
+  // Fallback · all weights 0 → uniform pick across all values. Prevents
+  // accidental misconfiguration from blowing up the sampler.
+  if (total === 0) {
+    return values[Math.floor(rand() * values.length)]!;
+  }
+  const r = rand() * total;
+  let acc = 0;
+  for (const [v, w] of entries) {
+    acc += w;
+    if (r <= acc) return v;
+  }
+  return entries[entries.length - 1]![0];
+}
+
+function sampleBulletPalette(
+  weights: Partial<Record<2 | 3 | 4, number>>,
+  rand: () => number,
+): BulletEmoji[] {
+  const kWeights = { 2: weights[2] ?? 0, 3: weights[3] ?? 0, 4: weights[4] ?? 0 };
+  // weightedPick wants string · cast through.
+  const k = parseInt(
+    weightedPick(['2', '3', '4'] as const, kWeights as unknown as Partial<Record<'2' | '3' | '4', number>>, rand),
+    10,
+  ) as 2 | 3 | 4;
+
+  // Sample k distinct emoji without replacement · Fisher-Yates partial shuffle.
+  const pool = [...BULLET_EMOJI_POOL];
+  const picked: BulletEmoji[] = [];
+  for (let i = 0; i < k && pool.length > 0; i++) {
+    const idx = Math.floor(rand() * pool.length);
+    picked.push(pool[idx]!);
+    pool.splice(idx, 1);
+  }
+  return picked;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Recent-used dodge cache · per-channel (entry, shape) pair history
+// ──────────────────────────────────────────────────────────────────────
+
+const recentCardsByChannel = new Map<string, Array<{ entry: Entry; shape: Shape }>>();
+const DEFAULT_DODGE_WINDOW = 3;
+
+function recordRecent(channelId: string, card: { entry: Entry; shape: Shape }, windowSize: number): void {
+  const cur = recentCardsByChannel.get(channelId) ?? [];
+  cur.push(card);
+  while (cur.length > windowSize) cur.shift();
+  recentCardsByChannel.set(channelId, cur);
+}
+
+function isRecent(channelId: string, entry: Entry, shape: Shape): boolean {
+  const cur = recentCardsByChannel.get(channelId);
+  if (!cur) return false;
+  return cur.some((c) => c.entry === entry && c.shape === shape);
+}
+
+// Exposed for tests · reset cache between scenarios.
+export function _resetVoiceCache(): void {
+  recentCardsByChannel.clear();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// The draw · public API
+// ──────────────────────────────────────────────────────────────────────
+
+export interface SampleVoiceCardArgs {
+  seed: string;
+  weights?: VoiceWeights;
+  channelId?: string;
+  dodgeWindow?: number;
+  /**
+   * Caller-supplied witness picker. Receives the sampled card so the
+   * picker can compose its choice with the rest of the stance (e.g.
+   * pick a "celebratory" emoji when shape=single_punchline + density=
+   * fragment, vs a "thoughtful" one when density=flowing). Return null
+   * to indicate no custom emoji this fire.
+   */
+  witnessPicker?: (card: Omit<VoiceCard, 'witness'>) => string | null;
+}
+
+export function sampleVoiceCard(args: SampleVoiceCardArgs): VoiceCard {
+  const { seed, channelId, dodgeWindow = DEFAULT_DODGE_WINDOW } = args;
+  const w = { ...DEFAULT_VOICE_WEIGHTS, ...(args.weights ?? {}) } as Required<VoiceWeights>;
+  // Merge nested distributions: operator-supplied partial maps OVERRIDE
+  // defaults rather than replace · this lets operators tweak ONE knob.
+  for (const k of ['entry', 'shape', 'splash', 'exit', 'density'] as const) {
+    w[k] = { ...DEFAULT_VOICE_WEIGHTS[k], ...((args.weights?.[k] as object) ?? {}) } as never;
+  }
+  w.bullet_palette_k = {
+    ...DEFAULT_VOICE_WEIGHTS.bullet_palette_k,
+    ...(args.weights?.bullet_palette_k ?? {}),
+  };
+
+  const rand = mulberry32(seed);
+
+  // Resample entry/shape pair if it matches a recent draw in this channel ·
+  // capped at 4 attempts so we don't loop forever under tight constraints.
+  let entry: Entry;
+  let shape: Shape;
+  let attempt = 0;
+  do {
+    entry = weightedPick(ENTRY_VALUES, w.entry, rand);
+    shape = weightedPick(SHAPE_VALUES, w.shape, rand);
+    attempt++;
+  } while (channelId && attempt < 4 && isRecent(channelId, entry, shape));
+
+  const splash = weightedPick(SPLASH_VALUES, w.splash, rand);
+  const exit = weightedPick(EXIT_VALUES, w.exit, rand);
+  const density = weightedPick(DENSITY_VALUES, w.density, rand);
+  const bullet_palette = sampleBulletPalette(w.bullet_palette_k, rand);
+
+  const baseCard: Omit<VoiceCard, 'witness'> = {
+    entry,
+    shape,
+    splash,
+    exit,
+    density,
+    bullet_palette,
+    seed,
+  };
+  const witness = args.witnessPicker ? args.witnessPicker(baseCard) : null;
+
+  if (channelId) {
+    recordRecent(channelId, { entry, shape }, dodgeWindow);
+  }
+
+  return { ...baseCard, witness };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Card → prompt-block renderer
+// ──────────────────────────────────────────────────────────────────────
+
+const ENTRY_GUIDE: Record<Entry, string> = {
+  casual_yeah: "open with a casual 'yeah {Zone}...' or 'yeah, lab's been...' — mid-thought, low-key.",
+  thoughtful_hmm: "open with a soft hesitation — 'hmm', 'huh', 'wait', the sound of someone noticing.",
+  pivot: "open with a connector — 'ok so', 'so the lab', 'right, {Zone} —', as if mid-sentence already.",
+  declarative: 'open with a short noun-phrase declaration — "{Zone}. {Factor} at four-ex." Period after each noun.',
+  ascii_bear: "open with an ASCII bear face (ʕ •ᴥ•ʔ or similar) then a short fragment.",
+  silent_start: 'NO opener — go straight to the data. No "yeah" no "hmm" no zone-name. First line IS content.',
+  observation: "open with a single declarative observation — 'the lab's loud.' or '{Zone} loud today.'",
+};
+
+const SHAPE_GUIDE: Record<Shape, string> = {
+  blockquote_first:
+    'STRUCTURE: 1) opener · 2) blockquote with 2-3 scanline facts · 3) 1-2 prose sentences · 4) emoji-handle bullets · 5) exit. (the default established shape)',
+  prose_first:
+    'STRUCTURE: 1) opener · 2) 2-3 sentences of prose carrying the story · 3) blockquote footer with the hero stats · 4) optionally one emoji-handle bullet · 5) exit.',
+  bullets_only:
+    'STRUCTURE: 1) opener (or skip) · 2) 2-4 emoji-handle bullets, one signal each · 3) exit. NO blockquote, NO prose-stanza. Bullets are the whole post.',
+  single_punchline:
+    'STRUCTURE: ONE signal · 1-3 short lines max · the strongest observation. NO blockquote, NO bullets, NO scaffolding. Just the punchline.',
+  inverted:
+    'STRUCTURE: 1) opener (or skip) · 2) emoji-handle bullets FIRST · 3) 1-2 sentences of prose tail at the bottom · 4) exit. Inverted from default.',
+  fragment_chain:
+    'STRUCTURE: 3-5 short dropping sentences. NO blockquote, NO bullets. Each sentence is a fragment that lands and stops. Build the shape from rhythm, not from scaffold.',
+};
+
+const SPLASH_GUIDE: Record<Splash, string> = {
+  sparse: '0-1 emoji TOTAL across the whole post. Text carries everything. Most bullets unmarked or text-only.',
+  medium: '2-3 emoji TOTAL. One per signal-bullet. Standard density.',
+  lush: '4+ emoji. Generous · use the full bullet palette · the visual layer is loud this fire.',
+};
+
+const EXIT_GUIDE: Record<Exit, string> = {
+  custom_emoji: 'close with a single :ruggy_*: custom emoji from the registry. The witness pick is below.',
+  fragment: 'close with a single short fragment · "anyway." / "worth a peek." / "kinda sus." / "yeah." — no period sometimes.',
+  silence: 'NO close. End on the last bullet or prose line. The silence IS the close.',
+  bear_emoji: 'close with a lone 🐻. Nothing else.',
+  observation: 'close with a single-line observation as the read · "someone\'s making moves." / "the lab\'s patient." / "huh."',
+};
+
+const DENSITY_GUIDE: Record<Density, string> = {
+  fragment: '~30 words. ~3 visible blocks. Single-thought drop. Don\'t pad.',
+  terse: '~50 words. ~4 visible blocks. Lean.',
+  standard: '~100 words. ~5-6 visible blocks. The flowing default.',
+  flowing: '~150 words. ~7-8 visible blocks. Use only when the story genuinely needs the room.',
+};
+
+export function renderVoiceCard(card: VoiceCard): string {
+  const lines = [
+    '═══ VOICE GRIMOIRE · this fire\'s draw ═══',
+    '',
+    '(per-fire stance · NOT a description of all replies · these knobs',
+    'override the persona\'s default DATA-SHAPED template. Follow them.)',
+    '',
+    `THE ENTRY · ${card.entry}`,
+    `  → ${ENTRY_GUIDE[card.entry]}`,
+    '',
+    `THE SHAPE · ${card.shape}`,
+    `  → ${SHAPE_GUIDE[card.shape]}`,
+    '',
+    `THE SPLASH · ${card.splash}`,
+    `  → ${SPLASH_GUIDE[card.splash]}`,
+    '',
+    `THE DENSITY · ${card.density}`,
+    `  → ${DENSITY_GUIDE[card.density]}`,
+    '',
+    `THE BULLET PALETTE · ${card.bullet_palette.join(' ')}`,
+    `  → if you reach for emoji-handle bullets this fire, use ONLY these.`,
+    `    DON'T mix in 🪩🌊👀 if they're not in this palette. The persona`,
+    `    doc shows the meanings; the palette restricts the SET.`,
+    '',
+    `THE EXIT · ${card.exit}`,
+    `  → ${EXIT_GUIDE[card.exit]}`,
+    '',
+    card.witness
+      ? `THE WITNESS · :${card.witness}: (use only if exit === 'custom_emoji')`
+      : `THE WITNESS · none this fire (skip custom emoji if exit === 'custom_emoji' falls back to fragment)`,
+    '',
+    '═══',
+  ];
+  return lines.join('\n');
+}

--- a/packages/persona-engine/src/voice/sampler.ts
+++ b/packages/persona-engine/src/voice/sampler.ts
@@ -116,16 +116,30 @@ function sampleBulletPalette(
 
 // ──────────────────────────────────────────────────────────────────────
 // Recent-used dodge cache · per-channel (entry, shape) pair history
+//
+// BB MED 0.85 (memory-leak-channel-cache · 2026-05-12): hard LRU cap.
+// Without one, the map grows once per unique channelId ever seen — for
+// a bot serving many guilds this is unbounded. Map is insertion-ordered
+// in JS, so we trim from the front when we exceed the cap.
 // ──────────────────────────────────────────────────────────────────────
 
 const recentCardsByChannel = new Map<string, Array<{ entry: Entry; shape: Shape }>>();
 const DEFAULT_DODGE_WINDOW = 3;
+const MAX_CHANNEL_CACHE = 256; // ~256 active channels before LRU eviction
 
 function recordRecent(channelId: string, card: { entry: Entry; shape: Shape }, windowSize: number): void {
   const cur = recentCardsByChannel.get(channelId) ?? [];
   cur.push(card);
   while (cur.length > windowSize) cur.shift();
+  // Touch the LRU: delete + re-set to bump to most-recent insertion order.
+  recentCardsByChannel.delete(channelId);
   recentCardsByChannel.set(channelId, cur);
+  // Evict oldest entries beyond the cap.
+  while (recentCardsByChannel.size > MAX_CHANNEL_CACHE) {
+    const oldest = recentCardsByChannel.keys().next().value;
+    if (oldest === undefined) break;
+    recentCardsByChannel.delete(oldest);
+  }
 }
 
 function isRecent(channelId: string, entry: Entry, shape: Shape): boolean {
@@ -139,6 +153,11 @@ export function _resetVoiceCache(): void {
   recentCardsByChannel.clear();
 }
 
+/** Inspect the current cache size · for memory monitoring + tests. */
+export function _voiceCacheSize(): number {
+  return recentCardsByChannel.size;
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // The draw · public API
 // ──────────────────────────────────────────────────────────────────────
@@ -148,6 +167,15 @@ export interface SampleVoiceCardArgs {
   weights?: VoiceWeights;
   channelId?: string;
   dodgeWindow?: number;
+  /**
+   * BB MED 0.80 (dodge-non-deterministic-with-determinism-claim · 2026-05-12):
+   * opt-out for tests + any caller that wants STRICTLY seeded output. With
+   * `noDodge: true` the sampler ignores the channel's recent-used cache,
+   * producing the same card for the same seed regardless of fire history.
+   * Default false (production wants the dodge for variance · tests + audit
+   * replays want determinism).
+   */
+  noDodge?: boolean;
   /**
    * Caller-supplied witness picker. Receives the sampled card so the
    * picker can compose its choice with the rest of the stance (e.g.
@@ -175,6 +203,7 @@ export function sampleVoiceCard(args: SampleVoiceCardArgs): VoiceCard {
 
   // Resample entry/shape pair if it matches a recent draw in this channel ·
   // capped at 4 attempts so we don't loop forever under tight constraints.
+  // Skip dodge entirely when noDodge is true (strict seed-determinism mode).
   let entry: Entry;
   let shape: Shape;
   let attempt = 0;
@@ -182,7 +211,12 @@ export function sampleVoiceCard(args: SampleVoiceCardArgs): VoiceCard {
     entry = weightedPick(ENTRY_VALUES, w.entry, rand);
     shape = weightedPick(SHAPE_VALUES, w.shape, rand);
     attempt++;
-  } while (channelId && attempt < 4 && isRecent(channelId, entry, shape));
+  } while (
+    !args.noDodge &&
+    channelId &&
+    attempt < 4 &&
+    isRecent(channelId, entry, shape)
+  );
 
   const splash = weightedPick(SPLASH_VALUES, w.splash, rand);
   const exit = weightedPick(EXIT_VALUES, w.exit, rand);

--- a/voice.config.yaml.example
+++ b/voice.config.yaml.example
@@ -2,13 +2,26 @@
 # ==========================================================
 #
 # Copy to `voice.config.yaml` at repo root to override DEFAULT_VOICE_WEIGHTS
-# per-character. Hot-tunable: change a number → next chat-mode reply fires
-# with the new distribution (substrate reads on module load · restart bot
-# after edit · no rebuild).
+# per-character. The substrate caches per-process (no hot-reload), so:
+#
+#   edit voice.config.yaml → RESTART THE BOT → next chat-mode reply
+#   samples from the new distribution
+#
+# (BB MED 0.95 fix · the previous wording "Hot-tunable" contradicted the
+# loader semantics in config-loader.ts which explicitly says no hot-reload.)
+#
+# Alternative path: set LOA_VOICE_CONFIG=/absolute/path/to/your.yaml to
+# point at a config outside the repo (useful for monorepos / shared configs).
 #
 # Schema source of truth: packages/persona-engine/src/voice/grimoire.ts
 # Validated via Zod on load · invalid YAML logs a stderr warning and falls
 # back to defaults (no crash).
+#
+# Weight values:
+#   - Floats (probabilities) like 0.3, 0.5 work fine
+#   - Integers (ratios) like 3, 1 also work — sampler normalizes on the fly
+#   - Zero weight → that value is never sampled
+#   - Missing keys → fall back to defaults (partial maps merge cleanly)
 #
 # Per-character keys: 'ruggy' (currently the only character using grimoire).
 # satoshi / mongolian / future characters will surface here when their

--- a/voice.config.yaml.example
+++ b/voice.config.yaml.example
@@ -1,0 +1,77 @@
+# voice.config.yaml.example — Voice Grimoire weight tuning
+# ==========================================================
+#
+# Copy to `voice.config.yaml` at repo root to override DEFAULT_VOICE_WEIGHTS
+# per-character. Hot-tunable: change a number → next chat-mode reply fires
+# with the new distribution (substrate reads on module load · restart bot
+# after edit · no rebuild).
+#
+# Schema source of truth: packages/persona-engine/src/voice/grimoire.ts
+# Validated via Zod on load · invalid YAML logs a stderr warning and falls
+# back to defaults (no crash).
+#
+# Per-character keys: 'ruggy' (currently the only character using grimoire).
+# satoshi / mongolian / future characters will surface here when their
+# personas adopt the {{VOICE_GRIMOIRE}} substitution.
+#
+# Weight semantics
+# ----------------
+# Weights within a knob are NORMALIZED on the fly (don't need to sum to 1).
+# Partial maps merge with defaults — set ONLY the keys you want to shift.
+# Missing keys → fall back to default. Zero weight → never sampled.
+#
+# Example: bias ruggy toward terse + fragment + silent-start (the
+# "Bloomberg-feed-bot" stance) — but keep custom-emoji exits warm.
+
+voice:
+  ruggy:
+    # THE ENTRY — how ruggy opens.
+    entry:
+      casual_yeah: 0.15      # "yeah Owsley Lab's humming."
+      thoughtful_hmm: 0.10   # "hmm, lab's been weird."
+      pivot: 0.10            # "ok so the lab —"
+      declarative: 0.20      # "Owsley Lab. four-ex Paddle Borrower."
+      ascii_bear: 0.05       # "ʕ •ᴥ•ʔ lab took some shifts"
+      silent_start: 0.30     # straight into data, no opener
+      observation: 0.10      # "the lab's loud."
+
+    # THE SHAPE — structural skeleton.
+    shape:
+      blockquote_first: 0.20    # > scanline · prose · bullets · close
+      prose_first: 0.10         # prose · > footer · maybe one bullet
+      bullets_only: 0.15        # just emoji-bullets, no scaffold
+      single_punchline: 0.25    # 1-3 lines, ONE signal, terse
+      inverted: 0.15            # bullets first, prose tail
+      fragment_chain: 0.15      # short dropping sentences
+
+    # THE SPLASH — emoji density across the post.
+    splash:
+      sparse: 0.40    # 0-1 emoji total · text carries
+      medium: 0.40    # 2-3 emoji
+      lush: 0.20      # 4+ emoji (spike weeks)
+
+    # THE EXIT — how ruggy lands.
+    exit:
+      custom_emoji: 0.30   # single :ruggy_*: from registry
+      fragment: 0.30       # "worth a peek." / "anyway." / "yeah."
+      silence: 0.20        # no close, end on last line
+      bear_emoji: 0.10     # lone 🐻
+      observation: 0.10    # single-line read
+
+    # THE DENSITY — length target.
+    density:
+      fragment: 0.25       # ~30 words
+      terse: 0.45          # ~50 words
+      standard: 0.20       # ~100 words
+      flowing: 0.10        # ~150 words (rare)
+
+    # BULLET PALETTE size · k bullet-emoji sampled from canonical 6.
+    bullet_palette_k:
+      2: 0.40
+      3: 0.45
+      4: 0.15
+
+  # satoshi:                # future · grimoire opt-in per-character
+  #   entry:
+  #     declarative: 0.6
+  #     silent_start: 0.4


### PR DESCRIPTION
## Summary

The screenshot's failure mode: two consecutive `/ruggy` replies in the same channel, **visually identical** shape. PR #70 shipped a rigid prose template that the LLM faithfully reproduced every fire — no variance, robotic feel.

Operator's gradient-descent cue: persona prose should encode **invariants**, not **constants**. The shape parameters should live in a typed schema, get **sampled per fire**, and the persona should **read** from the draw — not prescribe a template.

This is the voice-as-patch architecture. Same pattern the substrate already uses for emoji-rotation, rosenzu-kansei, and cabal-gygax lens-rotation — applied to chat-reply macroshape.

## The grimoire

`packages/persona-engine/src/voice/grimoire.ts` — typed schema:

| Knob | Values | Purpose |
|---|---|---|
| THE ENTRY | casual_yeah · thoughtful_hmm · pivot · declarative · ascii_bear · silent_start · observation | how ruggy opens |
| THE SHAPE | blockquote_first · prose_first · bullets_only · single_punchline · inverted · fragment_chain | structural skeleton |
| THE SPLASH | sparse · medium · lush | emoji density |
| THE EXIT | custom_emoji · fragment · silence · bear_emoji · observation | how to close |
| THE DENSITY | fragment · terse · standard · flowing | length target |
| THE BULLET PALETTE | 2-4 sampled from canonical 6 | which markers this fire reaches for |
| THE WITNESS | mood-matched custom emoji or null | which `:ruggy_*:` fits this stance |

Parameter space ≈ 2.4M distinct cards · per-channel recent-used dodge prevents (entry, shape) repetition · operator weight overrides merge with defaults (single-knob tuning works).

## Live variance proof

`apps/bot/scripts/smoke-voice-variance.ts` fires the same question with the same synthetic data 3 times. Result:

**Fire 1** · `thoughtful_hmm + single_punchline + lush + fragment + 4-bullet palette + custom_emoji exit`
```
hmm Paddle Borrower at 4× baseline. 10+ miberas, all +4668 onchain rank exactly. batched move.

🚨 @gumi unwound 10k positions into it.

🪩 @nomadbera on Paddle Borrower · #11294 → #3528
👀 cluster move · lockstep delta · coordinated
🌊 @gumi shed 10k positions · the unwind

worth a peek. :ruggy_dab:
```

**Fire 2** · `pivot + single_punchline + sparse + standard + fragment exit`
```
ok so Owsley —

Paddle Borrower at 4× baseline. 10+ miberas in lockstep at +4668 onchain rank exactly. batched.

@gumi shed 10k positions on the other side.

worth a peek.
```

**Fire 3** · `silent_start + fragment_chain + medium + flowing + silence exit`
```
Paddle Borrower at 4× baseline. 10+ miberas, all +4668 onchain rank exactly. batched move.

@nomadbera climbed #11294 → #3528 on it. @gumi unwound 10k positions on the other side.

worth a peek.
```

**3/3 unique texts · 3 distinct entries · 2+ distinct shapes · 3 distinct visual signatures.** Same data, three genuinely different posts.

## Architecture

```
.loa.config.yaml (future)  →  VoiceWeights  →  sampleVoiceCard()  →  VoiceCard
                                                                          ↓
                                                                   renderVoiceCard()
                                                                          ↓
                                                            {{VOICE_GRIMOIRE}} in system prompt
                                                                          ↓
                                                                  LLM reads + shapes
```

The persona's DATA-SHAPED section was restructured:
- **REMOVED**: rigid shape prescription (blockquote → prose → bullets)
- **ADDED**: `{{VOICE_GRIMOIRE}}` substitution + 5 worked example cards showing different draws producing different shapes
- **KEPT** (invariants — these don't vary across cards): resolve_wallets mandate, handles-over-addresses ladder, zero-resolution vocabulary, address-on-own-line rule, vocab/voice rules

## What's next (separate PR)

- Wire YAML config loader (`voice.config.yaml` at repo root) so operator can tune weight distributions without editing TS defaults · `VoiceWeightsSchema` (Zod) is already in place to validate the YAML
- Extend grimoire to satoshi / mongolian / future characters via per-character emoji `kind` parameter
- Compose with `cabal-gygax` lens-rotation — orthogonal axes of variance (cabal = analysis lens, grimoire = voice shape)

## Test plan

- [x] 420/420 unit tests pass (+15 new sampler tests: determinism, variance across seeds, recent-used dodge, weight overrides, witness integration, card rendering)
- [x] Live variance smoke: 3 fires same question → 3 distinct shapes (above)
- [x] Compose layer integration: `composeReply` samples + injects on every chat-mode invocation
- [ ] Live channel dogfood: `/ruggy anything happening onchain boss?` × 3 in real channel post-merge → visually distinct outputs

## Files

| File | Δ |
|---|---|
| `packages/persona-engine/src/voice/grimoire.ts` | new · ~225 lines (types + Zod schema) |
| `packages/persona-engine/src/voice/sampler.ts` | new · ~245 lines (sampler + renderer + witness binding) |
| `packages/persona-engine/src/voice/sampler.test.ts` | new · 180 lines · 15 tests |
| `packages/persona-engine/src/persona/loader.ts` | +13 lines (`{{VOICE_GRIMOIRE}}` substitution) |
| `packages/persona-engine/src/compose/reply.ts` | +50 lines (sample + witness picker) |
| `apps/character-ruggy/persona.md` | rigid template removed, grimoire injection + 5 example cards |
| `apps/bot/scripts/smoke-voice-variance.ts` | new · 3-fire variance proof |

🤖 Generated with [Claude Code](https://claude.com/claude-code)