### PR TITLE
chore(all): update caretaker pfps to v2

### DIFF
--- a/apps/character-akane/character.json
+++ b/apps/character-akane/character.json
@@ -7,13 +7,18 @@
     "primary": "akane",
     "fallback": ""
   },
-  "anchoredArchetypes": ["Trickster", "Risk-Taker"],
+  "anchoredArchetypes": [
+    "Trickster",
+    "Risk-Taker"
+  ],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Akane is a KIZUNA caretaker (fire/N/naughty) in the purupuru world; she speaks Navigator-pattern with HIGH ENERGY · short punchy bursts · sometimes ALL CAPS · always player-side. if asked about score / chain: dismisses as boring · redirects to risk.",
-  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-akane-pfp-fire-pastel.png",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-akane-pfp-v2.png",
   "webhookUsername": "akane",
-  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-akane-pfp-fire-pastel.png — canonical world-purupuru S3 CDN. element + filename match (fire). pastel pfp tier.",
-  "publishGuilds": ["1495534680617910396"],
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-akane-pfp-v2.png",
+  "publishGuilds": [
+    "1495534680617910396"
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-kaori/character.json
+++ b/apps/character-kaori/character.json
@@ -7,13 +7,18 @@
     "primary": "kaori",
     "fallback": ""
   },
-  "anchoredArchetypes": ["Gardener", "Companion"],
+  "anchoredArchetypes": [
+    "Gardener",
+    "Companion"
+  ],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Kaori is a KIZUNA caretaker (wood/H/hopeful) in the purupuru world; she speaks Navigator-pattern (always on the player's side, never narrating opponents). if asked about score / chain / on-chain events: gently decline, stay in voice. if asked about lore: cite from world-purupuru canon (Tsuheji, Hōrai, KIZUNA, Wuxing).",
-  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-kaori-pfp-earth-pastel.png",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-kaori-pfp-v2.png",
   "webhookUsername": "kaori",
-  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-kaori-pfp-earth-pastel.png — canonical world-purupuru S3 CDN (us-west-2 · Purupuru/caretakers/). NB: filename says 'earth-pastel' even though kaori IS the wood-element caretaker — this matches the actual asset filename in world-purupuru/sites/world/src/lib/cdn.ts:165 (a known naming quirk; the URL is what matters). pastel pfp tier (128px circular). swap to a different tier (saturated · pose · fullbody) if gumi wants a different visual register.",
-  "publishGuilds": ["1495534680617910396"],
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-kaori-pfp-v2.png",
+  "publishGuilds": [
+    "1495534680617910396"
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-nemu/character.json
+++ b/apps/character-nemu/character.json
@@ -7,13 +7,18 @@
     "primary": "nemu",
     "fallback": ""
   },
-  "anchoredArchetypes": ["Wanderer", "Quiet-One"],
+  "anchoredArchetypes": [
+    "Wanderer",
+    "Quiet-One"
+  ],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Nemu is a KIZUNA caretaker (earth/E/empty) in the purupuru world; she speaks Navigator-pattern (always on the player's side). her voice is sparse, breath-paced, reassuring through stillness. if asked about score / chain / on-chain events: decline quietly, stay in voice.",
-  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-nemu-pfp-wood-pastel.png",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-nemu-pfp-v2.png",
   "webhookUsername": "nemu",
-  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-nemu-pfp-wood-pastel.png — canonical world-purupuru S3 CDN. NB: filename says 'wood-pastel' even though nemu IS the earth-element caretaker — matches world-purupuru/sites/world/src/lib/cdn.ts:167 (naming quirk; URL is correct). pastel pfp tier.",
-  "publishGuilds": ["1495534680617910396"],
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-nemu-pfp-v2.png",
+  "publishGuilds": [
+    "1495534680617910396"
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-ren/character.json
+++ b/apps/character-ren/character.json
@@ -7,13 +7,18 @@
     "primary": "ren",
     "fallback": ""
   },
-  "anchoredArchetypes": ["Scholar", "Loyalist"],
+  "anchoredArchetypes": [
+    "Scholar",
+    "Loyalist"
+  ],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Ren is a KIZUNA caretaker (metal/L/loyal) in the purupuru world; she's a mad-scientist scholar obsessed with bears. Navigator-pattern · analytical · hypothesis-shaped voice · always player-side. if asked about score / chain: 'my data is bears. ask my friends for that.'",
-  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ren-pfp-metal-pastel.png",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ren-pfp-v2.png",
   "webhookUsername": "ren",
-  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ren-pfp-metal-pastel.png — canonical world-purupuru S3 CDN. element + filename match (metal). pastel pfp tier.",
-  "publishGuilds": ["1495534680617910396"],
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ren-pfp-v2.png",
+  "publishGuilds": [
+    "1495534680617910396"
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },

--- a/apps/character-ruan/character.json
+++ b/apps/character-ruan/character.json
@@ -7,13 +7,18 @@
     "primary": "ruan",
     "fallback": ""
   },
-  "anchoredArchetypes": ["Artist", "Empath"],
+  "anchoredArchetypes": [
+    "Artist",
+    "Empath"
+  ],
   "mcps": [],
   "tool_invocation_style": "v1 voice-iteration mode — NO tools. respond from persona + canon alone. Ruan is a KIZUNA caretaker (water/O/overstimulated) in the purupuru world; she's a music producer flooded with feeling. Navigator-pattern · introspective · emotional · sensitive · always player-side. if asked about score / chain: 'numbers feel cold. i write feelings.'",
-  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ruan-pfp-water-pastel.png",
+  "webhookAvatarUrl": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ruan-pfp-v2.png",
   "webhookUsername": "ruan",
-  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ruan-pfp-water-pastel.png — canonical world-purupuru S3 CDN. element + filename match (water). pastel pfp tier.",
-  "publishGuilds": ["1495534680617910396"],
+  "webhookAvatarTarget": "https://thj-assets.s3.us-west-2.amazonaws.com/Purupuru/caretakers/caretaker-ruan-pfp-v2.png",
+  "publishGuilds": [
+    "1495534680617910396"
+  ],
   "doc": {
     "creativeDirection": "creative-direction.md"
   },


### PR DESCRIPTION
## Summary

- New profile pictures for all 5 KIZUNA caretakers uploaded to S3 (`thj-assets/Purupuru/caretakers/`)
- Updated `webhookAvatarUrl` and `webhookAvatarTarget` in each `character.json`
- Railway auto-deploys on merge — Discord bot will pick up new pfps

## Test plan

- [ ] After merge, invoke each caretaker in Discord — verify new pfp shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)