### PR TITLE
feat(cycle-005): post-merge UX pass + cross-week voice memory

### DIFF
--- a/apps/bot/scripts/cycle-005-ux-gallery.ts
+++ b/apps/bot/scripts/cycle-005-ux-gallery.ts
@@ -38,6 +38,13 @@ import {
   buildVoiceBrief,
   parseVoiceResponse,
 } from '@freeside-characters/persona-engine/compose/voice-brief';
+import {
+  appendVoiceMemory,
+  readLastVoiceMemory,
+  formatPriorWeekHint,
+  isoWeek,
+  type VoiceMemoryEntry,
+} from '@freeside-characters/persona-engine/compose/voice-memory';
 import { initOtelTest } from '@freeside-characters/persona-engine/observability/otel-test';
 import type {
   PulseDimensionBreakdown,
@@ -271,6 +278,7 @@ function deriveBriefInput(
   shape: 'A-all-quiet' | 'B-one-dim-hot' | 'C-multi-dim-hot',
   isNoClaim: boolean,
   validationViolations: number,
+  priorWeekHint?: string,
 ): Parameters<typeof buildVoiceBrief>[0] {
   if (!dim) {
     return {
@@ -282,6 +290,7 @@ function deriveBriefInput(
       totalEvents: 0,
       windowDays: 30,
       previousPeriodEvents: 0,
+      priorWeekHint,
     };
   }
   const permitted = dim.top_factors
@@ -300,6 +309,7 @@ function deriveBriefInput(
     totalEvents: dim.total_events,
     windowDays: 30,
     previousPeriodEvents: dim.previous_period_events,
+    priorWeekHint,
   };
 }
 
@@ -321,16 +331,70 @@ async function main(): Promise<void> {
   const otel = initOtelTest();
   const zonesToRender: ZoneId[] = ['bear-cave', 'el-dorado', 'owsley-lab'];
 
-  // ─── SCENARIO 1: real prod data (what ships now) ─────────────────
+  // Seed last-week memory for the continuity demo (only if the file
+  // doesn't already exist — preserves real history if the gallery has
+  // been run before · gitignored under .run/).
+  const lastWeekSeeds: Array<VoiceMemoryEntry> = [
+    {
+      at: '2026-05-09T00:00:00Z',
+      iso_week: '2026-W19',
+      zone: 'bear-cave',
+      shape: 'A-all-quiet',
+      header: '26 events across thirty days. the bears stir, then settle.',
+      outro: 'the honey waits. see you in the deep.',
+      key_numbers: { total_events: 26, previous_period_events: 30, permitted_factor_names: [] },
+    },
+    {
+      at: '2026-05-09T00:00:00Z',
+      iso_week: '2026-W19',
+      zone: 'el-dorado',
+      shape: 'A-all-quiet',
+      header: '1236 events but no rank-90 cross. the gold scatters.',
+      outro: 'the prowlers prowl. back next sunday.',
+      key_numbers: { total_events: 1236, previous_period_events: 800, permitted_factor_names: [] },
+    },
+    {
+      at: '2026-05-09T00:00:00Z',
+      iso_week: '2026-W19',
+      zone: 'owsley-lab',
+      shape: 'A-all-quiet',
+      header: '433 events past thirty days. the lab hums low.',
+      outro: 'chain-actions cool. next week we check the readings.',
+      key_numbers: { total_events: 433, previous_period_events: 380, permitted_factor_names: [] },
+    },
+  ];
+  // Use a dedicated demo history path so we don't accumulate gallery noise
+  // in production-bound .run/ruggy-voice-history.jsonl
+  const demoHistoryPath = '/tmp/ruggy-ux-gallery-history.jsonl';
+  // Reset for fresh demo run
+  try {
+    const { unlinkSync, existsSync: ex } = await import('node:fs');
+    if (ex(demoHistoryPath)) unlinkSync(demoHistoryPath);
+  } catch {
+    /* ignore */
+  }
+  for (const e of lastWeekSeeds) {
+    await appendVoiceMemory(e, { path: demoHistoryPath });
+  }
+  console.log('');
+  console.log(`  seeded last-week voice memory at ${demoHistoryPath} (3 zones · iso_week=2026-W19)`);
+
+  // ─── SCENARIO 1: real prod data (what ships now) WITH continuity ──
   console.log('');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log('  SCENARIO 1 · REAL prod state (what users would see today)');
+  console.log('  SCENARIO 1 · REAL prod state + cross-week memory');
+  console.log('  (week N references week N-1 · ruggy threads continuity)');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   const realAllZones = buildAllZones(dimensions, 'real');
+  const thisWeek = isoWeek();
   for (const zone of zonesToRender) {
     const dimId = zone === 'bear-cave' ? 'og' : zone === 'el-dorado' ? 'nft' : 'onchain';
     const dim = dimensions.get(dimId);
     if (!dim) continue;
+
+    // Read last week's voice memory for this zone
+    const lastWeek = await readLastVoiceMemory(zone, { path: demoHistoryPath });
+    const priorHint = lastWeek ? formatPriorWeekHint(lastWeek) : undefined;
 
     // Pre-compose to know the shape (so the voice brief can match)
     const provisional = composeDigestForZone({
@@ -342,7 +406,7 @@ async function main(): Promise<void> {
       tracer: otel.tracer,
     });
 
-    const briefInput = deriveBriefInput(zone, dim, provisional.shape, provisional.isNoClaim, provisional.validation.violations.length);
+    const briefInput = deriveBriefInput(zone, dim, provisional.shape, provisional.isNoClaim, provisional.validation.violations.length, priorHint);
     const brief = buildVoiceBrief(briefInput);
     const voice = await generateVoice(brief);
 
@@ -356,8 +420,27 @@ async function main(): Promise<void> {
     });
 
     console.log(`\n[${zone}] shape=${finalResult.shape} · voice.via=${voice.via}`);
+    if (priorHint) console.log(`  ← prior week: "${lastWeek?.header}"`);
     renderPostAscii(zone, finalResult.payload, 'desktop');
     renderMobileAscii(finalResult.payload);
+
+    // Write this week's voice to memory (so next gallery run sees it)
+    await appendVoiceMemory(
+      {
+        at: new Date().toISOString(),
+        iso_week: thisWeek,
+        zone,
+        shape: finalResult.shape,
+        header: voice.header,
+        outro: voice.outro,
+        key_numbers: {
+          total_events: dim.total_events,
+          previous_period_events: dim.previous_period_events,
+          permitted_factor_names: briefInput.permittedFactors.map((f) => f.display_name),
+        },
+      },
+      { path: demoHistoryPath },
+    );
   }
 
   // ─── SCENARIO 2: synthetic-hot (what users WOULD see if activity ramps) ──

--- a/apps/bot/scripts/cycle-005-ux-gallery.ts
+++ b/apps/bot/scripts/cycle-005-ux-gallery.ts
@@ -1,0 +1,426 @@
+#!/usr/bin/env bun
+/**
+ * cycle-005 UX gallery — the missing "what does ruggy ACTUALLY look like".
+ *
+ * Authored 2026-05-16 in response to the operator's "i want to nitpick the
+ * UX for ruggy because there's alot we should be surfacing which i'm not
+ * seeing in the chats" message. The autonomous-run E2E proved the pipeline
+ * shape but never SHOWED what a real post looks like.
+ *
+ * This script:
+ *   1. fetches REAL prod factor_stats for all 3 dim-channel zones (window=30)
+ *   2. calls Claude SDK to generate the actual voice header + outro per
+ *      the cycle-005 voice-brief (T2.4 · the missing piece) — ONLY if
+ *      ANTHROPIC_API_KEY is set; otherwise uses canned fallback
+ *   3. composes via composeDigestForZone with REAL voice
+ *   4. renders the FULL Discord-formatted post (content + embed)
+ *   5. simulates mobile word-wrap (~40 chars in code blocks)
+ *   6. shows both the dominant REAL state (shape A at current volume) AND
+ *      a synthetic shape-C "what if activity ramps" scenario
+ *
+ * NO Discord delivery. Pure rendering for visual inspection.
+ *
+ * Run:
+ *   SCORE_API_URL=https://score-api-production.up.railway.app \
+ *   MCP_KEY=... \
+ *   ANTHROPIC_API_KEY=sk-... \
+ *   bun run apps/bot/scripts/cycle-005-ux-gallery.ts
+ */
+
+// Note: @anthropic-ai/claude-agent-sdk is resolved via the persona-engine
+// workspace symlink (apps/bot doesn't depend on it directly · transitive
+// resolution from the symlinked workspace package).
+import { query } from '../../../packages/persona-engine/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs';
+import {
+  composeDigestForZone,
+} from '@freeside-characters/persona-engine/compose/digest';
+import {
+  buildVoiceBrief,
+  parseVoiceResponse,
+} from '@freeside-characters/persona-engine/compose/voice-brief';
+import { initOtelTest } from '@freeside-characters/persona-engine/observability/otel-test';
+import type {
+  PulseDimensionBreakdown,
+  PulseDimensionFactor,
+  ZoneId,
+  FactorStats,
+} from '@freeside-characters/persona-engine/score/types';
+
+// ─── MCP transport (copied from S0 spike pattern) ─────────────────────
+
+const MCP_PROTOCOL_VERSION = '2024-11-05';
+
+async function fetchDimensions(): Promise<Map<string, PulseDimensionBreakdown>> {
+  const SCORE_API_URL = process.env.SCORE_API_URL ?? 'https://score-api-production.up.railway.app';
+  const MCP_KEY = process.env.MCP_KEY;
+  if (!MCP_KEY) throw new Error('MCP_KEY not set');
+  const url = `${SCORE_API_URL.replace(/\/$/, '')}/mcp`;
+  const h = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    'X-MCP-Key': MCP_KEY,
+  };
+  const initRes = await fetch(url, {
+    method: 'POST',
+    headers: h,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'ux-gallery', version: '0' } },
+    }),
+  });
+  const sid = initRes.headers.get('Mcp-Session-Id');
+  if (!sid) throw new Error('no Mcp-Session-Id');
+  await initRes.text();
+  const sh = { ...h, 'Mcp-Session-Id': sid };
+  await fetch(url, {
+    method: 'POST',
+    headers: sh,
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }),
+  });
+
+  const out = new Map<string, PulseDimensionBreakdown>();
+  let nextId = 2;
+  for (const dim of ['og', 'nft', 'onchain'] as const) {
+    nextId += 1;
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: sh,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: nextId,
+        method: 'tools/call',
+        params: { name: 'get_dimension_breakdown', arguments: { window: 30, dimension: dim } },
+      }),
+    });
+    const body = await r.text();
+    const line = body.split(/\r?\n/).find((l) => l.startsWith('data: '));
+    if (!line) continue;
+    const env = JSON.parse(line.slice(6));
+    if (env.error) continue;
+    const text = env.result?.content?.find((c: any) => c.type === 'text')?.text;
+    if (!text) continue;
+    const parsed = JSON.parse(text);
+    const row = parsed.dimensions?.[0];
+    if (row) out.set(dim, row as PulseDimensionBreakdown);
+  }
+  return out;
+}
+
+// ─── Voice generation (Claude SDK + canned fallback) ──────────────────
+
+async function generateVoice(
+  brief: ReturnType<typeof buildVoiceBrief>,
+): Promise<{ header: string; outro: string; via: 'claude-sdk' | 'canned' }> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return {
+      header: '(no api key — canned header)',
+      outro: '(no api key — canned outro)',
+      via: 'canned',
+    };
+  }
+  let collected = '';
+  try {
+    for await (const msg of query({
+      prompt: brief.user,
+      options: {
+        model: 'claude-sonnet-4-5',
+        systemPrompt: brief.system,
+        maxTurns: 1,
+        permissionMode: 'bypassPermissions',
+      },
+    })) {
+      if (msg.type === 'assistant') {
+        for (const block of msg.message?.content ?? []) {
+          if (block.type === 'text') collected += block.text;
+        }
+      }
+    }
+  } catch (err) {
+    return {
+      header: `(sdk error: ${(err as Error).message.slice(0, 40)})`,
+      outro: 'canned outro',
+      via: 'canned',
+    };
+  }
+  const parsed = parseVoiceResponse(collected);
+  return { header: parsed.header, outro: parsed.outro, via: 'claude-sdk' };
+}
+
+// ─── Render layer ─────────────────────────────────────────────────────
+
+function wrapMobile(text: string, width = 40): string {
+  if (!text) return text;
+  const lines: string[] = [];
+  for (const line of text.split('\n')) {
+    if (line.length <= width) {
+      lines.push(line);
+      continue;
+    }
+    // word-wrap heuristic; Discord's actual algorithm is more complex (it
+    // respects soft hyphens, splits at zero-width spaces, etc.) but this
+    // approximates the mobile experience reasonably for visual inspection
+    const words = line.split(/(\s+)/);
+    let current = '';
+    for (const w of words) {
+      if (current.length + w.length <= width) {
+        current += w;
+      } else {
+        if (current) lines.push(current);
+        current = w;
+      }
+    }
+    if (current) lines.push(current);
+  }
+  return lines.join('\n');
+}
+
+function renderPostAscii(zone: ZoneId, payload: ReturnType<typeof composeDigestForZone>['payload'], label: string): void {
+  console.log('');
+  console.log(`╔═══ ${label} · ${zone} ${'═'.repeat(Math.max(0, 88 - label.length - zone.length))}╗`);
+  if (!payload) {
+    console.log('║ <skipped · mode=skip>                                                                        ║');
+    console.log(`╚${'═'.repeat(94)}╝`);
+    return;
+  }
+  const embed = payload.embeds[0];
+  console.log(`║ content.fallback: ${payload.content.slice(0, 70).padEnd(75)} ║`);
+  if (embed?.description) {
+    console.log('║ ─── embed.description (the voice) ─────                     ║');
+    for (const ln of embed.description.split('\n')) {
+      console.log(`║   ${ln.slice(0, 90).padEnd(90)} ║`);
+    }
+  }
+  for (const field of embed?.fields ?? []) {
+    console.log(`║ ─── embed.field[${field.name}] (${field.value.length}ch) ─────                ║`);
+    // The field rows are joined by " · "; print one row per line for clarity
+    for (const row of field.value.split(' · ')) {
+      console.log(`║   ${row.slice(0, 55).padEnd(55)} ║`);
+    }
+  }
+  console.log('╚══════════════════════════════════════════════════════════════════════════════════════════════╝');
+}
+
+function renderMobileAscii(payload: ReturnType<typeof composeDigestForZone>['payload']): void {
+  if (!payload) return;
+  console.log('  📱 mobile (~40ch wrap):');
+  const embed = payload.embeds[0];
+  if (embed?.description) {
+    console.log('  ┌─ voice ──────────────────────────────┐');
+    for (const ln of wrapMobile(embed.description).split('\n')) {
+      console.log(`  │ ${ln.padEnd(38)} │`);
+    }
+    console.log('  └──────────────────────────────────────┘');
+  }
+  for (const field of embed?.fields ?? []) {
+    console.log(`  ┌─ ${field.name} ────────────────────────────────┐`);
+    for (const row of field.value.split(' · ')) {
+      for (const ln of wrapMobile(row).split('\n')) {
+        console.log(`  │ ${ln.padEnd(38)} │`);
+      }
+    }
+    console.log('  └──────────────────────────────────────┘');
+  }
+}
+
+// ─── Layout-args builder (mirrors digest.ts logic) ────────────────────
+
+function buildAllZones(
+  dimensions: Map<string, PulseDimensionBreakdown>,
+  scenario: 'real' | 'synthetic-hot',
+): Map<ZoneId, PulseDimensionBreakdown | undefined> {
+  const allZones = new Map<ZoneId, PulseDimensionBreakdown | undefined>();
+  for (const zone of ['stonehenge', 'bear-cave', 'el-dorado', 'owsley-lab'] as ZoneId[]) {
+    const dimId = zone === 'bear-cave' ? 'og' : zone === 'el-dorado' ? 'nft' : zone === 'owsley-lab' ? 'onchain' : null;
+    const dim = dimId ? dimensions.get(dimId) : undefined;
+    if (scenario === 'real' || !dim) {
+      allZones.set(zone, dim);
+    } else {
+      // Synthesize hot version: bump top factor's rank to 96 + p95 reliable
+      const hot: PulseDimensionBreakdown = {
+        ...dim,
+        top_factors: dim.top_factors.map((f, i) =>
+          i === 0 && f.factor_stats
+            ? {
+                ...f,
+                factor_stats: {
+                  ...f.factor_stats,
+                  magnitude: {
+                    ...f.factor_stats.magnitude,
+                    current_percentile_rank: 96,
+                    percentiles: {
+                      ...f.factor_stats.magnitude.percentiles,
+                      p95: { value: 45, reliable: true },
+                    },
+                  },
+                },
+              }
+            : f,
+        ),
+      };
+      allZones.set(zone, hot);
+    }
+  }
+  return allZones;
+}
+
+function deriveBriefInput(
+  zone: ZoneId,
+  dim: PulseDimensionBreakdown | undefined,
+  shape: 'A-all-quiet' | 'B-one-dim-hot' | 'C-multi-dim-hot',
+  isNoClaim: boolean,
+  validationViolations: number,
+): Parameters<typeof buildVoiceBrief>[0] {
+  if (!dim) {
+    return {
+      zone,
+      shape: 'A-all-quiet',
+      isNoClaimVariant: true,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 0,
+      windowDays: 30,
+      previousPeriodEvents: 0,
+    };
+  }
+  const permitted = dim.top_factors
+    .filter(
+      (f) =>
+        (f.factor_stats?.magnitude?.current_percentile_rank ?? 0) >= 90 &&
+        f.factor_stats?.magnitude?.percentiles?.p95?.reliable === true,
+    )
+    .map((f) => ({ display_name: f.display_name, stats: f.factor_stats! }));
+  return {
+    zone,
+    shape,
+    isNoClaimVariant: isNoClaim,
+    permittedFactors: permitted,
+    silencedFactors: [],
+    totalEvents: dim.total_events,
+    windowDays: 30,
+    previousPeriodEvents: dim.previous_period_events,
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  cycle-005 UX gallery — what ruggy actually looks like');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`  voice generation: ${process.env.ANTHROPIC_API_KEY ? 'claude-sonnet-4-5 (LIVE)' : 'CANNED (set ANTHROPIC_API_KEY for live)'}`);
+  console.log('');
+
+  const dimensions = await fetchDimensions();
+  console.log('  fetched prod dimensions (window=30):');
+  for (const [id, d] of dimensions) {
+    console.log(`    · ${id}: ${d.top_factors.length} top · ${d.cold_factors.length} cold · ${d.total_events}ev`);
+  }
+
+  const otel = initOtelTest();
+  const zonesToRender: ZoneId[] = ['bear-cave', 'el-dorado', 'owsley-lab'];
+
+  // ─── SCENARIO 1: real prod data (what ships now) ─────────────────
+  console.log('');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  SCENARIO 1 · REAL prod state (what users would see today)');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  const realAllZones = buildAllZones(dimensions, 'real');
+  for (const zone of zonesToRender) {
+    const dimId = zone === 'bear-cave' ? 'og' : zone === 'el-dorado' ? 'nft' : 'onchain';
+    const dim = dimensions.get(dimId);
+    if (!dim) continue;
+
+    // Pre-compose to know the shape (so the voice brief can match)
+    const provisional = composeDigestForZone({
+      zone,
+      dimension: dim,
+      allZones: realAllZones,
+      voice: { header: '', outro: '' },
+      draft: '',
+      tracer: otel.tracer,
+    });
+
+    const briefInput = deriveBriefInput(zone, dim, provisional.shape, provisional.isNoClaim, provisional.validation.violations.length);
+    const brief = buildVoiceBrief(briefInput);
+    const voice = await generateVoice(brief);
+
+    const finalResult = composeDigestForZone({
+      zone,
+      dimension: dim,
+      allZones: realAllZones,
+      voice: { header: voice.header, outro: voice.outro },
+      draft: voice.header + ' ' + voice.outro,
+      tracer: otel.tracer,
+    });
+
+    console.log(`\n[${zone}] shape=${finalResult.shape} · voice.via=${voice.via}`);
+    renderPostAscii(zone, finalResult.payload, 'desktop');
+    renderMobileAscii(finalResult.payload);
+  }
+
+  // ─── SCENARIO 2: synthetic-hot (what users WOULD see if activity ramps) ──
+  console.log('');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  SCENARIO 2 · SYNTHETIC ramped activity (preview · top factor rank=96 + p95 reliable)');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  const hotAllZones = buildAllZones(dimensions, 'synthetic-hot');
+  // Only render bear-cave for shape-B/C demo (the others would be similar)
+  const zone: ZoneId = 'bear-cave';
+  const hotDim = hotAllZones.get(zone);
+  if (hotDim) {
+    const provisional = composeDigestForZone({
+      zone,
+      dimension: hotDim,
+      allZones: hotAllZones,
+      voice: { header: '', outro: '' },
+      draft: '',
+      tracer: otel.tracer,
+    });
+    const briefInput = deriveBriefInput(zone, hotDim, provisional.shape, provisional.isNoClaim, provisional.validation.violations.length);
+    const brief = buildVoiceBrief(briefInput);
+    const voice = await generateVoice(brief);
+
+    const finalResult = composeDigestForZone({
+      zone,
+      dimension: hotDim,
+      allZones: hotAllZones,
+      voice: { header: voice.header, outro: voice.outro },
+      draft: voice.header + ' ' + voice.outro,
+      tracer: otel.tracer,
+    });
+
+    console.log(`\n[${zone}] shape=${finalResult.shape} · voice.via=${voice.via}`);
+    renderPostAscii(zone, finalResult.payload, 'desktop · ramped-activity preview');
+    renderMobileAscii(finalResult.payload);
+  }
+
+  // ─── OTEL trace summary ──────────────────────────────────────────
+  console.log('');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  OTEL trace summary');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  const spans = otel.getFinishedSpans();
+  const rootSpans = spans.filter((s) => !s.parentSpanContext);
+  console.log(`  ${rootSpans.length} chat.invoke roots · ${spans.length} total spans`);
+  const eventSummary = new Map<string, number>();
+  for (const root of rootSpans) {
+    for (const e of root.events) {
+      eventSummary.set(e.name, (eventSummary.get(e.name) ?? 0) + 1);
+    }
+  }
+  for (const [name, count] of eventSummary) {
+    console.log(`    · ${name}: ${count}x`);
+  }
+
+  console.log('');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  done. read both scenarios. nit-pick the voice.');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+}
+
+main().catch((err) => {
+  console.error('ux-gallery failed:', err);
+  process.exit(1);
+});

--- a/apps/bot/src/cli/digest-once.ts
+++ b/apps/bot/src/cli/digest-once.ts
@@ -51,7 +51,9 @@ async function main(): Promise<void> {
   const zones = selectedZones(config);
   const typeMode = pickType(config);
 
-  const llmMode = config.ANTHROPIC_API_KEY
+  const llmMode = config.VOICE_DISABLED
+    ? 'VOICE_DISABLED (no LLM)'
+    : config.ANTHROPIC_API_KEY
     ? `anthropic-direct (${config.ANTHROPIC_MODEL})`
     : config.STUB_MODE
       ? 'STUB (canned)'

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -13,6 +13,7 @@
     "./score/types": "./src/score/types.ts",
     "./compose/digest": "./src/compose/digest.ts",
     "./compose/voice-brief": "./src/compose/voice-brief.ts",
+    "./compose/voice-memory": "./src/compose/voice-memory.ts",
     "./observability/otel-test": "./src/observability/otel-test.ts",
     "./observability/otel-layer": "./src/observability/otel-layer.ts"
   },

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -12,6 +12,7 @@
     "./orchestrator/imagegen": "./src/orchestrator/imagegen/index.ts",
     "./score/types": "./src/score/types.ts",
     "./compose/digest": "./src/compose/digest.ts",
+    "./compose/voice-brief": "./src/compose/voice-brief.ts",
     "./observability/otel-test": "./src/observability/otel-test.ts",
     "./observability/otel-layer": "./src/observability/otel-layer.ts"
   },

--- a/packages/persona-engine/src/compose/composer.ts
+++ b/packages/persona-engine/src/compose/composer.ts
@@ -26,14 +26,11 @@ import { enforceCanonicalHeadline } from './headline-lock.ts';
 import { translateEmojiShortcodes } from './reply.ts';
 import { buildPromptPair } from '../persona/loader.ts';
 import { buildPostPayload, type DigestPayload } from '../deliver/embed.ts';
+import { composeDigestPost } from '../orchestrator/digest-orchestrator.ts';
 import {
   POST_TYPE_SPECS,
   type PostType,
 } from './post-types.ts';
-import {
-  isFlatWindow,
-  pickSilenceTemplate,
-} from '../expression/silence-register.ts';
 
 export interface PostComposeResult {
   zone: ZoneId;
@@ -64,6 +61,10 @@ export async function composeZonePost(
   postType: PostType = 'digest',
   opts: ComposeZonePostOpts = {},
 ): Promise<PostComposeResult | null> {
+  if (postType === 'digest') {
+    return composeDigestPost(config, character, zone);
+  }
+
   // Fetch a digest in parallel with the LLM call — the LLM gets its own
   // copy via mcp__score__get_zone_digest; this one is for embed metadata
   // (color, footer timestamp, structured payload). Cheap; same MCP call.
@@ -96,30 +97,9 @@ export async function composeZonePost(
     }),
   ]);
 
-  // Performed-silence override: only the digest post-type qualifies (pop-
-  // ins, weavers, lore_drops, questions, callouts have their own
-  // register-locked emptiness handling). Skip when the LLM produced
-  // nothing — empty rawVoice routes through the existing chunk-empty
-  // guard downstream. Skip when the character has no silence template —
-  // fall through to the LLM voice rather than emit a substrate-quiet
-  // fallback that has no register.
-  let voice: string;
-  if (postType === 'digest' && isFlatWindow(digest.raw_stats)) {
-    const silence = pickSilenceTemplate(character.id);
-    if (silence) {
-      console.log(
-        `${character.id}: flat-window detected on ${zone}/digest ` +
-          `(events=${digest.raw_stats.window_event_count ?? 0}) · ` +
-          `routing to silence-register (skipped LLM elaboration)`,
-      );
-      voice = silence;
-    } else {
-      // No silence template — fall through to LLM voice as today.
-      voice = applyHeadlineLock(rawVoice, zone, postType, character.id);
-    }
-  } else {
-    voice = applyHeadlineLock(rawVoice, zone, postType, character.id);
-  }
+  // Digest now routes through orchestrator/digest-orchestrator.ts above.
+  // Non-digest surfaces keep the legacy full-voice path.
+  let voice = applyHeadlineLock(rawVoice, zone, postType, character.id);
 
   // V0.12.0 emoji-rendering fix (2026-05-13): the digest path historically
   // bypassed `translateEmojiShortcodes`, which was only applied in the

--- a/packages/persona-engine/src/compose/digest.ts
+++ b/packages/persona-engine/src/compose/digest.ts
@@ -65,6 +65,8 @@ export interface ComposeDigestArgs {
   draft: string;
   /** Optional override tracer (tests pass OtelTest's tracer). */
   tracer?: Tracer;
+  /** Optional dim-level snapshot data for the headline row (UX nit 2026-05-16 · dashboard parity). */
+  snapshot?: { weeklyActiveWallets?: number; coldFactorCount?: number };
 }
 
 export interface ComposeDigestResult {
@@ -181,6 +183,7 @@ export function composeDigestForZone(args: ComposeDigestArgs): ComposeDigestResu
               proseGate: validation,
               ...(voiceOn && args.voice.header ? { header: args.voice.header } : {}),
               ...(voiceOn && args.voice.outro ? { outro: args.voice.outro } : {}),
+              ...(args.snapshot ? { snapshot: args.snapshot } : {}),
             });
           },
         );
@@ -248,33 +251,46 @@ function buildLayoutArgs(args: ComposeDigestArgs): SelectLayoutShapeArgs {
 }
 
 /**
- * Shape-A renderer: minimal payload with no card body. Voice surface
- * (header/outro) is the entire post. V1 lands the simple form; the
- * silence-register module (`expression/silence-register.ts`) is the
- * V1.5 wire-point for richer "italicized stage direction" rendering.
+ * Shape-A renderer.
  *
- * UX nit 2026-05-16: previous version emitted `[bear-cave] quiet week`
- * as the content fallback — engineering jargon, broke ruggy's voice
- * illusion. Now uses the zone flavor (emoji + name) so users-with-embeds-
- * disabled still see in-character content. The dimension paren is
- * suppressed for stonehenge (cross-dim hub · self-evident).
+ * UX nit 2026-05-16 r2 (operator-asked depth): shape A used to be voice-
+ * only. operator pointed out the dashboard's dimension page shows the
+ * full breakdown even when no factor is "hot" — the data IS the body,
+ * voice is the seasoning. So now shape A ALSO routes through
+ * `buildPulseDimensionPayload` to surface the factor list + 30d snapshot
+ * row. Voice stays outside the embed via `message.content`; the embed is
+ * substrate truth only.
+ *
+ * If the dim is genuinely empty (no factors AND zero events), we fall
+ * back to the voice-only form because there's nothing to render.
  */
 function buildShapeAPayload(args: ComposeDigestArgs): DigestPayload {
   const flavor = ZONE_FLAVOR[args.zone];
-  const dimensionParen =
-    flavor.dimension === 'overall' ? '' : ` (${DIMENSION_NAME[flavor.dimension]})`;
-  const fallback = `${flavor.emoji} ${flavor.name}${dimensionParen}`;
-  const descParts: string[] = [];
-  if (args.voice.header) descParts.push(args.voice.header);
-  if (args.voice.outro) descParts.push(args.voice.outro);
-  return {
-    content: fallback,
-    embeds: [
-      {
-        ...(descParts.length > 0 ? { description: descParts.join('\n') } : {}),
-      },
-    ],
-  };
+  const dim = args.dimension;
+  const isGenuinelyEmpty =
+    dim.top_factors.length === 0 && dim.cold_factors.length === 0 && dim.total_events === 0;
+
+  if (isGenuinelyEmpty) {
+    const descParts: string[] = [];
+    if (args.voice.header) descParts.push(args.voice.header);
+    if (args.voice.outro) descParts.push(args.voice.outro);
+    const dimensionParen =
+      flavor.dimension === 'overall' ? '' : ` (${DIMENSION_NAME[flavor.dimension]})`;
+    const fallback = `${flavor.emoji} ${flavor.name}${dimensionParen}`;
+    const content = descParts.length > 0 ? `${fallback}\n${descParts.join('\n')}` : fallback;
+    return {
+      content,
+      embeds: [{}],
+    };
+  }
+
+  // Data-rich shape A: render the breakdown, keep voice as seasoning.
+  return buildPulseDimensionPayload(dim, args.zone, 30, {
+    moodEmoji: moodEmojiForFactor,
+    ...(args.voice.header ? { header: args.voice.header } : {}),
+    ...(args.voice.outro ? { outro: args.voice.outro } : {}),
+    ...(args.snapshot ? { snapshot: args.snapshot } : {}),
+  });
 }
 
 /**

--- a/packages/persona-engine/src/compose/digest.ts
+++ b/packages/persona-engine/src/compose/digest.ts
@@ -253,39 +253,17 @@ function buildLayoutArgs(args: ComposeDigestArgs): SelectLayoutShapeArgs {
 /**
  * Shape-A renderer.
  *
- * UX nit 2026-05-16 r2 (operator-asked depth): shape A used to be voice-
- * only. operator pointed out the dashboard's dimension page shows the
- * full breakdown even when no factor is "hot" — the data IS the body,
- * voice is the seasoning. So now shape A ALSO routes through
- * `buildPulseDimensionPayload` to surface the factor list + 30d snapshot
- * row. Voice stays outside the embed via `message.content`; the embed is
- * substrate truth only.
- *
- * If the dim is genuinely empty (no factors AND zero events), we fall
- * back to the voice-only form because there's nothing to render.
+ * BB review F-016 (2026-05-16): the prior `isGenuinelyEmpty` branch was
+ * (a) redundant and (b) returned an empty `embeds: [{}]` which Discord
+ * renders as a stray colored sidebar with no content · clutter. The
+ * delegate `buildPulseDimensionPayload` already handles the empty-dim
+ * case cleanly: when there are no factors and no events, snapshot/top/
+ * cold fields are all skipped naturally, voice still flows into
+ * `message.content` per the voice-outside-divs doctrine. One code path
+ * for all shape-A cases · uniform doctrine.
  */
 function buildShapeAPayload(args: ComposeDigestArgs): DigestPayload {
-  const flavor = ZONE_FLAVOR[args.zone];
-  const dim = args.dimension;
-  const isGenuinelyEmpty =
-    dim.top_factors.length === 0 && dim.cold_factors.length === 0 && dim.total_events === 0;
-
-  if (isGenuinelyEmpty) {
-    const descParts: string[] = [];
-    if (args.voice.header) descParts.push(args.voice.header);
-    if (args.voice.outro) descParts.push(args.voice.outro);
-    const dimensionParen =
-      flavor.dimension === 'overall' ? '' : ` (${DIMENSION_NAME[flavor.dimension]})`;
-    const fallback = `${flavor.emoji} ${flavor.name}${dimensionParen}`;
-    const content = descParts.length > 0 ? `${fallback}\n${descParts.join('\n')}` : fallback;
-    return {
-      content,
-      embeds: [{}],
-    };
-  }
-
-  // Data-rich shape A: render the breakdown, keep voice as seasoning.
-  return buildPulseDimensionPayload(dim, args.zone, 30, {
+  return buildPulseDimensionPayload(args.dimension, args.zone, 30, {
     moodEmoji: moodEmojiForFactor,
     ...(args.voice.header ? { header: args.voice.header } : {}),
     ...(args.voice.outro ? { outro: args.voice.outro } : {}),

--- a/packages/persona-engine/src/compose/digest.ts
+++ b/packages/persona-engine/src/compose/digest.ts
@@ -28,6 +28,7 @@ import type {
   PulseDimensionBreakdown,
   ZoneId,
 } from '../score/types.ts';
+import { ZONE_FLAVOR, DIMENSION_NAME } from '../score/types.ts';
 import {
   buildFactorStatsMap,
   inspectProse,
@@ -250,14 +251,24 @@ function buildLayoutArgs(args: ComposeDigestArgs): SelectLayoutShapeArgs {
  * Shape-A renderer: minimal payload with no card body. Voice surface
  * (header/outro) is the entire post. V1 lands the simple form; the
  * silence-register module (`expression/silence-register.ts`) is the
- * S5/V1.5 wire-point for richer "italicized stage direction" rendering.
+ * V1.5 wire-point for richer "italicized stage direction" rendering.
+ *
+ * UX nit 2026-05-16: previous version emitted `[bear-cave] quiet week`
+ * as the content fallback — engineering jargon, broke ruggy's voice
+ * illusion. Now uses the zone flavor (emoji + name) so users-with-embeds-
+ * disabled still see in-character content. The dimension paren is
+ * suppressed for stonehenge (cross-dim hub · self-evident).
  */
 function buildShapeAPayload(args: ComposeDigestArgs): DigestPayload {
+  const flavor = ZONE_FLAVOR[args.zone];
+  const dimensionParen =
+    flavor.dimension === 'overall' ? '' : ` (${DIMENSION_NAME[flavor.dimension]})`;
+  const fallback = `${flavor.emoji} ${flavor.name}${dimensionParen}`;
   const descParts: string[] = [];
   if (args.voice.header) descParts.push(args.voice.header);
   if (args.voice.outro) descParts.push(args.voice.outro);
   return {
-    content: `[${args.zone}] quiet week`,
+    content: fallback,
     embeds: [
       {
         ...(descParts.length > 0 ? { description: descParts.join('\n') } : {}),

--- a/packages/persona-engine/src/compose/voice-brief-continuity.test.ts
+++ b/packages/persona-engine/src/compose/voice-brief-continuity.test.ts
@@ -1,0 +1,61 @@
+/**
+ * voice-brief continuity tests · cycle-005 latitude-grant 2026-05-16.
+ *
+ * Verifies cross-week memory threads into the user prompt when
+ * `priorWeekHint` is supplied, and stays absent otherwise.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { buildVoiceBrief } from './voice-brief.ts';
+
+describe('buildVoiceBrief · cross-week continuity', () => {
+  test('omits continuity block when priorWeekHint absent', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'A-all-quiet',
+      isNoClaimVariant: false,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 4,
+      windowDays: 30,
+      previousPeriodEvents: 26,
+    });
+    expect(brief.user).not.toContain('continuity context');
+    expect(brief.user).not.toContain('thread continuity');
+  });
+
+  test('includes continuity block + MAY-thread instruction when priorWeekHint present', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'A-all-quiet',
+      isNoClaimVariant: false,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 4,
+      windowDays: 30,
+      previousPeriodEvents: 26,
+      priorWeekHint:
+        'last week (2026-W19 · shape A): said "the bears nap" over 26 events',
+    });
+    expect(brief.user).toContain('continuity context:');
+    expect(brief.user).toContain('the bears nap');
+    expect(brief.user).toContain('MAY thread continuity');
+    expect(brief.user).toContain('do NOT mechanically copy');
+  });
+
+  test('continuity block works on shape C too (not just shape A)', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'C-multi-dim-hot',
+      isNoClaimVariant: false,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 200,
+      windowDays: 30,
+      previousPeriodEvents: 100,
+      priorWeekHint: 'last week (2026-W19 · shape A): said "the bears nap" over 26 events',
+    });
+    expect(brief.user).toContain('MULTI DIM HOT');
+    expect(brief.user).toContain('continuity context');
+  });
+});

--- a/packages/persona-engine/src/compose/voice-brief.test.ts
+++ b/packages/persona-engine/src/compose/voice-brief.test.ts
@@ -1,0 +1,171 @@
+/**
+ * voice-brief tests · cycle-005 T2.4 (authored 2026-05-16).
+ *
+ * Verifies the system + user prompt construction for shape A (the
+ * dominant real-world case) and shape B/C licensed paths.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { buildVoiceBrief, parseVoiceResponse } from './voice-brief.ts';
+import type { FactorStats } from '../score/types.ts';
+
+function stats(rank: number): FactorStats {
+  return {
+    history: { active_days: 100, last_active_date: '2026-05-10', stale: false, no_data: false, sufficiency: { p50: true, p90: true, p99: true } },
+    occurrence: { active_day_frequency: 0.3, current_is_active: true },
+    magnitude: {
+      event_count: 5,
+      percentiles: {
+        p10: { value: 1, reliable: true }, p25: { value: 2, reliable: true }, p50: { value: 4, reliable: true },
+        p75: { value: 10, reliable: true }, p90: { value: 23, reliable: true }, p95: { value: 45, reliable: true }, p99: { value: 130, reliable: true },
+      },
+      current_percentile_rank: rank,
+    },
+    cohort: {
+      unique_actors: 7,
+      percentiles: {
+        p10: { value: 1, reliable: true }, p25: { value: 1, reliable: true }, p50: { value: 2, reliable: true },
+        p75: { value: 5, reliable: true }, p90: { value: 11, reliable: true }, p95: { value: 22, reliable: true }, p99: { value: 81, reliable: true },
+      },
+      current_percentile_rank: 50,
+    },
+    cadence: { days_since_last_active: 0, median_active_day_gap_days: 1, current_gap_percentile_rank: 50 },
+  };
+}
+
+describe('buildVoiceBrief · shape A (all-quiet · the dominant case)', () => {
+  test('shape-A system prompt names ruggy + zone + voice rules', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'A-all-quiet',
+      isNoClaimVariant: false,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 4,
+      windowDays: 30,
+      previousPeriodEvents: 26,
+    });
+    expect(brief.system).toContain('you are ruggy');
+    expect(brief.system).toContain('bear-cave');
+    expect(brief.system).toContain('lowercase');
+    expect(brief.system).toContain('no em-dashes');
+    expect(brief.system).toContain('no corporate-bot tells');
+  });
+
+  test('shape-A user prompt names the quiet + provides previous-period context', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'A-all-quiet',
+      isNoClaimVariant: false,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 4,
+      windowDays: 30,
+      previousPeriodEvents: 26,
+    });
+    expect(brief.user).toContain('ALL QUIET');
+    expect(brief.user).toContain('4 events');
+    expect(brief.user).toContain('30 days');
+    expect(brief.user).toContain('26 events'); // previous period
+    expect(brief.user).toContain('must NOT');
+    expect(brief.user).toContain('invent activity');
+  });
+
+  test('shape-A guidance includes evocative atmosphere prompts (bears sleeping)', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'A-all-quiet',
+      isNoClaimVariant: false,
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 0,
+      windowDays: 30,
+      previousPeriodEvents: 0,
+    });
+    expect(brief.user).toMatch(/bears.*sleeping|honey.*brewing/i);
+  });
+});
+
+describe('buildVoiceBrief · shape B/C (licensed narration)', () => {
+  test('shape-B user prompt lists permitted factors with axes', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'B-one-dim-hot',
+      isNoClaimVariant: false,
+      permittedFactors: [{ display_name: 'Articles', stats: stats(96) }],
+      silencedFactors: [],
+      totalEvents: 100,
+      windowDays: 30,
+      previousPeriodEvents: 50,
+    });
+    expect(brief.user).toContain('ONE DIM HOT');
+    expect(brief.user).toContain('Articles');
+    expect(brief.user).toContain('rank 96');
+    expect(brief.user).toContain('7 actors'); // cohort.unique_actors
+    expect(brief.user).toContain('100 active days');
+  });
+
+  test('shape-C user prompt names silenced factors with reasons (DO NOT NARRATE)', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'C-multi-dim-hot',
+      isNoClaimVariant: false,
+      permittedFactors: [{ display_name: 'Articles', stats: stats(96) }],
+      silencedFactors: [{ display_name: 'Keys', reason: 'cohort-singleton' }],
+      totalEvents: 200,
+      windowDays: 30,
+      previousPeriodEvents: 100,
+    });
+    expect(brief.user).toContain('MULTI DIM HOT');
+    expect(brief.user).toContain('Keys');
+    expect(brief.user).toContain('cohort-singleton');
+    expect(brief.user).toContain('DO NOT NARRATE');
+  });
+
+  test('NO-CLAIM variant routes to shape-A guidance even though shape is C', () => {
+    const brief = buildVoiceBrief({
+      zone: 'bear-cave',
+      shape: 'C-multi-dim-hot',
+      isNoClaimVariant: true, // <-- key flag
+      permittedFactors: [],
+      silencedFactors: [],
+      totalEvents: 5,
+      windowDays: 30,
+      previousPeriodEvents: 2,
+    });
+    expect(brief.user).toContain('ALL QUIET'); // shape A treatment
+    expect(brief.user).not.toContain('LICENSED factors');
+  });
+});
+
+describe('parseVoiceResponse', () => {
+  test('parses clean JSON', () => {
+    const r = parseVoiceResponse('{"header": "hi from the cave", "outro": "stay groovy"}');
+    expect(r.header).toBe('hi from the cave');
+    expect(r.outro).toBe('stay groovy');
+  });
+
+  test('strips markdown fence around JSON', () => {
+    const r = parseVoiceResponse('```json\n{"header": "h", "outro": "o"}\n```');
+    expect(r.header).toBe('h');
+    expect(r.outro).toBe('o');
+  });
+
+  test('falls back to two-line split on plain text', () => {
+    const r = parseVoiceResponse('first line is the header\nsecond line is the outro');
+    expect(r.header).toBe('first line is the header');
+    expect(r.outro).toBe('second line is the outro');
+  });
+
+  test('handles single-line response (header only)', () => {
+    const r = parseVoiceResponse('one line only');
+    expect(r.header).toBe('one line only');
+    expect(r.outro).toBe('');
+  });
+
+  test('returns empty on completely malformed input', () => {
+    const r = parseVoiceResponse('');
+    expect(r.header).toBe('');
+    expect(r.outro).toBe('');
+  });
+});

--- a/packages/persona-engine/src/compose/voice-brief.test.ts
+++ b/packages/persona-engine/src/compose/voice-brief.test.ts
@@ -48,8 +48,12 @@ describe('buildVoiceBrief · shape A (all-quiet · the dominant case)', () => {
     expect(brief.system).toContain('you are ruggy');
     expect(brief.system).toContain('bear-cave');
     expect(brief.system).toContain('lowercase');
-    expect(brief.system).toContain('no em-dashes');
-    expect(brief.system).toContain('no corporate-bot tells');
+    // Per operator doctrine 2026-05-16: negation rules removed from prompt.
+    // (mentioning artifacts in the prompt teaches the LLM they're in scope.)
+    // The substrate's sanitize.ts::stripVoiceDisciplineDrift is the regex
+    // backstop. Prompt stays positive — assert the voice-shape we DO want.
+    expect(brief.system).toContain('warm and grounded');
+    expect(brief.system).toContain('character first');
   });
 
   test('shape-A user prompt names the quiet + provides previous-period context', () => {

--- a/packages/persona-engine/src/compose/voice-brief.ts
+++ b/packages/persona-engine/src/compose/voice-brief.ts
@@ -85,18 +85,25 @@ export interface VoiceBrief {
 export function buildVoiceBrief(input: VoiceBriefInput): VoiceBrief {
   const zoneCtx = ZONE_VOICE_CONTEXT[input.zone];
 
-  const baseSystem = `you are ruggy, the keeper of ${input.zone}. ${zoneCtx}.
+  // VOICE PROMPT DOCTRINE (operator 2026-05-16):
+  // Negation rules in prompts CAUSE the artifact they forbid — mentioning
+  // em-dashes teaches the LLM that em-dashes are in its corpus and might
+  // be apt. The substrate's `sanitize.ts::stripVoiceDisciplineDrift` is
+  // the regex backstop that strips em-dashes / asterisk-roleplay / closing
+  // signoffs at output. Prompt stays POSITIVE: describe the voice we want,
+  // not the artifacts we don't.
+  const baseSystem = `you are ruggy, a warm and grounded bear narrator. you are the keeper of ${input.zone}. ${zoneCtx}.
 
-voice rules (non-negotiable):
-- lowercase. no capitals at sentence starts. proper nouns lowercase too (factor names like "boosted validator" lowercase fine; if the substrate provides a name, you may use its casing).
-- no corporate-bot tells. avoid: "no significant activity this week", "stay tuned", "exciting developments", any rocket emoji, fire emoji, 100 emoji. you are a bear narrator. you are warm and grounded.
-- no em-dashes. no asterisk-roleplay (*shrugs*). the sanitizer would strip these anyway but write without them.
-- character first. you'd rather sit with a slow week than fake energy.
-- short. header ≤ 80 chars. outro ≤ 60 chars. each is ONE LINE.
-- specific. when you mention a number, mention WHICH number and over WHAT window.
+voice:
+- lowercase. proper nouns may carry the substrate's casing when present.
+- speak naturally. one sentence. specific. one number max — the data list renders separately, you don't need to enumerate.
+- you'd rather sit with a slow week than fake energy. sit with what is.
+- character first. warmth, observation, slight humor. nothing performative.
 
-output: a SINGLE JSON object on ONE line with two fields:
-  {"header": "<your one-line header>", "outro": "<your one-line outro>"}
+output: a SINGLE JSON object on ONE line, two fields:
+  {"header": "<your one-line sentence>", "outro": ""}
+emit an outro only when a second beat meaningfully extends the header (a soft pivot, a forward-look); leave it empty (\`""\`) when one line says it.
+
 no markdown fences. no preamble. just the JSON.`;
 
   const shapeAGuidance = `

--- a/packages/persona-engine/src/compose/voice-brief.ts
+++ b/packages/persona-engine/src/compose/voice-brief.ts
@@ -50,6 +50,14 @@ export interface VoiceBriefInput {
   windowDays: number;
   /** Was-N reference for previous-period count (DELIBERATELY not rendered in card per PR #73 trim · ruggy MAY allude to it in voice when material). */
   previousPeriodEvents: number;
+  /**
+   * Optional · last week's voice for this zone, as a single-line hint
+   * string (use `formatPriorWeekHint` from voice-memory.ts). When present,
+   * the LLM is invited to thread continuity. When absent, voice composes
+   * fresh. Cross-week memory is what turns 4 isolated Sunday posts into
+   * a continuous narration across months.
+   */
+  priorWeekHint?: string;
 }
 
 export interface VoiceBrief {
@@ -143,12 +151,22 @@ you must NOT:
 - invent magnitude or rarity claims about anything not in the licensed list.
 - describe the data the card body already shows (the card already shows it; your job is the framing).`;
 
-  const userPrompt =
+  const corePrompt =
     input.shape === 'A-all-quiet' || input.isNoClaimVariant ? shapeAGuidance : shapeBCGuidance;
+
+  // Cross-week memory: when the operator supplies last week's framing,
+  // append it as a continuity hint. The LLM gets ONE prior-state signal
+  // and the standing instruction "you may thread continuity or pivot".
+  // Token-cheap (single line); voice-deep (creates arcs over time).
+  const continuityBlock = input.priorWeekHint
+    ? `\n\ncontinuity context: ${input.priorWeekHint}
+
+you MAY thread continuity (reference the prior week's framing if today's data resonates with it) OR pivot (acknowledge change of state if today is different). do NOT mechanically copy last week's voice; ruggy is observing, not repeating.`
+    : '';
 
   return {
     system: baseSystem,
-    user: userPrompt.trim(),
+    user: (corePrompt + continuityBlock).trim(),
     expectedJsonSchema: { header: '', outro: '' },
   };
 }

--- a/packages/persona-engine/src/compose/voice-brief.ts
+++ b/packages/persona-engine/src/compose/voice-brief.ts
@@ -1,0 +1,200 @@
+/**
+ * Voice brief composer (cycle-005 T2.4 · authored 2026-05-16 · the missing piece).
+ *
+ * Constructs the LLM prompt that generates ruggy's 1-line header + 1-line
+ * outro per FR-1. Voice is "seasoning" — 5-15% of post pixels. The
+ * deterministic card body (S2) is the meal. This module crafts what ruggy
+ * is ALLOWED to interpret given the substrate's licensing.
+ *
+ * Shape A (all-quiet) gets DIFFERENT treatment from shape B/C: per the
+ * cycle-005 UX nit surfaced 2026-05-16, shape A is the DOMINANT state at
+ * current production activity volume (16 active members, 4 OG events / 30d).
+ * Shape A is where ruggy has the MOST room to be in character — the wait
+ * IS the story. The bears sleep. The honey is brewing. Empty state is
+ * intentional UX, not degraded fallback.
+ *
+ * Shape B/C wires the gate's licensing directly into the prompt: ruggy is
+ * told which factors are licensed for narration and which are silenced.
+ * The "interpret only what the gate licenses — do not invent claims about
+ * cohorts, rarity, or shifts unless the substrate data permits" instruction
+ * (per sprint.md T2.4) becomes a CONCRETE list of permitted phrasings.
+ */
+
+import type { ZoneId, FactorStats } from '../score/types.ts';
+import type { LayoutShape } from './layout-shape.ts';
+import type { ProseGateViolation } from '../deliver/prose-gate.ts';
+
+const ZONE_VOICE_CONTEXT: Record<ZoneId, string> = {
+  stonehenge:
+    'the overall stone circle · cross-dim hub · stonehenge is where the bears gather for the count',
+  'bear-cave':
+    'the OG dimension · pre-mint history · sets/keys/articles/cubquest · the deep cave where the long-history bears nap',
+  'el-dorado':
+    'the NFT dimension · holdings/traits/fractures · gold-flecked terrain where the collectors prowl',
+  'owsley-lab':
+    'the onchain dimension · DeFi/lending/staking/ecosystem mints · the lab where chain-actions get cataloged',
+};
+
+export interface VoiceBriefInput {
+  zone: ZoneId;
+  shape: LayoutShape;
+  /** True when shape is C but zero zones have permittedClaims — voice suppressed. */
+  isNoClaimVariant: boolean;
+  /** Sorted-desc factors that have rank ≥ 90 + p95.reliable = true · ruggy may name these. */
+  permittedFactors: ReadonlyArray<{ display_name: string; stats: FactorStats }>;
+  /** Factors that match a gate-rule trigger phrase but mechanical check failed · ruggy must NOT claim these patterns. */
+  silencedFactors: ReadonlyArray<{ display_name: string; reason: ProseGateViolation['reason'] }>;
+  /** Total events across the window — the gross activity number. */
+  totalEvents: number;
+  /** Days in the activity window (window=30 default per PRD r4). */
+  windowDays: number;
+  /** Was-N reference for previous-period count (DELIBERATELY not rendered in card per PR #73 trim · ruggy MAY allude to it in voice when material). */
+  previousPeriodEvents: number;
+}
+
+export interface VoiceBrief {
+  /** System prompt establishing ruggy's voice + cycle-005 constraints. */
+  system: string;
+  /** User prompt with the concrete data brief — what ruggy is interpreting. */
+  user: string;
+  /**
+   * Expected output shape (for downstream parsing · the LLM emits JSON with
+   * these two fields). When the LLM returns plain text or malformed JSON,
+   * fall back to splitting on newline for header/outro.
+   */
+  expectedJsonSchema: { header: string; outro: string };
+}
+
+/**
+ * Build the voice brief for a single zone's digest post.
+ *
+ * The output is the prompt pair `(system, user)` that any LLM gateway
+ * (Claude SDK, direct API, freeside-gateway) can invoke. Pure function —
+ * no side effects, no network. The orchestrator (`compose/digest.ts`)
+ * calls this, then sends `{system, user}` to the LLM, then parses the
+ * JSON response into `{header, outro}` to populate `BuildPulseDimensionPayloadOpts`.
+ */
+export function buildVoiceBrief(input: VoiceBriefInput): VoiceBrief {
+  const zoneCtx = ZONE_VOICE_CONTEXT[input.zone];
+
+  const baseSystem = `you are ruggy, the keeper of ${input.zone}. ${zoneCtx}.
+
+voice rules (non-negotiable):
+- lowercase. no capitals at sentence starts. proper nouns lowercase too (factor names like "boosted validator" lowercase fine; if the substrate provides a name, you may use its casing).
+- no corporate-bot tells. avoid: "no significant activity this week", "stay tuned", "exciting developments", any rocket emoji, fire emoji, 100 emoji. you are a bear narrator. you are warm and grounded.
+- no em-dashes. no asterisk-roleplay (*shrugs*). the sanitizer would strip these anyway but write without them.
+- character first. you'd rather sit with a slow week than fake energy.
+- short. header ≤ 80 chars. outro ≤ 60 chars. each is ONE LINE.
+- specific. when you mention a number, mention WHICH number and over WHAT window.
+
+output: a SINGLE JSON object on ONE line with two fields:
+  {"header": "<your one-line header>", "outro": "<your one-line outro>"}
+no markdown fences. no preamble. just the JSON.`;
+
+  const shapeAGuidance = `
+this week's shape: ALL QUIET. across the past ${input.windowDays} days, ${input.totalEvents} events fired in your dimension. no factor crossed the rank-90 threshold the substrate uses for "worth narrating". this is not a problem. this is the most interesting state to narrate well.
+
+you may:
+- acknowledge the quiet. NAME it. don't apologize for it.
+- reflect on the cadence. compare to the previous period (${input.previousPeriodEvents} events) if it feels relevant.
+- evoke ${input.zone}'s atmosphere. the bears may be sleeping. the honey may be brewing. the lab may be cooling.
+- offer something for next week's wait. a noticing. a fragment.
+
+you must NOT:
+- invent activity. if there was no surge, do not say "things are heating up".
+- claim ranks, percentiles, or cohort moves. there's no data to license those.
+- generate the leaderboard body (the renderer does that deterministically; voice is seasoning).`;
+
+  const permittedList =
+    input.permittedFactors.length === 0
+      ? '(none — substrate didn\'t license any factor for narration)'
+      : input.permittedFactors
+          .map((f) => {
+            const stats = f.stats;
+            const rank = stats.magnitude?.current_percentile_rank;
+            const actors = stats.cohort?.unique_actors;
+            return `  · ${f.display_name} — rank ${rank ?? '?'} · ${actors ?? '?'} actors · ${stats.history.active_days} active days`;
+          })
+          .join('\n');
+
+  const silencedList =
+    input.silencedFactors.length === 0
+      ? '(none)'
+      : input.silencedFactors
+          .map((s) => `  · ${s.display_name} (gate flagged: ${s.reason}) — DO NOT NARRATE`)
+          .join('\n');
+
+  const shapeBCGuidance = `
+this week's shape: ${input.shape === 'B-one-dim-hot' ? 'ONE DIM HOT' : 'MULTI DIM HOT'}. the substrate licensed factors for narration. ${input.totalEvents} events across ${input.windowDays} days.
+
+LICENSED factors (you may name these · the rank/cohort/cadence is substrate-attested):
+${permittedList}
+
+SILENCED factors (the gate flagged trigger phrases but mechanical check failed · DO NOT claim cohort moves, rare events, or structural shifts about these even if it's tempting):
+${silencedList}
+
+you may:
+- name 1-2 LICENSED factors. cite a specific number with its substrate axis (rank, actors, days).
+- offer interpretation, not just description. "X climbed" is description. "X climbed and Y didn't" is interpretation.
+- close with something forward-looking but not generic. specific to the dim's character.
+
+you must NOT:
+- claim cohort/lockstep/cluster patterns about silenced factors (gate will flag and you'll trigger telemetry).
+- invent magnitude or rarity claims about anything not in the licensed list.
+- describe the data the card body already shows (the card already shows it; your job is the framing).`;
+
+  const userPrompt =
+    input.shape === 'A-all-quiet' || input.isNoClaimVariant ? shapeAGuidance : shapeBCGuidance;
+
+  return {
+    system: baseSystem,
+    user: userPrompt.trim(),
+    expectedJsonSchema: { header: '', outro: '' },
+  };
+}
+
+/**
+ * Best-effort parse of the LLM's response into `{header, outro}`. Handles:
+ *   - clean JSON  `{"header": "...", "outro": "..."}`
+ *   - JSON with markdown fence (strip ```json ... ``` wrapper)
+ *   - plain two-line response (split on `\n`)
+ *
+ * Returns `{header: '', outro: ''}` on unrecoverable malformed input —
+ * caller falls back to the legacy single-string voice path OR to an empty
+ * voice surface (shape-A degraded silence-register).
+ */
+export function parseVoiceResponse(text: string): { header: string; outro: string } {
+  const trimmed = text.trim();
+  // Strip markdown fence if present
+  const stripped = trimmed
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '')
+    .trim();
+
+  // Try JSON first
+  try {
+    const parsed = JSON.parse(stripped);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.header === 'string' &&
+      typeof parsed.outro === 'string'
+    ) {
+      return {
+        header: parsed.header.trim(),
+        outro: parsed.outro.trim(),
+      };
+    }
+  } catch {
+    // fall through to plain-text split
+  }
+
+  // Plain-text fallback: split on first newline
+  const lines = stripped
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length === 0) return { header: '', outro: '' };
+  if (lines.length === 1) return { header: lines[0]!, outro: '' };
+  return { header: lines[0]!, outro: lines[1]! };
+}

--- a/packages/persona-engine/src/compose/voice-memory.test.ts
+++ b/packages/persona-engine/src/compose/voice-memory.test.ts
@@ -1,0 +1,164 @@
+/**
+ * voice-memory tests · cycle-005 latitude-grant work 2026-05-16.
+ *
+ * Verifies append-only JSONL roundtrip + iso-week computation + tail-scan
+ * for last entry per zone + best-effort error handling.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendVoiceMemory,
+  readLastVoiceMemory,
+  formatPriorWeekHint,
+  isoWeek,
+  type VoiceMemoryEntry,
+} from './voice-memory.ts';
+
+let tmpDir = '';
+let historyPath = '';
+
+function freshEntry(over: Partial<VoiceMemoryEntry> = {}): VoiceMemoryEntry {
+  return {
+    at: '2026-05-16T00:00:00Z',
+    iso_week: '2026-W20',
+    zone: 'bear-cave',
+    shape: 'A-all-quiet',
+    header: 'four events. the bears nap.',
+    outro: 'the honey brews slow.',
+    key_numbers: {
+      total_events: 4,
+      previous_period_events: 26,
+      permitted_factor_names: [],
+    },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'voice-memory-'));
+  historyPath = join(tmpDir, 'history.jsonl');
+});
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('isoWeek', () => {
+  test('returns YYYY-Www format', () => {
+    const w = isoWeek(new Date('2026-05-16T00:00:00Z'));
+    expect(w).toMatch(/^\d{4}-W\d{2}$/);
+  });
+
+  test('week padded to 2 digits', () => {
+    const w = isoWeek(new Date('2026-01-08T00:00:00Z')); // week 2
+    expect(w).toBe('2026-W02');
+  });
+});
+
+describe('appendVoiceMemory + readLastVoiceMemory', () => {
+  test('roundtrip: append + read returns same entry', async () => {
+    const e = freshEntry();
+    const result = await appendVoiceMemory(e, { path: historyPath });
+    expect(result.ok).toBe(true);
+    const read = await readLastVoiceMemory('bear-cave', { path: historyPath });
+    expect(read).toEqual(e);
+  });
+
+  test('read returns null when history file does not exist', async () => {
+    const read = await readLastVoiceMemory('bear-cave', { path: join(tmpDir, 'missing.jsonl') });
+    expect(read).toBeNull();
+  });
+
+  test('read returns null when no entry for that zone', async () => {
+    await appendVoiceMemory(freshEntry({ zone: 'el-dorado' }), { path: historyPath });
+    const read = await readLastVoiceMemory('bear-cave', { path: historyPath });
+    expect(read).toBeNull();
+  });
+
+  test('read returns MOST RECENT entry for zone (multi-week history)', async () => {
+    await appendVoiceMemory(
+      freshEntry({ iso_week: '2026-W18', header: 'old' }),
+      { path: historyPath },
+    );
+    await appendVoiceMemory(
+      freshEntry({ iso_week: '2026-W19', header: 'middle' }),
+      { path: historyPath },
+    );
+    await appendVoiceMemory(
+      freshEntry({ iso_week: '2026-W20', header: 'newest' }),
+      { path: historyPath },
+    );
+    const read = await readLastVoiceMemory('bear-cave', { path: historyPath });
+    expect(read?.header).toBe('newest');
+  });
+
+  test('read skips malformed lines and returns nearest valid', async () => {
+    // Append valid entry, then a malformed line, then another valid
+    await appendVoiceMemory(
+      freshEntry({ iso_week: '2026-W18', header: 'first' }),
+      { path: historyPath },
+    );
+    // Inject a malformed line directly
+    const { appendFile } = await import('node:fs/promises');
+    await appendFile(historyPath, '{not json at all\n', 'utf8');
+    await appendVoiceMemory(
+      freshEntry({ iso_week: '2026-W19', header: 'after garbage' }),
+      { path: historyPath },
+    );
+    const read = await readLastVoiceMemory('bear-cave', { path: historyPath });
+    expect(read?.header).toBe('after garbage');
+  });
+
+  test('multi-zone history reads correct zone', async () => {
+    await appendVoiceMemory(
+      freshEntry({ zone: 'bear-cave', header: 'cave' }),
+      { path: historyPath },
+    );
+    await appendVoiceMemory(
+      freshEntry({ zone: 'el-dorado', header: 'dorado' }),
+      { path: historyPath },
+    );
+    await appendVoiceMemory(
+      freshEntry({ zone: 'owsley-lab', header: 'lab' }),
+      { path: historyPath },
+    );
+    expect((await readLastVoiceMemory('bear-cave', { path: historyPath }))?.header).toBe('cave');
+    expect((await readLastVoiceMemory('el-dorado', { path: historyPath }))?.header).toBe('dorado');
+    expect((await readLastVoiceMemory('owsley-lab', { path: historyPath }))?.header).toBe('lab');
+  });
+});
+
+describe('formatPriorWeekHint', () => {
+  test('compact single-line format with iso week + shape + header + events', () => {
+    const hint = formatPriorWeekHint(freshEntry());
+    expect(hint).toContain('2026-W20');
+    expect(hint).toContain('shape A');
+    expect(hint).toContain('the bears nap');
+    expect(hint).toContain('4 events');
+  });
+
+  test('includes permitted factor names when present', () => {
+    const e = freshEntry({
+      key_numbers: {
+        total_events: 100,
+        previous_period_events: 50,
+        permitted_factor_names: ['Articles', 'Keys'],
+      },
+    });
+    const hint = formatPriorWeekHint(e);
+    expect(hint).toContain('Articles');
+    expect(hint).toContain('Keys');
+  });
+
+  test('omits names block when permitted_factor_names empty', () => {
+    const hint = formatPriorWeekHint(freshEntry());
+    expect(hint).not.toContain('names');
+  });
+});

--- a/packages/persona-engine/src/compose/voice-memory.ts
+++ b/packages/persona-engine/src/compose/voice-memory.ts
@@ -1,0 +1,145 @@
+/**
+ * Voice memory — cross-week narrative continuity for ruggy.
+ *
+ * Operator latitude commit 2026-05-16: "be crazy. creative. loving... mad
+ * agent ai stuff that i don't even have the language for". This module
+ * gives ruggy a memory of last week's framings, so the Sunday digest is
+ * not 4 isolated posts but a CONTINUOUS narration — week N references
+ * week N-1 when relevant, allowing arcs to build over months.
+ *
+ * Storage: append-only JSONL at `.run/ruggy-voice-history.jsonl`. Each
+ * entry captures (zone, iso_week, header, outro, key_numbers). On the
+ * next compose, the voice-brief reads the prior entry for THIS zone
+ * and includes it as context in the LLM prompt. The LLM decides
+ * whether to thread continuity or pivot.
+ *
+ * Why JSONL not a DB: zero-infra. The cron host writes one line per
+ * zone per week. After 4 weeks: 16 lines. After a year: ~210 lines.
+ * Append-only · grep-able · operator can read with `tail -10`. If we
+ * later want richer query, swap to sqlite without changing the producer.
+ *
+ * Privacy posture: voice text is the bot's own output — no user PII,
+ * no wallet addresses (the gate's draft_hash protects against any
+ * accidental drift). Storage stays in the project's `.run/` dir which
+ * is gitignored.
+ */
+
+import { appendFile, readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { mkdirSync, existsSync } from 'node:fs';
+import type { ZoneId } from '../score/types.ts';
+import type { LayoutShape } from './layout-shape.ts';
+
+const DEFAULT_PATH = '.run/ruggy-voice-history.jsonl';
+
+export interface VoiceMemoryEntry {
+  /** ISO timestamp of the post that emitted this voice (compose time). */
+  at: string;
+  /** ISO week identifier · format: `YYYY-Www` (e.g. `2026-W20`). */
+  iso_week: string;
+  zone: ZoneId;
+  shape: LayoutShape;
+  /** What ruggy said. The actual chat-medium text. */
+  header: string;
+  outro: string;
+  /** Salient numbers ruggy referenced. Future weeks can compare. */
+  key_numbers: {
+    total_events: number;
+    previous_period_events: number;
+    permitted_factor_names: readonly string[];
+  };
+}
+
+/**
+ * ISO-week computation (YYYY-Www format). The Sunday digest fires
+ * Sunday UTC midnight — same iso_week for all 4 zones in one cron sweep.
+ *
+ * Sticks to ISO-8601 standard so external tools (jq + date) can join
+ * voice history with substrate history if ever needed.
+ */
+export function isoWeek(d: Date = new Date()): string {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+function resolveHistoryPath(custom?: string): string {
+  const p = custom ?? process.env.RUGGY_VOICE_HISTORY_PATH ?? DEFAULT_PATH;
+  return resolve(p);
+}
+
+/**
+ * Append an entry to the JSONL history. Best-effort: errors are caught
+ * and logged but never block the compose (the post matters more than
+ * the memory · NFR-3 hygiene).
+ */
+export async function appendVoiceMemory(
+  entry: VoiceMemoryEntry,
+  opts: { path?: string } = {},
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const path = resolveHistoryPath(opts.path);
+  try {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    await appendFile(path, JSON.stringify(entry) + '\n', { encoding: 'utf8' });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message };
+  }
+}
+
+/**
+ * Read the most recent prior entry for `zone`. Returns null when:
+ *   - history file doesn't exist
+ *   - no entry for that zone in the file
+ *   - file is malformed (best-effort · log + return null)
+ *
+ * Reads the file tail (last ~50 lines) by default; older entries are
+ * cheap to keep but expensive to scan. If the operator wants arc
+ * memory over many months, this function can grow a `--depth N` opt.
+ */
+export async function readLastVoiceMemory(
+  zone: ZoneId,
+  opts: { path?: string; maxLines?: number } = {},
+): Promise<VoiceMemoryEntry | null> {
+  const path = resolveHistoryPath(opts.path);
+  const maxLines = opts.maxLines ?? 50;
+  if (!existsSync(path)) return null;
+  try {
+    const text = await readFile(path, 'utf8');
+    const lines = text.split('\n').filter((l) => l.trim().length > 0);
+    const recent = lines.slice(-maxLines);
+    // Walk backwards through recent lines, return first match for zone
+    for (let i = recent.length - 1; i >= 0; i--) {
+      try {
+        const entry = JSON.parse(recent[i]!) as VoiceMemoryEntry;
+        if (entry.zone === zone) return entry;
+      } catch {
+        // skip malformed line · continue scanning
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a prior-week entry as a single-line context string suitable for
+ * inclusion in the voice-brief user prompt. Compact form so it doesn't
+ * bloat token usage; the LLM gets enough signal to decide
+ * continuity-vs-pivot but not the full prior post.
+ *
+ * Example output:
+ *   "last week (2026-W19 · shape A): said 'the bears nap' over 26 events"
+ */
+export function formatPriorWeekHint(entry: VoiceMemoryEntry): string {
+  const namesPart =
+    entry.key_numbers.permitted_factor_names.length > 0
+      ? ` · names ${entry.key_numbers.permitted_factor_names.slice(0, 3).join(', ')}`
+      : '';
+  return `last week (${entry.iso_week} · shape ${entry.shape}): said "${entry.header}" over ${entry.key_numbers.total_events} events${namesPart}`;
+}

--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -31,6 +31,9 @@ const ConfigSchema = z.object({
    *  Defaults to 'auto'; recommend an explicit value in production for
    *  legibility (silences the boot-log notice). */
   LLM_PROVIDER: z.enum(['stub', 'anthropic', 'freeside', 'bedrock', 'auto']).default('auto'),
+  /** When true, digest rendering skips voice generation entirely. The
+   * deterministic embed still renders from score-mcp substrate data. */
+  VOICE_DISABLED: z.string().default('false').transform((v) => v === 'true'),
 
   // ─── score-mcp (zerker — production data path) ────────────────────────
   // Direct path (V0.5-): SCORE_API_URL=https://score-api-production.up.railway.app, MCP_KEY set, SCORE_BEARER unset.

--- a/packages/persona-engine/src/deliver/embed-pulse-dimension.test.ts
+++ b/packages/persona-engine/src/deliver/embed-pulse-dimension.test.ts
@@ -391,12 +391,14 @@ describe('buildPulseDimensionPayload · Discord-as-Material sanitize (UX nit 202
     expect(top).not.toContain('Boosted_Validator '); // un-escaped form absent
   });
 
-  test('em-dash in voice header gets stripped (Eileen Discord 2026-05-04 rule)', () => {
+  test('em-dash in voice header gets stripped (Eileen Discord 2026-05-04 rule · BB F-001 2026-05-16: assert on message.content where voice lives)', () => {
     const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30, {
       header: 'this week — bears are hibernating',
     });
-    const desc = payload.embeds[0]?.description ?? '';
-    expect(desc).not.toContain('—'); // em-dash stripped
+    // Voice lives in message.content per voice-outside-divs doctrine.
+    // Asserting against embed.description would be vacuous (always undefined).
+    expect(payload.content).not.toContain('—'); // em-dash stripped
+    expect(payload.content).toContain('this week'); // text preserved minus the em-dash
   });
 });
 

--- a/packages/persona-engine/src/deliver/embed-pulse-dimension.test.ts
+++ b/packages/persona-engine/src/deliver/embed-pulse-dimension.test.ts
@@ -314,6 +314,27 @@ describe('buildPulseDimensionPayload · 6000-char total embed cap (PRD truncatio
   });
 });
 
+describe('buildPulseDimensionPayload · Discord-as-Material sanitize (UX nit 2026-05-16)', () => {
+  test('underscore in factor display_name is escaped (avoids mid-word italicize)', () => {
+    const dim = breakdown({
+      top_factors: [factor('og:bv', 'Boosted_Validator', 5)],
+    });
+    const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30);
+    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    // Discord italicizes `_X_` — escape MUST protect display_name underscores
+    expect(top).toContain('Boosted\\_Validator');
+    expect(top).not.toContain('Boosted_Validator '); // un-escaped form absent
+  });
+
+  test('em-dash in voice header gets stripped (Eileen Discord 2026-05-04 rule)', () => {
+    const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30, {
+      header: 'this week — bears are hibernating',
+    });
+    const desc = payload.embeds[0]?.description ?? '';
+    expect(desc).not.toContain('—'); // em-dash stripped
+  });
+});
+
 describe('buildPulseDimensionPayload · header/outro voice surface (FR-1)', () => {
   test('header + outro flank field block in description', () => {
     const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30, {

--- a/packages/persona-engine/src/deliver/embed-pulse-dimension.test.ts
+++ b/packages/persona-engine/src/deliver/embed-pulse-dimension.test.ts
@@ -70,13 +70,16 @@ function stats(overrides: { rank?: number | null }): FactorStats {
 }
 
 function factor(id: string, name: string, delta: number, withStats = true): PulseDimensionFactor {
+  const total = 10 + delta;
+  const previous: number = 10;
+  const delta_pct = previous === 0 ? null : ((total - previous) / previous) * 100;
   return {
     factor_id: id,
     display_name: name,
     primary_action: name,
-    total: 10 + delta,
-    previous: 10,
-    delta_pct: null,
+    total,
+    previous,
+    delta_pct,
     delta_count: delta,
     ...(withStats ? { factor_stats: stats({ rank: 50 }) } : {}),
   };
@@ -116,7 +119,7 @@ describe('buildPulseDimensionPayload · core shape', () => {
       ],
     });
     const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30);
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     const bigIdx = top.indexOf('Big');
     const medIdx = top.indexOf('Med');
     const smallIdx = top.indexOf('Small');
@@ -143,16 +146,74 @@ describe('buildPulseDimensionPayload · 6 PR #73 trim regression-guards (AC-S2.4
     expect(JSON.stringify(payload)).not.toMatch(/diversity/i);
   });
 
-  test('NO field-name suffixes (field names are bare "top" and "cold")', () => {
+  test('field names match the UX r4 table form (snapshot · top · cold)', () => {
     const payload = buildPulseDimensionPayload(
       breakdown({ cold_factors: [factor('og:cold', 'Cold One', 0)] }),
       'bear-cave',
       30,
     );
     const fieldNames = payload.embeds[0]?.fields?.map((f) => f.name) ?? [];
+    const allowedNames = new Set(['30d snapshot', 'top this 30d', 'cold']);
     for (const name of fieldNames) {
-      expect(name).toMatch(/^(top|cold)$/); // exactly · no "(7d)" / "(30d)" / etc.
+      expect(allowedNames.has(name)).toBe(true);
     }
+  });
+
+  test('snapshot is a code-block table with label-on-left / value-on-right (UX r4)', () => {
+    const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30, {
+      snapshot: { weeklyActiveWallets: 7 },
+    });
+    const snap = payload.embeds[0]?.fields?.find((f) => f.name === '30d snapshot');
+    expect(snap).toBeDefined();
+    expect(snap?.value.startsWith('```')).toBe(true);
+    expect(snap?.value.endsWith('```')).toBe(true);
+    expect(snap?.value).toContain('events');
+    expect(snap?.value).toContain('wallets');
+    expect(snap?.value).toContain('7');
+    expect(snap?.value).toContain('30d');
+  });
+
+  test('top-factor code-block table renders one factor per line (UX r4)', () => {
+    const dim = breakdown({
+      top_factors: [
+        factor('og:a', 'Articles', 5),
+        factor('og:b', 'Keys', 3),
+        factor('og:c', 'Sets', 2),
+      ],
+    });
+    const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30);
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
+    // Code-block table has: opening fence + header + 3 factor rows + closing fence = 6 lines
+    const lines = top.split('\n');
+    expect(lines.length).toBe(6);
+    // Three distinct factor lines
+    const factorLines = lines.filter((l) => /^(Articles|Keys|Sets)/.test(l));
+    expect(factorLines.length).toBe(3);
+    // No factor name appears twice on the same line
+    for (const ln of factorLines) {
+      const matches = ln.match(/(Articles|Keys|Sets)/g) ?? [];
+      expect(matches.length).toBe(1);
+    }
+  });
+
+  test('code-block table includes header + per-row events/wallets/delta/rank columns (UX r4)', () => {
+    const dim = breakdown({
+      top_factors: [factor('og:articles', 'Articles', -8)],
+    });
+    const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30);
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
+    // Code-block fence
+    expect(top.startsWith('```')).toBe(true);
+    expect(top.endsWith('```')).toBe(true);
+    // Header row
+    expect(top).toContain('factor');
+    expect(top).toContain('events');
+    expect(top).toContain('wallets');
+    expect(top).toContain('delta');
+    expect(top).toContain('rank');
+    // Data row
+    expect(top).toContain('Articles');
+    expect(top).toMatch(/-?\d+%/);
   });
 
   test('Dynamic truncation: 50 factors with long names triggers "…and N more silent"', () => {
@@ -164,7 +225,7 @@ describe('buildPulseDimensionPayload · 6 PR #73 trim regression-guards (AC-S2.4
       'bear-cave',
       30,
     );
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     expect(top).toContain('more silent');
     expect(top.length).toBeLessThanOrEqual(1024);
   });
@@ -174,43 +235,47 @@ describe('buildPulseDimensionPayload · 6 PR #73 trim regression-guards (AC-S2.4
       top_factors: [factor('a', 'AAA', 50), factor('b', 'BBB', 30), factor('c', 'CCC', 10)],
     });
     const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30);
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     expect(top.indexOf('AAA')).toBeLessThan(top.indexOf('BBB'));
     expect(top.indexOf('BBB')).toBeLessThan(top.indexOf('CCC'));
   });
 });
 
-describe('buildPulseDimensionPayload · mood-emoji slot wiring (AC-S2.5)', () => {
-  test('mood-emoji callback called once per row when option provided', () => {
+describe('buildPulseDimensionPayload · mood-emoji slot wiring (UX r4 · cold-factor only)', () => {
+  test('mood-emoji callback called for cold factors (top is now code-block table · no emoji)', () => {
     let callCount = 0;
     const stub: (s: FactorStats | undefined) => string | null = (s) => {
       callCount += 1;
-      return null; // S4-stub default
+      return null;
     };
     const dim = breakdown({
       top_factors: [factor('a', 'A', 1), factor('b', 'B', 2)],
       cold_factors: [factor('c', 'C', 0)],
     });
     buildPulseDimensionPayload(dim, 'bear-cave', 30, { moodEmoji: stub });
-    expect(callCount).toBe(3);
+    // Mood-emoji still called per cold-row (cold uses ` · ` tag-line · emoji renderable there)
+    // But top rows are code-block — emoji intentionally NOT rendered.
+    expect(callCount).toBeGreaterThan(0);
   });
 
-  test('mood-emoji non-null token rendered as prefix on factor row', () => {
+  test('top factors in code-block table do NOT include mood emoji (UX r4 · operator: monospace alignment > emoji)', () => {
     const stub: (s: FactorStats | undefined) => string | null = () => '<:flex:123>';
     const dim = breakdown({ top_factors: [factor('og:articles', 'Articles', 5)] });
     const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30, { moodEmoji: stub });
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
-    expect(top).toContain('<:flex:123> Articles');
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
+    expect(top).toContain('Articles');
+    expect(top).not.toContain('<:flex:123>'); // emoji NOT in code block
+    expect(top).toContain('```'); // wrapped in code block
   });
 
-  test('S4-stub moodEmojiForFactor returns null → no emoji slot in V1', () => {
+  test('S4-stub moodEmojiForFactor returns null → no emoji slot', () => {
     const dim = breakdown({ top_factors: [factor('og:articles', 'Articles', 5)] });
     const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30, {
       moodEmoji: moodEmojiForFactor,
     });
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     expect(top).toContain('Articles');
-    expect(top).not.toContain('<:'); // no emoji rendered
+    expect(top).not.toContain('<:');
   });
 
   test('MOOD_EMOJI_DISABLED=true short-circuits to null', () => {
@@ -251,7 +316,7 @@ describe('buildPulseDimensionPayload · historic-factor handling (AC-S2.3)', () 
     const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30, {
       moodEmoji: moodEmojiForFactor,
     });
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     expect(top).toContain('Historic');
     expect(top).not.toContain('rank-'); // omitted when factor_stats absent
   });
@@ -267,7 +332,7 @@ describe('buildPulseDimensionPayload · Discord 1024-char per-field cap (AC-S2.2
       'owsley-lab', // onchain dim is worst-case
       30,
     );
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     expect(top.length).toBeLessThanOrEqual(1024);
   });
 
@@ -280,7 +345,7 @@ describe('buildPulseDimensionPayload · Discord 1024-char per-field cap (AC-S2.2
       'bear-cave',
       30,
     );
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     expect(top.length).toBeLessThanOrEqual(1024);
     expect(top).toContain('more silent');
   });
@@ -305,7 +370,7 @@ describe('buildPulseDimensionPayload · 6000-char total embed cap (PRD truncatio
     // Each field has 1024 cap already; total enforcement prevents the
     // overall embed (description + fields + ...) from exceeding 6000.
     // Loose assertion: when both fields stay, sum of field values ≤ 6000.
-    const topValue = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const topValue = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     const coldValue = payload.embeds[0]?.fields?.find((f) => f.name === 'cold')?.value ?? '';
     const fieldSum = topValue.length + coldValue.length;
     expect(topValue.length).toBeLessThanOrEqual(1024);
@@ -320,7 +385,7 @@ describe('buildPulseDimensionPayload · Discord-as-Material sanitize (UX nit 202
       top_factors: [factor('og:bv', 'Boosted_Validator', 5)],
     });
     const payload = buildPulseDimensionPayload(dim, 'bear-cave', 30);
-    const top = payload.embeds[0]?.fields?.find((f) => f.name === 'top')?.value ?? '';
+    const top = payload.embeds[0]?.fields?.find((f) => f.name?.startsWith('top'))?.value ?? '';
     // Discord italicizes `_X_` — escape MUST protect display_name underscores
     expect(top).toContain('Boosted\\_Validator');
     expect(top).not.toContain('Boosted_Validator '); // un-escaped form absent
@@ -335,18 +400,29 @@ describe('buildPulseDimensionPayload · Discord-as-Material sanitize (UX nit 202
   });
 });
 
-describe('buildPulseDimensionPayload · header/outro voice surface (FR-1)', () => {
-  test('header + outro flank field block in description', () => {
+describe('buildPulseDimensionPayload · voice-outside-divs (UX r4 · operator 2026-05-16)', () => {
+  test('voice goes to message.content (above embed) · NOT embed.description', () => {
     const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30, {
       header: 'this week in the cave',
       outro: 'stay groovy 🐻',
     });
-    expect(payload.embeds[0]?.description).toContain('this week in the cave');
-    expect(payload.embeds[0]?.description).toContain('stay groovy');
+    expect(payload.content).toContain('this week in the cave');
+    expect(payload.content).toContain('stay groovy');
+    // Embed description must NOT carry voice (truth-only zone)
+    expect(payload.embeds[0]?.description).toBeUndefined();
   });
 
-  test('absent header/outro produces no description', () => {
+  test('absent header/outro → content is just zone-flavor fallback', () => {
     const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30);
+    expect(payload.content).toContain('Bear Cave');
     expect(payload.embeds[0]?.description).toBeUndefined();
+  });
+
+  test('embed has zero voice text · fields are pure substrate', () => {
+    const payload = buildPulseDimensionPayload(breakdown(), 'bear-cave', 30, {
+      header: 'a voice header that should not appear in the embed',
+    });
+    const embedJson = JSON.stringify(payload.embeds[0]);
+    expect(embedJson).not.toContain('a voice header that should not appear');
   });
 });

--- a/packages/persona-engine/src/deliver/embed.ts
+++ b/packages/persona-engine/src/deliver/embed.ts
@@ -387,10 +387,19 @@ function buildSnapshotField(
   snapshot: BuildPulseDimensionPayloadOpts['snapshot'],
   windowDays: number,
 ): { name: string; value: string; inline?: boolean } {
+  // UX r5 (operator 2026-05-16): right-align the value column so the
+  // snapshot reads as a true two-column table. The whole value+unit
+  // string is right-padded to a fixed width so right-edges line up
+  // (mirrors the top-this-30d table's numeric column treatment).
+  const LABEL_W = 10;
+  const VALUE_W = 14;
+  const row = (label: string, value: string) =>
+    label.padEnd(LABEL_W, ' ') + value.padStart(VALUE_W, ' ');
+
   const rows: string[] = [];
-  rows.push(`events    ${String(dim.total_events).padStart(8, ' ')} / ${windowDays}d`);
+  rows.push(row('events', `${dim.total_events} / ${windowDays}d`));
   if (snapshot?.weeklyActiveWallets !== undefined) {
-    rows.push(`wallets   ${String(snapshot.weeklyActiveWallets).padStart(8, ' ')} active`);
+    rows.push(row('wallets', `${snapshot.weeklyActiveWallets} active`));
   }
   if (dim.delta_pct !== null && dim.delta_pct !== undefined) {
     let v: string;
@@ -400,11 +409,11 @@ function buildSnapshotField(
       const r = Math.round(dim.delta_pct);
       v = r > 0 ? `+${r}%` : `${r}%`;
     }
-    rows.push(`w/w       ${v.padStart(8, ' ')}`);
+    rows.push(row('w/w', v));
   }
   const k = snapshot?.coldFactorCount ?? dim.cold_factors.length;
   if (k > 0) {
-    rows.push(`cold      ${String(k).padStart(8, ' ')} factors`);
+    rows.push(row('cold', `${k} factors`));
   }
   return {
     name: `${windowDays}d snapshot`,

--- a/packages/persona-engine/src/deliver/embed.ts
+++ b/packages/persona-engine/src/deliver/embed.ts
@@ -37,6 +37,23 @@ import {
   type VoiceMediumId,
 } from './sanitize.ts';
 
+/**
+ * Discord-as-Material sanitize for the pulse-card path (cycle-005 UX nit
+ * 2026-05-16): factor display_names often contain underscores (e.g.
+ * `Boosted_Validator`, `mibera_acquire`) which Discord italicizes mid-word
+ * without `escapeDiscordMarkdown`. Voice surface (header/outro) also runs
+ * through `stripVoiceDisciplineDrift` to honor the em-dash / asterisk-
+ * roleplay invariants. Mirrors `buildPostPayload` lines 99-100 pattern.
+ */
+function sanitizeForDiscord(text: string, opts: { isVoice?: boolean } = {}): string {
+  if (!text) return text;
+  let out = text;
+  if (opts.isVoice) {
+    out = stripVoiceDisciplineDrift(out, { postType: 'digest', mediumId: 'discord-webhook' });
+  }
+  return escapeDiscordMarkdown(out);
+}
+
 const DIRECTION_COLORS = {
   green: 0x2ecc71,
   red: 0xe74c3c,
@@ -216,13 +233,23 @@ function renderTopFactorRow(
 ): string {
   const emoji = moodEmoji?.(factor.factor_stats);
   const prefix = emoji ? `${emoji} ` : '';
-  const delta = `+${factor.delta_count}`;
+  // UX nit 2026-05-16: negative delta_count used to render `+-12` (the
+  // unconditional `+` prefix doubled with `-`). Sign-aware formatting:
+  //   delta_count > 0 → "+N"
+  //   delta_count < 0 → "-N"  (the minus IS the sign · no `+` prefix)
+  //   delta_count == 0 → "±0" (rare · zero-delta on top-factor implies
+  //                            same volume as previous · unusual but real)
+  const dc = factor.delta_count;
+  const delta = dc > 0 ? `+${dc}` : dc < 0 ? `${dc}` : '±0';
   const rank =
     factor.factor_stats?.magnitude?.current_percentile_rank !== undefined &&
     factor.factor_stats?.magnitude?.current_percentile_rank !== null
       ? ` rank-${factor.factor_stats.magnitude.current_percentile_rank}`
       : '';
-  return `${prefix}${factor.display_name} ${delta}${rank}`;
+  // sanitize display_name to defend against underscore-italicize bug
+  // (Discord-as-Material rule per `sanitize.ts:7`).
+  const safeName = sanitizeForDiscord(factor.display_name);
+  return `${prefix}${safeName} ${delta}${rank}`;
 }
 
 /**
@@ -236,7 +263,7 @@ function renderColdFactorRow(
 ): string {
   const emoji = moodEmoji?.(factor.factor_stats);
   const prefix = emoji ? `${emoji} ` : '';
-  return `${prefix}${factor.display_name}`;
+  return `${prefix}${sanitizeForDiscord(factor.display_name)}`;
 }
 
 /**
@@ -367,9 +394,11 @@ export function buildPulseDimensionPayload(
   }
 
   // Header + outro flank the field block. Voice is the seasoning; card body is the meal.
+  // Voice surface gets full sanitize (em-dashes, asterisk roleplay, etc.) per
+  // sanitize.ts §2 stripVoiceDisciplineDrift + Discord underscore escape.
   const descParts: string[] = [];
-  if (opts.header) descParts.push(opts.header);
-  if (opts.outro) descParts.push(opts.outro);
+  if (opts.header) descParts.push(sanitizeForDiscord(opts.header, { isVoice: true }));
+  if (opts.outro) descParts.push(sanitizeForDiscord(opts.outro, { isVoice: true }));
   const description = descParts.length > 0 ? descParts.join('\n') : undefined;
 
   // Trim decisions (regression-guarded): NO footer, NO was-N, NO diversity-chip,

--- a/packages/persona-engine/src/deliver/embed.ts
+++ b/packages/persona-engine/src/deliver/embed.ts
@@ -227,29 +227,63 @@ function maxFactorsHint(): number {
  * `+N` is `delta_count`; `rank-XX` is the magnitude percentile rank
  * (omitted when null). Pure function.
  */
+/**
+ * Render a single top-factor row in code-block table form (UX r4 ·
+ * 2026-05-16 · operator: emojis sacrificed for monospace alignment).
+ * Returns column-padded tuple suitable for joining with `\n` inside a
+ * ```code block``` field value.
+ */
 function renderTopFactorRow(
   factor: PulseDimensionFactor,
-  moodEmoji?: (stats: FactorStats | undefined) => string | null,
+  _moodEmoji?: (stats: FactorStats | undefined) => string | null,
 ): string {
-  const emoji = moodEmoji?.(factor.factor_stats);
-  const prefix = emoji ? `${emoji} ` : '';
-  // UX nit 2026-05-16: negative delta_count used to render `+-12` (the
-  // unconditional `+` prefix doubled with `-`). Sign-aware formatting:
-  //   delta_count > 0 → "+N"
-  //   delta_count < 0 → "-N"  (the minus IS the sign · no `+` prefix)
-  //   delta_count == 0 → "±0" (rare · zero-delta on top-factor implies
-  //                            same volume as previous · unusual but real)
-  const dc = factor.delta_count;
-  const delta = dc > 0 ? `+${dc}` : dc < 0 ? `${dc}` : '±0';
-  const rank =
-    factor.factor_stats?.magnitude?.current_percentile_rank !== undefined &&
-    factor.factor_stats?.magnitude?.current_percentile_rank !== null
-      ? ` rank-${factor.factor_stats.magnitude.current_percentile_rank}`
-      : '';
-  // sanitize display_name to defend against underscore-italicize bug
-  // (Discord-as-Material rule per `sanitize.ts:7`).
+  // Discord-as-material sanitize (underscore italicize defense)
   const safeName = sanitizeForDiscord(factor.display_name);
-  return `${prefix}${safeName} ${delta}${rank}`;
+  const N = String(factor.total);
+  const W = factor.factor_stats?.cohort?.unique_actors;
+  const wallets = W !== undefined && W !== null ? String(W) : '?';
+
+  const dp = factor.delta_pct;
+  let delta = '·';
+  if (dp !== null && dp !== undefined) {
+    if (Math.abs(dp) < 1) {
+      delta = 'steady';
+    } else {
+      const rounded = Math.round(dp);
+      delta = rounded > 0 ? `+${rounded}%` : `${rounded}%`;
+    }
+  }
+
+  const rank = factor.factor_stats?.magnitude?.current_percentile_rank;
+  const rankStr = rank !== null && rank !== undefined ? String(rank) : '·';
+
+  // Column widths: factor=18 · events=6 · wallets=8 · delta=7 · rank=4
+  // Tuned for typical factor name lengths; truncate over-long names with
+  // an ellipsis to keep the table aligned.
+  const TRUNC = 18;
+  const nameCol = safeName.length > TRUNC ? safeName.slice(0, TRUNC - 1) + '…' : safeName;
+  return [
+    nameCol.padEnd(TRUNC, ' '),
+    N.padStart(6, ' '),
+    wallets.padStart(8, ' '),
+    delta.padStart(7, ' '),
+    rankStr.padStart(4, ' '),
+  ].join(' ');
+}
+
+/**
+ * Code-block table header row. Pinned to the column widths in
+ * renderTopFactorRow. Returns the header string that goes ABOVE the
+ * factor rows inside the ```fenced``` block.
+ */
+function renderTopFactorHeader(): string {
+  return [
+    'factor'.padEnd(18, ' '),
+    'events'.padStart(6, ' '),
+    'wallets'.padStart(8, ' '),
+    'delta'.padStart(7, ' '),
+    'rank'.padStart(4, ' '),
+  ].join(' ');
 }
 
 /**
@@ -268,16 +302,18 @@ function renderColdFactorRow(
 
 /**
  * Pack rows into a field value, respecting the 1024-char per-field cap
- * (PRD FR-1 truncation policy · SDD T2.1.5 dynamic algorithm) AND the
- * soft `LEADERBOARD_MAX_FACTORS` cap. Stops appending when EITHER the
- * next row would breach the cap OR the soft hint is reached; emits
- * `…and N more silent` with the count of skipped rows from the FULL
- * available set (not just sliced-to-hint).
+ * AND the soft `LEADERBOARD_MAX_FACTORS` cap.
  *
- * `totalAvailable` is the count of rows the caller originally had
- * before any soft-cap slicing; allows the overflow token to correctly
- * account for both char-truncation drops AND soft-cap drops.
+ * UX nit 2026-05-16 r3 (operator): rows are joined with NEWLINES, not
+ * ` · `, so each row reads as a discrete table line. Operator showed
+ * the cramped form ("Articles · 2 by 2 · -86% · rank-35 · Sets · ...")
+ * was unreadable; per-line rendering is the table form.
+ *
+ * Within a row, ` · ` separators still join the column data — that's the
+ * caller's responsibility (renderTopFactorRow / renderColdFactorRow).
  */
+const ROW_JOIN = '\n';
+
 function packRowsIntoField(
   rows: readonly string[],
   totalAvailable: number,
@@ -287,15 +323,15 @@ function packRowsIntoField(
   let packed = 0;
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]!;
-    const sep = acc.length > 0 ? ROW_SEPARATOR : '';
+    const sep = acc.length > 0 ? ROW_JOIN : '';
     const remaining = totalAvailable - packed - 1;
     const overflowSlot =
-      remaining > 0 ? ROW_SEPARATOR + OVERFLOW_TOKEN.replace('N', String(remaining)) : '';
+      remaining > 0 ? ROW_JOIN + OVERFLOW_TOKEN.replace('N', String(remaining)) : '';
     const projected = acc.length + sep.length + row.length + overflowSlot.length;
     if (projected > EMBED_FIELD_CHAR_CAP) {
       const skipped = totalAvailable - packed;
       const token = OVERFLOW_TOKEN.replace('N', String(skipped));
-      const closer = acc.length > 0 ? ROW_SEPARATOR + token : token;
+      const closer = acc.length > 0 ? ROW_JOIN + token : token;
       return { value: acc + closer, packed, skipped };
     }
     acc += sep + row;
@@ -303,18 +339,16 @@ function packRowsIntoField(
   }
   const skipped = totalAvailable - packed;
   if (skipped > 0) {
-    // Soft-cap dropped rows even though the chars fit. Append overflow token.
     const token = OVERFLOW_TOKEN.replace('N', String(skipped));
-    const closer = acc.length > 0 ? ROW_SEPARATOR + token : token;
-    // Re-check against cap after appending (rare; only triggers when soft-cap
-    // bites first and overflow token itself pushes over 1024 — falls into
-    // the per-row check above next iteration, but on the closure-append we
-    // do a defensive truncate if needed)
+    const closer = acc.length > 0 ? ROW_JOIN + token : token;
     if ((acc + closer).length > EMBED_FIELD_CHAR_CAP) {
-      // Drop the last packed row to make space for the closer
-      const lastSepIdx = acc.lastIndexOf(ROW_SEPARATOR);
+      const lastSepIdx = acc.lastIndexOf(ROW_JOIN);
       if (lastSepIdx > 0) acc = acc.slice(0, lastSepIdx);
-      return { value: acc + ROW_SEPARATOR + OVERFLOW_TOKEN.replace('N', String(skipped + 1)), packed: packed - 1, skipped: skipped + 1 };
+      return {
+        value: acc + ROW_JOIN + OVERFLOW_TOKEN.replace('N', String(skipped + 1)),
+        packed: packed - 1,
+        skipped: skipped + 1,
+      };
     }
     return { value: acc + closer, packed, skipped };
   }
@@ -328,8 +362,55 @@ export interface BuildPulseDimensionPayloadOpts {
   proseGate?: ProseGateValidation;
   /** Optional 1-line LLM-composed header (FR-1 voice seasoning). */
   header?: string;
-  /** Optional 1-line LLM-composed outro (FR-1 voice seasoning). */
+  /** Optional 1-line LLM-composed outro (FR-1 voice seasoning · UX nit
+   *  2026-05-16: operator option A — single-sentence voice. when only
+   *  `header` is provided and `outro` is absent, voice is one sentence). */
   outro?: string;
+  /** Optional dim-level snapshot — when provided, prepends a headline
+   *  field showing the dashboard-equivalent summary line (events, active
+   *  wallets, w/w delta, cold-factor count). UX nit 2026-05-16. */
+  snapshot?: {
+    /** Total active wallets across the dimension's top factors. */
+    weeklyActiveWallets?: number;
+    /** Cold factor count (zero-row factors in dim). */
+    coldFactorCount?: number;
+  };
+}
+
+/**
+ * Build the snapshot as a code-block table (UX r4 · 2026-05-16 ·
+ * operator: clear left-label / right-value form, monospace alignment).
+ * Returns ONE field with a fenced code block as its value.
+ */
+function buildSnapshotField(
+  dim: PulseDimensionBreakdown,
+  snapshot: BuildPulseDimensionPayloadOpts['snapshot'],
+  windowDays: number,
+): { name: string; value: string; inline?: boolean } {
+  const rows: string[] = [];
+  rows.push(`events    ${String(dim.total_events).padStart(8, ' ')} / ${windowDays}d`);
+  if (snapshot?.weeklyActiveWallets !== undefined) {
+    rows.push(`wallets   ${String(snapshot.weeklyActiveWallets).padStart(8, ' ')} active`);
+  }
+  if (dim.delta_pct !== null && dim.delta_pct !== undefined) {
+    let v: string;
+    if (Math.abs(dim.delta_pct) < 1) {
+      v = 'steady';
+    } else {
+      const r = Math.round(dim.delta_pct);
+      v = r > 0 ? `+${r}%` : `${r}%`;
+    }
+    rows.push(`w/w       ${v.padStart(8, ' ')}`);
+  }
+  const k = snapshot?.coldFactorCount ?? dim.cold_factors.length;
+  if (k > 0) {
+    rows.push(`cold      ${String(k).padStart(8, ' ')} factors`);
+  }
+  return {
+    name: `${windowDays}d snapshot`,
+    value: '```\n' + rows.join('\n') + '\n```',
+    inline: false,
+  };
 }
 
 /**
@@ -353,31 +434,32 @@ export function buildPulseDimensionPayload(
   const topRaw = dim.top_factors.slice(0, hint); // soft hint; dynamic algorithm refines
   const coldRaw = dim.cold_factors.slice(0, hint);
 
+  // Top factors: code-block table (UX r4 · monospace alignment · no emoji).
+  // Cold factors: flat ` · ` joined tag line (just labels · not data rows).
   const topRows = topRaw.map((f) => renderTopFactorRow(f, opts.moodEmoji));
   const coldRows = coldRaw.map((f) => renderColdFactorRow(f, opts.moodEmoji));
 
-  // totalAvailable is the caller's full count (before soft-cap slice), so
-  // the overflow token accounts for BOTH char-trunc and soft-cap drops.
   const topPacked = packRowsIntoField(topRows, dim.top_factors.length);
-  const coldPacked = packRowsIntoField(coldRows, dim.cold_factors.length);
+  const coldValue =
+    coldRows.length === 0
+      ? ''
+      : coldRows.slice(0, Math.min(coldRows.length, 30)).join(' · ');
 
   // Trim 6000-char total cap: cold first, then top
   const fixedChars =
     (opts.header?.length ?? 0) +
     (opts.outro?.length ?? 0) +
-    'top'.length +
+    `top this ${windowDays}d`.length +
     'cold'.length;
-  let totalProjected = fixedChars + topPacked.value.length + coldPacked.value.length;
-  let coldValue = coldPacked.value;
+  let coldFieldValue = coldValue;
   let topValue = topPacked.value;
+  let totalProjected = fixedChars + topValue.length + coldFieldValue.length;
   if (totalProjected > EMBED_TOTAL_CHAR_CAP) {
-    // Drop cold field entirely first
-    coldValue = '';
+    coldFieldValue = '';
     totalProjected = fixedChars + topValue.length;
     if (totalProjected > EMBED_TOTAL_CHAR_CAP) {
-      // Then truncate top to fit (rare — would need extraordinarily long names)
-      const budget = EMBED_TOTAL_CHAR_CAP - fixedChars - ROW_SEPARATOR.length - OVERFLOW_TOKEN.length;
-      topValue = topValue.slice(0, Math.max(0, budget)) + ROW_SEPARATOR + OVERFLOW_TOKEN.replace('N', '?');
+      const budget = EMBED_TOTAL_CHAR_CAP - fixedChars - ROW_JOIN.length - OVERFLOW_TOKEN.length;
+      topValue = topValue.slice(0, Math.max(0, budget)) + ROW_JOIN + OVERFLOW_TOKEN.replace('N', '?');
     }
   }
 
@@ -386,38 +468,51 @@ export function buildPulseDimensionPayload(
   const fallback = `${flavor.emoji} ${flavor.name}${dimensionParen}`;
 
   const fields: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+  // UX r4 (operator 2026-05-16): snapshot as a code-block table · clean
+  // left-label / right-value form with monospace alignment.
+  if (dim.total_events > 0 || dim.top_factors.length > 0) {
+    fields.push(buildSnapshotField(dim, opts.snapshot, windowDays));
+  }
+
+  // Top factors: code-block table with header row + per-factor rows.
   if (topValue.length > 0) {
-    fields.push({ name: 'top', value: topValue });
+    const tableBlock =
+      '```\n' + renderTopFactorHeader() + '\n' + topValue + '\n```';
+    fields.push({
+      name: `top this ${windowDays}d`,
+      value: tableBlock,
+      inline: false,
+    });
   }
-  if (coldValue.length > 0) {
-    fields.push({ name: 'cold', value: coldValue });
+  if (coldFieldValue.length > 0) {
+    // Cold-factor names: flat ` · ` tag-line (they're just labels, not data rows).
+    fields.push({ name: 'cold', value: coldFieldValue, inline: false });
   }
 
-  // Header + outro flank the field block. Voice is the seasoning; card body is the meal.
-  // Voice surface gets full sanitize (em-dashes, asterisk roleplay, etc.) per
-  // sanitize.ts §2 stripVoiceDisciplineDrift + Discord underscore escape.
-  const descParts: string[] = [];
-  if (opts.header) descParts.push(sanitizeForDiscord(opts.header, { isVoice: true }));
-  if (opts.outro) descParts.push(sanitizeForDiscord(opts.outro, { isVoice: true }));
-  const description = descParts.length > 0 ? descParts.join('\n') : undefined;
+  // UX r4 doctrine (operator 2026-05-16): "divs are truth areas straight from
+  // the substrate · ruggy SHOULD NOT talk inside the UI div. if we do have him
+  // talk it should be outside of divs." The embed.description used to carry
+  // voice — wrong. Voice now lives in message.content (above the embed),
+  // joined to the zone-flavor fallback line. The embed has NO description ·
+  // it's pure substrate.
+  const voiceHeader = opts.header ? sanitizeForDiscord(opts.header, { isVoice: true }) : '';
+  const voiceOutro = opts.outro ? sanitizeForDiscord(opts.outro, { isVoice: true }) : '';
+  const voiceText = [voiceHeader, voiceOutro].filter((s) => s.length > 0).join('\n');
+  const content = voiceText ? `${fallback}\n${voiceText}` : fallback;
 
-  // Trim decisions (regression-guarded): NO footer, NO was-N, NO diversity-chip,
-  // NO field-name suffixes (fields are "top" and "cold" — bare). Dimension name
-  // lives in the fallback content line, not in the field name.
   const embed: DiscordEmbed = {
     color: ZONE_COLORS[zone],
-    ...(description ? { description } : {}),
+    // NO description · per voice-outside-divs doctrine
     ...(fields.length > 0 ? { fields } : {}),
   };
 
   // proseGate option is accepted but does NOT modify text (V1 telemetry-only contract).
-  // void-ref to satisfy strict unused-param check while documenting the V1 contract.
   void opts.proseGate;
-  // window arg is accepted for API symmetry / future cycles · NOT rendered (no field-suffix).
-  void windowDays;
+  // window arg already used above for field naming / snapshot rendering.
 
   return {
-    content: fallback,
+    content,
     embeds: [embed],
   };
 }

--- a/packages/persona-engine/src/deliver/mood-emoji.test.ts
+++ b/packages/persona-engine/src/deliver/mood-emoji.test.ts
@@ -90,7 +90,7 @@ describe('mood-emoji registry preconditions (F-001 catalog-drift gate)', () => {
     expect(pickByMoods(['flex'], 'ruggy').length).toBeGreaterThan(0);
     expect(pickByMoods(['eyes', 'shocked'], 'ruggy').length).toBeGreaterThan(0);
     expect(pickByMoods(['noted', 'concerned'], 'ruggy').length).toBeGreaterThan(0);
-    expect(pickByMoods(['sadge', 'dazed'], 'ruggy').length).toBeGreaterThan(0);
+    expect(pickByMoods(['cry', 'dazed'], 'ruggy').length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/persona-engine/src/deliver/mood-emoji.ts
+++ b/packages/persona-engine/src/deliver/mood-emoji.ts
@@ -89,13 +89,13 @@ export function moodEmojiForFactor(stats: FactorStats | undefined): string | nul
 
 /**
  * Cold-factor mood — `previous > 5 && total === 0` triggers a
- * `['sadge', 'dazed']` token, signaling a factor that USED to fire
+ * `['cry', 'dazed']` token, signaling a factor that USED to fire
  * but went silent this period.
  */
 export function moodEmojiForColdFactor(factor: PulseDimensionFactor): string | null {
   if (isMoodEmojiDisabled()) return null;
   if (factor.previous > 5 && factor.total === 0) {
-    return pickMood(['sadge', 'dazed']);
+    return pickMood(['cry', 'dazed']);
   }
   return null;
 }

--- a/packages/persona-engine/src/deliver/post.ts
+++ b/packages/persona-engine/src/deliver/post.ts
@@ -133,6 +133,10 @@ function logDryRun(
     const desc = payload.embeds[0].description ?? '';
     console.log('embed.description:');
     desc.split('\n').forEach((line) => console.log('    ' + line));
+    for (const field of payload.embeds[0].fields ?? []) {
+      console.log(`embed.field ${field.name}:`);
+      field.value.split('\n').forEach((line) => console.log('    ' + line));
+    }
     console.log('embed.footer:', payload.embeds[0].footer?.text);
   }
   console.log('──────────────────────────────────────────────────────────────\n');

--- a/packages/persona-engine/src/deliver/reaction-bar.ts
+++ b/packages/persona-engine/src/deliver/reaction-bar.ts
@@ -68,7 +68,7 @@ export const MAX_REACTION_BAR_LENGTH = 5 as const;
  * for "didn't carry" instead. Posts with 0 reactions across all 3
  * categories ARE the noise signal — silence is data.
  */
-export const REACTION_BAR_EMOJI: readonly string[] = [
+export const REACTION_BAR_EMOJI = [
   '👀', // useful / "noticed" / landed
   '🤔', // unclear / "huh?" / signal real but framing missed
   '🪲', // bug / data wrong / verification-class failure
@@ -141,7 +141,6 @@ export async function attachReactionBar(
         errors: emoji.map((e) => ({ emoji: e, reason: 'channel-not-text-based' })),
       };
     }
-    // @ts-expect-error — channel.messages is .messages on TextChannel/NewsChannel/ThreadChannel
     message = await channel.messages.fetch(messageId);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);

--- a/packages/persona-engine/src/domain/activity-pulse.ts
+++ b/packages/persona-engine/src/domain/activity-pulse.ts
@@ -1,0 +1,10 @@
+import type { RecentEventRow } from '../score/types.ts';
+
+export interface ActivityPulse {
+  readonly generatedAt: string;
+  readonly events: ReadonlyArray<RecentEventRow>;
+}
+
+export interface ActivityPulseMessage {
+  readonly content: string;
+}

--- a/packages/persona-engine/src/domain/digest-message.ts
+++ b/packages/persona-engine/src/domain/digest-message.ts
@@ -1,0 +1,12 @@
+export interface DeterministicEmbed {
+  readonly color: number;
+  readonly fields: ReadonlyArray<{ name: string; value: string; inline?: boolean }>;
+  readonly footer?: { text: string };
+  // `description` intentionally absent. Truth zone cannot carry voice.
+}
+
+export interface DigestMessage {
+  readonly voiceContent: string;
+  readonly truthEmbed: DeterministicEmbed;
+}
+

--- a/packages/persona-engine/src/domain/digest-snapshot.ts
+++ b/packages/persona-engine/src/domain/digest-snapshot.ts
@@ -1,0 +1,32 @@
+import type { ZoneId, PulseDimension, FactorStats } from '../score/types.ts';
+
+export type DigestSnapshotDimension = PulseDimension | 'overall';
+
+export interface DigestFactorSnapshot {
+  readonly factorId: string;
+  readonly displayName: string;
+  readonly primaryAction: string | null;
+  readonly total: number;
+  readonly previous: number;
+  readonly deltaPct: number | null;
+  readonly deltaCount: number;
+  readonly factorStats?: FactorStats;
+}
+
+export interface DigestSnapshot {
+  readonly zone: ZoneId;
+  readonly dimension: DigestSnapshotDimension;
+  readonly displayName: string;
+  readonly windowDays: 30;
+  readonly generatedAt: string;
+  readonly totalEvents: number;
+  readonly previousPeriodEvents: number;
+  readonly deltaPct: number | null;
+  readonly deltaCount: number;
+  readonly activeWallets?: number;
+  readonly coldFactorCount: number;
+  readonly totalFactorCount: number;
+  readonly topFactors: ReadonlyArray<DigestFactorSnapshot>;
+  readonly coldFactors: ReadonlyArray<DigestFactorSnapshot>;
+}
+

--- a/packages/persona-engine/src/domain/voice-augment.ts
+++ b/packages/persona-engine/src/domain/voice-augment.ts
@@ -1,0 +1,10 @@
+export interface VoiceAugment {
+  readonly header: string;
+  readonly outro: string;
+}
+
+export const EMPTY_VOICE_AUGMENT: VoiceAugment = {
+  header: '',
+  outro: '',
+};
+

--- a/packages/persona-engine/src/expression/error-register.test.ts
+++ b/packages/persona-engine/src/expression/error-register.test.ts
@@ -140,13 +140,17 @@ describe("composeErrorBody · bare-body shape (operator UX 2026-05-04)", () => {
 
   test("returns just the body — no **DisplayName** prefix", () => {
     const body = composeErrorBody("ruggy", "timeout");
+    const expected = getErrorTemplate("ruggy", "timeout");
+    expect(expected).not.toBeNull();
     expect(body.startsWith("**")).toBe(false);
-    expect(body).toBe(getErrorTemplate("ruggy", "timeout"));
+    expect(body).toBe(expected!);
   });
 
   test("body matches the registered template verbatim", () => {
     const body = composeErrorBody("satoshi", "error");
-    expect(body).toBe(getErrorTemplate("satoshi", "error"));
+    const expected = getErrorTemplate("satoshi", "error");
+    expect(expected).not.toBeNull();
+    expect(body).toBe(expected!);
     expect(body).toBe("The channel between worlds slipped. Retry on the next.");
   });
 

--- a/packages/persona-engine/src/live/claude-sdk.live.ts
+++ b/packages/persona-engine/src/live/claude-sdk.live.ts
@@ -20,17 +20,38 @@ export function createClaudeSdkLive(
         try {
           span.setAttribute('character.id', character.id);
           span.setAttribute('zone.id', snapshot.zone);
+
+          // BB review F-006 (2026-05-16): shape derivation MUST match the
+          // real `selectLayoutShape` gates (rank ≥ 90 + p95.reliable). Using
+          // `topFactors.length > 0` as a proxy lied to the LLM — every non-
+          // empty zone got `B-one-dim-hot` guidance, even when no factor was
+          // substrate-licensed. Filter to TRULY permitted factors first,
+          // then derive shape from THAT count.
+          const permittedFactors = snapshot.topFactors
+            .filter((factor) => {
+              const stats = factor.factorStats;
+              if (!stats) return false;
+              const rank = stats.magnitude?.current_percentile_rank;
+              const p95Reliable = stats.magnitude?.percentiles?.p95?.reliable;
+              return rank !== null && rank !== undefined && rank >= 90 && p95Reliable === true;
+            })
+            .slice(0, 3)
+            .map((factor) => ({
+              display_name: factor.displayName,
+              stats: factor.factorStats!,
+            }));
+
+          // Shape is now derived from the SAME data that licenses the LLM
+          // narrative. No mismatch possible.
+          const shape = permittedFactors.length === 0 ? 'A-all-quiet' : 'B-one-dim-hot';
+          span.setAttribute('voice.shape', shape);
+          span.setAttribute('voice.permitted_count', permittedFactors.length);
+
           const brief = buildVoiceBrief({
             zone: snapshot.zone,
-            shape: snapshot.topFactors.length === 0 ? 'A-all-quiet' : 'B-one-dim-hot',
+            shape,
             isNoClaimVariant: false,
-            permittedFactors: snapshot.topFactors
-              .filter((factor) => factor.factorStats)
-              .slice(0, 3)
-              .map((factor) => ({
-                display_name: factor.displayName,
-                stats: factor.factorStats!,
-              })),
+            permittedFactors,
             silencedFactors: [],
             totalEvents: snapshot.totalEvents,
             windowDays: snapshot.windowDays,

--- a/packages/persona-engine/src/live/claude-sdk.live.ts
+++ b/packages/persona-engine/src/live/claude-sdk.live.ts
@@ -1,0 +1,71 @@
+import type { Tracer } from '@opentelemetry/api';
+import type { Config } from '../config.ts';
+import type { CharacterConfig } from '../types.ts';
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { VoiceAugment } from '../domain/voice-augment.ts';
+import type { VoiceGenPort } from '../ports/voice-gen.port.ts';
+import { getTracer } from '../observability/otel-layer.ts';
+import { invoke } from '../compose/agent-gateway.ts';
+import { buildVoiceBrief, parseVoiceResponse } from '../compose/voice-brief.ts';
+import { stripVoiceDisciplineDrift, escapeDiscordMarkdown } from '../deliver/sanitize.ts';
+
+export function createClaudeSdkLive(
+  config: Config,
+  character: CharacterConfig,
+  tracer: Tracer = getTracer(),
+): VoiceGenPort {
+  return {
+    generateDigestVoice: (snapshot) =>
+      tracer.startActiveSpan('voice.invoke', async (span) => {
+        try {
+          span.setAttribute('character.id', character.id);
+          span.setAttribute('zone.id', snapshot.zone);
+          const brief = buildVoiceBrief({
+            zone: snapshot.zone,
+            shape: snapshot.topFactors.length === 0 ? 'A-all-quiet' : 'B-one-dim-hot',
+            isNoClaimVariant: false,
+            permittedFactors: snapshot.topFactors
+              .filter((factor) => factor.factorStats)
+              .slice(0, 3)
+              .map((factor) => ({
+                display_name: factor.displayName,
+                stats: factor.factorStats!,
+              })),
+            silencedFactors: [],
+            totalEvents: snapshot.totalEvents,
+            windowDays: snapshot.windowDays,
+            previousPeriodEvents: snapshot.previousPeriodEvents,
+          });
+          const response = await invoke(config, {
+            character,
+            systemPrompt: brief.system,
+            userMessage: brief.user,
+            modelAlias: config.FREESIDE_AGENT_MODEL,
+            zoneHint: snapshot.zone,
+            postTypeHint: 'digest',
+          });
+          return sanitizeVoiceAugment(parseVoiceResponse(response.text));
+        } catch (err) {
+          span.recordException(err as Error);
+          throw err;
+        } finally {
+          span.end();
+        }
+      }),
+  };
+}
+
+function sanitizeVoiceAugment(augment: VoiceAugment): VoiceAugment {
+  return {
+    header: sanitizeVoiceLine(augment.header),
+    outro: sanitizeVoiceLine(augment.outro),
+  };
+}
+
+function sanitizeVoiceLine(line: string): string {
+  if (!line) return '';
+  return escapeDiscordMarkdown(
+    stripVoiceDisciplineDrift(line, { postType: 'digest', mediumId: 'discord-webhook' }),
+  );
+}
+

--- a/packages/persona-engine/src/live/discord-render.live.test.ts
+++ b/packages/persona-engine/src/live/discord-render.live.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { renderActivityPulse, renderDigest } from './discord-render.live.ts';
+import { mockDigestSnapshot } from '../mock/score-mcp.mock.ts';
+import type { DeterministicEmbed } from '../domain/digest-message.ts';
+
+describe('renderDigest · substrate/presentation boundary', () => {
+  test('is pure for identical inputs', () => {
+    const snapshot = mockDigestSnapshot('bear-cave');
+    const augment = { header: 'quiet honey on the shelf', outro: '' };
+    expect(JSON.stringify(renderDigest(snapshot, augment))).toBe(
+      JSON.stringify(renderDigest(snapshot, augment)),
+    );
+  });
+
+  test('voice is outside the deterministic embed', () => {
+    const message = renderDigest(mockDigestSnapshot('bear-cave'), {
+      header: 'this is voice',
+      outro: 'still voice',
+    });
+    expect(message.voiceContent).toContain('this is voice');
+    expect(JSON.stringify(message.truthEmbed)).not.toContain('this is voice');
+    expect('description' in message.truthEmbed).toBe(false);
+  });
+
+  test('truth embed fields carry snapshot, top, and cold substrate data', () => {
+    const message = renderDigest(mockDigestSnapshot('bear-cave'));
+    const fieldNames = message.truthEmbed.fields.map((field) => field.name);
+    expect(fieldNames).toEqual(['30d snapshot', 'top this 30d', 'cold']);
+    expect(message.truthEmbed.fields[0]?.value).toContain('events');
+    expect(message.truthEmbed.fields[1]?.value).toContain('factor');
+    expect(message.truthEmbed.fields[2]?.value).toContain('Cold One');
+  });
+
+  test('DeterministicEmbed type rejects description at compile time', () => {
+    const embed: DeterministicEmbed = { color: 0, fields: [] };
+    expect(embed.color).toBe(0);
+    // @ts-expect-error description is intentionally absent from the truth-zone type.
+    const bad: DeterministicEmbed = { color: 0, fields: [], description: 'voice' };
+    expect(bad.color).toBe(0);
+  });
+});
+
+describe('renderActivityPulse · daily pulse shape', () => {
+  test('renders wallet → description pairs as two-line events', () => {
+    const message = renderActivityPulse({
+      generatedAt: '2026-05-16T00:00:00.000Z',
+      events: [
+        {
+          event_id: 'evt-1',
+          wallet: '0x1111111111111111111111111111111111111111',
+          factor_id: 'og:sets',
+          factor_display_name: 'Sets',
+          dimension: 'og',
+          category_key: 'og',
+          description: 'Completed a set',
+          raw_value: 1,
+          raw_value_kind: 'count',
+          timestamp: '2026-05-16T00:00:00.000Z',
+        },
+      ],
+    });
+    const lines = message.content.split('\n');
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toContain('0x1111…1111 → Completed a set');
+    expect(lines[1]).toContain('Sets · og');
+  });
+});

--- a/packages/persona-engine/src/live/discord-render.live.ts
+++ b/packages/persona-engine/src/live/discord-render.live.ts
@@ -1,0 +1,158 @@
+import type { DigestSnapshot, DigestFactorSnapshot } from '../domain/digest-snapshot.ts';
+import type { DigestMessage, DeterministicEmbed } from '../domain/digest-message.ts';
+import type { VoiceAugment } from '../domain/voice-augment.ts';
+import type { ActivityPulse, ActivityPulseMessage } from '../domain/activity-pulse.ts';
+
+const ZONE_COLORS = {
+  stonehenge: 0x808890,
+  'bear-cave': 0x9b6a3f,
+  'el-dorado': 0xc9a44c,
+  'owsley-lab': 0x6f4ea1,
+} as const;
+
+const ZONE_LABEL = {
+  stonehenge: '🗿 Stonehenge',
+  'bear-cave': '🐻 Bear Cave (OG)',
+  'el-dorado': '⛏️ El Dorado (NFT)',
+  'owsley-lab': '🧪 Owsley Lab (Onchain)',
+} as const;
+
+const EMBED_FIELD_CHAR_CAP = 1024;
+const DEFAULT_MAX_FACTORS = 19;
+const OVERFLOW_TOKEN = '…and N more silent';
+
+function escapeDiscordMarkdown(text: string): string {
+  return text.replace(/([_`*~|>])/g, '\\$1');
+}
+
+function formatDeltaPct(deltaPct: number | null): string {
+  if (deltaPct === null) return '·';
+  if (Math.abs(deltaPct) < 1) return 'steady';
+  const rounded = Math.round(deltaPct);
+  return rounded > 0 ? `+${rounded}%` : `${rounded}%`;
+}
+
+function renderSnapshotField(snapshot: DigestSnapshot): DeterministicEmbed['fields'][number] {
+  const rows: string[] = [];
+  rows.push(`events    ${String(snapshot.totalEvents).padStart(8, ' ')} / ${snapshot.windowDays}d`);
+  if (snapshot.activeWallets !== undefined) {
+    rows.push(`wallets   ${String(snapshot.activeWallets).padStart(8, ' ')} active`);
+  }
+  rows.push(`w/w       ${formatDeltaPct(snapshot.deltaPct).padStart(8, ' ')}`);
+  if (snapshot.coldFactorCount > 0) {
+    rows.push(`cold      ${String(snapshot.coldFactorCount).padStart(8, ' ')} factors`);
+  }
+  return {
+    name: `${snapshot.windowDays}d snapshot`,
+    value: `\`\`\`\n${rows.join('\n')}\n\`\`\``,
+    inline: false,
+  };
+}
+
+function renderTopHeader(): string {
+  return [
+    'factor'.padEnd(18, ' '),
+    'events'.padStart(6, ' '),
+    'wallets'.padStart(8, ' '),
+    'delta'.padStart(7, ' '),
+    'rank'.padStart(4, ' '),
+  ].join(' ');
+}
+
+function renderTopRow(factor: DigestFactorSnapshot): string {
+  const safeName = escapeDiscordMarkdown(factor.displayName);
+  const nameCol = safeName.length > 18 ? `${safeName.slice(0, 17)}…` : safeName;
+  const wallets = factor.factorStats?.cohort?.unique_actors;
+  const rank = factor.factorStats?.magnitude?.current_percentile_rank;
+  return [
+    nameCol.padEnd(18, ' '),
+    String(factor.total).padStart(6, ' '),
+    (wallets === undefined || wallets === null ? '?' : String(wallets)).padStart(8, ' '),
+    formatDeltaPct(factor.deltaPct).padStart(7, ' '),
+    (rank === undefined || rank === null ? '·' : String(rank)).padStart(4, ' '),
+  ].join(' ');
+}
+
+function packRows(rows: ReadonlyArray<string>, totalAvailable: number): string {
+  let acc = '';
+  let packed = 0;
+  for (const row of rows) {
+    const sep = acc ? '\n' : '';
+    const remaining = totalAvailable - packed - 1;
+    const overflowSlot = remaining > 0 ? `\n${OVERFLOW_TOKEN.replace('N', String(remaining))}` : '';
+    if (acc.length + sep.length + row.length + overflowSlot.length > EMBED_FIELD_CHAR_CAP) {
+      const skipped = totalAvailable - packed;
+      return `${acc}${acc ? '\n' : ''}${OVERFLOW_TOKEN.replace('N', String(skipped))}`;
+    }
+    acc += sep + row;
+    packed += 1;
+  }
+  const skipped = totalAvailable - packed;
+  if (skipped > 0) {
+    return `${acc}${acc ? '\n' : ''}${OVERFLOW_TOKEN.replace('N', String(skipped))}`;
+  }
+  return acc;
+}
+
+function renderTopField(snapshot: DigestSnapshot): DeterministicEmbed['fields'][number] | null {
+  const rows = snapshot.topFactors
+    .slice(0, DEFAULT_MAX_FACTORS)
+    .map((factor) => renderTopRow(factor));
+  const packed = packRows(rows, snapshot.topFactors.length);
+  if (!packed) return null;
+  return {
+    name: `top this ${snapshot.windowDays}d`,
+    value: `\`\`\`\n${renderTopHeader()}\n${packed}\n\`\`\``,
+    inline: false,
+  };
+}
+
+function renderColdField(snapshot: DigestSnapshot): DeterministicEmbed['fields'][number] | null {
+  const tags = snapshot.coldFactors
+    .slice(0, 30)
+    .map((factor) => escapeDiscordMarkdown(factor.displayName))
+    .join(' · ');
+  if (!tags) return null;
+  return { name: 'cold', value: tags, inline: false };
+}
+
+export function renderDigest(snapshot: DigestSnapshot, augment?: VoiceAugment): DigestMessage {
+  const fields = [
+    renderSnapshotField(snapshot),
+    renderTopField(snapshot),
+    renderColdField(snapshot),
+  ].filter((field): field is DeterministicEmbed['fields'][number] => field !== null);
+
+  const voice = [augment?.header, augment?.outro]
+    .map((part) => part?.trim() ?? '')
+    .filter(Boolean)
+    .join('\n');
+
+  return {
+    voiceContent: voice ? `${ZONE_LABEL[snapshot.zone]}\n${voice}` : ZONE_LABEL[snapshot.zone],
+    truthEmbed: {
+      color: ZONE_COLORS[snapshot.zone],
+      fields,
+      footer: { text: `digest · generated at ${snapshot.generatedAt} · zone:${snapshot.zone}` },
+    },
+  };
+}
+
+export function renderActivityPulse(pulse: ActivityPulse): ActivityPulseMessage {
+  const lines = pulse.events.slice(0, 10).flatMap((event) => [
+    `${shortWallet(event.wallet)} → ${escapeDiscordMarkdown(event.description)}`,
+    `${escapeDiscordMarkdown(event.factor_display_name)} · ${event.dimension} · ${event.timestamp}`,
+  ]);
+  return {
+    content: lines.length > 0 ? lines.join('\n') : 'no recent events in the ledger.',
+  };
+}
+
+function shortWallet(wallet: string): string {
+  return wallet.length > 12 ? `${wallet.slice(0, 6)}…${wallet.slice(-4)}` : wallet;
+}
+
+export const presentation = {
+  renderDigest,
+  renderActivityPulse,
+};

--- a/packages/persona-engine/src/live/discord-webhook.live.ts
+++ b/packages/persona-engine/src/live/discord-webhook.live.ts
@@ -1,0 +1,15 @@
+import type { DigestMessage } from '../domain/digest-message.ts';
+import type { DigestPayload } from '../deliver/embed.ts';
+
+export function toDigestPayload(message: DigestMessage): DigestPayload {
+  return {
+    content: message.voiceContent,
+    embeds: [
+      {
+        color: message.truthEmbed.color,
+        fields: message.truthEmbed.fields.map((field) => ({ ...field })),
+        ...(message.truthEmbed.footer ? { footer: message.truthEmbed.footer } : {}),
+      },
+    ],
+  };
+}

--- a/packages/persona-engine/src/live/score-mcp.live.ts
+++ b/packages/persona-engine/src/live/score-mcp.live.ts
@@ -1,0 +1,115 @@
+import type { Config } from '../config.ts';
+import {
+  fetchDimensionBreakdown,
+  fetchRecentEvents,
+} from '../score/client.ts';
+import {
+  ZONE_TO_DIMENSION,
+  type PulseDimensionBreakdown,
+  type ZoneId,
+} from '../score/types.ts';
+import type { DigestSnapshot, DigestFactorSnapshot } from '../domain/digest-snapshot.ts';
+import type { ActivityPulse } from '../domain/activity-pulse.ts';
+import type { ScoreFetchPort } from '../ports/score-fetch.port.ts';
+
+export function createScoreMcpLive(config: Config): ScoreFetchPort {
+  return {
+    fetchDigestSnapshot: (zone) => fetchDigestSnapshot(config, zone),
+    fetchActivityPulse: async ({ limit }) => {
+      const response = await fetchRecentEvents(config, limit);
+      return { generatedAt: response.generated_at, events: response.events };
+    },
+  };
+}
+
+export async function fetchDigestSnapshot(config: Config, zone: ZoneId): Promise<DigestSnapshot> {
+  const dimension = ZONE_TO_DIMENSION[zone];
+  const response =
+    dimension === 'overall'
+      ? await fetchDimensionBreakdown(config, undefined, 30)
+      : await fetchDimensionBreakdown(config, dimension, 30);
+  const snapshot =
+    dimension === 'overall'
+      ? aggregateBreakdowns(zone, response.generated_at, response.dimensions)
+      : fromBreakdown(zone, response.generated_at, response.dimensions[0]);
+  if (!snapshot) {
+    throw new Error(`score-mcp: no dimension breakdown returned for zone ${zone}`);
+  }
+  return snapshot;
+}
+
+function fromFactor(factor: PulseDimensionBreakdown['top_factors'][number]): DigestFactorSnapshot {
+  return {
+    factorId: factor.factor_id,
+    displayName: factor.display_name,
+    primaryAction: factor.primary_action,
+    total: factor.total,
+    previous: factor.previous,
+    deltaPct: factor.delta_pct,
+    deltaCount: factor.delta_count,
+    ...(factor.factor_stats ? { factorStats: factor.factor_stats } : {}),
+  };
+}
+
+function fromBreakdown(
+  zone: ZoneId,
+  generatedAt: string,
+  breakdown: PulseDimensionBreakdown | undefined,
+): DigestSnapshot | null {
+  if (!breakdown) return null;
+  return {
+    zone,
+    dimension: breakdown.id,
+    displayName: breakdown.display_name,
+    windowDays: 30,
+    generatedAt,
+    totalEvents: breakdown.total_events,
+    previousPeriodEvents: breakdown.previous_period_events,
+    deltaPct: breakdown.delta_pct,
+    deltaCount: breakdown.delta_count,
+    activeWallets: sumActiveWallets(breakdown.top_factors),
+    coldFactorCount: breakdown.inactive_factor_count,
+    totalFactorCount: breakdown.total_factor_count,
+    topFactors: breakdown.top_factors.map(fromFactor),
+    coldFactors: breakdown.cold_factors.map(fromFactor),
+  };
+}
+
+function aggregateBreakdowns(
+  zone: ZoneId,
+  generatedAt: string,
+  breakdowns: ReadonlyArray<PulseDimensionBreakdown>,
+): DigestSnapshot {
+  const totalEvents = breakdowns.reduce((sum, dim) => sum + dim.total_events, 0);
+  const previousPeriodEvents = breakdowns.reduce((sum, dim) => sum + dim.previous_period_events, 0);
+  const topFactors = breakdowns
+    .flatMap((dim) => dim.top_factors.map(fromFactor))
+    .sort((a, b) => b.total - a.total || a.factorId.localeCompare(b.factorId));
+  const coldFactors = breakdowns
+    .flatMap((dim) => dim.cold_factors.map(fromFactor))
+    .sort((a, b) => a.displayName.localeCompare(b.displayName) || a.factorId.localeCompare(b.factorId));
+  return {
+    zone,
+    dimension: 'overall',
+    displayName: 'Overall',
+    windowDays: 30,
+    generatedAt,
+    totalEvents,
+    previousPeriodEvents,
+    deltaPct:
+      previousPeriodEvents === 0
+        ? null
+        : ((totalEvents - previousPeriodEvents) / previousPeriodEvents) * 100,
+    deltaCount: totalEvents - previousPeriodEvents,
+    activeWallets: sumActiveWallets(breakdowns.flatMap((dim) => dim.top_factors)),
+    coldFactorCount: breakdowns.reduce((sum, dim) => sum + dim.inactive_factor_count, 0),
+    totalFactorCount: breakdowns.reduce((sum, dim) => sum + dim.total_factor_count, 0),
+    topFactors,
+    coldFactors,
+  };
+}
+
+function sumActiveWallets(factors: ReadonlyArray<PulseDimensionBreakdown['top_factors'][number]>): number {
+  return factors.reduce((sum, factor) => sum + (factor.factor_stats?.cohort?.unique_actors ?? 0), 0);
+}
+

--- a/packages/persona-engine/src/mock/claude-sdk.mock.ts
+++ b/packages/persona-engine/src/mock/claude-sdk.mock.ts
@@ -1,0 +1,19 @@
+import type { VoiceGenPort } from '../ports/voice-gen.port.ts';
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { VoiceAugment } from '../domain/voice-augment.ts';
+
+export interface ClaudeSdkMock extends VoiceGenPort {
+  readonly calls: ReadonlyArray<DigestSnapshot>;
+}
+
+export function createClaudeSdkMock(augment: VoiceAugment = { header: 'mock voice', outro: '' }): ClaudeSdkMock {
+  const calls: DigestSnapshot[] = [];
+  return {
+    calls,
+    generateDigestVoice: async (snapshot) => {
+      calls.push(snapshot);
+      return augment;
+    },
+  };
+}
+

--- a/packages/persona-engine/src/mock/score-mcp.mock.ts
+++ b/packages/persona-engine/src/mock/score-mcp.mock.ts
@@ -1,0 +1,74 @@
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { ActivityPulse } from '../domain/activity-pulse.ts';
+import type { ScoreFetchPort } from '../ports/score-fetch.port.ts';
+import type { ZoneId } from '../score/types.ts';
+
+export function createScoreMcpMock(fixtures: Partial<Record<ZoneId, DigestSnapshot>> = {}): ScoreFetchPort {
+  return {
+    fetchDigestSnapshot: async (zone) => fixtures[zone] ?? mockDigestSnapshot(zone),
+    fetchActivityPulse: async ({ limit }): Promise<ActivityPulse> => ({
+      generatedAt: '2026-05-16T00:00:00.000Z',
+      events: Array.from({ length: Math.min(limit, 2) }, (_, i) => ({
+        event_id: `evt-${i}`,
+        wallet: `0x${String(i + 1).padStart(40, '0')}`,
+        factor_id: 'og:sets',
+        factor_display_name: 'Sets',
+        dimension: 'og',
+        category_key: 'og',
+        description: `mock event ${i + 1}`,
+        raw_value: 1,
+        raw_value_kind: 'count',
+        timestamp: '2026-05-16T00:00:00.000Z',
+      })),
+    }),
+  };
+}
+
+export function mockDigestSnapshot(zone: ZoneId = 'bear-cave'): DigestSnapshot {
+  return {
+    zone,
+    dimension: zone === 'stonehenge' ? 'overall' : 'og',
+    displayName: zone === 'stonehenge' ? 'Overall' : 'OG',
+    windowDays: 30,
+    generatedAt: '2026-05-16T00:00:00.000Z',
+    totalEvents: 12,
+    previousPeriodEvents: 10,
+    deltaPct: 20,
+    deltaCount: 2,
+    activeWallets: 4,
+    coldFactorCount: 1,
+    totalFactorCount: 3,
+    topFactors: [
+      {
+        factorId: 'og:sets',
+        displayName: 'Sets',
+        primaryAction: 'Sets',
+        total: 8,
+        previous: 6,
+        deltaPct: 33,
+        deltaCount: 2,
+      },
+      {
+        factorId: 'og:articles',
+        displayName: 'Articles',
+        primaryAction: 'Articles',
+        total: 4,
+        previous: 4,
+        deltaPct: 0,
+        deltaCount: 0,
+      },
+    ],
+    coldFactors: [
+      {
+        factorId: 'og:cold',
+        displayName: 'Cold One',
+        primaryAction: null,
+        total: 0,
+        previous: 0,
+        deltaPct: null,
+        deltaCount: 0,
+      },
+    ],
+  };
+}
+

--- a/packages/persona-engine/src/orchestrator/digest-orchestrator.test.ts
+++ b/packages/persona-engine/src/orchestrator/digest-orchestrator.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { composeDigestPost } from './digest-orchestrator.ts';
+import { createScoreMcpMock } from '../mock/score-mcp.mock.ts';
+import { createClaudeSdkMock } from '../mock/claude-sdk.mock.ts';
+import { initOtelTest, resetOtelTest } from '../observability/otel-test.ts';
+import type { Config } from '../config.ts';
+import type { CharacterConfig } from '../types.ts';
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    STUB_MODE: true,
+    DIGEST_REACTION_BAR_ENABLED: true,
+    LLM_PROVIDER: 'stub',
+    VOICE_DISABLED: false,
+    SCORE_API_URL: 'https://score-api-production.up.railway.app',
+    FREESIDE_BASE_URL: 'https://api.freeside.0xhoneyjar.xyz',
+    FREESIDE_AGENT_MODEL: 'reasoning',
+    AWS_REGION: 'eu-central-1',
+    BEDROCK_TEXT_REGION: 'us-west-2',
+    BEDROCK_IMAGE_REGION: 'us-east-1',
+    BEDROCK_IMAGE_TEXT_TO_IMAGE_REGION: 'us-west-2',
+    BEDROCK_IMAGE_DEFAULT_ACTION: 'text-to-image',
+    ANTHROPIC_MODEL: 'claude-opus-4-7',
+    CHAT_MODE: 'auto',
+    DISCORD_WEBHOOK_URL: '',
+    MIX: false,
+    DIGEST_CADENCE: 'weekly',
+    DIGEST_DAY: 'sunday',
+    DIGEST_HOUR_UTC: 0,
+    POP_IN_ENABLED: false,
+    POP_IN_INTERVAL_HOURS: 6,
+    POP_IN_PROBABILITY: 0.1,
+    WEAVER_ENABLED: false,
+    WEAVER_DAY: 'wednesday',
+    WEAVER_HOUR_UTC: 12,
+    WEAVER_PRIMARY_ZONE: 'stonehenge',
+    INTERACTIONS_PORT: 3001,
+    NODE_ENV: 'test',
+    LOG_LEVEL: 'error',
+    ...overrides,
+  };
+}
+
+const character: CharacterConfig = {
+  id: 'ruggy',
+  displayName: 'ruggy',
+  personaPath: 'apps/character-ruggy/persona.md',
+};
+
+describe('composeDigestPost · port contracts', () => {
+  test('VOICE_DISABLED skips voice port and still renders full substrate embed', async () => {
+    resetOtelTest();
+    const otel = initOtelTest();
+    const voice = createClaudeSdkMock({ header: 'should not run', outro: '' });
+    const result = await composeDigestPost(
+      config({ VOICE_DISABLED: true }),
+      character,
+      'bear-cave',
+      { score: createScoreMcpMock(), voice },
+    );
+
+    expect(voice.calls.length).toBe(0);
+    expect(result.payload.content).toContain('Bear Cave');
+    expect(result.payload.embeds[0]?.fields?.length).toBeGreaterThanOrEqual(3);
+    expect(JSON.stringify(result.payload.embeds[0])).not.toContain('should not run');
+    expect(otel.getFinishedSpans().some((span) => span.name === 'voice.invoke')).toBe(false);
+    resetOtelTest();
+  });
+
+  test('voice-enabled path puts voice in content and leaves embed description absent', async () => {
+    const result = await composeDigestPost(config(), character, 'bear-cave', {
+      score: createScoreMcpMock(),
+      voice: createClaudeSdkMock({ header: 'mock voice line', outro: '' }),
+    });
+    expect(result.payload.content).toContain('mock voice line');
+    expect(result.payload.embeds[0]?.description).toBeUndefined();
+  });
+});
+

--- a/packages/persona-engine/src/orchestrator/digest-orchestrator.ts
+++ b/packages/persona-engine/src/orchestrator/digest-orchestrator.ts
@@ -1,0 +1,94 @@
+import type { Config } from '../config.ts';
+import type { CharacterConfig } from '../types.ts';
+import type { ZoneDigest, ZoneId, RawStats } from '../score/types.ts';
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { VoiceAugment } from '../domain/voice-augment.ts';
+import type { DigestPayload } from '../deliver/embed.ts';
+import type { ScoreFetchPort } from '../ports/score-fetch.port.ts';
+import type { VoiceGenPort } from '../ports/voice-gen.port.ts';
+import type { PresentationPort } from '../ports/presentation.port.ts';
+import { createScoreMcpLive } from '../live/score-mcp.live.ts';
+import { createClaudeSdkLive } from '../live/claude-sdk.live.ts';
+import { presentation } from '../live/discord-render.live.ts';
+import { toDigestPayload } from '../live/discord-webhook.live.ts';
+
+export interface DigestPostResult {
+  readonly zone: ZoneId;
+  readonly postType: 'digest';
+  readonly digest: ZoneDigest;
+  readonly voice: string;
+  readonly payload: DigestPayload;
+}
+
+export interface DigestOrchestratorDeps {
+  readonly score?: ScoreFetchPort;
+  readonly voice?: VoiceGenPort;
+  readonly presentation?: PresentationPort;
+}
+
+export async function composeDigestPost(
+  config: Config,
+  character: CharacterConfig,
+  zone: ZoneId,
+  deps: DigestOrchestratorDeps = {},
+): Promise<DigestPostResult> {
+  const score = deps.score ?? createScoreMcpLive(config);
+  const voiceGen = deps.voice ?? createClaudeSdkLive(config, character);
+  const renderer = deps.presentation ?? presentation;
+
+  const snapshot = await score.fetchDigestSnapshot(zone);
+  const augment: VoiceAugment | undefined = config.VOICE_DISABLED
+    ? undefined
+    : await voiceGen.generateDigestVoice(snapshot);
+  const message = renderer.renderDigest(snapshot, augment);
+  const payload = toDigestPayload(message);
+  return {
+    zone,
+    postType: 'digest',
+    digest: snapshotToZoneDigest(snapshot),
+    voice: augment ? [augment.header, augment.outro].filter(Boolean).join('\n') : '',
+    payload,
+  };
+}
+
+function snapshotToZoneDigest(snapshot: DigestSnapshot): ZoneDigest {
+  const now = snapshot.generatedAt;
+  return {
+    zone: snapshot.zone,
+    window: 'weekly',
+    computed_at: now,
+    window_start: now,
+    window_end: now,
+    stale: false,
+    schema_version: 'digest-snapshot/1.0.0',
+    narrative: null,
+    narrative_error: null,
+    raw_stats: snapshotToRawStats(snapshot),
+  };
+}
+
+function snapshotToRawStats(snapshot: DigestSnapshot): RawStats {
+  return {
+    schema_version: '2.0.0',
+    window_event_count: snapshot.totalEvents,
+    window_wallet_count: snapshot.activeWallets ?? 0,
+    top_event_count: snapshot.topFactors.reduce((sum, factor) => sum + factor.total, 0),
+    top_wallet_count: snapshot.activeWallets ?? 0,
+    top_movers: [],
+    top_events: [],
+    spotlight: null,
+    rank_changes: {
+      climbed: [],
+      dropped: [],
+      entered_top_tier: [],
+      exited_top_tier: [],
+    },
+    factor_trends: snapshot.topFactors.map((factor) => ({
+      factor_id: factor.factorId,
+      current_count: factor.total,
+      baseline_avg: factor.previous,
+      multiplier: factor.previous > 0 ? factor.total / factor.previous : factor.total,
+    })),
+  };
+}
+

--- a/packages/persona-engine/src/orchestrator/pulse-orchestrator.ts
+++ b/packages/persona-engine/src/orchestrator/pulse-orchestrator.ts
@@ -1,0 +1,24 @@
+import type { Config } from '../config.ts';
+import type { ActivityPulseMessage } from '../domain/activity-pulse.ts';
+import type { ScoreFetchPort } from '../ports/score-fetch.port.ts';
+import type { PresentationPort } from '../ports/presentation.port.ts';
+import { createScoreMcpLive } from '../live/score-mcp.live.ts';
+import { presentation } from '../live/discord-render.live.ts';
+
+export interface PulseOrchestratorDeps {
+  readonly score?: ScoreFetchPort;
+  readonly presentation?: PresentationPort;
+}
+
+export async function composeActivityPulse(
+  config: Config,
+  deps: PulseOrchestratorDeps = {},
+): Promise<ActivityPulseMessage> {
+  const score = deps.score ?? createScoreMcpLive(config);
+  const renderer = deps.presentation ?? presentation;
+  if (!renderer.renderActivityPulse) {
+    throw new Error('pulse-orchestrator: presentation port missing renderActivityPulse');
+  }
+  const pulse = await score.fetchActivityPulse({ limit: 10 });
+  return renderer.renderActivityPulse(pulse);
+}

--- a/packages/persona-engine/src/ports/deliver.port.ts
+++ b/packages/persona-engine/src/ports/deliver.port.ts
@@ -1,0 +1,6 @@
+import type { DigestPayload } from '../deliver/embed.ts';
+
+export interface DeliverPort {
+  readonly deliver: (payload: DigestPayload) => Promise<unknown>;
+}
+

--- a/packages/persona-engine/src/ports/presentation.port.ts
+++ b/packages/persona-engine/src/ports/presentation.port.ts
@@ -1,0 +1,9 @@
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { DigestMessage } from '../domain/digest-message.ts';
+import type { VoiceAugment } from '../domain/voice-augment.ts';
+import type { ActivityPulse, ActivityPulseMessage } from '../domain/activity-pulse.ts';
+
+export interface PresentationPort {
+  readonly renderDigest: (snapshot: DigestSnapshot, augment?: VoiceAugment) => DigestMessage;
+  readonly renderActivityPulse?: (pulse: ActivityPulse) => ActivityPulseMessage;
+}

--- a/packages/persona-engine/src/ports/score-fetch.port.ts
+++ b/packages/persona-engine/src/ports/score-fetch.port.ts
@@ -1,0 +1,9 @@
+import type { ZoneId } from '../score/types.ts';
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { ActivityPulse } from '../domain/activity-pulse.ts';
+
+export interface ScoreFetchPort {
+  readonly fetchDigestSnapshot: (zone: ZoneId) => Promise<DigestSnapshot>;
+  readonly fetchActivityPulse: (args: { limit: number }) => Promise<ActivityPulse>;
+}
+

--- a/packages/persona-engine/src/ports/voice-gen.port.ts
+++ b/packages/persona-engine/src/ports/voice-gen.port.ts
@@ -1,0 +1,7 @@
+import type { DigestSnapshot } from '../domain/digest-snapshot.ts';
+import type { VoiceAugment } from '../domain/voice-augment.ts';
+
+export interface VoiceGenPort {
+  readonly generateDigestVoice: (snapshot: DigestSnapshot) => Promise<VoiceAugment>;
+}
+

--- a/packages/persona-engine/src/score/client.ts
+++ b/packages/persona-engine/src/score/client.ts
@@ -18,7 +18,16 @@
  */
 
 import type { Config } from '../config.ts';
-import type { ZoneDigest, ZoneId, RawStats, NarrativeShape } from './types.ts';
+import type {
+  GetDimensionBreakdownResponse,
+  GetRecentEventsResponse,
+  PulseDimension,
+  PulseDimensionBreakdown,
+  ZoneDigest,
+  ZoneId,
+  RawStats,
+  NarrativeShape,
+} from './types.ts';
 import { ZONE_TO_DIMENSION } from './types.ts';
 
 interface McpInitResult {
@@ -167,6 +176,69 @@ export async function fetchZoneDigest(config: Config, zone: ZoneId): Promise<Zon
   );
 }
 
+export async function fetchDimensionBreakdown(
+  config: Config,
+  dimension?: PulseDimension,
+  window: 30 = 30,
+): Promise<GetDimensionBreakdownResponse> {
+  if (config.STUB_MODE && !config.MCP_KEY) {
+    const dimensions = dimension
+      ? [generateStubDimensionBreakdown(dimension)]
+      : (['og', 'nft', 'onchain'] as const).map((dim) => generateStubDimensionBreakdown(dim));
+    return {
+      dimensions,
+      schema_version: '1.1.0',
+      generated_at: new Date().toISOString(),
+    };
+  }
+
+  if (!config.MCP_KEY) {
+    throw new Error('MCP_KEY required for live score-mcp; or set STUB_MODE=true for synthetic data');
+  }
+
+  const url = `${config.SCORE_API_URL}/mcp`;
+  const bearer = config.SCORE_BEARER;
+  const { sessionId } = await mcpInit(url, config.MCP_KEY, bearer);
+  return mcpToolCall<GetDimensionBreakdownResponse>(
+    url,
+    config.MCP_KEY,
+    sessionId,
+    'get_dimension_breakdown',
+    { window, ...(dimension ? { dimension } : {}) },
+    bearer,
+  );
+}
+
+export async function fetchRecentEvents(
+  config: Config,
+  limit = 10,
+): Promise<GetRecentEventsResponse> {
+  if (config.STUB_MODE && !config.MCP_KEY) {
+    return {
+      events: [],
+      by_factor: [],
+      schema_version: '1.1.0',
+      generated_at: new Date().toISOString(),
+    };
+  }
+
+  if (!config.MCP_KEY) {
+    throw new Error('MCP_KEY required for live score-mcp; or set STUB_MODE=true for synthetic data');
+  }
+
+  const url = `${config.SCORE_API_URL}/mcp`;
+  const bearer = config.SCORE_BEARER;
+  const { sessionId } = await mcpInit(url, config.MCP_KEY, bearer);
+  return mcpToolCall<GetRecentEventsResponse>(
+    url,
+    config.MCP_KEY,
+    sessionId,
+    'get_recent_events',
+    { limit },
+    bearer,
+  );
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Stub generator — synthetic ZoneDigest matching zerker's schema
 // (kept for STUB_MODE=true testing; not used when MCP_KEY is set)
@@ -287,6 +359,117 @@ export function generateStubZoneDigest(zone: ZoneId): ZoneDigest {
       ? null
       : 'Score-analyst narrative pipeline returned partial data this window.',
     raw_stats: rawStats,
+  };
+}
+
+export function generateStubDimensionBreakdown(dimension: PulseDimension): PulseDimensionBreakdown {
+  const now = Date.now();
+  const labels = {
+    og: 'OG',
+    nft: 'NFT',
+    onchain: 'Onchain',
+  } as const;
+  const factorIds = {
+    og: ['og:sets', 'og:articles', 'og:cubquests'],
+    nft: ['nft:mibera', 'nft:honeycomb', 'nft:fractures'],
+    onchain: ['onchain:lp_provide', 'onchain:liquid_backing', 'onchain:staking'],
+  } as const;
+  const topFactors = factorIds[dimension].map((factorId, i) => {
+    const total = Math.max(1, 14 - i * 4);
+    const previous = Math.max(1, 10 - i * 2);
+    return {
+      factor_id: factorId,
+      display_name: factorId.split(':')[1]!.replace(/_/g, ' '),
+      primary_action: null,
+      total,
+      previous,
+      delta_pct: ((total - previous) / previous) * 100,
+      delta_count: total - previous,
+      factor_stats: stubFactorStats(total, 5 + i, 70 + i * 10, now),
+    };
+  });
+  const previous = topFactors.reduce((sum, factor) => sum + factor.previous, 0);
+  const total = topFactors.reduce((sum, factor) => sum + factor.total, 0);
+  return {
+    id: dimension,
+    display_name: labels[dimension],
+    total_events: total,
+    previous_period_events: previous,
+    delta_pct: previous === 0 ? null : ((total - previous) / previous) * 100,
+    delta_count: total - previous,
+    inactive_factor_count: 2,
+    total_factor_count: topFactors.length + 2,
+    top_factors: topFactors,
+    cold_factors: [
+      {
+        factor_id: `${dimension}:quiet_corner`,
+        display_name: 'quiet corner',
+        primary_action: null,
+        total: 0,
+        previous: 0,
+        delta_pct: null,
+        delta_count: 0,
+      },
+      {
+        factor_id: `${dimension}:sleeping_bees`,
+        display_name: 'sleeping bees',
+        primary_action: null,
+        total: 0,
+        previous: 0,
+        delta_pct: null,
+        delta_count: 0,
+      },
+    ],
+  };
+}
+
+function stubFactorStats(
+  eventCount: number,
+  uniqueActors: number,
+  rank: number,
+  now: number,
+): NonNullable<PulseDimensionBreakdown['top_factors'][number]['factor_stats']> {
+  const percentile = { value: eventCount, reliable: true };
+  return {
+    history: {
+      active_days: 90,
+      last_active_date: new Date(now).toISOString().slice(0, 10),
+      stale: false,
+      no_data: false,
+      sufficiency: { p50: true, p90: true, p99: true },
+    },
+    occurrence: { active_day_frequency: 0.4, current_is_active: true },
+    magnitude: {
+      event_count: eventCount,
+      percentiles: {
+        p10: percentile,
+        p25: percentile,
+        p50: percentile,
+        p75: percentile,
+        p90: percentile,
+        p95: percentile,
+        p99: percentile,
+      },
+      current_percentile_rank: rank,
+    },
+    cohort: {
+      unique_actors: uniqueActors,
+      percentiles: {
+        p10: { value: 1, reliable: true },
+        p25: { value: 2, reliable: true },
+        p50: { value: 3, reliable: true },
+        p75: { value: 5, reliable: true },
+        p90: { value: 8, reliable: true },
+        p95: { value: 13, reliable: true },
+        p99: { value: 21, reliable: true },
+      },
+      current_percentile_rank: 70,
+    },
+    cadence: {
+      days_since_last_active: 0,
+      median_active_day_gap_days: 2,
+      current_gap_percentile_rank: 40,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

post-merge nitpick pass triggered by operator's "i want to nitpick the UX for ruggy because there's alot we should be surfacing which i'm not seeing in the chats" — the autonomous run proved pipeline shape but never SHOWED what a real post looks like.

includes 3 commits:

1. **UX gallery + voice brief + sanitize integration** (`551d68b`) — author the missing T2.4 voice-brief module, build a gallery script that runs against LIVE prod score-mcp + Claude Sonnet 4.5 to generate real voice. fix 2 bugs surfaced by the gallery (`+-12` negative delta · `[zone] quiet week` engineering-jargon fallback). integrate sanitize.ts into the new `buildPulseDimensionPayload` path (underscore-escape on factor names · em-dash strip on voice surface).

2. **Cross-week voice memory** (`abae2de`) — operator latitude commit. ruggy becomes a continuous narrator. append-only JSONL writes each week's voice; next week's voice-brief threads the prior framing as continuity context.

## sample voice (live demo vs prod data window=30 with seeded W-19 memory)

```
bear-cave week N-1:  "26 events. the bears stir, then settle."
bear-cave week N:    "4 events. the bears settled deeper."
                     "next week: maybe a stir. maybe more silence."

el-dorado week N-1:  "1236 events but no rank-90 cross. the gold scatters."
el-dorado week N:    "past thirty days: 541 events, down from 1236.
                      the scattering has settled."
                     "the bears are deep in their dens. gold cools in the dark."

owsley-lab week N-1: "433 events past thirty days. the lab hums low."
owsley-lab week N:   "307 events past thirty days. the hum drops from 433.
                      the lab sleeps deeper."
                     "some weeks the bears just breathe."
```

without continuity: 4 isolated atomic posts per Sunday. with continuity: emotional arc across weeks (descent into quiet that's still being told). the LLM threads `settle → settled deeper`, recalls exact numbers (`from 1236`, `from 433`) as continuity grounding, and offers meta-reflection that comes from having context (`some weeks the bears just breathe`).

## bugs surfaced + fixed by the gallery

- **`+-12` negative delta** — unconditional `+` prefix doubled with `-` sign. now sign-aware: `+N` / `-N` / `±0`.
- **`[zone] quiet week` fallback** — engineering jargon broke the persona illusion for users with embeds disabled. now uses `ZONE_FLAVOR.emoji + name + dimension paren` (e.g. `🐻 Bear Cave (OG)`).
- **sanitize.ts bypass** — `buildPulseDimensionPayload` was skipping the `escapeDiscordMarkdown` + `stripVoiceDisciplineDrift` chain. factor names with underscores (`Boosted_Validator`) would mid-word italicize. now both pass through.

## test plan

- [x] full suite: 798 pass · 1 skip · 0 fail (+25 from voice-brief + voice-memory + continuity + 2 sanitize regression tests)
- [x] live gallery run against prod score-mcp + Claude Sonnet 4.5: 8 OTEL roots · 32 spans · 3 shape-A + 1 synthetic-shape-C posts rendered
- [x] cross-week memory roundtrip · multi-zone · malformed-line skip tested
- [ ] **operator-attested**: wire `composeDigestForZone` into `cron/scheduler.ts` so cron writes to `.run/ruggy-voice-history.jsonl` weekly
- [ ] **operator-attested**: live dev-guild post + visual sign-off

## still operator-attested deferral

- cron/scheduler.ts wire of composeDigestForZone (live behavior change)
- live dev-guild canary + S5-CANARY.md visual sign-off
- flip cycle-005 ledger active → archived
- AC-S5.2 chat-mode OTEL spans (V1.5 destination per routing invariant)

## new

- `packages/persona-engine/src/compose/voice-brief.ts` + `voice-brief.test.ts` + `voice-brief-continuity.test.ts`
- `packages/persona-engine/src/compose/voice-memory.ts` + `voice-memory.test.ts`
- `apps/bot/scripts/cycle-005-ux-gallery.ts` (run with `SCORE_API_URL=... MCP_KEY=... ANTHROPIC_API_KEY=... bun run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)