### PR TITLE
fix(persona-engine): ambient stir survives unconfigured freeside-auth MCP

### DIFF
--- a/packages/persona-engine/src/ambient/endpoint-criticality.test.ts
+++ b/packages/persona-engine/src/ambient/endpoint-criticality.test.ts
@@ -1,0 +1,126 @@
+// Regression gate for the ambient-stir boot-disable bug: an unset
+// FREESIDE_AUTH_MCP_URL (the intended state until identity-api ships its
+// resolve_wallet MCP) must NOT disable the entire stir tier. Before this fix,
+// boot validation treated freeside-auth as equally tier-fatal to the event
+// source, so production logged "AMBIENT STIR TIER DISABLED ... freeside-auth:
+// freeside-auth-mcp URL not configured" hourly across all zones.
+//
+// Pure-policy tests — no env, no I/O, no effect runtime — so they run under
+// `bun test` without installed deps.
+
+import { describe, expect, test } from "bun:test";
+import {
+  AMBIENT_ALL_ENDPOINTS,
+  AMBIENT_OPTIONAL_ENDPOINTS,
+  AMBIENT_REQUIRED_ENDPOINTS,
+  classifyEndpointCriticality,
+  isOptionalAmbientEndpoint,
+  type EndpointValidationResult,
+} from "./endpoint-criticality.ts";
+
+// The exact reason validateEndpointConfig("freeside-auth", …) returns when the
+// URL is unset (score-mcp-client.ts) — what production actually logged.
+const FREESIDE_AUTH_UNCONFIGURED = "freeside-auth-mcp URL not configured";
+
+describe("ambient endpoint criticality — policy membership", () => {
+  test("score and codex are required; freeside-auth is optional", () => {
+    expect(AMBIENT_REQUIRED_ENDPOINTS).toEqual(["score", "codex"]);
+    expect(AMBIENT_OPTIONAL_ENDPOINTS).toEqual(["freeside-auth"]);
+  });
+
+  test("AMBIENT_ALL_ENDPOINTS lists every endpoint, required first", () => {
+    expect(AMBIENT_ALL_ENDPOINTS).toEqual(["score", "codex", "freeside-auth"]);
+  });
+
+  test("isOptionalAmbientEndpoint reflects the policy", () => {
+    expect(isOptionalAmbientEndpoint("freeside-auth")).toBe(true);
+    expect(isOptionalAmbientEndpoint("score")).toBe(false);
+    expect(isOptionalAmbientEndpoint("codex")).toBe(false);
+  });
+});
+
+describe("classifyEndpointCriticality — the production regression", () => {
+  test("unset FREESIDE_AUTH_MCP_URL alone does NOT disable the tier", () => {
+    const results: EndpointValidationResult[] = [
+      { endpoint: "score", ok: true },
+      { endpoint: "codex", ok: true },
+      {
+        endpoint: "freeside-auth",
+        ok: false,
+        reason: FREESIDE_AUTH_UNCONFIGURED,
+      },
+    ];
+
+    const outcome = classifyEndpointCriticality(results);
+
+    expect(outcome.disabled).toBe(false);
+    expect(outcome.reasons).toEqual([]);
+    expect(outcome.warnings).toEqual([
+      `freeside-auth: ${FREESIDE_AUTH_UNCONFIGURED}`,
+    ]);
+  });
+});
+
+describe("classifyEndpointCriticality — required endpoints stay tier-fatal", () => {
+  test("a failed score endpoint disables the tier", () => {
+    const outcome = classifyEndpointCriticality([
+      { endpoint: "score", ok: false, reason: "score-mcp URL not configured" },
+      { endpoint: "codex", ok: true },
+      { endpoint: "freeside-auth", ok: true },
+    ]);
+
+    expect(outcome.disabled).toBe(true);
+    expect(outcome.reasons).toEqual(["score: score-mcp URL not configured"]);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  test("a failed codex endpoint disables the tier", () => {
+    const outcome = classifyEndpointCriticality([
+      { endpoint: "score", ok: true },
+      { endpoint: "codex", ok: false, reason: "codex-mcp URL not configured" },
+      { endpoint: "freeside-auth", ok: true },
+    ]);
+
+    expect(outcome.disabled).toBe(true);
+    expect(outcome.reasons).toEqual(["codex: codex-mcp URL not configured"]);
+    expect(outcome.warnings).toEqual([]);
+  });
+});
+
+describe("classifyEndpointCriticality — mixed and edge cases", () => {
+  test("a required failure disables even alongside an optional failure", () => {
+    const outcome = classifyEndpointCriticality([
+      { endpoint: "score", ok: false, reason: "score-mcp must use https://" },
+      { endpoint: "codex", ok: true },
+      {
+        endpoint: "freeside-auth",
+        ok: false,
+        reason: FREESIDE_AUTH_UNCONFIGURED,
+      },
+    ]);
+
+    expect(outcome.disabled).toBe(true);
+    expect(outcome.reasons).toEqual(["score: score-mcp must use https://"]);
+    expect(outcome.warnings).toEqual([
+      `freeside-auth: ${FREESIDE_AUTH_UNCONFIGURED}`,
+    ]);
+  });
+
+  test("all endpoints healthy — not disabled, no reasons, no warnings", () => {
+    const outcome = classifyEndpointCriticality([
+      { endpoint: "score", ok: true },
+      { endpoint: "codex", ok: true },
+      { endpoint: "freeside-auth", ok: true },
+    ]);
+
+    expect(outcome).toEqual({ disabled: false, reasons: [], warnings: [] });
+  });
+
+  test("missing reason falls back to a generic detail", () => {
+    const outcome = classifyEndpointCriticality([
+      { endpoint: "score", ok: false },
+    ]);
+
+    expect(outcome.reasons).toEqual(["score: validation failed"]);
+  });
+});

--- a/packages/persona-engine/src/ambient/endpoint-criticality.test.ts
+++ b/packages/persona-engine/src/ambient/endpoint-criticality.test.ts
@@ -9,6 +9,7 @@
 // `bun test` without installed deps.
 
 import { describe, expect, test } from "bun:test";
+import type { AmbientMcpEndpoint } from "./live/score-mcp-client.ts";
 import {
   AMBIENT_ALL_ENDPOINTS,
   AMBIENT_OPTIONAL_ENDPOINTS,
@@ -116,11 +117,21 @@ describe("classifyEndpointCriticality — mixed and edge cases", () => {
     expect(outcome).toEqual({ disabled: false, reasons: [], warnings: [] });
   });
 
-  test("missing reason falls back to a generic detail", () => {
+  test("an endpoint absent from the policy map fails safe to required", () => {
+    // Fail-safe contract (F-004): if a future AmbientMcpEndpoint slips past the
+    // exhaustiveness check (e.g. via a cast) and is not in the criticality map,
+    // it must be treated as REQUIRED — tier-fatal until classified, never
+    // silently optional.
     const outcome = classifyEndpointCriticality([
-      { endpoint: "score", ok: false },
+      {
+        endpoint: "unknown-endpoint" as unknown as AmbientMcpEndpoint,
+        ok: false,
+        reason: "not in policy map",
+      },
     ]);
 
-    expect(outcome.reasons).toEqual(["score: validation failed"]);
+    expect(outcome.disabled).toBe(true);
+    expect(outcome.reasons).toEqual(["unknown-endpoint: not in policy map"]);
+    expect(outcome.warnings).toEqual([]);
   });
 });

--- a/packages/persona-engine/src/ambient/endpoint-criticality.ts
+++ b/packages/persona-engine/src/ambient/endpoint-criticality.ts
@@ -1,0 +1,103 @@
+/**
+ * Ambient MCP endpoint criticality policy.
+ *
+ * Boot-time endpoint validation (runtime.ts) must distinguish two kinds of
+ * MCP endpoint, because they fail in fundamentally different ways:
+ *
+ *   REQUIRED — the stir tier cannot do its job without it. A production
+ *     validation failure disables the tier (digest cron + read-side stay
+ *     healthy). `score` is the event source — no events, no stir. `codex`
+ *     (mibera lookup) is here too because MiberaResolverLive PROPAGATES its
+ *     error on transport/timeout failure (no terminal catchAll), so it is not
+ *     yet fully fail-soft — its absence stays tier-fatal until that resolver
+ *     also degrades gracefully.
+ *
+ *   OPTIONAL — soft-degradable enrichment. Its live resolver already returns a
+ *     safe fallback on ANY failure, so an absent or misconfigured URL must NOT
+ *     take the tier down — narration simply runs without the enrichment.
+ *     `freeside-auth` (wallet → handle): WalletResolverLive returns
+ *     ANONYMOUS_KEEPER on circuit-break / failure / timeout and NEVER leaks a
+ *     raw 0x… (NFR-29). When identity-api deploys its `resolve_wallet` MCP and
+ *     FREESIDE_AUTH_MCP_URL is set, real resolution lights up with no further
+ *     code change.
+ *
+ * This mirrors the identity-api PRD G-5 doctrine ("when a downstream building
+ * is unreachable the response degrades gracefully rather than failing") on the
+ * CONSUMER side.
+ *
+ * The previous policy treated all three endpoints as equally tier-fatal, so an
+ * unset FREESIDE_AUTH_MCP_URL — the intended state until identity-api ships —
+ * disabled the entire ambient stir tier in production. This module makes that
+ * decision explicit, named, and unit-testable.
+ *
+ * Pure (no I/O, no env, no side effects) so it is importable in tests without
+ * triggering runtime.ts's module-load ManagedRuntime construction.
+ */
+
+import type { AmbientMcpEndpoint } from "./live/score-mcp-client.ts";
+
+/** Endpoints whose absence/misconfiguration disables the stir tier in prod. */
+export const AMBIENT_REQUIRED_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
+  "score",
+  "codex",
+];
+
+/** Soft-degradable enrichment endpoints — failures warn, never disable. */
+export const AMBIENT_OPTIONAL_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
+  "freeside-auth",
+];
+
+/** All endpoints the bootstrap validates, required first. */
+export const AMBIENT_ALL_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
+  ...AMBIENT_REQUIRED_ENDPOINTS,
+  ...AMBIENT_OPTIONAL_ENDPOINTS,
+];
+
+/** Per-endpoint validation result fed into the criticality classifier. */
+export interface EndpointValidationResult {
+  readonly endpoint: AmbientMcpEndpoint;
+  readonly ok: boolean;
+  /** Present when `ok` is false — the human-readable failure reason. */
+  readonly reason?: string;
+}
+
+/** Outcome of classifying a set of validation results. */
+export interface EndpointCriticalityOutcome {
+  /** True when ≥1 REQUIRED endpoint failed — caller disables the stir tier. */
+  readonly disabled: boolean;
+  /** Failure details for REQUIRED endpoints (drive the disable). */
+  readonly reasons: ReadonlyArray<string>;
+  /** Failure details for OPTIONAL endpoints (degraded enrichment; non-fatal). */
+  readonly warnings: ReadonlyArray<string>;
+}
+
+export function isOptionalAmbientEndpoint(endpoint: AmbientMcpEndpoint): boolean {
+  return AMBIENT_OPTIONAL_ENDPOINTS.includes(endpoint);
+}
+
+/**
+ * Classify per-endpoint validation results into the tier-disable decision.
+ *
+ * Pure policy: a REQUIRED endpoint failure contributes to `reasons` and forces
+ * `disabled: true`; an OPTIONAL endpoint failure contributes only to
+ * `warnings`. Endpoints that validated OK are ignored. Prod-vs-dev gating is
+ * the caller's concern — this function never reads the environment.
+ */
+export function classifyEndpointCriticality(
+  results: ReadonlyArray<EndpointValidationResult>,
+): EndpointCriticalityOutcome {
+  const reasons: string[] = [];
+  const warnings: string[] = [];
+
+  for (const result of results) {
+    if (result.ok) continue;
+    const detail = `${result.endpoint}: ${result.reason ?? "validation failed"}`;
+    if (isOptionalAmbientEndpoint(result.endpoint)) {
+      warnings.push(detail);
+    } else {
+      reasons.push(detail);
+    }
+  }
+
+  return { disabled: reasons.length > 0, reasons, warnings };
+}

--- a/packages/persona-engine/src/ambient/endpoint-criticality.ts
+++ b/packages/persona-engine/src/ambient/endpoint-criticality.ts
@@ -4,15 +4,17 @@
  * Boot-time endpoint validation (runtime.ts) must distinguish two kinds of
  * MCP endpoint, because they fail in fundamentally different ways:
  *
- *   REQUIRED — the stir tier cannot do its job without it. A production
+ *   required — the stir tier cannot do its job without it. A production
  *     validation failure disables the tier (digest cron + read-side stay
  *     healthy). `score` is the event source — no events, no stir. `codex`
  *     (mibera lookup) is here too because MiberaResolverLive PROPAGATES its
  *     error on transport/timeout failure (no terminal catchAll), so it is not
  *     yet fully fail-soft — its absence stays tier-fatal until that resolver
- *     also degrades gracefully.
+ *     also degrades gracefully. (Tracked follow-up: once MiberaResolverLive
+ *     anonymizes / null-fallbacks like WalletResolverLive, move codex to
+ *     "optional" and this comment goes away.)
  *
- *   OPTIONAL — soft-degradable enrichment. Its live resolver already returns a
+ *   optional — soft-degradable enrichment. Its live resolver already returns a
  *     safe fallback on ANY failure, so an absent or misconfigured URL must NOT
  *     take the tier down — narration simply runs without the enrichment.
  *     `freeside-auth` (wallet → handle): WalletResolverLive returns
@@ -36,16 +38,38 @@
 
 import type { AmbientMcpEndpoint } from "./live/score-mcp-client.ts";
 
+export type EndpointCriticality = "required" | "optional";
+
+/**
+ * Single source of truth for endpoint criticality.
+ *
+ * `Record<AmbientMcpEndpoint, …>` makes this map EXHAUSTIVE: if
+ * score-mcp-client.ts adds a new member to the `AmbientMcpEndpoint` union and
+ * it is not classified here, this object literal fails to type-check. That
+ * closes the silent-drift gap where an unclassified endpoint would never be
+ * validated at boot. The required/optional arrays below are DERIVED from this
+ * map, so they cannot fall out of sync with it.
+ */
+export const AMBIENT_ENDPOINT_CRITICALITY: Record<
+  AmbientMcpEndpoint,
+  EndpointCriticality
+> = {
+  score: "required",
+  codex: "required",
+  "freeside-auth": "optional",
+};
+
+const _ENDPOINTS = Object.keys(
+  AMBIENT_ENDPOINT_CRITICALITY,
+) as AmbientMcpEndpoint[];
+
 /** Endpoints whose absence/misconfiguration disables the stir tier in prod. */
-export const AMBIENT_REQUIRED_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
-  "score",
-  "codex",
-];
+export const AMBIENT_REQUIRED_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> =
+  _ENDPOINTS.filter((e) => AMBIENT_ENDPOINT_CRITICALITY[e] === "required");
 
 /** Soft-degradable enrichment endpoints — failures warn, never disable. */
-export const AMBIENT_OPTIONAL_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
-  "freeside-auth",
-];
+export const AMBIENT_OPTIONAL_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> =
+  _ENDPOINTS.filter((e) => AMBIENT_ENDPOINT_CRITICALITY[e] === "optional");
 
 /** All endpoints the bootstrap validates, required first. */
 export const AMBIENT_ALL_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
@@ -53,33 +77,45 @@ export const AMBIENT_ALL_ENDPOINTS: ReadonlyArray<AmbientMcpEndpoint> = [
   ...AMBIENT_OPTIONAL_ENDPOINTS,
 ];
 
-/** Per-endpoint validation result fed into the criticality classifier. */
-export interface EndpointValidationResult {
-  readonly endpoint: AmbientMcpEndpoint;
-  readonly ok: boolean;
-  /** Present when `ok` is false — the human-readable failure reason. */
-  readonly reason?: string;
-}
+/**
+ * Per-endpoint validation result fed into the criticality classifier.
+ *
+ * Discriminated on `ok`: a failure result MUST carry a `reason`, so the
+ * classifier never has to invent diagnostic text for a context-free failure.
+ */
+export type EndpointValidationResult =
+  | { readonly endpoint: AmbientMcpEndpoint; readonly ok: true }
+  | {
+      readonly endpoint: AmbientMcpEndpoint;
+      readonly ok: false;
+      readonly reason: string;
+    };
 
 /** Outcome of classifying a set of validation results. */
 export interface EndpointCriticalityOutcome {
-  /** True when ≥1 REQUIRED endpoint failed — caller disables the stir tier. */
+  /** True when ≥1 required endpoint failed — caller disables the stir tier. */
   readonly disabled: boolean;
-  /** Failure details for REQUIRED endpoints (drive the disable). */
+  /** Failure details for required endpoints (drive the disable). */
   readonly reasons: ReadonlyArray<string>;
-  /** Failure details for OPTIONAL endpoints (degraded enrichment; non-fatal). */
+  /** Failure details for optional endpoints (degraded enrichment; non-fatal). */
   readonly warnings: ReadonlyArray<string>;
 }
 
+/**
+ * Whether an endpoint is soft-degradable. Fail-safe default: an endpoint NOT
+ * present in the criticality map (e.g. a brand-new union member that slipped
+ * past the exhaustiveness check via a cast) is treated as REQUIRED — the safe
+ * direction is "tier-fatal until classified", never "silently optional".
+ */
 export function isOptionalAmbientEndpoint(endpoint: AmbientMcpEndpoint): boolean {
-  return AMBIENT_OPTIONAL_ENDPOINTS.includes(endpoint);
+  return AMBIENT_ENDPOINT_CRITICALITY[endpoint] === "optional";
 }
 
 /**
  * Classify per-endpoint validation results into the tier-disable decision.
  *
- * Pure policy: a REQUIRED endpoint failure contributes to `reasons` and forces
- * `disabled: true`; an OPTIONAL endpoint failure contributes only to
+ * Pure policy: a required endpoint failure contributes to `reasons` and forces
+ * `disabled: true`; an optional endpoint failure contributes only to
  * `warnings`. Endpoints that validated OK are ignored. Prod-vs-dev gating is
  * the caller's concern — this function never reads the environment.
  */
@@ -91,7 +127,7 @@ export function classifyEndpointCriticality(
 
   for (const result of results) {
     if (result.ok) continue;
-    const detail = `${result.endpoint}: ${result.reason ?? "validation failed"}`;
+    const detail = `${result.endpoint}: ${result.reason}`;
     if (isOptionalAmbientEndpoint(result.endpoint)) {
       warnings.push(detail);
     } else {

--- a/packages/persona-engine/src/ambient/runtime.ts
+++ b/packages/persona-engine/src/ambient/runtime.ts
@@ -89,17 +89,10 @@ function _bootstrapEndpointValidation(): void {
 
   const { disabled, reasons, warnings } = classifyEndpointCriticality(results);
 
-  // Optional-endpoint failures are non-fatal — surface them so the gap is
-  // visible, but the tier stays up and narration runs without the enrichment.
-  for (const warning of warnings) {
-    console.warn(
-      `ambient-runtime: optional endpoint degraded [${warning}] — stir tier ` +
-        "stays ENABLED; narration runs without this enrichment until the " +
-        "endpoint is configured.",
-    );
-  }
-
-  // Dev/test: required failures warn and continue (preserves STUB_MODE flows).
+  // Dev/test: nothing is fatal. Surface required-endpoint gaps as
+  // continue-warnings and stay QUIET on optional enrichment — in dev the URL
+  // is commonly unset, the dev already knows, and STUB_MODE covers it, so an
+  // optional warning here is just module-load noise (preserves STUB_MODE flows).
   if (!isProd) {
     for (const reason of reasons) {
       console.warn(
@@ -110,7 +103,18 @@ function _bootstrapEndpointValidation(): void {
     return;
   }
 
-  // Production: only REQUIRED-endpoint failures disable the stir tier.
+  // Production. Optional-endpoint failures are non-fatal — surface them so the
+  // gap is visible, but the tier stays up and narration runs without the
+  // enrichment.
+  for (const warning of warnings) {
+    console.warn(
+      `ambient-runtime: optional endpoint degraded [${warning}] — stir tier ` +
+        "stays ENABLED; narration runs without this enrichment until the " +
+        "endpoint is configured.",
+    );
+  }
+
+  // Only REQUIRED-endpoint failures disable the stir tier.
   for (const reason of reasons) {
     console.error(`ambient-runtime: endpoint validation failed [${reason}]`);
   }

--- a/packages/persona-engine/src/ambient/runtime.ts
+++ b/packages/persona-engine/src/ambient/runtime.ts
@@ -23,11 +23,13 @@ import { MiberaResolverLive } from "./live/mibera-resolver.live.ts";
 import { WalletResolverLive } from "./live/wallet-resolver.live.ts";
 import { CircuitBreakerLive } from "./live/circuit-breaker.live.ts";
 import { PopInLedgerLive } from "./live/pop-in-ledger.live.ts";
-import {
-  validateEndpointConfig,
-  type AmbientMcpEndpoint,
-} from "./live/score-mcp-client.ts";
+import { validateEndpointConfig } from "./live/score-mcp-client.ts";
 import { loadConfig } from "../config.ts";
+import {
+  AMBIENT_ALL_ENDPOINTS,
+  classifyEndpointCriticality,
+  type EndpointValidationResult,
+} from "./endpoint-criticality.ts";
 
 // BB pass-3 F10 + pass-4 F10 closure: validate MCP endpoint config at
 // module load.
@@ -69,30 +71,55 @@ function _bootstrapEndpointValidation(): void {
     return;
   }
   const isProd = process.env.NODE_ENV === "production";
-  const endpoints: ReadonlyArray<AmbientMcpEndpoint> = [
-    "score",
-    "codex",
-    "freeside-auth",
-  ];
-  const reasons: Array<string> = [];
-  for (const endpoint of endpoints) {
-    const result = validateEndpointConfig(endpoint, config);
-    if (!result.ok) {
-      const msg = `ambient-runtime: endpoint validation failed [${endpoint}] — ${result.reason}`;
-      if (isProd) {
-        console.error(msg);
-        reasons.push(`${endpoint}: ${result.reason}`);
-      } else {
-        console.warn(msg + " (dev mode — continuing)");
-      }
-    }
+
+  // Cycle-003 follow-up: endpoints are NOT equally critical. `score`/`codex`
+  // are required; `freeside-auth` is soft-degradable enrichment whose live
+  // resolver anonymizes on failure (NFR-29). Classifying them keeps the stir
+  // tier ENABLED when only an optional endpoint (e.g. an unset
+  // FREESIDE_AUTH_MCP_URL, the intended state until identity-api ships) is
+  // missing. See ./endpoint-criticality.ts for the full policy + rationale.
+  const results: EndpointValidationResult[] = AMBIENT_ALL_ENDPOINTS.map(
+    (endpoint) => {
+      const result = validateEndpointConfig(endpoint, config);
+      return result.ok
+        ? { endpoint, ok: true }
+        : { endpoint, ok: false, reason: result.reason };
+    },
+  );
+
+  const { disabled, reasons, warnings } = classifyEndpointCriticality(results);
+
+  // Optional-endpoint failures are non-fatal — surface them so the gap is
+  // visible, but the tier stays up and narration runs without the enrichment.
+  for (const warning of warnings) {
+    console.warn(
+      `ambient-runtime: optional endpoint degraded [${warning}] — stir tier ` +
+        "stays ENABLED; narration runs without this enrichment until the " +
+        "endpoint is configured.",
+    );
   }
-  if (isProd && reasons.length > 0) {
+
+  // Dev/test: required failures warn and continue (preserves STUB_MODE flows).
+  if (!isProd) {
+    for (const reason of reasons) {
+      console.warn(
+        `ambient-runtime: endpoint validation failed [${reason}] ` +
+          "(dev mode — continuing)",
+      );
+    }
+    return;
+  }
+
+  // Production: only REQUIRED-endpoint failures disable the stir tier.
+  for (const reason of reasons) {
+    console.error(`ambient-runtime: endpoint validation failed [${reason}]`);
+  }
+  if (disabled) {
     _ambientStirDisabled = true;
     _ambientStirDisabledReasons = reasons;
     console.error(
       "ambient-runtime: AMBIENT STIR TIER DISABLED in production — " +
-        `${reasons.length} endpoint(s) misconfigured. Digest cron + ` +
+        `${reasons.length} required endpoint(s) misconfigured. Digest cron + ` +
         "read-side continue normally. Resolve endpoint config to re-enable.",
     );
   }


### PR DESCRIPTION
## what broke

`ruggy` (and all 8 characters) logged this **hourly across all 4 zones** — stonehenge · bear-cave · el-dorado · owsley-lab:

```
ambient-runtime: AMBIENT STIR TIER DISABLED in production — 1 endpoint(s) misconfigured.
ambient-stir: zone=... error=ambient-stir disabled at boot: freeside-auth: freeside-auth-mcp URL not configured
```

The bot was otherwise healthy (digest cron, read-side, Discord, score-mcp all LIVE). Only the **ambient-stir tier** was down — and it disabled *itself* at boot.

## root cause

`runtime.ts` boot validation treated all three ambient MCP endpoints (`score`, `codex`, `freeside-auth`) as **equally tier-fatal**. So an unset `FREESIDE_AUTH_MCP_URL` — the *intended* state until `identity-api` ships its `resolve_wallet` MCP — took the whole tier down.

But `freeside-auth` is **soft-degradable enrichment**: `WalletResolverLive` returns `ANONYMOUS_KEEPER` on any failure/timeout/circuit-break and never leaks a raw `0x…` (NFR-29). Its absence should degrade narration (anonymized handles), not kill the tier.

## fix

Classify endpoints by criticality (new `endpoint-criticality.ts`, pure + unit-tested):

| endpoint | class | on failure |
|---|---|---|
| `score` | **required** | disable tier (event source — no events, no stir) |
| `codex` | **required** | disable tier (`MiberaResolverLive` still propagates errors — not yet fully fail-soft) |
| `freeside-auth` | **optional** | warn only — tier stays up, narration anonymizes |

The `FREESIDE_AUTH_MCP_URL` seam is untouched — when `identity-api` deploys its MCP and the var is set, real handle resolution lights up with **zero further change**. Consumer-side mirror of the identity-api PRD **G-5** graceful-degradation doctrine.

## verification

Real prod-`NODE_ENV` boot simulation (not just units):

- `freeside-auth` unset → tier **ENABLED**, `disabled=false` ✅ (the fix)
- `codex` unset → tier **DISABLED**, `reasons=[codex]` ✅ (required preserved; `freeside-auth` correctly demoted to a warning even when also unset)
- `tsc --noEmit` clean · **23/23** ambient tests pass (9 new)

## files

```
endpoint-criticality.ts        +103   new · policy + rationale
endpoint-criticality.test.ts   +126   new · 9 tests, pins exact prod symptom string
runtime.ts                     ±49    classify required vs optional
```

## ⚠️ deploy note

Live bot banner reads `v0.6.0-A` but `main` is `v0.12.0`. If that's a real version (not a persona display string), merging to `main` won't reach prod without deploying current `main` or backporting onto the release line. Flagging — deploy is operator domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)