### PR TITLE
fix(observability): bedrock-aware boot banner + digest-cron fingerprint (#78)

### DIFF
--- a/apps/bot/src/cli/digest-once.ts
+++ b/apps/bot/src/cli/digest-once.ts
@@ -51,8 +51,13 @@ async function main(): Promise<void> {
   const zones = selectedZones(config);
   const typeMode = pickType(config);
 
+  // bedrock-aware (mirrors describeLlmMode in apps/bot/src/index.ts and
+  // resolveProvider in agent-gateway.ts). Was previously bedrock-blind.
+  const hasBedrock = Boolean(config.AWS_BEARER_TOKEN_BEDROCK || config.BEDROCK_API_KEY);
   const llmMode = config.VOICE_DISABLED
     ? 'VOICE_DISABLED (no LLM)'
+    : config.LLM_PROVIDER === 'bedrock' || (config.LLM_PROVIDER === 'auto' && hasBedrock)
+    ? `bedrock (${config.BEDROCK_TEXT_MODEL_ID ?? 'no-model-id'} @ ${config.BEDROCK_TEXT_REGION})`
     : config.ANTHROPIC_API_KEY
     ? `anthropic-direct (${config.ANTHROPIC_MODEL})`
     : config.STUB_MODE

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -50,8 +50,9 @@ import {
 import { pgPoolBuilder } from './lib/pg-pool-builder.ts';
 import type { WorldManifestQuestSubset } from './world-resolver.ts';
 import { publishCommands } from './lib/publish-commands.ts';
+import pkg from '../package.json' with { type: 'json' };
 
-const banner = `─── freeside-characters bot · v0.6.0-A ────────────────────────`;
+const banner = `─── freeside-characters bot · v${pkg.version} ────────────────────────`;
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -70,7 +71,7 @@ async function main(): Promise<void> {
   console.log(`llm:            ${describeLlmMode(config)}`);
   console.log(`zones:          ${selectedZones(config).map((z) => `${ZONE_REGISTRY[z].emoji} ${z}`).join(' · ')}`);
   console.log(`digest cadence: ${config.DIGEST_CADENCE}` + (config.DIGEST_CADENCE !== 'manual' ? ` · ${config.DIGEST_DAY} ${String(config.DIGEST_HOUR_UTC).padStart(2, '0')}:00 UTC` : ''));
-  console.log(`pop-ins:        ${config.POP_IN_ENABLED ? `every ${config.POP_IN_INTERVAL_HOURS}h · ${config.POP_IN_PROBABILITY * 100}% chance/zone/tick` : 'disabled'}`);
+  console.log(`pop-ins:        ${config.POP_IN_ENABLED ? 'event-driven (cycle-008 · router-gated via ambient-stir)' : 'disabled (POP_IN_ENABLED=false)'}`);
   console.log(`weaver:         ${config.WEAVER_ENABLED ? `${config.WEAVER_DAY} ${String(config.WEAVER_HOUR_UTC).padStart(2, '0')}:00 UTC → ${config.WEAVER_PRIMARY_ZONE}` : 'disabled'}`);
   console.log(`delivery:       ${describeDelivery(config)}`);
 
@@ -385,10 +386,33 @@ async function main(): Promise<void> {
 }
 
 function describeLlmMode(config: ReturnType<typeof loadConfig>): string {
-  if (config.ANTHROPIC_API_KEY) return `anthropic-direct (${config.ANTHROPIC_MODEL})`;
-  if (config.STUB_MODE) return 'STUB (canned digest)';
-  if (config.FREESIDE_API_KEY) return `freeside agent-gw (${config.FREESIDE_AGENT_MODEL})`;
-  return 'UNCONFIGURED';
+  // Mirrors `resolveProvider` in packages/persona-engine/src/compose/agent-gateway.ts.
+  // V0.12 auto-rule (operator-named 2026-05-01): bedrock-first when AWS env present.
+  // Banner was previously bedrock-blind — reported UNCONFIGURED even when bedrock was
+  // wired, masking the real provider on cost-bearing production deploys.
+  const hasBedrock = Boolean(config.AWS_BEARER_TOKEN_BEDROCK || config.BEDROCK_API_KEY);
+  switch (config.LLM_PROVIDER) {
+    case 'stub':
+      return 'STUB (canned digest)';
+    case 'anthropic':
+      return config.ANTHROPIC_API_KEY
+        ? `anthropic-direct (${config.ANTHROPIC_MODEL})`
+        : 'anthropic-MISCONFIGURED (ANTHROPIC_API_KEY unset)';
+    case 'freeside':
+      return config.FREESIDE_API_KEY
+        ? `freeside agent-gw (${config.FREESIDE_AGENT_MODEL})`
+        : 'freeside-MISCONFIGURED (FREESIDE_API_KEY unset)';
+    case 'bedrock':
+      return hasBedrock
+        ? `bedrock (${config.BEDROCK_TEXT_MODEL_ID ?? 'no-model-id'} @ ${config.BEDROCK_TEXT_REGION})`
+        : 'bedrock-MISCONFIGURED (AWS_BEARER_TOKEN_BEDROCK / BEDROCK_API_KEY unset)';
+    case 'auto':
+      if (hasBedrock) return `auto→bedrock (${config.BEDROCK_TEXT_MODEL_ID ?? 'no-model-id'} @ ${config.BEDROCK_TEXT_REGION})`;
+      if (config.ANTHROPIC_API_KEY) return `auto→anthropic (${config.ANTHROPIC_MODEL})`;
+      if (config.STUB_MODE) return 'auto→stub';
+      if (config.FREESIDE_API_KEY) return `auto→freeside (${config.FREESIDE_AGENT_MODEL})`;
+      return 'UNCONFIGURED (no provider available — set LLM_PROVIDER or supply a key)';
+  }
 }
 
 function describeDelivery(config: ReturnType<typeof loadConfig>): string {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -412,6 +412,14 @@ function describeLlmMode(config: ReturnType<typeof loadConfig>): string {
       if (config.STUB_MODE) return 'auto→stub';
       if (config.FREESIDE_API_KEY) return `auto→freeside (${config.FREESIDE_AGENT_MODEL})`;
       return 'UNCONFIGURED (no provider available — set LLM_PROVIDER or supply a key)';
+    default: {
+      // Bridgebuilder F1 closure: exhaustiveness guard. A new LLM_PROVIDER enum
+      // value (or a Zod relaxation that lets unknown strings through) fails at
+      // compile time here — preventing the silent `llm: undefined` banner that
+      // this PR was filed to eliminate elsewhere.
+      const _exhaustive: never = config.LLM_PROVIDER;
+      return `UNKNOWN_PROVIDER (${String(_exhaustive)})`;
+    }
   }
 }
 

--- a/packages/persona-engine/src/cron/scheduler.ts
+++ b/packages/persona-engine/src/cron/scheduler.ts
@@ -101,6 +101,11 @@ export function schedule(args: ScheduleArgs): SchedulerHandles {
       cron.schedule(
         expr,
         async () => {
+          // silent-digest fingerprint (issue #78): logs BEFORE per-zone work
+          // so a future missed digest can be told apart from a missed tick.
+          console.log(
+            `digest cron tick at ${new Date().toISOString()} · zones=[${zones.join(',')}] · expr=${expr}`,
+          );
           for (const zone of zones) {
             await withZoneLock(zone, () => onFire({ zone, postType: 'digest' }), 'digest cron');
           }


### PR DESCRIPTION
## Summary

three small observability fixes so the silent-digest investigation (issue #78) leaves an actual fingerprint on the next missed cycle, and the boot banner stops lying about LLM provider state on bedrock-routed deploys.

- **banner version**: was hardcoded `v0.6.0-A` while `package.json` sits at `v0.12.0` → now pulled from `package.json` so every deploy reports its real version.
- **`describeLlmMode()` bedrock-aware**: mirrors `resolveProvider()` in `agent-gateway.ts`. previously reported `UNCONFIGURED` on bedrock-only prod even though the chat path was successfully routing through bedrock. matches the operator's exact "ruggy: UNCONFIGURED" confusion in current prod logs.
- **stale pop-in banner string**: cycle-008 slice-2a moved pop-ins to event-driven via ambient-stir router. the `every Nh · X% chance/zone` string was a holdover from the deleted §2 cadence.
- **`digest cron tick` fingerprint**: log timestamp + zones + cron-expr BEFORE the per-zone fire loop in `scheduler.ts`. lets us tell apart "cron didn't fire" from "cron fired but composeForCharacter threw silently" on the next deploy. same shape across the bot CLI for parity.

## Context · why now

55h of production logs (2026-05-24T22:34 boot → 2026-05-26T06:00 tail) captured a missed Sunday 2026-05-25T00:00 UTC digest fire. between the boot-time `ruggy: digest cron · 0 0 * * 0` line and the next ambient-stir tick at 00:00:12, ZERO entries — making it impossible to tell whether cron triggered or `composeForCharacter` swallowed an error. this PR doesn't fix the silent-digest itself; it just stops blinding the next debug pass.

`describeLlmMode()` bedrock-blindness compounded the confusion: prod banner read `llm: UNCONFIGURED` while chat-route logs at 2026-05-26T04:23 clearly showed `llmProvider: "bedrock"` working end-to-end.

## Test plan

- [x] `bun test apps/bot` → 193 pass / 0 fail
- [x] `bun test packages/persona-engine` → 959 pass / 2 skip / 0 fail
- [x] `tsc --noEmit` clean both packages
- [ ] (post-merge / next deploy) verify the banner shows `v0.12.x` + `auto→bedrock (…)` instead of `v0.6.0-A` + `UNCONFIGURED`
- [ ] (post-merge / next sunday) verify `digest cron tick at <iso>` appears in logs at 00:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)