### PR TITLE
Phase 33B docs: add Recall Wedge fixture projections

### DIFF
--- a/docs/recall-wedge/fixtures/README.md
+++ b/docs/recall-wedge/fixtures/README.md
@@ -1,0 +1,170 @@
+# Recall Wedge fixtures — Phase 33B
+
+Deterministic fixtures attached to `docs/RECALL-WEDGE-MEMORY-MVP.md`
+(Phase 33A boundary doc). These exist so Phase 33C can build a
+public-safe renderer + no-leak validator and Phase 33D can stage the
+cross-interface continuity demo, without having to re-author the shape
+of the proof.
+
+## What lives here
+
+```
+docs/recall-wedge/fixtures/
+  seed-memory/
+    shared-substrate-demo.memory.json    reviewed seed memory packet
+  projected-dto/
+    operator-private-view.dto.json       operator_private projection
+    public-discord-view.dto.json         public_discord projection
+    character-boundary-referral.dto.json public_discord referral projection
+  validate-fixtures.mjs                  phase 33b no-leak fixture validator
+  README.md                              this file
+```
+
+`projected-dto/` is the neutral home for **all** projected views of the
+seed packet — operator-private and public-safe alike. Naming it
+`public-dto/` was misleading because the operator-private projection is
+not a public projection; "projected DTO" describes what they all are
+(narrow projections of the Dixie-safe Recall Wedge envelope) without
+implying every projection is public-safe. Public-safety is a per-file
+property enforced by the validator, not by the directory name.
+
+## What seed memory packets are (and aren't)
+
+Seed memory packets in `seed-memory/` represent **already-admitted
+Straylight memory** for deterministic MVP proof. They are reviewed,
+synthetic fixtures. They are **not**:
+
+- runtime storage;
+- a production memory database;
+- raw Discord chat history;
+- candidate memory;
+- a canonical Straylight schema.
+
+GitHub does not store memory. Straylight is the memory authority. GitHub
+holds reviewed fixtures whose admission has already occurred upstream of
+the demo. Live admission of new assertions is post-MVP and out of scope
+(see `RECALL-WEDGE-MEMORY-MVP.md` §5–6).
+
+The packet self-describes with this wording:
+
+> This packet represents already-admitted Straylight memory for
+> deterministic MVP proof.
+
+## What projected DTOs are (and aren't)
+
+DTO fixtures in `projected-dto/` are **public-channel projections of
+the Dixie-safe Recall Wedge envelope**. They are deliberately narrow.
+The operator-private view is also a projection — it is the projection
+authorized for the `operator_private` frame, and it is not public-safe.
+
+They are **not**:
+
+- the full Straylight schema;
+- the full Dixie response;
+- the source of recall semantics;
+- a replacement for Hounfour / Straylight types.
+
+When the renderer lands in 33C it consumes seed memory and emits DTO
+shapes like these for the requested frame. The renderer narrows the
+Dixie envelope for the Discord public surface — it does not re-author
+memory semantics.
+
+## What the fixture set proves
+
+Same continuity actor (`freeside-characters:shared-substrate`), same
+already-admitted seed packet, three different authorized views:
+
+| DTO fixture                          | recall_interface  | render_surface             | what it demonstrates                                              |
+|--------------------------------------|-------------------|----------------------------|-------------------------------------------------------------------|
+| `operator-private-view.dto.json`     | `operator_private`| `operator_debug`           | broader context, diagnostic counts, operator-only material allowed |
+| `public-discord-view.dto.json`       | `public_discord`  | `discord_public_character` | redacted/excluded counts only, no private payload                 |
+| `character-boundary-referral.dto.json`| `public_discord` | `discord_public_character` | safe referral when request is outside ruggy's boundary             |
+
+The same packet under different frames yields demonstrably different
+output. That is the Recall Wedge boundary — necessary for the cross-
+interface demo (Phase 33D, see §1 of the boundary doc).
+
+## Public-safety contract
+
+The two **public-safe** projections — `public-discord-view.dto.json`
+and `character-boundary-referral.dto.json` — must not contain:
+
+- `raw_reasons`;
+- raw JSON arrays of private reasons;
+- debug payloads;
+- hidden / private boundary reasons;
+- unknown reason strings;
+- full assertion bodies;
+- private assertion IDs;
+- private source material;
+- hidden estate payloads;
+- private identifiers;
+- `PRIVATE_SENTINEL_*` strings.
+
+Sentinel strings appear deliberately in the seed packet and the
+operator-private projection. The Phase 33B no-leak validator
+(`validate-fixtures.mjs`) greps the public-safe projections for these
+substrings and fails loudly if any are present.
+
+## Phase 33B no-leak fixture validator
+
+`validate-fixtures.mjs` is a deterministic, dependency-free, Node-
+compatible validator that locks the Phase 33B invariants in place.
+
+Run it:
+
+```bash
+node docs/recall-wedge/fixtures/validate-fixtures.mjs
+```
+
+It checks:
+
+- every fixture JSON parses;
+- the seed packet is `synthetic: true`,
+  `fixture_kind: reviewed_seed_memory_packet`,
+  `admission_state: already_admitted`, and names Straylight as authority;
+- all projected DTOs share the same `continuity_actor_id` as the seed;
+- the operator-private projection references the seed packet by id;
+- the operator-private projection is `recall_interface: operator_private`
+  and `render_surface: operator_debug`;
+- the public-discord and character-boundary-referral projections are
+  `recall_interface: public_discord` and
+  `render_surface: discord_public_character`;
+- the referral projection has a `safe_referral_target` and a generic
+  `public_referral_message`;
+- the public-safe projections contain no `PRIVATE_SENTINEL` strings or
+  banned-key substrings (`raw_reasons`, `debug`, `private_assertion_id`,
+  `source_material`, `hidden estate`, `assertion_id`,
+  `full assertion bodies`, `private identifiers`).
+
+The validator exits 0 on success and nonzero on any failure. It is
+fixture-only — it does not import Straylight types, it does not call a
+live Dixie client, and it does not attempt rendering. Renderer
+implementation is Phase 33C; the cross-interface continuity demo is
+Phase 33D.
+
+## Categories that are not Recall Wedge memory
+
+Per `RECALL-WEDGE-MEMORY-MVP.md` §6–7, two categories are explicitly not
+governed memory by default and must not be promoted in the MVP:
+
+- **Mibera / onchain holder stats** — external tool output (mibera-codex,
+  score-mcp). They become Recall Wedge memory only if explicitly
+  admitted as governed assertions. For the MVP, they stay separate from
+  governed continuity memory.
+- **Discord interaction logs** — raw source / candidate at most. They do
+  not become Straylight assertions in the MVP.
+
+The seed packet includes notes restating both, so the renderer and the
+demo can show that the MVP keeps these categories distinct.
+
+## Phase ladder (recap)
+
+- 33A — boundary decision doc (`RECALL-WEDGE-MEMORY-MVP.md`)
+- **33B — these fixtures**
+- 33C — public-safe Recall Wedge renderer + no-leak validator
+- 33D — cross-interface continuity demo
+- 34A — final MVP acceptance handoff
+
+If a later phase needs anything beyond what these fixtures shape, re-open
+the 33A doc — do not silently expand scope here.

--- a/docs/recall-wedge/fixtures/projected-dto/character-boundary-referral.dto.json
+++ b/docs/recall-wedge/fixtures/projected-dto/character-boundary-referral.dto.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "character-boundary-referral-001",
+  "fixture_kind": "recall_wedge_dto_projection",
+  "fixture_version": "phase-33b.0",
+  "dto_scope_note": "a public-channel projection of the Dixie-safe Recall Wedge envelope, narrowed for a character-boundary referral on the public_discord render surface; not the full Straylight schema, not the full Dixie response, not the source of recall semantics, not a replacement for Hounfour/Straylight types",
+  "synthetic": true,
+  "outcome": "referral",
+  "recall_interface": "public_discord",
+  "render_surface": "discord_public_character",
+  "character_frame": "ruggy",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "public_summary": "this question lives closer to a different character frame",
+  "public_referral_message": "that lives closer to satoshi — try /satoshi for codex matters",
+  "safe_referral_target": "satoshi",
+  "included_count": 0,
+  "marked_count": 0,
+  "redacted_count": 0,
+  "excluded_count": 0,
+  "public_reason_counts": {},
+  "public_reason_labels": [],
+  "denied_or_refused": true
+}

--- a/docs/recall-wedge/fixtures/projected-dto/operator-private-view.dto.json
+++ b/docs/recall-wedge/fixtures/projected-dto/operator-private-view.dto.json
@@ -1,0 +1,60 @@
+{
+  "fixture_id": "operator-private-view-001",
+  "fixture_kind": "recall_wedge_dto_projection",
+  "fixture_version": "phase-33b.0",
+  "dto_scope_note": "a public-channel projection of the Dixie-safe Recall Wedge envelope, narrowed for the operator_private frame; not the full Straylight schema, not the full Dixie response, not the source of recall semantics, not a replacement for Hounfour/Straylight types",
+  "synthetic": true,
+  "source_seed_fixture": "shared-substrate-demo-001",
+  "outcome": "ok",
+  "source_interface": "github_seed",
+  "recall_interface": "operator_private",
+  "render_surface": "operator_debug",
+  "character_frame": "ruggy",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "operator_private_marker": "OPERATOR_PRIVATE_FRAME — diagnostics in this fixture are not for public_discord rendering",
+  "public_summary": "actor is rehearsing the cross-interface continuity demo; voice prefs and participation observed across both frames",
+  "operator_private_summary": "broader operator context — includes operator-only diagnostic note PRIVATE_SENTINEL_OPERATOR_ONLY, redacted/excluded payload acknowledgement, character-boundary referral target, and external-data category separation reminder",
+  "included_count": 3,
+  "marked_count": 0,
+  "redacted_count": 1,
+  "excluded_count": 1,
+  "operator_private_count": 1,
+  "referral_count": 1,
+  "external_data_note_count": 1,
+  "interaction_log_note_count": 1,
+  "public_reason_counts": {
+    "redacted_for_public_surface": 1,
+    "excluded_from_public_surface": 1
+  },
+  "public_reason_labels": [
+    "redacted_for_public_surface",
+    "excluded_from_public_surface"
+  ],
+  "operator_private_diagnostics": {
+    "raw_reasons_for_operator_review": [
+      "seed_authored_by_operator_PRIVATE_SENTINEL_RAW_REASON",
+      "voice_doctrine_seed_PRIVATE_SENTINEL_RAW_REASON",
+      "fixture_seed_context_PRIVATE_SENTINEL_RAW_REASON",
+      "operator_only_diagnostic_PRIVATE_SENTINEL_RAW_REASON",
+      "boundary_redaction_rule_PRIVATE_SENTINEL_RAW_REASON",
+      "boundary_exclusion_rule_PRIVATE_SENTINEL_RAW_REASON",
+      "outside_ruggy_boundary_PRIVATE_SENTINEL_RAW_REASON",
+      "category_separation_doctrine_PRIVATE_SENTINEL_RAW_REASON",
+      "anti_admission_doctrine_PRIVATE_SENTINEL_RAW_REASON"
+    ],
+    "private_assertion_id_index_for_operator_review": [
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_001",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_002",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_003",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_004",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_005",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_006",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_007",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_008",
+      "assn_PRIVATE_SENTINEL_ASSERTION_ID_009"
+    ],
+    "operator_private_note": "operator-only diagnostic context for this packet PRIVATE_SENTINEL_OPERATOR_ONLY"
+  },
+  "safe_referral_target": "satoshi",
+  "denied_or_refused": false
+}

--- a/docs/recall-wedge/fixtures/projected-dto/public-discord-view.dto.json
+++ b/docs/recall-wedge/fixtures/projected-dto/public-discord-view.dto.json
@@ -1,0 +1,26 @@
+{
+  "fixture_id": "public-discord-view-001",
+  "fixture_kind": "recall_wedge_dto_projection",
+  "fixture_version": "phase-33b.0",
+  "dto_scope_note": "a public-channel projection of the Dixie-safe Recall Wedge envelope, narrowed for the public_discord render surface; not the full Straylight schema, not the full Dixie response, not the source of recall semantics, not a replacement for Hounfour/Straylight types",
+  "synthetic": true,
+  "outcome": "ok",
+  "recall_interface": "public_discord",
+  "render_surface": "discord_public_character",
+  "character_frame": "ruggy",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "public_summary": "actor is rehearsing the cross-interface continuity demo; voice preferences and participation observed across the substrate's character frames",
+  "included_count": 3,
+  "marked_count": 0,
+  "redacted_count": 1,
+  "excluded_count": 1,
+  "public_reason_counts": {
+    "redacted_for_public_surface": 1,
+    "excluded_from_public_surface": 1
+  },
+  "public_reason_labels": [
+    "redacted_for_public_surface",
+    "excluded_from_public_surface"
+  ],
+  "denied_or_refused": false
+}

--- a/docs/recall-wedge/fixtures/seed-memory/shared-substrate-demo.memory.json
+++ b/docs/recall-wedge/fixtures/seed-memory/shared-substrate-demo.memory.json
@@ -1,0 +1,111 @@
+{
+  "fixture_id": "shared-substrate-demo-001",
+  "fixture_kind": "reviewed_seed_memory_packet",
+  "fixture_version": "phase-33b.0",
+  "schema_version": "recall-wedge-mvp.0",
+  "synthetic": true,
+  "admission_state": "already_admitted",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "actor_model": "shared_freeside_characters_app_substrate",
+  "source_authority_note": "Straylight is the authority for governed memory. This packet is a deterministic GitHub seed fixture representing memory whose admission has already occurred upstream of the demo. GitHub does not store memory; it stores reviewed fixtures.",
+  "non_production_authorization_note": "This packet is synthetic and reviewed. It contains no real user data. It is authorized for non-production fixture use in Phase 33B/33C/33D only. Live admission of new assertions is post-MVP and out of scope.",
+  "self_description": "This packet represents already-admitted Straylight memory for deterministic MVP proof.",
+  "assertions": [
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_001",
+      "kind": "observation",
+      "boundary": "public_safe",
+      "summary_public": "operator participates in the freeside-characters substrate demo",
+      "body_private": "operator interacted with shared-substrate fixture during deterministic MVP rehearsal",
+      "raw_reasons": ["seed_authored_by_operator_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "synthetic_seed_text_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_002",
+      "kind": "preference",
+      "boundary": "public_safe",
+      "summary_public": "actor prefers lowercase, no corporate-bot tells",
+      "body_private": "voice discipline preference noted across both ruggy and satoshi frames",
+      "raw_reasons": ["voice_doctrine_seed_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "voice_config_excerpt_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_003",
+      "kind": "context",
+      "boundary": "public_safe",
+      "summary_public": "actor is rehearsing the cross-interface continuity demo",
+      "body_private": "context attached for orientation under public_discord and operator_private frames",
+      "raw_reasons": ["fixture_seed_context_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "phase_33b_seed_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_004",
+      "kind": "operator_private_note",
+      "boundary": "operator_private",
+      "summary_public": null,
+      "summary_operator_private": "operator-only diagnostic context for this packet PRIVATE_SENTINEL_OPERATOR_ONLY",
+      "body_private": "diagnostic notes intended for operator_private frame only — must never reach public_discord PRIVATE_SENTINEL_OPERATOR_ONLY",
+      "raw_reasons": ["operator_only_diagnostic_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "operator_journal_excerpt_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_005",
+      "kind": "redacted_field",
+      "boundary": "redacted",
+      "summary_public": "[redacted: present but not shown on public surface]",
+      "body_private": "private payload that is acknowledged on the public surface as a redacted count, but never rendered PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "raw_reasons": ["boundary_redaction_rule_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "redacted_source_blob_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "public_reason_label": "redacted_for_public_surface",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_006",
+      "kind": "excluded_field",
+      "boundary": "excluded",
+      "summary_public": null,
+      "body_private": "excluded entirely from public projection — not even counted publicly beyond an excluded_count tally PRIVATE_SENTINEL_OPERATOR_ONLY",
+      "raw_reasons": ["boundary_exclusion_rule_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "excluded_source_blob_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "public_reason_label": "excluded_from_public_surface",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_007",
+      "kind": "character_boundary_referral",
+      "boundary": "character_frame_referral",
+      "summary_public": "this question belongs to a different character frame",
+      "body_private": "request is outside ruggy's boundary; refer the user to satoshi for codex-domain answers PRIVATE_SENTINEL_OPERATOR_ONLY",
+      "raw_reasons": ["outside_ruggy_boundary_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "character_boundary_seed_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "safe_referral_target": "satoshi",
+      "public_referral_message": "that lives closer to satoshi — try /satoshi for codex matters",
+      "character_frame_scope": ["ruggy"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_008",
+      "kind": "external_data_note",
+      "boundary": "external_tool_output",
+      "summary_public": "mibera / onchain holder stats are external tool output, not governed memory",
+      "body_private": "score-mcp and mibera-codex outputs flow through their existing channels and are rendered in-voice as data; they do not enter the recall envelope unless explicitly admitted as governed assertions PRIVATE_SENTINEL_OPERATOR_ONLY",
+      "raw_reasons": ["category_separation_doctrine_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "doctrine_excerpt_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "external_categories": ["mibera_codex", "score_mcp", "onchain_holder_stats"],
+      "character_frame_scope": ["ruggy", "satoshi"]
+    },
+    {
+      "private_assertion_id": "assn_PRIVATE_SENTINEL_ASSERTION_ID_009",
+      "kind": "interaction_log_note",
+      "boundary": "raw_source_not_memory",
+      "summary_public": "discord interaction logs are raw source, not governed memory by default",
+      "body_private": "ambient discord traffic is not memory; admission to Straylight is a separate, post-MVP path PRIVATE_SENTINEL_OPERATOR_ONLY",
+      "raw_reasons": ["anti_admission_doctrine_PRIVATE_SENTINEL_RAW_REASON"],
+      "source_material": "doctrine_excerpt_PRIVATE_SENTINEL_SOURCE_MATERIAL",
+      "character_frame_scope": ["ruggy", "satoshi"]
+    }
+  ]
+}

--- a/docs/recall-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/recall-wedge/fixtures/validate-fixtures.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+// Phase 33B no-leak fixture validator for the Recall Wedge memory MVP.
+// Deterministic, dependency-free, Node-compatible.
+//
+// Scope: parses the seed memory packet and the projected DTO fixtures,
+// verifies same continuity actor across frames, and grep-enforces that
+// public-safe DTOs carry no private sentinel strings or banned fields.
+// This is fixture validation only — not the renderer (33C) and not the
+// cross-interface demo (33D).
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = __dirname;
+const SEED_DIR = join(FIXTURES_DIR, "seed-memory");
+const PROJECTED_DIR = join(FIXTURES_DIR, "projected-dto");
+
+const SEED_FILE = "shared-substrate-demo.memory.json";
+const OPERATOR_PRIVATE_FILE = "operator-private-view.dto.json";
+const PUBLIC_DISCORD_FILE = "public-discord-view.dto.json";
+const REFERRAL_FILE = "character-boundary-referral.dto.json";
+
+const PUBLIC_SAFE_DTOS = [PUBLIC_DISCORD_FILE, REFERRAL_FILE];
+
+const BANNED_PUBLIC_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "debug",
+  "private_assertion_id",
+  "private assertion",
+  "source_material",
+  "hidden estate",
+  "assertion_id",
+  "full assertion bodies",
+  "private identifiers",
+];
+
+const failures = [];
+const successes = [];
+
+function fail(msg) {
+  failures.push(msg);
+}
+function ok(msg) {
+  successes.push(msg);
+}
+
+function loadJson(path) {
+  try {
+    const raw = readFileSync(path, "utf8");
+    return { raw, parsed: JSON.parse(raw) };
+  } catch (err) {
+    fail(`could not parse ${path}: ${err.message}`);
+    return null;
+  }
+}
+
+function listJsonFiles(dir) {
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => join(dir, name))
+      .filter((p) => statSync(p).isFile());
+  } catch (err) {
+    fail(`could not list ${dir}: ${err.message}`);
+    return [];
+  }
+}
+
+// --- 1. parse all fixture JSON files ---------------------------------------
+
+const seedFiles = listJsonFiles(SEED_DIR);
+const projectedFiles = listJsonFiles(PROJECTED_DIR);
+
+if (seedFiles.length === 0) fail("no seed-memory fixtures found");
+if (projectedFiles.length < 3)
+  fail(`expected at least 3 projected DTO fixtures, found ${projectedFiles.length}`);
+
+for (const f of [...seedFiles, ...projectedFiles]) {
+  const loaded = loadJson(f);
+  if (loaded) ok(`parsed ${f}`);
+}
+
+const seed = loadJson(join(SEED_DIR, SEED_FILE));
+const opPriv = loadJson(join(PROJECTED_DIR, OPERATOR_PRIVATE_FILE));
+const pubDisc = loadJson(join(PROJECTED_DIR, PUBLIC_DISCORD_FILE));
+const referral = loadJson(join(PROJECTED_DIR, REFERRAL_FILE));
+
+// --- 2. seed memory invariants ---------------------------------------------
+
+if (seed?.parsed) {
+  const s = seed.parsed;
+  if (s.synthetic !== true) fail("seed: synthetic must be true");
+  else ok("seed: synthetic === true");
+
+  if (s.fixture_kind !== "reviewed_seed_memory_packet")
+    fail(`seed: fixture_kind must be reviewed_seed_memory_packet, got ${s.fixture_kind}`);
+  else ok("seed: fixture_kind === reviewed_seed_memory_packet");
+
+  if (s.admission_state !== "already_admitted")
+    fail(`seed: admission_state must be already_admitted, got ${s.admission_state}`);
+  else ok("seed: admission_state === already_admitted");
+
+  if (!s.continuity_actor_id) fail("seed: continuity_actor_id missing");
+  else ok(`seed: continuity_actor_id === ${s.continuity_actor_id}`);
+
+  if (!s.fixture_id) fail("seed: fixture_id missing");
+  else ok(`seed: fixture_id === ${s.fixture_id}`);
+
+  if (!s.source_authority_note || !/Straylight/i.test(s.source_authority_note))
+    fail("seed: source_authority_note missing or does not name Straylight");
+  else ok("seed: source_authority_note names Straylight");
+
+  if (!s.non_production_authorization_note)
+    fail("seed: non_production_authorization_note missing");
+  else ok("seed: non_production_authorization_note present");
+
+  if (!Array.isArray(s.assertions) || s.assertions.length < 1)
+    fail("seed: assertions array missing or empty");
+  else ok(`seed: ${s.assertions.length} assertions present`);
+}
+
+// --- 3. cross-DTO continuity invariants ------------------------------------
+
+const expectedActor = seed?.parsed?.continuity_actor_id;
+const expectedSeedId = seed?.parsed?.fixture_id;
+
+for (const [label, dto] of [
+  ["operator-private", opPriv],
+  ["public-discord", pubDisc],
+  ["referral", referral],
+]) {
+  if (!dto?.parsed) continue;
+  const d = dto.parsed;
+  if (expectedActor && d.continuity_actor_id !== expectedActor)
+    fail(`${label}: continuity_actor_id mismatch (expected ${expectedActor}, got ${d.continuity_actor_id})`);
+  else if (expectedActor)
+    ok(`${label}: continuity_actor_id matches seed (${expectedActor})`);
+
+  if (label === "operator-private") {
+    if (expectedSeedId && d.source_seed_fixture !== expectedSeedId)
+      fail(`${label}: source_seed_fixture should reference seed (${expectedSeedId})`);
+    else if (expectedSeedId) ok(`${label}: source_seed_fixture references seed`);
+  }
+}
+
+// --- 4. operator-private frame invariants ----------------------------------
+
+if (opPriv?.parsed) {
+  const d = opPriv.parsed;
+  if (d.recall_interface !== "operator_private")
+    fail(`operator-private: recall_interface must be operator_private, got ${d.recall_interface}`);
+  else ok("operator-private: recall_interface === operator_private");
+
+  if (d.render_surface !== "operator_debug")
+    fail(`operator-private: render_surface must be operator_debug, got ${d.render_surface}`);
+  else ok("operator-private: render_surface === operator_debug");
+}
+
+// --- 5. public-discord + referral frame invariants -------------------------
+
+for (const [label, dto] of [
+  ["public-discord", pubDisc],
+  ["referral", referral],
+]) {
+  if (!dto?.parsed) continue;
+  const d = dto.parsed;
+  if (d.recall_interface !== "public_discord")
+    fail(`${label}: recall_interface must be public_discord, got ${d.recall_interface}`);
+  else ok(`${label}: recall_interface === public_discord`);
+
+  if (d.render_surface !== "discord_public_character")
+    fail(`${label}: render_surface must be discord_public_character, got ${d.render_surface}`);
+  else ok(`${label}: render_surface === discord_public_character`);
+}
+
+// --- 6. referral-specific invariants ---------------------------------------
+
+if (referral?.parsed) {
+  const d = referral.parsed;
+  if (!d.safe_referral_target)
+    fail("referral: safe_referral_target missing");
+  else ok(`referral: safe_referral_target === ${d.safe_referral_target}`);
+
+  if (!d.public_referral_message || d.public_referral_message.length < 4)
+    fail("referral: public_referral_message missing or too short");
+  else ok("referral: public_referral_message present");
+
+  if (d.outcome !== "referral")
+    fail(`referral: outcome must be referral, got ${d.outcome}`);
+  else ok("referral: outcome === referral");
+
+  if (d.denied_or_refused !== true)
+    fail("referral: denied_or_refused must be true");
+  else ok("referral: denied_or_refused === true");
+}
+
+// --- 7. public-safe leak grep ----------------------------------------------
+
+for (const fname of PUBLIC_SAFE_DTOS) {
+  const path = join(PROJECTED_DIR, fname);
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    fail(`could not read ${fname}: ${err.message}`);
+    continue;
+  }
+
+  for (const banned of BANNED_PUBLIC_SUBSTRINGS) {
+    if (raw.includes(banned)) {
+      fail(`leak: ${fname} contains banned public substring "${banned}"`);
+    }
+  }
+  ok(`${fname}: no banned public substrings`);
+}
+
+// --- report ----------------------------------------------------------------
+
+const fixtures = [
+  ...seedFiles.map((f) => `  seed:      ${f.replace(FIXTURES_DIR + "/", "")}`),
+  ...projectedFiles.map((f) => `  projected: ${f.replace(FIXTURES_DIR + "/", "")}`),
+].sort();
+
+console.log("recall-wedge phase 33b fixture validator");
+console.log("----------------------------------------");
+console.log("fixtures:");
+for (const line of fixtures) console.log(line);
+console.log("");
+console.log(`checks passed: ${successes.length}`);
+console.log(`checks failed: ${failures.length}`);
+
+if (failures.length > 0) {
+  console.log("");
+  console.log("failures:");
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log("");
+console.log("ok — all phase 33b fixture invariants hold; no public-side leaks detected.");
+process.exit(0);


### PR DESCRIPTION
## Summary

Phase 33B adds deterministic Recall Wedge seed memory and projected DTO fixtures for `freeside-characters`, plus a dependency-free no-leak validator.

This is the medium-slice follow-up to Phase 33A. It does not implement the renderer, Discord wiring, live Dixie client, Straylight integration, production storage, or live memory admission.

The PR adds:

- reviewed synthetic already-admitted seed memory fixture
- projected DTO fixture for `operator_private` / `operator_debug`
- projected DTO fixture for sanitized `public_discord` output
- projected DTO fixture for character-boundary referral
- fixture README documenting the contract
- Node-compatible no-leak validator

## Files

- `docs/recall-wedge/fixtures/README.md`
- `docs/recall-wedge/fixtures/validate-fixtures.mjs`
- `docs/recall-wedge/fixtures/seed-memory/shared-substrate-demo.memory.json`
- `docs/recall-wedge/fixtures/projected-dto/operator-private-view.dto.json`
- `docs/recall-wedge/fixtures/projected-dto/public-discord-view.dto.json`
- `docs/recall-wedge/fixtures/projected-dto/character-boundary-referral.dto.json`

## Boundary locked by this PR

This fixture set demonstrates:

- one shared `continuity_actor_id`
- seed memory represented as synthetic already-admitted Straylight memory
- GitHub/repo fixtures as deterministic MVP proof material, not production memory storage
- operator-private view that may carry broader diagnostic context
- public Discord view that is sanitized
- character-boundary referral view that gives safe referral text without hidden boundary reasons
- Mibera/onchain stats treated as external tool output, not governed memory by default
- Discord interaction logs treated as raw source/candidate memory, not governed memory by default

## Validator

The validator is:

- `docs/recall-wedge/fixtures/validate-fixtures.mjs`
- dependency-free Node ESM
- no package.json changes required
- local deterministic regression gate for Phase 33C

It checks:

- all JSON fixtures parse
- seed memory is synthetic, `reviewed_seed_memory_packet`, and `already_admitted`
- projected DTOs share the same `continuity_actor_id`
- operator-private DTO is `operator_private` / `operator_debug`
- public DTOs are `public_discord` / `discord_public_character`
- referral DTO includes safe referral fields
- public-safe DTOs contain no `PRIVATE_SENTINEL_*`
- public-safe DTOs contain no banned raw/private/debug fields

## Validation

Claude report:

- added six docs/fixture files only
- no package, lockfile, source, runtime, test, renderer, Discord wiring, Dixie client, Straylight import, production storage, or live admission changes
- validator output: 28 checks passed, 0 failed

Codex audit:

- VERDICT: ACCEPT
- no exact file/line concerns
- scope confirmed as only the six expected untracked fixture files
- JSON fixtures parse cleanly
- validator passes with 28 checks passed, 0 failed
- public DTO no-leak assessment accepted
- continuity proof accepted
- `projected-dto/` folder/path accepted
- no overclaims found

Local validation before commit:

```bash
node docs/recall-wedge/fixtures/validate-fixtures.mjs
