### PR TITLE
Phase 33C feat(persona-engine): add Recall Wedge public renderer

### DIFF
--- a/packages/persona-engine/src/recall-wedge/render-public-recall.test.ts
+++ b/packages/persona-engine/src/recall-wedge/render-public-recall.test.ts
@@ -1,0 +1,334 @@
+// Phase 33C · public-safe Recall Wedge renderer regression gate.
+//
+// Drives `renderPublicRecallProjection` against the Phase 33B projected-DTO
+// fixtures shipped in `docs/recall-wedge/fixtures/projected-dto/`. Proves:
+//
+//   1. public_discord/discord_public_character DTOs render successfully;
+//   2. character-boundary referrals render with safe target + message;
+//   3. operator_private/operator_debug DTOs are rejected for public render;
+//   4. unknown recall_interface / unknown render_surface are rejected;
+//   5. rendered public output contains none of the Phase 33B banned
+//      substrings (PRIVATE_SENTINEL, raw_reasons, debug, assertion_id, etc);
+//   6. rendered public output never carries a continuity actor identifier —
+//      `actor:` line and the `freeside-characters:shared-substrate` id stay
+//      off the public surface per docs/RECALL-WEDGE-MEMORY-MVP.md §9.
+//
+// Fixture files are read directly so the renderer is exercised on the
+// canonical Phase 33B DTOs, not on hand-crafted inlined JSON.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PublicRecallRenderError,
+  isPublicRecallProjectionRenderable,
+  renderPublicRecallProjection,
+  renderPublicRecallProjectionLines,
+} from "./render-public-recall.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/recall-wedge/fixtures/projected-dto",
+);
+
+function loadFixture(name: string): unknown {
+  const path = resolve(FIXTURE_DIR, name);
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+const PUBLIC_DISCORD_DTO = loadFixture("public-discord-view.dto.json");
+const REFERRAL_DTO = loadFixture("character-boundary-referral.dto.json");
+const OPERATOR_PRIVATE_DTO = loadFixture("operator-private-view.dto.json");
+
+const BANNED_PUBLIC_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "debug",
+  "private_assertion",
+  "private assertion",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+] as const;
+
+describe("isPublicRecallProjectionRenderable", () => {
+  test("accepts a public_discord/discord_public_character ok DTO", () => {
+    expect(isPublicRecallProjectionRenderable(PUBLIC_DISCORD_DTO)).toBe(true);
+  });
+
+  test("accepts a public_discord referral DTO", () => {
+    expect(isPublicRecallProjectionRenderable(REFERRAL_DTO)).toBe(true);
+  });
+
+  test("rejects an operator_private/operator_debug DTO", () => {
+    expect(isPublicRecallProjectionRenderable(OPERATOR_PRIVATE_DTO)).toBe(false);
+  });
+
+  test("rejects unknown recall_interface", () => {
+    expect(
+      isPublicRecallProjectionRenderable({
+        ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+        recall_interface: "web_chat_fixture",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects unknown render_surface", () => {
+    expect(
+      isPublicRecallProjectionRenderable({
+        ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+        render_surface: "operator_debug",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects non-object input", () => {
+    expect(isPublicRecallProjectionRenderable(null)).toBe(false);
+    expect(isPublicRecallProjectionRenderable("nope")).toBe(false);
+    expect(isPublicRecallProjectionRenderable([PUBLIC_DISCORD_DTO])).toBe(false);
+  });
+});
+
+describe("renderPublicRecallProjection · public-discord ok DTO", () => {
+  const text = renderPublicRecallProjection(PUBLIC_DISCORD_DTO);
+  const lines = renderPublicRecallProjectionLines(PUBLIC_DISCORD_DTO);
+
+  test("returns a non-empty multi-line billboard", () => {
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(0);
+    expect(lines.length).toBeGreaterThan(1);
+  });
+
+  test("header tags the public character frame", () => {
+    expect(lines[0]).toContain("[recall · public · ruggy · ok]");
+  });
+
+  test("includes counts derived from the DTO (not raw private reasons)", () => {
+    expect(text).toContain("included=3");
+    expect(text).toContain("redacted=1");
+    expect(text).toContain("excluded=1");
+    expect(text).toContain("marked=0");
+  });
+
+  test("includes safe public reason labels and counts", () => {
+    expect(text).toContain("redacted_for_public_surface=1");
+    expect(text).toContain("excluded_from_public_surface=1");
+    expect(text).toContain("redacted_for_public_surface");
+    expect(text).toContain("excluded_from_public_surface");
+  });
+
+  test("includes the DTO's public_summary verbatim", () => {
+    expect(text).toContain(
+      "actor is rehearsing the cross-interface continuity demo",
+    );
+  });
+
+  test("contains no banned-public substrings", () => {
+    for (const banned of BANNED_PUBLIC_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("does not emit a continuity actor line on the public surface", () => {
+    // §9 allowlist excludes continuity_actor_id from public output. The
+    // renderer must never emit an `actor:` line, even when the DTO carries
+    // a non-empty continuity_actor_id.
+    expect(text).not.toContain("actor:");
+    expect(text).not.toContain("freeside-characters:shared-substrate");
+    for (const line of lines) {
+      expect(line.startsWith("actor:")).toBe(false);
+    }
+  });
+});
+
+describe("renderPublicRecallProjection · character-boundary referral DTO", () => {
+  const text = renderPublicRecallProjection(REFERRAL_DTO);
+  const lines = renderPublicRecallProjectionLines(REFERRAL_DTO);
+
+  test("header tags the referral outcome", () => {
+    expect(lines[0]).toContain("referral");
+  });
+
+  test("includes the safe_referral_target", () => {
+    expect(text).toContain("referral target: satoshi");
+  });
+
+  test("includes the public_referral_message", () => {
+    expect(text).toContain("referral message: that lives closer to satoshi");
+  });
+
+  test("contains no banned-public substrings", () => {
+    for (const banned of BANNED_PUBLIC_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("does not emit a continuity actor line on the public surface", () => {
+    expect(text).not.toContain("actor:");
+    expect(text).not.toContain("freeside-characters:shared-substrate");
+    for (const line of lines) {
+      expect(line.startsWith("actor:")).toBe(false);
+    }
+  });
+});
+
+describe("renderPublicRecallProjection · rejection paths", () => {
+  test("rejects operator_private DTO with a typed render error", () => {
+    expect(() => renderPublicRecallProjection(OPERATOR_PRIVATE_DTO)).toThrow(
+      PublicRecallRenderError,
+    );
+  });
+
+  test("operator_debug render_surface is rejected", () => {
+    const dto = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      render_surface: "operator_debug",
+    };
+    expect(() => renderPublicRecallProjection(dto)).toThrow(
+      /render_surface must be discord_public_character/,
+    );
+  });
+
+  test("unknown recall_interface is rejected", () => {
+    const dto = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      recall_interface: "totally_unknown_frame",
+    };
+    expect(() => renderPublicRecallProjection(dto)).toThrow(
+      /recall_interface must be public_discord/,
+    );
+  });
+
+  test("unknown outcome is rejected", () => {
+    const dto = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      outcome: "exploding",
+    };
+    expect(() => renderPublicRecallProjection(dto)).toThrow(/outcome must be/);
+  });
+
+  test("referral outcome without safe_referral_target is rejected", () => {
+    const dto = {
+      ...(REFERRAL_DTO as Record<string, unknown>),
+      safe_referral_target: undefined,
+    };
+    expect(() => renderPublicRecallProjection(dto)).toThrow(
+      /safe_referral_target/,
+    );
+  });
+
+  test("referral outcome without public_referral_message is rejected", () => {
+    const dto = {
+      ...(REFERRAL_DTO as Record<string, unknown>),
+      public_referral_message: undefined,
+    };
+    expect(() => renderPublicRecallProjection(dto)).toThrow(
+      /public_referral_message/,
+    );
+  });
+
+  test("non-object input is rejected", () => {
+    expect(() => renderPublicRecallProjection(null)).toThrow(
+      PublicRecallRenderError,
+    );
+    expect(() => renderPublicRecallProjection("nope")).toThrow(
+      PublicRecallRenderError,
+    );
+  });
+});
+
+describe("renderPublicRecallProjection · fail-closed on contaminated public-framed DTOs", () => {
+  // A public-framed DTO that smuggles operator-private material must fail
+  // closed — the renderer rejects on input deep-scan before any projection,
+  // even if the banned field would be ignored by the safe-output allowlist.
+  // Defense in depth: the rendered-output scan still catches anything that
+  // somehow slips into a surfaced field.
+  test("rejects when public framing is claimed but PRIVATE_SENTINEL is smuggled in public_summary", () => {
+    const smuggled = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      public_summary:
+        "summary with PRIVATE_SENTINEL_OPERATOR_ONLY embedded — must not be emitted",
+    };
+    expect(() => renderPublicRecallProjection(smuggled)).toThrow(
+      PublicRecallRenderError,
+    );
+    try {
+      renderPublicRecallProjection(smuggled);
+    } catch (err) {
+      expect(err).toBeInstanceOf(PublicRecallRenderError);
+      expect((err as PublicRecallRenderError).code).toMatch(
+        /banned_private_material_in_input|banned_substring_in_output/,
+      );
+    }
+  });
+
+  test("rejects a public-framed DTO contaminated with raw_reasons_for_operator_review and PRIVATE_SENTINEL in an ignored field", () => {
+    const polluted = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      operator_private_diagnostics: {
+        raw_reasons_for_operator_review: ["should_not_appear"],
+        operator_private_note: "PRIVATE_SENTINEL_OPERATOR_ONLY",
+      },
+    };
+    expect(() => renderPublicRecallProjection(polluted)).toThrow(
+      PublicRecallRenderError,
+    );
+    try {
+      renderPublicRecallProjection(polluted);
+    } catch (err) {
+      expect(err).toBeInstanceOf(PublicRecallRenderError);
+      expect((err as PublicRecallRenderError).code).toBe(
+        "banned_private_material_in_input",
+      );
+    }
+  });
+
+  test("isPublicRecallProjectionRenderable returns false for a contaminated public-framed DTO", () => {
+    const polluted = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      operator_private_diagnostics: {
+        raw_reasons_for_operator_review: ["should_not_appear"],
+        operator_private_note: "PRIVATE_SENTINEL_OPERATOR_ONLY",
+      },
+    };
+    expect(isPublicRecallProjectionRenderable(polluted)).toBe(false);
+  });
+
+  test("rejects a banned substring buried in a deeply nested array value", () => {
+    const buried = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      extra_envelope: {
+        nested: [
+          { harmless: "fine" },
+          { also_harmless: ["ok", "PRIVATE_SENTINEL_DEEPLY_BURIED"] },
+        ],
+      },
+    };
+    expect(() => renderPublicRecallProjection(buried)).toThrow(
+      PublicRecallRenderError,
+    );
+    try {
+      renderPublicRecallProjection(buried);
+    } catch (err) {
+      expect((err as PublicRecallRenderError).code).toBe(
+        "banned_private_material_in_input",
+      );
+    }
+  });
+
+  test("rejects a banned key name even when the value is innocuous", () => {
+    const bannedKey = {
+      ...(PUBLIC_DISCORD_DTO as Record<string, unknown>),
+      private_assertion_id: "anything-here",
+    };
+    expect(() => renderPublicRecallProjection(bannedKey)).toThrow(
+      PublicRecallRenderError,
+    );
+    expect(isPublicRecallProjectionRenderable(bannedKey)).toBe(false);
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/render-public-recall.ts
+++ b/packages/persona-engine/src/recall-wedge/render-public-recall.ts
@@ -1,0 +1,339 @@
+// Phase 33C · public-safe Recall Wedge renderer.
+//
+// Pure deterministic projection of a public-safe Recall Wedge DTO into
+// voiceless / public-safe billboard text. Consumes the projected-DTO shape
+// shipped in Phase 33B (docs/recall-wedge/fixtures/projected-dto/*.dto.json).
+//
+// Boundary (per docs/RECALL-WEDGE-MEMORY-MVP.md §9, §11, §12):
+//   - accepts only recall_interface=public_discord +
+//     render_surface=discord_public_character;
+//   - rejects operator_private / operator_debug and any unknown frame;
+//   - emits no character voice, calls no LLM, infers no field that is not
+//     directly present in the DTO;
+//   - fails closed on contaminated input: operator-private / debug fields
+//     anywhere in a public-framed DTO cause the renderer to reject the
+//     projection rather than silently strip them, so private material can
+//     never smuggle through "ignored" fields;
+//   - rendered public output is restricted to the §9 allowlist —
+//     summary, counts, public reason labels/counts, refusal text, safe
+//     referral target/message — and emits no continuity actor identifier.
+//
+// This renderer is fixture/test-only for Phase 33C. It is not wired to any
+// live Discord command path.
+
+const PUBLIC_RECALL_INTERFACE = "public_discord" as const;
+const PUBLIC_RENDER_SURFACE = "discord_public_character" as const;
+
+const ALLOWED_OUTCOMES = ["ok", "referral"] as const;
+type AllowedOutcome = (typeof ALLOWED_OUTCOMES)[number];
+
+// Strings that must never appear anywhere in a public-framed input DTO — keys
+// or string values, at any depth. Fail-closed: a contaminated public-framed DTO
+// is rejected before any allowlist projection happens, so private material
+// cannot smuggle through "ignored" fields.
+const BANNED_INPUT_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "raw_reasons_for_operator_review",
+  "debug",
+  "operator_private",
+  "operator_private_diagnostics",
+  "operator_private_note",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+] as const;
+
+// Strings that must never appear in rendered public output. Defense-in-depth:
+// the renderer only reads a small allowlist of safe fields, so these would not
+// normally be reachable, but a final scan guarantees no leak even under future
+// drift in the DTO shape.
+const BANNED_OUTPUT_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "debug",
+  "private_assertion",
+  "private assertion",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+] as const;
+
+export class PublicRecallRenderError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "PublicRecallRenderError";
+    this.code = code;
+  }
+}
+
+interface PublicRecallProjection {
+  recall_interface: typeof PUBLIC_RECALL_INTERFACE;
+  render_surface: typeof PUBLIC_RENDER_SURFACE;
+  outcome: AllowedOutcome;
+  character_frame?: string;
+  continuity_actor_id?: string;
+  public_summary?: string;
+  included_count?: number;
+  marked_count?: number;
+  redacted_count?: number;
+  excluded_count?: number;
+  public_reason_labels?: readonly string[];
+  public_reason_counts?: Readonly<Record<string, number>>;
+  denied_or_refused?: boolean;
+  safe_referral_target?: string;
+  public_referral_message?: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isFiniteNonNegativeInt(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+function asAllowedOutcome(value: unknown): AllowedOutcome | null {
+  return typeof value === "string" && (ALLOWED_OUTCOMES as readonly string[]).includes(value)
+    ? (value as AllowedOutcome)
+    : null;
+}
+
+// Walk every key and every string value in the DTO and report the first
+// banned substring encountered, or null if clean. Cycle-safe via a visited set.
+// Numbers/booleans/nulls cannot leak text and are skipped.
+function findBannedInputMaterial(
+  value: unknown,
+  visited: WeakSet<object> = new WeakSet(),
+): string | null {
+  if (typeof value === "string") {
+    for (const banned of BANNED_INPUT_SUBSTRINGS) {
+      if (value.includes(banned)) return banned;
+    }
+    return null;
+  }
+  if (Array.isArray(value)) {
+    if (visited.has(value)) return null;
+    visited.add(value);
+    for (const item of value) {
+      const hit = findBannedInputMaterial(item, visited);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (isPlainObject(value)) {
+    if (visited.has(value)) return null;
+    visited.add(value);
+    for (const [key, sub] of Object.entries(value)) {
+      for (const banned of BANNED_INPUT_SUBSTRINGS) {
+        if (key.includes(banned)) return banned;
+      }
+      const hit = findBannedInputMaterial(sub, visited);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  return null;
+}
+
+export function isPublicRecallProjectionRenderable(dto: unknown): boolean {
+  if (!isPlainObject(dto)) return false;
+  if (dto.recall_interface !== PUBLIC_RECALL_INTERFACE) return false;
+  if (dto.render_surface !== PUBLIC_RENDER_SURFACE) return false;
+  if (asAllowedOutcome(dto.outcome) === null) return false;
+  if (findBannedInputMaterial(dto) !== null) return false;
+  return true;
+}
+
+function validateForPublicRender(dto: unknown): PublicRecallProjection {
+  if (!isPlainObject(dto)) {
+    throw new PublicRecallRenderError(
+      "not_object",
+      "recall projection must be a plain object",
+    );
+  }
+
+  const ri = dto.recall_interface;
+  if (ri !== PUBLIC_RECALL_INTERFACE) {
+    throw new PublicRecallRenderError(
+      "wrong_recall_interface",
+      `recall_interface must be ${PUBLIC_RECALL_INTERFACE} for public render; refusing to render`,
+    );
+  }
+
+  const rs = dto.render_surface;
+  if (rs !== PUBLIC_RENDER_SURFACE) {
+    throw new PublicRecallRenderError(
+      "wrong_render_surface",
+      `render_surface must be ${PUBLIC_RENDER_SURFACE} for public render; refusing to render`,
+    );
+  }
+
+  // Fail-closed input deep-scan. A public-framed DTO that contains operator
+  // private material — anywhere, including nested keys and values that the
+  // safe-output allowlist would otherwise ignore — is rejected before any
+  // projection happens. Defense-in-depth alongside the rendered-output scan.
+  const bannedHit = findBannedInputMaterial(dto);
+  if (bannedHit !== null) {
+    throw new PublicRecallRenderError(
+      "banned_private_material_in_input",
+      `public-framed recall projection contained banned private material in input ("${bannedHit}"); refusing to render`,
+    );
+  }
+
+  const outcome = asAllowedOutcome(dto.outcome);
+  if (outcome === null) {
+    throw new PublicRecallRenderError(
+      "unknown_outcome",
+      `outcome must be one of ${ALLOWED_OUTCOMES.join("|")}`,
+    );
+  }
+
+  if (outcome === "referral") {
+    if (!isNonEmptyString(dto.safe_referral_target)) {
+      throw new PublicRecallRenderError(
+        "missing_referral_target",
+        "referral outcome requires a safe_referral_target",
+      );
+    }
+    if (!isNonEmptyString(dto.public_referral_message)) {
+      throw new PublicRecallRenderError(
+        "missing_referral_message",
+        "referral outcome requires a public_referral_message",
+      );
+    }
+  }
+
+  return {
+    recall_interface: PUBLIC_RECALL_INTERFACE,
+    render_surface: PUBLIC_RENDER_SURFACE,
+    outcome,
+    character_frame: isNonEmptyString(dto.character_frame) ? dto.character_frame : undefined,
+    continuity_actor_id: isNonEmptyString(dto.continuity_actor_id)
+      ? dto.continuity_actor_id
+      : undefined,
+    public_summary: isNonEmptyString(dto.public_summary) ? dto.public_summary : undefined,
+    included_count: isFiniteNonNegativeInt(dto.included_count) ? dto.included_count : undefined,
+    marked_count: isFiniteNonNegativeInt(dto.marked_count) ? dto.marked_count : undefined,
+    redacted_count: isFiniteNonNegativeInt(dto.redacted_count) ? dto.redacted_count : undefined,
+    excluded_count: isFiniteNonNegativeInt(dto.excluded_count) ? dto.excluded_count : undefined,
+    public_reason_labels: isStringArray(dto.public_reason_labels)
+      ? dto.public_reason_labels
+      : undefined,
+    public_reason_counts: isPlainObject(dto.public_reason_counts)
+      ? Object.fromEntries(
+          Object.entries(dto.public_reason_counts).filter(
+            (entry): entry is [string, number] => isFiniteNonNegativeInt(entry[1]),
+          ),
+        )
+      : undefined,
+    denied_or_refused: typeof dto.denied_or_refused === "boolean" ? dto.denied_or_refused : false,
+    safe_referral_target: isNonEmptyString(dto.safe_referral_target)
+      ? dto.safe_referral_target
+      : undefined,
+    public_referral_message: isNonEmptyString(dto.public_referral_message)
+      ? dto.public_referral_message
+      : undefined,
+  };
+}
+
+function header(p: PublicRecallProjection): string {
+  const tag = p.outcome === "referral"
+    ? "referral"
+    : p.denied_or_refused
+      ? "refused"
+      : "ok";
+  const frame = p.character_frame ?? "unknown";
+  return `[recall · public · ${frame} · ${tag}]`;
+}
+
+function countsLine(p: PublicRecallProjection): string | null {
+  const parts: string[] = [];
+  if (p.included_count !== undefined) parts.push(`included=${p.included_count}`);
+  if (p.marked_count !== undefined) parts.push(`marked=${p.marked_count}`);
+  if (p.redacted_count !== undefined) parts.push(`redacted=${p.redacted_count}`);
+  if (p.excluded_count !== undefined) parts.push(`excluded=${p.excluded_count}`);
+  return parts.length === 0 ? null : `counts: ${parts.join(" · ")}`;
+}
+
+function labelsLine(p: PublicRecallProjection): string | null {
+  if (!p.public_reason_labels || p.public_reason_labels.length === 0) return null;
+  return `labels: ${p.public_reason_labels.join(", ")}`;
+}
+
+function reasonCountsLine(p: PublicRecallProjection): string | null {
+  if (!p.public_reason_counts) return null;
+  const entries = Object.entries(p.public_reason_counts);
+  if (entries.length === 0) return null;
+  const parts = entries.map(([k, v]) => `${k}=${v}`);
+  return `reason counts: ${parts.join(" · ")}`;
+}
+
+function buildLines(p: PublicRecallProjection): string[] {
+  const lines: string[] = [header(p)];
+
+  // continuity_actor_id is intentionally NOT emitted on the public surface —
+  // §9 allowlist restricts public output to summary / counts / labels /
+  // refusal / referral. The id is retained on the projection only for
+  // upstream DTO validation and is never rendered.
+  if (p.public_summary) lines.push(`summary: ${p.public_summary}`);
+
+  if (p.outcome === "referral") {
+    lines.push(`referral target: ${p.safe_referral_target}`);
+    lines.push(`referral message: ${p.public_referral_message}`);
+  } else if (p.denied_or_refused) {
+    lines.push("status: this frame cannot answer publicly");
+  }
+
+  const c = countsLine(p);
+  if (c) lines.push(c);
+  const rc = reasonCountsLine(p);
+  if (rc) lines.push(rc);
+  const lab = labelsLine(p);
+  if (lab) lines.push(lab);
+
+  return lines;
+}
+
+function assertNoLeak(text: string): void {
+  for (const banned of BANNED_OUTPUT_SUBSTRINGS) {
+    if (text.includes(banned)) {
+      throw new PublicRecallRenderError(
+        "banned_substring_in_output",
+        `rendered public output contained a banned substring; refusing to emit`,
+      );
+    }
+  }
+}
+
+export function renderPublicRecallProjectionLines(dto: unknown): string[] {
+  const projection = validateForPublicRender(dto);
+  const lines = buildLines(projection);
+  for (const line of lines) assertNoLeak(line);
+  return lines;
+}
+
+export function renderPublicRecallProjection(dto: unknown): string {
+  return renderPublicRecallProjectionLines(dto).join("\n");
+}


### PR DESCRIPTION
## Summary

Phase 33C adds a deterministic public-safe Recall Wedge renderer for `freeside-characters`.

This PR implements a pure renderer over the Phase 33B projected DTO fixtures. It remains fixture/test-bound and does not wire into Discord, Dixie, Straylight, production storage, or live memory admission.

The renderer:

- accepts only `recall_interface: public_discord`
- accepts only `render_surface: discord_public_character`
- rejects `operator_private` / `operator_debug`
- rejects unknown interfaces, surfaces, outcomes, malformed referrals, and non-object input
- fails closed when banned private material appears anywhere in a public-framed input DTO
- emits a voiceless public-safe data billboard
- emits only public summary/counts/labels/referral/refusal-safe fields
- does not emit `continuity_actor_id`, `actor:`, or internal actor identifiers
- does not call an LLM
- does not use character voice
- does not infer beyond DTO fields

## Files

- `packages/persona-engine/src/recall-wedge/render-public-recall.ts`
- `packages/persona-engine/src/recall-wedge/render-public-recall.test.ts`

## Public safety behavior

The renderer rejects public-framed DTOs containing banned private material anywhere in the input object, including nested arrays/objects.

Banned input/output material includes:

- `PRIVATE_SENTINEL`
- `raw_reasons`
- `raw_reasons_for_operator_review`
- `debug`
- `operator_private`
- `operator_private_diagnostics`
- `operator_private_note`
- `private_assertion`
- `private assertion`
- `private_assertion_id`
- `assertion_id`
- `source_material`
- `hidden estate`
- `full assertion bodies`
- `private identifiers`

The rendered output is also scanned as defense in depth.

## Tests

The colocated test suite covers:

- public DTO render success
- referral DTO render success
- operator-private fixture rejection
- operator-debug rejection
- unknown frame rejection
- malformed referral rejection
- non-object rejection
- contaminated public-framed DTO input rejection
- nested contaminated input rejection
- banned key-name rejection
- rendered-output no-leak checks
- no actor identifier output

## Validation

Claude report:

- patched only the Phase 33C renderer and test files
- no package/lockfile/source-runtime wiring changes
- no Discord/Dixie/Straylight integration
- no production storage
- no live admission
- Phase 33B validator: 28 passed, 0 failed
- Phase 33C tests: 30 passed, 0 failed
- typecheck does not mention `recall-wedge` or `render-public-recall`

Codex audit:

- VERDICT: ACCEPT
- no exact file/line concerns
- scope confirmed as only the two expected Phase 33C files
- input no-leak accepted
- rendered-output no-leak accepted
- no-actor-output accepted
- typecheck failures are pre-existing and unrelated to Phase 33C
- no live integration or overclaims found

Local validation before commit:

```bash
node docs/recall-wedge/fixtures/validate-fixtures.mjs
