### PR TITLE
Phase 33D feat(persona-engine): add Recall Wedge continuity demo

### DIFF
--- a/docs/recall-wedge/fixtures/README.md
+++ b/docs/recall-wedge/fixtures/README.md
@@ -124,7 +124,10 @@ It checks:
   `fixture_kind: reviewed_seed_memory_packet`,
   `admission_state: already_admitted`, and names Straylight as authority;
 - all projected DTOs share the same `continuity_actor_id` as the seed;
-- the operator-private projection references the seed packet by id;
+- every projected DTO (operator-private, public-discord, character-
+  boundary-referral) references the seed packet by id via
+  `source_seed_fixture`, so Phase 33D can mechanically prove the same
+  seed packet underlies all three views;
 - the operator-private projection is `recall_interface: operator_private`
   and `render_surface: operator_debug`;
 - the public-discord and character-boundary-referral projections are

--- a/docs/recall-wedge/fixtures/projected-dto/character-boundary-referral.dto.json
+++ b/docs/recall-wedge/fixtures/projected-dto/character-boundary-referral.dto.json
@@ -4,6 +4,7 @@
   "fixture_version": "phase-33b.0",
   "dto_scope_note": "a public-channel projection of the Dixie-safe Recall Wedge envelope, narrowed for a character-boundary referral on the public_discord render surface; not the full Straylight schema, not the full Dixie response, not the source of recall semantics, not a replacement for Hounfour/Straylight types",
   "synthetic": true,
+  "source_seed_fixture": "shared-substrate-demo-001",
   "outcome": "referral",
   "recall_interface": "public_discord",
   "render_surface": "discord_public_character",

--- a/docs/recall-wedge/fixtures/projected-dto/public-discord-view.dto.json
+++ b/docs/recall-wedge/fixtures/projected-dto/public-discord-view.dto.json
@@ -4,6 +4,7 @@
   "fixture_version": "phase-33b.0",
   "dto_scope_note": "a public-channel projection of the Dixie-safe Recall Wedge envelope, narrowed for the public_discord render surface; not the full Straylight schema, not the full Dixie response, not the source of recall semantics, not a replacement for Hounfour/Straylight types",
   "synthetic": true,
+  "source_seed_fixture": "shared-substrate-demo-001",
   "outcome": "ok",
   "recall_interface": "public_discord",
   "render_surface": "discord_public_character",

--- a/docs/recall-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/recall-wedge/fixtures/validate-fixtures.mjs
@@ -139,11 +139,10 @@ for (const [label, dto] of [
   else if (expectedActor)
     ok(`${label}: continuity_actor_id matches seed (${expectedActor})`);
 
-  if (label === "operator-private") {
-    if (expectedSeedId && d.source_seed_fixture !== expectedSeedId)
-      fail(`${label}: source_seed_fixture should reference seed (${expectedSeedId})`);
-    else if (expectedSeedId) ok(`${label}: source_seed_fixture references seed`);
-  }
+  if (expectedSeedId && d.source_seed_fixture !== expectedSeedId)
+    fail(`${label}: source_seed_fixture must reference seed (expected ${expectedSeedId}, got ${d.source_seed_fixture})`);
+  else if (expectedSeedId)
+    ok(`${label}: source_seed_fixture references seed`);
 }
 
 // --- 4. operator-private frame invariants ----------------------------------

--- a/packages/persona-engine/src/recall-wedge/demo-cross-interface.test.ts
+++ b/packages/persona-engine/src/recall-wedge/demo-cross-interface.test.ts
@@ -1,0 +1,287 @@
+// Phase 33D · cross-interface continuity demo regression gate.
+//
+// Drives the deterministic fixture-bound demo against the Phase 33B
+// projected-DTO fixtures and the Phase 33C public-safe renderer, proving
+// the §1 boundary requirements: same seed packet, same continuity actor,
+// different authorized views, public-safe output, no leak of any private
+// material on the public surface.
+//
+// Fixture-only. No live Discord/Dixie/Straylight/Finn integration is
+// touched here.
+
+import { describe, test, expect } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PublicRecallRenderError,
+  renderPublicRecallProjection,
+} from "./render-public-recall.ts";
+import {
+  buildRecallWedgeCrossInterfaceDemo,
+  loadRecallWedgeFixtures,
+  renderRecallWedgeCrossInterfaceDemo,
+} from "./demo-cross-interface.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../../..");
+const FIXTURE_DIR = resolve(REPO_ROOT, "docs/recall-wedge/fixtures");
+const VALIDATOR = resolve(FIXTURE_DIR, "validate-fixtures.mjs");
+const PROJECTED_DIR = resolve(FIXTURE_DIR, "projected-dto");
+
+function loadProjected(name: string): unknown {
+  return JSON.parse(readFileSync(resolve(PROJECTED_DIR, name), "utf8"));
+}
+
+const PUBLIC_OUTPUT_BANNED_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+describe("phase 33b validator (regression gate)", () => {
+  test("validate-fixtures.mjs exits 0 against the shipped fixtures", () => {
+    // Throws non-zero exit -> test fails.
+    const out = execFileSync("node", [VALIDATOR], { encoding: "utf8" });
+    expect(out).toContain("ok — all phase 33b fixture invariants hold");
+  });
+});
+
+describe("phase 33c renderer (regression gate against fixtures)", () => {
+  test("renders the public-discord DTO", () => {
+    const text = renderPublicRecallProjection(
+      loadProjected("public-discord-view.dto.json"),
+    );
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("[recall · public · ruggy · ok]");
+  });
+
+  test("renders the character-boundary referral DTO", () => {
+    const text = renderPublicRecallProjection(
+      loadProjected("character-boundary-referral.dto.json"),
+    );
+    expect(text).toContain("referral target: satoshi");
+  });
+
+  test("rejects the operator-private DTO with a typed render error", () => {
+    expect(() =>
+      renderPublicRecallProjection(
+        loadProjected("operator-private-view.dto.json"),
+      ),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("buildRecallWedgeCrossInterfaceDemo · structural shape", () => {
+  const demo = buildRecallWedgeCrossInterfaceDemo();
+
+  test("exposes the seed fixture id from the seed packet", () => {
+    expect(demo.seed_fixture_id).toBe("shared-substrate-demo-001");
+  });
+
+  test("exposes the internal continuity actor id (structured proof field only)", () => {
+    expect(demo.continuity_actor_id_internal).toBe(
+      "freeside-characters:shared-substrate",
+    );
+  });
+
+  test("includes operator_private, public_discord, and character_boundary_referral views", () => {
+    expect(demo.views.operator_private.recall_interface).toBe(
+      "operator_private",
+    );
+    expect(demo.views.operator_private.render_surface).toBe("operator_debug");
+    expect(demo.views.public_discord.recall_interface).toBe("public_discord");
+    expect(demo.views.public_discord.render_surface).toBe(
+      "discord_public_character",
+    );
+    expect(demo.views.character_boundary_referral.recall_interface).toBe(
+      "public_discord",
+    );
+    expect(demo.views.character_boundary_referral.render_surface).toBe(
+      "discord_public_character",
+    );
+  });
+
+  test("renderRecallWedgeCrossInterfaceDemo is an alias of buildRecallWedgeCrossInterfaceDemo", () => {
+    const a = buildRecallWedgeCrossInterfaceDemo();
+    const b = renderRecallWedgeCrossInterfaceDemo();
+    expect(a).toEqual(b);
+  });
+
+  test("accepts injected fixtures for deterministic test composition", () => {
+    const fixtures = loadRecallWedgeFixtures();
+    const injected = buildRecallWedgeCrossInterfaceDemo(fixtures);
+    expect(injected.seed_fixture_id).toBe("shared-substrate-demo-001");
+  });
+});
+
+describe("buildRecallWedgeCrossInterfaceDemo · continuity proof", () => {
+  const demo = buildRecallWedgeCrossInterfaceDemo();
+
+  test("same seed fixture across all views", () => {
+    expect(demo.proof.same_seed_fixture).toBe(true);
+    // Mechanically prove: the seed packet's fixture_id is referenced by every
+    // projected DTO via source_seed_fixture — operator-private, public-
+    // discord, and the character-boundary referral. Same packet under three
+    // authorized frames is the §1 boundary requirement.
+    const fixtures = loadRecallWedgeFixtures();
+    expect(fixtures.seed.fixture_id).toBe(demo.seed_fixture_id);
+    expect(fixtures.operatorPrivate.source_seed_fixture).toBe(
+      demo.seed_fixture_id,
+    );
+    expect(fixtures.publicDiscord.source_seed_fixture).toBe(
+      demo.seed_fixture_id,
+    );
+    expect(fixtures.characterBoundaryReferral.source_seed_fixture).toBe(
+      demo.seed_fixture_id,
+    );
+  });
+
+  test("same_seed_fixture is false if publicDiscord points elsewhere (negative regression)", () => {
+    const fixtures = loadRecallWedgeFixtures();
+    const mutated = {
+      ...fixtures,
+      publicDiscord: {
+        ...fixtures.publicDiscord,
+        source_seed_fixture: "some-other-seed-fixture-999",
+      },
+    };
+    const result = buildRecallWedgeCrossInterfaceDemo(mutated);
+    expect(result.proof.same_seed_fixture).toBe(false);
+  });
+
+  test("same_seed_fixture is false if characterBoundaryReferral points elsewhere (negative regression)", () => {
+    const fixtures = loadRecallWedgeFixtures();
+    const mutated = {
+      ...fixtures,
+      characterBoundaryReferral: {
+        ...fixtures.characterBoundaryReferral,
+        source_seed_fixture: "some-other-seed-fixture-999",
+      },
+    };
+    const result = buildRecallWedgeCrossInterfaceDemo(mutated);
+    expect(result.proof.same_seed_fixture).toBe(false);
+  });
+
+  test("same internal continuity actor across all views", () => {
+    expect(demo.proof.same_continuity_actor_internal).toBe(true);
+    const fixtures = loadRecallWedgeFixtures();
+    const expected = demo.continuity_actor_id_internal;
+    expect(fixtures.seed.continuity_actor_id).toBe(expected);
+    expect(fixtures.operatorPrivate.continuity_actor_id).toBe(expected);
+    expect(fixtures.publicDiscord.continuity_actor_id).toBe(expected);
+    expect(fixtures.characterBoundaryReferral.continuity_actor_id).toBe(
+      expected,
+    );
+  });
+
+  test("operator-private view is not publicly renderable", () => {
+    expect(demo.views.operator_private.renderable_publicly).toBe(false);
+    expect(demo.views.operator_private.reason).toBe(
+      "operator_private_not_public_renderable",
+    );
+    expect(demo.views.operator_private.rendered_text).toBeUndefined();
+  });
+
+  test("public-discord and referral views are publicly renderable", () => {
+    expect(demo.views.public_discord.renderable_publicly).toBe(true);
+    expect(demo.views.character_boundary_referral.renderable_publicly).toBe(
+      true,
+    );
+    expect(typeof demo.views.public_discord.rendered_text).toBe("string");
+    expect(
+      typeof demo.views.character_boundary_referral.rendered_text,
+    ).toBe("string");
+  });
+
+  test("produces at least two different public-safe outputs (normal recall + referral)", () => {
+    expect(demo.proof.different_authorized_views).toBe(true);
+    expect(demo.views.public_discord.rendered_text).not.toBe(
+      demo.views.character_boundary_referral.rendered_text,
+    );
+  });
+});
+
+describe("buildRecallWedgeCrossInterfaceDemo · no-leak proof on public surface", () => {
+  const demo = buildRecallWedgeCrossInterfaceDemo();
+
+  test("proof flag reports public outputs are leak-free", () => {
+    expect(demo.proof.public_outputs_no_leak).toBe(true);
+  });
+
+  for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+    test(`public_discord rendered text contains no "${banned}"`, () => {
+      expect(demo.views.public_discord.rendered_text).not.toContain(banned);
+    });
+    test(`character_boundary_referral rendered text contains no "${banned}"`, () => {
+      expect(demo.views.character_boundary_referral.rendered_text).not.toContain(
+        banned,
+      );
+    });
+  }
+
+  test("public-surface outputs do not begin any line with actor:", () => {
+    const pub = demo.views.public_discord.rendered_text ?? "";
+    const ref = demo.views.character_boundary_referral.rendered_text ?? "";
+    for (const line of pub.split("\n")) {
+      expect(line.startsWith("actor:")).toBe(false);
+    }
+    for (const line of ref.split("\n")) {
+      expect(line.startsWith("actor:")).toBe(false);
+    }
+  });
+
+  test("public-surface outputs never reveal the internal continuity actor id", () => {
+    const pub = demo.views.public_discord.rendered_text ?? "";
+    const ref = demo.views.character_boundary_referral.rendered_text ?? "";
+    expect(pub).not.toContain(demo.continuity_actor_id_internal);
+    expect(ref).not.toContain(demo.continuity_actor_id_internal);
+  });
+
+  test("public-surface outputs do not include the operator-private summary", () => {
+    const fixtures = loadRecallWedgeFixtures();
+    const opSummary = String(
+      fixtures.operatorPrivate.operator_private_summary ?? "",
+    );
+    expect(opSummary.length).toBeGreaterThan(0);
+    const pub = demo.views.public_discord.rendered_text ?? "";
+    const ref = demo.views.character_boundary_referral.rendered_text ?? "";
+    expect(pub).not.toContain(opSummary);
+    expect(ref).not.toContain(opSummary);
+  });
+});
+
+describe("buildRecallWedgeCrossInterfaceDemo · voiceless billboard posture", () => {
+  // Per docs/RECALL-WEDGE-MEMORY-MVP.md §12 the recall surface is a
+  // voiceless / data-billboard. These spot-checks lock in that the
+  // demo's rendered text comes structurally from the renderer (counts,
+  // labels, generic referral text) and not from any LLM rewrite.
+  const demo = buildRecallWedgeCrossInterfaceDemo();
+
+  test("public-discord text uses billboard markers, not character voice", () => {
+    const text = demo.views.public_discord.rendered_text ?? "";
+    expect(text).toContain("[recall · public · ");
+    expect(text).toContain("counts:");
+    expect(text).toContain("labels:");
+  });
+
+  test("referral text uses generic referral framing, not character voice", () => {
+    const text = demo.views.character_boundary_referral.rendered_text ?? "";
+    expect(text).toContain("referral target:");
+    expect(text).toContain("referral message:");
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/demo-cross-interface.ts
+++ b/packages/persona-engine/src/recall-wedge/demo-cross-interface.ts
@@ -1,0 +1,220 @@
+// Phase 33D · fixture-bound cross-interface Recall Wedge continuity demo.
+//
+// Pure deterministic demo proving the Phase 33A boundary
+// (docs/RECALL-WEDGE-MEMORY-MVP.md §1):
+//   1. one shared seed memory fixture underlies multiple projected views;
+//   2. one internal continuity actor is referenced across operator/private,
+//      public-discord, and character-boundary referral projections;
+//   3. different interface frames yield different authorized views;
+//   4. public projections render through the Phase 33C public-safe renderer;
+//   5. the operator-private projection is rejected by that renderer and
+//      recorded as not publicly renderable;
+//   6. public rendered outputs carry no private sentinels, raw_reasons,
+//      operator-private payload, assertion ids, source material, or any
+//      continuity actor identifier on the public surface (§9 allowlist).
+//
+// Voiceless / data-billboard only. The continuity actor id is retained on
+// the structured demo result for proof and test purposes; it never reaches
+// the public rendered text — the Phase 33C renderer drops it from the
+// allowlist, and this demo's no-leak guard re-checks for it. No LLM, no
+// Discord client, no Dixie client, no Straylight wiring, no Finn, no
+// network behavior. Fixture-bound.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PublicRecallRenderError,
+  renderPublicRecallProjection,
+} from "./render-public-recall.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = resolve(
+  __dirname,
+  "../../../../docs/recall-wedge/fixtures",
+);
+
+// Defense-in-depth public-output guard. Strictly broader than the renderer's
+// own internal scan: this demo additionally rejects any continuity actor
+// identifier line on the public surface, per §9 allowlist.
+const PUBLIC_OUTPUT_BANNED_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+export interface RecallWedgeFixtureBundle {
+  readonly seed: Record<string, unknown>;
+  readonly operatorPrivate: Record<string, unknown>;
+  readonly publicDiscord: Record<string, unknown>;
+  readonly characterBoundaryReferral: Record<string, unknown>;
+}
+
+export interface CrossInterfaceView {
+  readonly recall_interface: string;
+  readonly render_surface: string;
+  readonly renderable_publicly: boolean;
+  readonly rendered_text?: string;
+  readonly reason?: string;
+}
+
+export interface CrossInterfaceDemo {
+  readonly seed_fixture_id: string;
+  readonly continuity_actor_id_internal: string;
+  readonly views: {
+    readonly operator_private: CrossInterfaceView;
+    readonly public_discord: CrossInterfaceView;
+    readonly character_boundary_referral: CrossInterfaceView;
+  };
+  readonly proof: {
+    readonly same_seed_fixture: boolean;
+    readonly same_continuity_actor_internal: boolean;
+    readonly different_authorized_views: boolean;
+    readonly public_outputs_no_leak: boolean;
+  };
+}
+
+function loadJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+export function loadRecallWedgeFixtures(): RecallWedgeFixtureBundle {
+  return {
+    seed: loadJson(
+      resolve(FIXTURE_ROOT, "seed-memory/shared-substrate-demo.memory.json"),
+    ),
+    operatorPrivate: loadJson(
+      resolve(FIXTURE_ROOT, "projected-dto/operator-private-view.dto.json"),
+    ),
+    publicDiscord: loadJson(
+      resolve(FIXTURE_ROOT, "projected-dto/public-discord-view.dto.json"),
+    ),
+    characterBoundaryReferral: loadJson(
+      resolve(FIXTURE_ROOT, "projected-dto/character-boundary-referral.dto.json"),
+    ),
+  };
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+type RenderAttempt =
+  | { readonly renderable: true; readonly text: string }
+  | { readonly renderable: false; readonly reason: string };
+
+function tryRenderPublic(dto: Record<string, unknown>): RenderAttempt {
+  try {
+    const text = renderPublicRecallProjection(dto);
+    return { renderable: true, text };
+  } catch (err) {
+    if (err instanceof PublicRecallRenderError) {
+      return { renderable: false, reason: err.code };
+    }
+    return { renderable: false, reason: "unknown_render_error" };
+  }
+}
+
+function publicOutputHasNoLeak(text: string): boolean {
+  for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+    if (text.includes(banned)) return false;
+  }
+  return true;
+}
+
+export function buildRecallWedgeCrossInterfaceDemo(
+  fixtures: RecallWedgeFixtureBundle = loadRecallWedgeFixtures(),
+): CrossInterfaceDemo {
+  const { seed, operatorPrivate, publicDiscord, characterBoundaryReferral } =
+    fixtures;
+
+  const seedFixtureId = asString(seed.fixture_id);
+  const continuityActor = asString(seed.continuity_actor_id);
+
+  const opAttempt = tryRenderPublic(operatorPrivate);
+  const operatorPrivateView: CrossInterfaceView = {
+    recall_interface: asString(operatorPrivate.recall_interface),
+    render_surface: asString(operatorPrivate.render_surface),
+    renderable_publicly: false,
+    reason: opAttempt.renderable
+      ? "unexpected_public_render_succeeded"
+      : "operator_private_not_public_renderable",
+  };
+
+  const pubAttempt = tryRenderPublic(publicDiscord);
+  const publicDiscordView: CrossInterfaceView = {
+    recall_interface: asString(publicDiscord.recall_interface),
+    render_surface: asString(publicDiscord.render_surface),
+    renderable_publicly: pubAttempt.renderable,
+    rendered_text: pubAttempt.renderable ? pubAttempt.text : undefined,
+    reason: pubAttempt.renderable ? undefined : pubAttempt.reason,
+  };
+
+  const refAttempt = tryRenderPublic(characterBoundaryReferral);
+  const referralView: CrossInterfaceView = {
+    recall_interface: asString(characterBoundaryReferral.recall_interface),
+    render_surface: asString(characterBoundaryReferral.render_surface),
+    renderable_publicly: refAttempt.renderable,
+    rendered_text: refAttempt.renderable ? refAttempt.text : undefined,
+    reason: refAttempt.renderable ? undefined : refAttempt.reason,
+  };
+
+  const sameSeedFixture =
+    seedFixtureId.length > 0 &&
+    asString(operatorPrivate.source_seed_fixture) === seedFixtureId &&
+    asString(publicDiscord.source_seed_fixture) === seedFixtureId &&
+    asString(characterBoundaryReferral.source_seed_fixture) === seedFixtureId;
+
+  const sameContinuityActorInternal =
+    continuityActor.length > 0 &&
+    asString(operatorPrivate.continuity_actor_id) === continuityActor &&
+    asString(publicDiscord.continuity_actor_id) === continuityActor &&
+    asString(characterBoundaryReferral.continuity_actor_id) === continuityActor;
+
+  const differentAuthorizedViews =
+    operatorPrivateView.renderable_publicly !==
+      publicDiscordView.renderable_publicly &&
+    publicDiscordView.rendered_text !== referralView.rendered_text &&
+    publicDiscordView.rendered_text !== undefined &&
+    referralView.rendered_text !== undefined;
+
+  const publicOutputsNoLeak =
+    publicDiscordView.rendered_text !== undefined &&
+    referralView.rendered_text !== undefined &&
+    publicOutputHasNoLeak(publicDiscordView.rendered_text) &&
+    publicOutputHasNoLeak(referralView.rendered_text);
+
+  return {
+    seed_fixture_id: seedFixtureId,
+    continuity_actor_id_internal: continuityActor,
+    views: {
+      operator_private: operatorPrivateView,
+      public_discord: publicDiscordView,
+      character_boundary_referral: referralView,
+    },
+    proof: {
+      same_seed_fixture: sameSeedFixture,
+      same_continuity_actor_internal: sameContinuityActorInternal,
+      different_authorized_views: differentAuthorizedViews,
+      public_outputs_no_leak: publicOutputsNoLeak,
+    },
+  };
+}
+
+export function renderRecallWedgeCrossInterfaceDemo(
+  fixtures?: RecallWedgeFixtureBundle,
+): CrossInterfaceDemo {
+  return buildRecallWedgeCrossInterfaceDemo(fixtures);
+}


### PR DESCRIPTION
## Summary

Phase 33D adds a fixture-bound cross-interface Recall Wedge continuity demo for `freeside-characters`.

This PR proves the MVP boundary without live Discord, Dixie, Straylight, Finn, storage, admission, or LLM/voice integration.

The demo proves:

- same seed fixture across all projected views
- same internal continuity actor across seed + projected DTOs
- different authorized views
- operator-private view is not publicly renderable
- public Discord normal view renders through the Phase 33C public renderer
- character-boundary referral renders through the Phase 33C public renderer
- public normal output differs from referral output
- public rendered outputs contain no private/debug/source/actor identifiers

## Files

- `packages/persona-engine/src/recall-wedge/demo-cross-interface.ts`
- `packages/persona-engine/src/recall-wedge/demo-cross-interface.test.ts`
- `docs/recall-wedge/fixtures/projected-dto/public-discord-view.dto.json`
- `docs/recall-wedge/fixtures/projected-dto/character-boundary-referral.dto.json`
- `docs/recall-wedge/fixtures/validate-fixtures.mjs`
- `docs/recall-wedge/fixtures/README.md`

## Seed provenance hardening

This PR adds `source_seed_fixture: "shared-substrate-demo-001"` to the public Discord and character-boundary referral projected DTO fixtures.

The validator now requires every projected DTO to reference the seed fixture:

- operator-private
- public-discord
- character-boundary referral

The cross-interface demo’s `same_seed_fixture` proof is true only when all three projected DTOs reference the same seed fixture.

## Validation

Claude report:

- patched only Phase 33D demo/test plus fixture provenance/validator docs
- no package/lockfile changes
- no dependencies
- no Discord/Dixie/Straylight/Finn wiring
- no production storage
- no live admission
- no LLM/voice rewrite
- fixture validator: 30 passed, 0 failed
- recall-wedge tests: 80 passed, 0 failed
- typecheck grep found no `recall-wedge`, `render-public-recall`, or `demo-cross-interface` errors

Codex audit:

- VERDICT: ACCEPT
- no exact file/line concerns
- seed-provenance proof accepted
- continuity proof accepted
- public no-leak accepted
- fixture-bound/no-live-integration accepted
- test coverage accepted
- no overclaims found

Local validation before commit:

- `node docs/recall-wedge/fixtures/validate-fixtures.mjs`
  - 30 passed, 0 failed
- `cd packages/persona-engine && bun test src/recall-wedge/`
  - 80 passed, 0 failed
- `bun run typecheck 2>&1 | grep -E 'recall-wedge|render-public-recall|demo-cross-interface' || true`
  - no output

Note: repo-wide `bun run typecheck` still reports pre-existing unrelated workspace dependency/type errors outside Recall Wedge files.

## Non-goals

This PR intentionally does not add:

- Discord command wiring
- live Dixie client
- `@loa/straylight`
- `@loa/dixie`
- Finn integration
- production storage
- live Discord-to-memory admission
- LLM-based recall rewriting
- character-voiced recall summaries
- renderer registration into bot runtime
- production cross-user authorization
- production consent or identity binding

Phase 34A should be the final MVP acceptance handoff.
