### PR TITLE
Phase 35B feat(persona-engine): add Recall Wedge demo runner

### DIFF
--- a/packages/persona-engine/src/recall-wedge/run-demo.test.ts
+++ b/packages/persona-engine/src/recall-wedge/run-demo.test.ts
@@ -1,0 +1,318 @@
+// Phase 35B · explicit dev/operator Recall Wedge demo runner regression gate.
+//
+// Proves the runner module:
+//   1. invokes the existing fixture-bound cross-interface demo;
+//   2. exposes public rendered text from the Phase 33C public renderer
+//      via the public-discord and character-boundary referral sections;
+//   3. clearly separates internal proof data from public output;
+//   4. reports the operator-private view as not publicly renderable;
+//   5. never leaks banned private substrings into any public section;
+//   6. labels the internal proof section as INTERNAL / operator-only;
+//   7. introduces no Discord / Dixie / Straylight / Finn / storage /
+//      admission / LLM behavior.
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  buildRecallWedgeCrossInterfaceDemo,
+  loadRecallWedgeFixtures,
+} from "./demo-cross-interface.ts";
+import {
+  buildRecallWedgeDemoReport,
+  extractFormattedPublicSection,
+  formatRecallWedgeDemoReport,
+  INTERNAL_PROOF_HEADER,
+  NON_GOALS_HEADER,
+  PUBLIC_SECTION_HEADER_PREFIX,
+  RECALL_WEDGE_DEMO_REPORT_TITLE,
+  runRecallWedgeDemo,
+} from "./run-demo.ts";
+
+const PUBLIC_OUTPUT_BANNED_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+describe("buildRecallWedgeDemoReport · uses the existing cross-interface demo", () => {
+  const report = buildRecallWedgeDemoReport();
+  const referenceDemo = buildRecallWedgeCrossInterfaceDemo();
+
+  test("seed_fixture_id matches the cross-interface demo seed_fixture_id", () => {
+    expect(report.internal_proof.seed_fixture_id).toBe(
+      referenceDemo.seed_fixture_id,
+    );
+    expect(report.internal_proof.seed_fixture_id).toBe(
+      "shared-substrate-demo-001",
+    );
+  });
+
+  test("continuity_actor_id_internal matches the cross-interface demo", () => {
+    expect(report.internal_proof.continuity_actor_id_internal).toBe(
+      referenceDemo.continuity_actor_id_internal,
+    );
+    expect(report.internal_proof.continuity_actor_id_internal).toBe(
+      "freeside-characters:shared-substrate",
+    );
+  });
+
+  test("public-discord rendered text comes through verbatim from Phase 33C renderer", () => {
+    const referenceText = referenceDemo.views.public_discord.rendered_text;
+    expect(typeof referenceText).toBe("string");
+    expect(report.public_sections.public_discord.rendered_text).toBe(
+      referenceText as string,
+    );
+    expect(report.public_sections.public_discord.recall_interface).toBe(
+      "public_discord",
+    );
+    expect(report.public_sections.public_discord.render_surface).toBe(
+      "discord_public_character",
+    );
+    expect(report.public_sections.public_discord.rendered_text).toContain(
+      "[recall · public · ruggy · ok]",
+    );
+  });
+
+  test("character-boundary referral rendered text comes through verbatim from Phase 33C renderer", () => {
+    const referenceText =
+      referenceDemo.views.character_boundary_referral.rendered_text;
+    expect(typeof referenceText).toBe("string");
+    expect(
+      report.public_sections.character_boundary_referral.rendered_text,
+    ).toBe(referenceText as string);
+    expect(
+      report.public_sections.character_boundary_referral.rendered_text,
+    ).toContain("referral target: satoshi");
+  });
+
+  test("proof booleans match the underlying cross-interface demo", () => {
+    expect(report.internal_proof.proof).toEqual(referenceDemo.proof);
+    expect(report.internal_proof.proof.same_seed_fixture).toBe(true);
+    expect(report.internal_proof.proof.same_continuity_actor_internal).toBe(
+      true,
+    );
+    expect(report.internal_proof.proof.different_authorized_views).toBe(true);
+    expect(report.internal_proof.proof.public_outputs_no_leak).toBe(true);
+  });
+
+  test("accepts injected fixtures for deterministic test composition", () => {
+    const fixtures = loadRecallWedgeFixtures();
+    const injected = buildRecallWedgeDemoReport(fixtures);
+    expect(injected.internal_proof.seed_fixture_id).toBe(
+      "shared-substrate-demo-001",
+    );
+  });
+});
+
+describe("buildRecallWedgeDemoReport · operator-private view is not publicly renderable", () => {
+  const report = buildRecallWedgeDemoReport();
+
+  test("operator_private projection is reported as publicly_renderable=false", () => {
+    expect(report.internal_proof.operator_private_view.publicly_renderable).toBe(
+      false,
+    );
+    expect(report.internal_proof.operator_private_view.reason).toBe(
+      "operator_private_not_public_renderable",
+    );
+    expect(report.internal_proof.operator_private_view.recall_interface).toBe(
+      "operator_private",
+    );
+    expect(report.internal_proof.operator_private_view.render_surface).toBe(
+      "operator_debug",
+    );
+  });
+
+  test("public sections cover only public_discord and character_boundary_referral", () => {
+    const keys = Object.keys(report.public_sections).sort();
+    expect(keys).toEqual(
+      ["character_boundary_referral", "public_discord"].sort(),
+    );
+  });
+});
+
+describe("formatRecallWedgeDemoReport · structural separation", () => {
+  const report = buildRecallWedgeDemoReport();
+  const formatted = formatRecallWedgeDemoReport(report);
+
+  test("title section names the fixture-bound demo", () => {
+    expect(formatted).toContain(`# ${RECALL_WEDGE_DEMO_REPORT_TITLE}`);
+  });
+
+  test("includes a public-discord public section header", () => {
+    expect(formatted).toContain(
+      `## ${PUBLIC_SECTION_HEADER_PREFIX}public_discord`,
+    );
+  });
+
+  test("includes a character-boundary referral public section header", () => {
+    expect(formatted).toContain(
+      `## ${PUBLIC_SECTION_HEADER_PREFIX}character_boundary_referral`,
+    );
+  });
+
+  test("internal proof section is labeled INTERNAL / operator-only", () => {
+    expect(formatted).toContain(`## ${INTERNAL_PROOF_HEADER}`);
+    expect(formatted).toContain("INTERNAL / operator-only");
+  });
+
+  test("non-goals section enumerates the live integrations not present", () => {
+    expect(formatted).toContain(`## ${NON_GOALS_HEADER}`);
+    expect(formatted).toContain("no Discord");
+    expect(formatted).toContain("no live Dixie client");
+    expect(formatted).toContain("no live memory admission");
+    expect(formatted).toContain("no LLM / voice rewrite");
+  });
+
+  test("internal proof and public sections are textually distinct (proof appears after public sections)", () => {
+    const pubIdx = formatted.indexOf(
+      `## ${PUBLIC_SECTION_HEADER_PREFIX}public_discord`,
+    );
+    const refIdx = formatted.indexOf(
+      `## ${PUBLIC_SECTION_HEADER_PREFIX}character_boundary_referral`,
+    );
+    const internalIdx = formatted.indexOf(`## ${INTERNAL_PROOF_HEADER}`);
+    expect(pubIdx).toBeGreaterThan(-1);
+    expect(refIdx).toBeGreaterThan(pubIdx);
+    expect(internalIdx).toBeGreaterThan(refIdx);
+  });
+});
+
+describe("formatRecallWedgeDemoReport · public sections never leak private material", () => {
+  const report = buildRecallWedgeDemoReport();
+  const formatted = formatRecallWedgeDemoReport(report);
+  const publicSection = extractFormattedPublicSection(
+    formatted,
+    "public_discord",
+  );
+  const referralSection = extractFormattedPublicSection(
+    formatted,
+    "character_boundary_referral",
+  );
+
+  for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+    test(`public_discord public section contains no "${banned}"`, () => {
+      expect(publicSection.body).not.toContain(banned);
+    });
+    test(`character_boundary_referral public section contains no "${banned}"`, () => {
+      expect(referralSection.body).not.toContain(banned);
+    });
+  }
+
+  test("no public section line begins with actor:", () => {
+    for (const body of [publicSection.body, referralSection.body]) {
+      for (const line of body.split("\n")) {
+        expect(line.startsWith("actor:")).toBe(false);
+      }
+    }
+  });
+
+  test("public sections do not embed the operator-private summary", () => {
+    const fixtures = loadRecallWedgeFixtures();
+    const opSummary = String(
+      fixtures.operatorPrivate.operator_private_summary ?? "",
+    );
+    expect(opSummary.length).toBeGreaterThan(0);
+    expect(publicSection.body).not.toContain(opSummary);
+    expect(referralSection.body).not.toContain(opSummary);
+  });
+
+  test("public sections never include the internal continuity actor id", () => {
+    const internalActor = report.internal_proof.continuity_actor_id_internal;
+    expect(publicSection.body).not.toContain(internalActor);
+    expect(referralSection.body).not.toContain(internalActor);
+  });
+
+  test("public sections never include the seed_fixture_id (internal proof field)", () => {
+    const seedId = report.internal_proof.seed_fixture_id;
+    expect(publicSection.body).not.toContain(seedId);
+    expect(referralSection.body).not.toContain(seedId);
+  });
+});
+
+describe("runRecallWedgeDemo · invocation surface", () => {
+  test("returns the report and formatted text without printing by default", () => {
+    const printed: string[] = [];
+    const result = runRecallWedgeDemo({
+      print: (line) => printed.push(line),
+    });
+    expect(result.report.title).toBe(RECALL_WEDGE_DEMO_REPORT_TITLE);
+    expect(typeof result.formatted).toBe("string");
+    expect(result.formatted.length).toBeGreaterThan(0);
+    expect(printed.length).toBe(1);
+    expect(printed[0]).toBe(result.formatted);
+  });
+
+  test("does not print when no print sink is provided", () => {
+    const result = runRecallWedgeDemo();
+    expect(result.report.title).toBe(RECALL_WEDGE_DEMO_REPORT_TITLE);
+    expect(result.formatted).toContain(`# ${RECALL_WEDGE_DEMO_REPORT_TITLE}`);
+  });
+
+  test("formatted output is deterministic across invocations", () => {
+    const a = runRecallWedgeDemo().formatted;
+    const b = runRecallWedgeDemo().formatted;
+    expect(a).toBe(b);
+  });
+});
+
+describe("runRecallWedgeDemo · no live integration surface", () => {
+  // Static-source guards: the runner must not introduce Discord / Dixie /
+  // Straylight / Finn / storage / admission / LLM imports. The cross-
+  // interface demo it composes is fixture-bound and so is this runner.
+  const moduleSource = (() => {
+    // Read the source from disk via the same fileURLToPath trick the demo
+    // uses elsewhere — keeps the assertion close to the file under test.
+    // Lazy import so test discovery is unaffected.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    const { dirname, resolve } = require("node:path") as typeof import("node:path");
+    const { fileURLToPath } = require("node:url") as typeof import("node:url");
+    const here = dirname(fileURLToPath(import.meta.url));
+    return readFileSync(resolve(here, "run-demo.ts"), "utf8");
+  })();
+
+  // These guards check actual `from "..."` import specifiers — they are
+  // intentionally narrower than substring matching because the file's
+  // header comment legitimately *names* the integrations it omits.
+
+  test("runner source imports no Discord client", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*discord-interactions[^"']*["']/,
+    );
+  });
+
+  test("runner source imports no Dixie / Straylight / Finn", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+  });
+
+  test("runner source does not call an LLM SDK", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test("runner source does not pull in pg / production storage", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+  });
+
+  test("runner source does not register or dispatch Discord commands", () => {
+    expect(moduleSource).not.toMatch(/registerCommand\s*\(/);
+    expect(moduleSource).not.toMatch(/applicationCommands/);
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/run-demo.ts
+++ b/packages/persona-engine/src/recall-wedge/run-demo.ts
@@ -1,0 +1,256 @@
+// Phase 35B · explicit dev/operator Recall Wedge demo runner.
+//
+// Operator ergonomics over the accepted Phase 33D fixture-bound proof
+// (docs/RECALL-WEDGE-MVP-ACCEPTANCE.md, docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+// §9). This module:
+//
+//   1. invokes the existing fixture-bound cross-interface demo
+//      (`buildRecallWedgeCrossInterfaceDemo`);
+//   2. produces a deterministic, operator-readable report that visibly
+//      separates public rendered text from internal proof data;
+//   3. never copies internal proof fields into public-rendered sections;
+//   4. surfaces the proof booleans (same_seed_fixture,
+//      same_continuity_actor_internal, different_authorized_views,
+//      public_outputs_no_leak) in an explicitly INTERNAL / operator-only
+//      section;
+//   5. records that the operator-private projection is not publicly
+//      renderable;
+//   6. emits the public-discord and character-boundary referral
+//      rendered text verbatim from the Phase 33C public renderer.
+//
+// Hard non-goals (per Phase 35B brief and the post-MVP decision map):
+// no Discord wiring, no command registration, no Discord API call, no
+// production / public API surface, no live Dixie client, no Straylight
+// admission, no Finn integration, no production storage, no live memory
+// admission, no LLM/voice rewrite. Fixture-bound and deterministic.
+
+import {
+  buildRecallWedgeCrossInterfaceDemo,
+  loadRecallWedgeFixtures,
+  type CrossInterfaceDemo,
+  type RecallWedgeFixtureBundle,
+} from "./demo-cross-interface.ts";
+
+const NON_GOALS = [
+  "no Discord client / command registration / Discord API call",
+  "no live Dixie client",
+  "no @loa/straylight or @loa/dixie integration",
+  "no Finn runtime",
+  "no production storage",
+  "no live memory admission",
+  "no LLM / voice rewrite",
+] as const;
+
+export interface RecallWedgeDemoPublicSection {
+  readonly view_id: "public_discord" | "character_boundary_referral";
+  readonly recall_interface: string;
+  readonly render_surface: string;
+  readonly rendered_text: string;
+}
+
+export interface RecallWedgeDemoInternalProof {
+  readonly seed_fixture_id: string;
+  readonly continuity_actor_id_internal: string;
+  readonly operator_private_view: {
+    readonly recall_interface: string;
+    readonly render_surface: string;
+    readonly publicly_renderable: false;
+    readonly reason: string;
+  };
+  readonly proof: CrossInterfaceDemo["proof"];
+}
+
+export interface RecallWedgeDemoReport {
+  readonly title: string;
+  readonly public_sections: {
+    readonly public_discord: RecallWedgeDemoPublicSection;
+    readonly character_boundary_referral: RecallWedgeDemoPublicSection;
+  };
+  readonly internal_proof: RecallWedgeDemoInternalProof;
+  readonly non_goals: readonly string[];
+}
+
+export const RECALL_WEDGE_DEMO_REPORT_TITLE =
+  "Recall Wedge fixture-bound demo" as const;
+
+export const PUBLIC_SECTION_HEADER_PREFIX =
+  "Public rendered output: " as const;
+
+export const INTERNAL_PROOF_HEADER =
+  "Internal proof summary [INTERNAL / operator-only]" as const;
+
+export const NON_GOALS_HEADER =
+  "Non-goals / live integration not present" as const;
+
+function requireRenderedText(
+  view: CrossInterfaceDemo["views"]["public_discord"],
+  label: string,
+): string {
+  const text = view.rendered_text;
+  if (typeof text !== "string" || text.length === 0) {
+    throw new Error(
+      `recall-wedge run-demo: expected ${label} to be publicly renderable, got reason="${
+        view.reason ?? "unknown"
+      }"`,
+    );
+  }
+  return text;
+}
+
+export function buildRecallWedgeDemoReport(
+  fixtures: RecallWedgeFixtureBundle = loadRecallWedgeFixtures(),
+): RecallWedgeDemoReport {
+  const demo = buildRecallWedgeCrossInterfaceDemo(fixtures);
+
+  const publicDiscord: RecallWedgeDemoPublicSection = {
+    view_id: "public_discord",
+    recall_interface: demo.views.public_discord.recall_interface,
+    render_surface: demo.views.public_discord.render_surface,
+    rendered_text: requireRenderedText(
+      demo.views.public_discord,
+      "public_discord",
+    ),
+  };
+
+  const referral: RecallWedgeDemoPublicSection = {
+    view_id: "character_boundary_referral",
+    recall_interface: demo.views.character_boundary_referral.recall_interface,
+    render_surface: demo.views.character_boundary_referral.render_surface,
+    rendered_text: requireRenderedText(
+      demo.views.character_boundary_referral,
+      "character_boundary_referral",
+    ),
+  };
+
+  const internalProof: RecallWedgeDemoInternalProof = {
+    seed_fixture_id: demo.seed_fixture_id,
+    continuity_actor_id_internal: demo.continuity_actor_id_internal,
+    operator_private_view: {
+      recall_interface: demo.views.operator_private.recall_interface,
+      render_surface: demo.views.operator_private.render_surface,
+      publicly_renderable: false,
+      reason:
+        demo.views.operator_private.reason ??
+        "operator_private_not_public_renderable",
+    },
+    proof: demo.proof,
+  };
+
+  return {
+    title: RECALL_WEDGE_DEMO_REPORT_TITLE,
+    public_sections: {
+      public_discord: publicDiscord,
+      character_boundary_referral: referral,
+    },
+    internal_proof: internalProof,
+    non_goals: NON_GOALS,
+  };
+}
+
+function formatPublicSection(section: RecallWedgeDemoPublicSection): string {
+  return [
+    `## ${PUBLIC_SECTION_HEADER_PREFIX}${section.view_id}`,
+    section.rendered_text,
+  ].join("\n");
+}
+
+function formatInternalProof(proof: RecallWedgeDemoInternalProof): string {
+  const lines: string[] = [
+    `## ${INTERNAL_PROOF_HEADER}`,
+    "the fields below are operator-only and must not be relayed to any",
+    "public surface; they are surfaced here for operator inspection of",
+    "the accepted MVP proof",
+    "",
+    `seed_fixture_id (internal): ${proof.seed_fixture_id}`,
+    `continuity_actor_id_internal (internal): ${proof.continuity_actor_id_internal}`,
+    "",
+    "operator_private projection:",
+    `  recall_interface: ${proof.operator_private_view.recall_interface}`,
+    `  render_surface:   ${proof.operator_private_view.render_surface}`,
+    `  publicly_renderable: ${String(
+      proof.operator_private_view.publicly_renderable,
+    )}`,
+    `  reason: ${proof.operator_private_view.reason}`,
+    "",
+    "proof booleans:",
+    `  same_seed_fixture:              ${String(proof.proof.same_seed_fixture)}`,
+    `  same_continuity_actor_internal: ${String(
+      proof.proof.same_continuity_actor_internal,
+    )}`,
+    `  different_authorized_views:     ${String(
+      proof.proof.different_authorized_views,
+    )}`,
+    `  public_outputs_no_leak:         ${String(
+      proof.proof.public_outputs_no_leak,
+    )}`,
+  ];
+  return lines.join("\n");
+}
+
+function formatNonGoals(nonGoals: readonly string[]): string {
+  const lines: string[] = [`## ${NON_GOALS_HEADER}`];
+  for (const item of nonGoals) lines.push(`- ${item}`);
+  return lines.join("\n");
+}
+
+export function formatRecallWedgeDemoReport(
+  report: RecallWedgeDemoReport,
+): string {
+  return [
+    `# ${report.title}`,
+    formatPublicSection(report.public_sections.public_discord),
+    formatPublicSection(report.public_sections.character_boundary_referral),
+    formatInternalProof(report.internal_proof),
+    formatNonGoals(report.non_goals),
+  ].join("\n\n");
+}
+
+export interface ExtractedPublicSection {
+  readonly header: string;
+  readonly body: string;
+}
+
+// Locate a single public section's body inside a formatted report. Stops at
+// the next "## " header or end-of-report. Used by tests to verify that no
+// banned substring appears inside any public section.
+export function extractFormattedPublicSection(
+  formatted: string,
+  view_id: RecallWedgeDemoPublicSection["view_id"],
+): ExtractedPublicSection {
+  const header = `## ${PUBLIC_SECTION_HEADER_PREFIX}${view_id}`;
+  const headerIdx = formatted.indexOf(header);
+  if (headerIdx < 0) {
+    throw new Error(
+      `recall-wedge run-demo: public section header not found for ${view_id}`,
+    );
+  }
+  const afterHeader = formatted.slice(headerIdx + header.length);
+  const nextHeaderRel = afterHeader.search(/\n## /);
+  const body =
+    nextHeaderRel < 0
+      ? afterHeader.trimStart()
+      : afterHeader.slice(0, nextHeaderRel).trimStart();
+  return { header, body };
+}
+
+export interface RunRecallWedgeDemoOptions {
+  readonly fixtures?: RecallWedgeFixtureBundle;
+  readonly print?: (line: string) => void;
+}
+
+export function runRecallWedgeDemo(
+  options: RunRecallWedgeDemoOptions = {},
+): { readonly report: RecallWedgeDemoReport; readonly formatted: string } {
+  const report = buildRecallWedgeDemoReport(options.fixtures);
+  const formatted = formatRecallWedgeDemoReport(report);
+  if (options.print) options.print(formatted);
+  return { report, formatted };
+}
+
+const isCli =
+  typeof import.meta !== "undefined" &&
+  (import.meta as { main?: boolean }).main === true;
+
+if (isCli) {
+  runRecallWedgeDemo({ print: (line) => console.log(line) });
+}


### PR DESCRIPTION
## Summary

Phase 35B adds an explicit dev/operator Recall Wedge demo runner for `freeside-characters`.

This PR makes the accepted fixture-bound Recall Wedge proof runnable and inspectable without adding Discord command work, live Dixie, production storage, memory admission, or character voice.

The runner:

- composes the existing cross-interface Recall Wedge demo
- formats deterministic operator-readable output
- clearly separates public rendered output from internal proof data
- reports proof booleans for the accepted fixture-bound proof
- shows operator-private is not publicly renderable
- shows public Discord normal output
- shows character-boundary referral output
- remains local/dev/operator only

## Files

- `packages/persona-engine/src/recall-wedge/run-demo.ts`
- `packages/persona-engine/src/recall-wedge/run-demo.test.ts`

## Scope boundaries

This PR intentionally does not add:

- package or lockfile changes
- dependencies
- `apps/bot/src/discord-interactions/*`
- Discord command registration
- Discord API usage
- delivery path changes
- production/public API surface
- live Dixie client
- `@loa/straylight`
- `@loa/dixie`
- Finn integration
- production storage
- live memory admission
- LLM or character-voice rewrite
- bot runtime registration

## Public/internal separation

The formatted report separates:

- public rendered output sections
- internal proof summary marked `INTERNAL / operator-only`

Public sections contain only text produced by the Phase 33C public renderer. Internal proof booleans, seed fixture IDs, and internal continuity actor IDs are kept in the internal/operator-only section.

## Validation

Claude report:

- added only the two Phase 35B runner files
- no package/lockfile/Discord/Dixie/storage/admission/voice changes
- fixture validator: 30 passed, 0 failed
- recall-wedge tests: 134 passed, 0 failed
- typecheck grep found no `recall-wedge`, `render-public-recall`, `demo-cross-interface`, or `run-demo` diagnostics

Codex audit:

- VERDICT: ACCEPT
- no exact file/line concerns
- scope accepted
- runner behavior accepted
- public/internal separation accepted
- public no-leak accepted
- side-effect/CLI behavior accepted
- test coverage accepted
- no overclaims found

Local validation before commit:

- `node docs/recall-wedge/fixtures/validate-fixtures.mjs`
  - 30 passed, 0 failed
- `cd packages/persona-engine && bun test src/recall-wedge/`
  - 134 passed, 0 failed
- `bun run typecheck 2>&1 | grep -E 'recall-wedge|render-public-recall|demo-cross-interface|run-demo' || true`
  - no output

Note: repo-wide `bun run typecheck` still reports pre-existing unrelated workspace dependency/type errors outside Recall Wedge files.
