### PR TITLE
feat(events): NATS mint-event subscriber + bot boot wire — cluster-events-pillar-v1 DEP-1

### DIFF
--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -382,6 +382,27 @@ async function main(): Promise<void> {
           `kansei-router=stub (DEP-1 · DEP-2 will wire real routing)`,
       );
     } catch (err) {
+      // BB#105 rd-3 F-001 HIGH: distinguish JWKS-init failures (operator
+      // configured verification; misconfig is meaningful) from other
+      // subscriber failures (NATS broker down, network blip — bot can
+      // still serve cron + interactions). The events-subscriber lib's
+      // rd-1 throw on JWKS init reached HERE but was previously swallowed
+      // unconditionally, hiding the misconfig.
+      //
+      // Posture:
+      //   JWKS_URL set + subscriber throws → fail loud (process.exit(1)).
+      //     Operator opted into verification; refusing to silently disable.
+      //   JWKS_URL unset → log + continue. Subscriber failure is unexpected
+      //     but the bot's other functions (cron digests, weaver, Discord
+      //     interactions) are independent and shouldn't take a hard outage.
+      if (process.env.JWKS_URL?.trim()) {
+        console.error(
+          'events: JWKS_URL was configured but subscriber startup failed — refusing to boot the bot. ' +
+            'Fix JWKS reachability or unset JWKS_URL to fall back to dev verifier (every sig surfaces as invalid).',
+          err,
+        );
+        process.exit(1);
+      }
       console.error('events: failed to start NATS subscriber (bot continues without it):', err);
       mintEventSubscriber = null;
     }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -50,6 +50,11 @@ import {
 import { pgPoolBuilder } from './lib/pg-pool-builder.ts';
 import type { WorldManifestQuestSubset } from './world-resolver.ts';
 import { publishCommands } from './lib/publish-commands.ts';
+import {
+  startMintEventSubscriber,
+  createKanseiRouterStub,
+  type MintEventSubscriberHandle,
+} from '@freeside-characters/persona-engine/events/mint-event-subscriber';
 import pkg from '../package.json' with { type: 'json' };
 
 const banner = `─── freeside-characters bot · v${pkg.version} ────────────────────────`;
@@ -340,6 +345,52 @@ async function main(): Promise<void> {
   if (handle.popInExpression) console.log(`${primary.id}: pop-in cron · ${handle.popInExpression}`);
   if (handle.weaverExpression) console.log(`${primary.id}: weaver cron · ${handle.weaverExpression}`);
 
+  // ─── Cross-cell NATS mint-event subscriber (cluster-events-pillar DEP-1) ───
+  // Subscribes to `nft.mint.detected.>` published by sonar-api, verifies each
+  // ACVP envelope (sig + hash-chain + payload-schema), and hands the typed
+  // payload to a kansei router. DEP-1 ships a STUB router that always returns
+  // { announce: false } — DEP-2 wires the real threshold-based router + the
+  // Discord channel announcement.
+  //
+  // Gated on NATS_URL being set so the bot still boots cleanly without NATS
+  // (e.g. local dev without the cluster broker). When absent, we log a warn
+  // and skip rather than crash — keeps the substrate optional during rollout.
+  let mintEventSubscriber: MintEventSubscriberHandle | null = null;
+  const natsUrl = process.env.NATS_URL?.trim();
+  if (natsUrl) {
+    try {
+      const subscriberLogger = {
+        info: (obj: unknown, msg?: string) => console.log(msg ?? '[events]', JSON.stringify(obj)),
+        warn: (obj: unknown, msg?: string) => console.warn(msg ?? '[events]', JSON.stringify(obj)),
+        error: (obj: unknown, msg?: string) => console.error(msg ?? '[events]', JSON.stringify(obj)),
+      };
+      mintEventSubscriber = await startMintEventSubscriber({
+        natsUrl,
+        natsTlsCa: process.env.NATS_TLS_CA?.trim() || undefined,
+        jwksUrl: process.env.JWKS_URL?.trim() || undefined,
+        // kansei stub — DEP-2 will wire real routing.
+        kanseiRouter: createKanseiRouterStub(subscriberLogger),
+        logger: subscriberLogger,
+        initialPrevHashPolicy: (process.env.MINT_EVENT_INITIAL_ANCHOR_POLICY?.trim() as
+          | 'any'
+          | 'genesis'
+          | undefined) ?? 'any',
+      });
+      console.log(
+        `events:         NATS subscriber wired · subject=nft.mint.detected.> · ` +
+          `jwks=${process.env.JWKS_URL ? 'configured' : 'DEV (sigs surface as invalid)'} · ` +
+          `kansei-router=stub (DEP-1 · DEP-2 will wire real routing)`,
+      );
+    } catch (err) {
+      console.error('events: failed to start NATS subscriber (bot continues without it):', err);
+      mintEventSubscriber = null;
+    }
+  } else {
+    console.log(
+      'events:         DISABLED (set NATS_URL to enable cross-cell mint subscriber)',
+    );
+  }
+
   // V0.7-A.0: Discord Interactions endpoint for slash commands.
   // Disjoint from digest cron — failure here doesn't affect Pattern B writes.
   let interactionServer: InteractionServerHandle | null = null;
@@ -370,6 +421,7 @@ async function main(): Promise<void> {
     console.log(`${primary.id}: manual mode — exiting after single fire`);
     handle.stop();
     interactionServer?.stop();
+    if (mintEventSubscriber) await mintEventSubscriber.stop();
     await shutdownClient();
     process.exit(0);
   }
@@ -378,6 +430,13 @@ async function main(): Promise<void> {
     console.log(`\n${primary.id}: ${signal} — shutting down`);
     handle.stop();
     interactionServer?.stop();
+    if (mintEventSubscriber) {
+      try {
+        await mintEventSubscriber.stop();
+      } catch (err) {
+        console.warn('events: subscriber stop error during shutdown:', err);
+      }
+    }
     await shutdownClient();
     process.exit(0);
   };

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/bot": {
       "name": "@freeside-characters/bot",
-      "version": "0.8.0",
+      "version": "0.12.0",
       "dependencies": {
         "@0xhoneyjar/quests-discord-renderer": "^0.1.2",
         "@0xhoneyjar/quests-engine": "^0.1.2",
@@ -37,11 +37,15 @@
     },
     "packages/persona-engine": {
       "name": "@freeside-characters/persona-engine",
-      "version": "0.8.0",
+      "version": "0.12.0",
       "dependencies": {
+        "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#0948a5344b21aef6a7ba7ce6e39a9258994638c0",
         "@0xhoneyjar/medium-registry": "^0.2.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.122",
         "@aws-sdk/client-bedrock-runtime": "^3.1048.0",
+        "@effect/schema": "^0.75.0",
+        "@noble/curves": "^1.7.0",
+        "@noble/hashes": "^1.6.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
@@ -51,8 +55,10 @@
         "@opentelemetry/semantic-conventions": "^1.41.1",
         "@raindrop-ai/bedrock": "^0.0.3",
         "@raindrop-ai/claude-agent-sdk": "^0.0.13",
+        "canonicalize": "^2.0.0",
         "discord.js": "^14.16.3",
         "effect": "^3.21.2",
+        "nats": "^2.28.0",
         "node-cron": "^3.0.3",
         "pg": "^8.20.0",
         "yaml": "^2.9.0",
@@ -65,13 +71,15 @@
     },
     "packages/protocol": {
       "name": "@freeside-characters/protocol",
-      "version": "0.8.0",
+      "version": "0.12.0",
       "dependencies": {
         "zod": "^3.24.1",
       },
     },
   },
   "packages": {
+    "@0xhoneyjar/events": ["loa-freeside@github:0xHoneyJar/loa-freeside#0948a53", { "dependencies": { "aws-embedded-metrics": "^4.2.1" } }, "0xHoneyJar-loa-freeside-0948a53", "sha512-W1d4fsZReIo5xGDKqpOhgu0PYL036zhDPkzt0c6DtEiMEmh9ImXJCahmT3Xg0LosZRV/CYzRLz0ATYfwCbl+OA=="],
+
     "@0xhoneyjar/medium-registry": ["@0xhoneyjar/medium-registry@0.2.0", "", { "peerDependencies": { "effect": "^3.10.0" } }, "sha512-A7Kpd8UjfymCzQ6Gdod8ZcGn2LvWmgaksYhiY8M3RpUWAziJ/0VSc0SBG7PLt5dCwtWdf0xiOLG3TPJ5qitIqw=="],
 
     "@0xhoneyjar/quests-discord-renderer": ["@0xhoneyjar/quests-discord-renderer@0.1.2", "", { "dependencies": { "@0xhoneyjar/quests-engine": "^0.1.2", "@0xhoneyjar/quests-protocol": "^0.1.2" }, "peerDependencies": { "discord-api-types": "^0.37.0", "effect": "^3.10.0" } }, "sha512-1X8XALTMs825xEzdE5e6fpj0vjILzn/r4w1PA8OcGk8ihCKFszXa0DikmZ2N+bE5SicX0ie5J20MxBeNmVN9yA=="],
@@ -152,6 +160,8 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
+    "@datastructures-js/heap": ["@datastructures-js/heap@4.3.7", "", {}, "sha512-Dx4un7Uj0dVxkfoq4RkpzsY2OrvNJgQYZ3n3UlGdl88RxxdHd7oTi21/l3zoxUUe0sXFuNUrfmWqlHzqnoN6Ug=="],
+
     "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
 
     "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
@@ -163,6 +173,8 @@
     "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
+    "@effect/schema": ["@effect/schema@0.75.5", "", { "dependencies": { "fast-check": "^3.21.0" }, "peerDependencies": { "effect": "^3.9.2" } }, "sha512-TQInulTVCuF+9EIbJpyLP6dvxbQJMphrnRqgexm/Ze39rSjfhJuufF7XvU3SxTgg3HnL7B/kpORTJbHhlE6thw=="],
 
     "@freeside-characters/bot": ["@freeside-characters/bot@workspace:apps/bot"],
 
@@ -185,6 +197,10 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
@@ -322,6 +338,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "aws-embedded-metrics": ["aws-embedded-metrics@4.2.1", "", { "dependencies": { "@datastructures-js/heap": "^4.0.2" } }, "sha512-uzydBXlGQVTB2sZ9ACCQZM3y0u4wdvxxRKFL9LP6RdfI2GcOrCcAsz65UKQvX9iagxFhah322VvvatgP8E7MIg=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
@@ -333,6 +351,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "canonicalize": ["canonicalize@2.1.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
@@ -474,7 +494,11 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
 
     "node-cron": ["node-cron@3.0.3", "", { "dependencies": { "uuid": "8.3.2" } }, "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A=="],
 
@@ -577,6 +601,8 @@
     "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "bash scripts/fixup-events-bun.sh && (cd packages/persona-engine && bash ../../scripts/rebuild-events-dist.sh)",
     "dev": "bun run --cwd apps/bot dev",
     "start": "bun run --cwd apps/bot start",
     "build": "bun run --cwd apps/bot build",

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -19,14 +19,20 @@
     "./compose/voice-memory": "./src/compose/voice-memory.ts",
     "./preview": "./src/preview/index.ts",
     "./observability/otel-test": "./src/observability/otel-test.ts",
-    "./observability/otel-layer": "./src/observability/otel-layer.ts"
+    "./observability/otel-layer": "./src/observability/otel-layer.ts",
+    "./events/mint-event-subscriber": "./src/events/mint-event-subscriber.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {
+    "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#0948a5344b21aef6a7ba7ce6e39a9258994638c0",
     "@0xhoneyjar/medium-registry": "^0.2.0",
+    "@effect/schema": "^0.75.0",
+    "@noble/curves": "^1.7.0",
+    "@noble/hashes": "^1.6.0",
+    "canonicalize": "^2.0.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.122",
     "@aws-sdk/client-bedrock-runtime": "^3.1048.0",
     "@opentelemetry/api": "^1.9.1",
@@ -40,6 +46,7 @@
     "@raindrop-ai/claude-agent-sdk": "^0.0.13",
     "discord.js": "^14.16.3",
     "effect": "^3.21.2",
+    "nats": "^2.28.0",
     "node-cron": "^3.0.3",
     "pg": "^8.20.0",
     "yaml": "^2.9.0",

--- a/packages/persona-engine/src/events/mint-event-subscriber.test.ts
+++ b/packages/persona-engine/src/events/mint-event-subscriber.test.ts
@@ -1,0 +1,420 @@
+/**
+ * mint-event-subscriber.test.ts — DEP-1 tests
+ *
+ * Verifies the subscriber's contract against the @0xhoneyjar/events library:
+ *   1. Subscriber starts at boot (returns a working stop() handle).
+ *   2. Valid envelope → kansei.route called with typed payload + event_type.
+ *   3. Broken-sig envelope → onVerificationFailure with reason 'signature-invalid'.
+ *   4. Schema-invalid payload → reason 'payload-schema-invalid'.
+ *   5. Subscriber stays alive after kansei throws.
+ *
+ * Uses an in-memory FakeNats mirroring the shape from the library's own
+ * roundtrip.test.ts. The subscriber is exercised directly via subscribeEnvelope
+ * (because startMintEventSubscriber calls `connect()` against a real socket);
+ * the logger + router stubs are spies we assert against. This isolates the
+ * DEP-1 contract surface (kansei wiring + verification-failure surfacing)
+ * from the NATS connect path which is integration-tested upstream.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  publishEnvelope,
+  InMemoryPrevHashStore,
+  LocalEd25519Signer,
+  StaticPubkeyVerifier,
+  subscribeEnvelope,
+  nftMintDetectedTopic,
+  NftMintDetectedSchema,
+  type NftMintDetected,
+  type EventEnvelope,
+} from '@0xhoneyjar/events';
+
+import {
+  createKanseiRouterStub,
+  type KanseiRouter,
+  type MintEventSubscriberLogger,
+} from './mint-event-subscriber.ts';
+
+// ── FakeNats (mirrors @0xhoneyjar/events/tests/roundtrip.test.ts) ─────────────
+
+interface FakeMessage {
+  subject: string;
+  data: Uint8Array;
+}
+
+class FakeNats {
+  #queues = new Map<string, FakeMessage[]>();
+  #waiters = new Map<string, Array<(msg: FakeMessage) => void>>();
+  #subscriptions = new Set<string>();
+
+  publish(subject: string, data: Uint8Array): void {
+    const msg: FakeMessage = { subject, data };
+    for (const sub of this.#subscriptions) {
+      if (subjectMatches(sub, subject)) {
+        const waiters = this.#waiters.get(sub);
+        if (waiters && waiters.length > 0) {
+          const resolve = waiters.shift()!;
+          resolve(msg);
+        } else {
+          const q = this.#queues.get(sub) ?? [];
+          q.push(msg);
+          this.#queues.set(sub, q);
+        }
+      }
+    }
+  }
+
+  subscribe(subject: string): AsyncIterable<FakeMessage> & { unsubscribe: () => void } {
+    this.#subscriptions.add(subject);
+    let cancelled = false;
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          if (cancelled) return { value: undefined as unknown as FakeMessage, done: true as const };
+          const q = this.#queues.get(subject) ?? [];
+          if (q.length > 0) {
+            const m = q.shift()!;
+            this.#queues.set(subject, q);
+            return { value: m, done: false as const };
+          }
+          return new Promise<{ value: FakeMessage; done: false }>((resolve) => {
+            const waiters = this.#waiters.get(subject) ?? [];
+            waiters.push((m) => resolve({ value: m, done: false as const }));
+            this.#waiters.set(subject, waiters);
+          });
+        },
+      }),
+      unsubscribe: () => {
+        cancelled = true;
+        this.#subscriptions.delete(subject);
+      },
+    };
+  }
+}
+
+function subjectMatches(pattern: string, subject: string): boolean {
+  if (pattern === subject) return true;
+  if (pattern.endsWith('>')) return subject.startsWith(pattern.slice(0, -1));
+  return false;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_PAYLOAD: NftMintDetected = {
+  chain_id: 80094,
+  contract: '0x048327a187b944ddac61c6e202bfccd20d17c008',
+  token_id: '234',
+  minter: '0x000000000000000000000000000000000000abcd',
+  block_number: 12345678,
+  transaction_hash: '0x' + 'ab'.repeat(32),
+  timestamp: '2026-05-26T21:30:00Z',
+};
+
+async function buildSigner() {
+  const signer = await LocalEd25519Signer.fromSeedHex('0'.repeat(64), 'sonar-api-1');
+  const verifier = new StaticPubkeyVerifier().add('sonar-api-1', signer.publicKeyBytes());
+  return { signer, verifier };
+}
+
+async function tick(ms = 10): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+function makeSpyLogger(): MintEventSubscriberLogger & {
+  infos: Array<{ obj: unknown; msg?: string }>;
+  warns: Array<{ obj: unknown; msg?: string }>;
+  errors: Array<{ obj: unknown; msg?: string }>;
+} {
+  const infos: Array<{ obj: unknown; msg?: string }> = [];
+  const warns: Array<{ obj: unknown; msg?: string }> = [];
+  const errors: Array<{ obj: unknown; msg?: string }> = [];
+  return {
+    info: (obj, msg) => infos.push({ obj, msg }),
+    warn: (obj, msg) => warns.push({ obj, msg }),
+    error: (obj, msg) => errors.push({ obj, msg }),
+    infos,
+    warns,
+    errors,
+  };
+}
+
+function makeSpyRouter(
+  routeImpl?: (input: { eventType: string; payload: NftMintDetected }) => Promise<{ announce: boolean; channelId?: string }>,
+): KanseiRouter & { calls: Array<{ eventType: string; payload: NftMintDetected }> } {
+  const calls: Array<{ eventType: string; payload: NftMintDetected }> = [];
+  return {
+    route: async (input) => {
+      calls.push(input);
+      if (routeImpl) return routeImpl(input);
+      return { announce: false };
+    },
+    calls,
+  };
+}
+
+/**
+ * Bridge used by tests: mirror the production subscriber's contract using
+ * subscribeEnvelope + the FakeNats. This factors out the NATS-connect path
+ * (which requires a real socket) while exercising the SAME handler +
+ * onVerificationFailure wiring that startMintEventSubscriber sets up.
+ */
+async function startSubscriberWithFakeNats(opts: {
+  nats: FakeNats;
+  verifier: StaticPubkeyVerifier;
+  router: KanseiRouter;
+  logger: MintEventSubscriberLogger;
+  subject?: string;
+}) {
+  const subject = opts.subject ?? 'nft.mint.detected.>';
+  const handle = await subscribeEnvelope({
+    nats: opts.nats,
+    subject,
+    schema: NftMintDetectedSchema,
+    verifier: opts.verifier,
+    chainStore: new InMemoryPrevHashStore(),
+    initialPrevHashPolicy: 'any',
+    handler: async ({ payload, envelope, subject: delivered }) => {
+      try {
+        const decision = await opts.router.route({
+          eventType: envelope.event_type,
+          payload,
+        });
+        opts.logger.info(
+          {
+            subject: delivered,
+            tokenId: payload.token_id,
+            contract: payload.contract,
+            chainId: payload.chain_id,
+            announce: decision.announce,
+            channelId: decision.channelId ?? null,
+          },
+          '[events-subscriber] mint routed',
+        );
+      } catch (err) {
+        opts.logger.error(
+          { err, subject: delivered },
+          '[events-subscriber] kansei router threw',
+        );
+      }
+    },
+    onVerificationFailure: (reason, detail) => {
+      opts.logger.warn(
+        {
+          reason,
+          subject: detail.subject,
+          emitted_by: detail.envelope?.emitted_by,
+          signing_key_id: detail.envelope?.signing_key_id,
+          error: detail.error ? String(detail.error).slice(0, 200) : undefined,
+        },
+        '[events-subscriber] envelope verification failed',
+      );
+    },
+  });
+  return {
+    stop: async () => {
+      handle.unsubscribe();
+    },
+  };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('DEP-1 · mint-event-subscriber', () => {
+  test('1. starts and returns a working stop() handle', async () => {
+    const nats = new FakeNats();
+    const { verifier } = await buildSigner();
+    const router = makeSpyRouter();
+    const logger = makeSpyLogger();
+
+    const sub = await startSubscriberWithFakeNats({ nats, verifier, router, logger });
+
+    expect(typeof sub.stop).toBe('function');
+    expect(router.calls.length).toBe(0);
+
+    await sub.stop();
+    // stop() must be safely re-callable (idempotent for our purposes)
+    await sub.stop();
+  });
+
+  test('2. valid envelope → kansei.route invoked with typed payload + event_type; logger.info "mint routed"', async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const router = makeSpyRouter();
+    const logger = makeSpyLogger();
+    const subject = nftMintDetectedTopic({ collectionSlug: 'mibera-shadow' });
+
+    const sub = await startSubscriberWithFakeNats({ nats, verifier, router, logger });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: 'sonar-api',
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await tick();
+
+    expect(router.calls.length).toBe(1);
+    expect(router.calls[0]!.payload.token_id).toBe('234');
+    expect(router.calls[0]!.payload.chain_id).toBe(80094);
+    expect(router.calls[0]!.eventType).toBe(subject);
+
+    const routedLogs = logger.infos.filter((l) => l.msg === '[events-subscriber] mint routed');
+    expect(routedLogs.length).toBe(1);
+    expect((routedLogs[0]!.obj as { announce: boolean }).announce).toBe(false);
+
+    await sub.stop();
+  });
+
+  test('3. broken-sig envelope → onVerificationFailure with reason "signature-invalid"; kansei NOT called', async () => {
+    const nats = new FakeNats();
+    const goodSigner = await LocalEd25519Signer.fromSeedHex('0'.repeat(64), 'sonar-api-1');
+    const wrongSigner = await LocalEd25519Signer.fromSeedHex('1'.repeat(64), 'sonar-api-1');
+    const verifier = new StaticPubkeyVerifier().add(
+      'sonar-api-1',
+      goodSigner.publicKeyBytes(),
+    );
+    const router = makeSpyRouter();
+    const logger = makeSpyLogger();
+    const subject = nftMintDetectedTopic({ collectionSlug: 'mibera-shadow' });
+
+    const sub = await startSubscriberWithFakeNats({ nats, verifier, router, logger });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: 'sonar-api',
+      signer: wrongSigner,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await tick();
+
+    expect(router.calls.length).toBe(0);
+    const failWarns = logger.warns.filter(
+      (w) => w.msg === '[events-subscriber] envelope verification failed',
+    );
+    expect(failWarns.length).toBe(1);
+    expect((failWarns[0]!.obj as { reason: string }).reason).toBe('signature-invalid');
+
+    await sub.stop();
+  });
+
+  test('4. schema-invalid payload → reason "payload-schema-invalid"; kansei NOT called', async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const router = makeSpyRouter();
+    const logger = makeSpyLogger();
+    const subject = nftMintDetectedTopic({ collectionSlug: 'mibera-shadow' });
+
+    const sub = await startSubscriberWithFakeNats({ nats, verifier, router, logger });
+
+    // Intentionally drop required field (token_id) to trip the schema check.
+    const bad = { ...VALID_PAYLOAD, token_id: undefined } as unknown as NftMintDetected;
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: bad,
+      emittedBy: 'sonar-api',
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await tick();
+
+    expect(router.calls.length).toBe(0);
+    const failWarns = logger.warns.filter(
+      (w) => w.msg === '[events-subscriber] envelope verification failed',
+    );
+    expect(failWarns.length).toBe(1);
+    expect((failWarns[0]!.obj as { reason: string }).reason).toBe(
+      'payload-schema-invalid',
+    );
+
+    await sub.stop();
+  });
+
+  test('5. subscriber stays alive after kansei throws; processes next envelope', async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const logger = makeSpyLogger();
+    const subject = nftMintDetectedTopic({ collectionSlug: 'mibera-shadow' });
+
+    let callCount = 0;
+    const router: KanseiRouter = {
+      route: async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('kansei is unhealthy');
+        }
+        return { announce: false };
+      },
+    };
+
+    const sub = await startSubscriberWithFakeNats({ nats, verifier, router, logger });
+
+    // Use a single per-publisher chain so the second envelope's prev_hash
+    // correctly references the first envelope's hash (the subscriber
+    // advances its chain tip before the handler runs per rd-3 F-002).
+    const publisherStore = new InMemoryPrevHashStore();
+
+    // first envelope — kansei throws (subscriber surfaces handler-error)
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: 'sonar-api',
+      signer,
+      prevHashStore: publisherStore,
+    });
+    // second envelope — kansei recovers; subscriber must still process it
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: '235' },
+      emittedBy: 'sonar-api',
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    await tick(20);
+
+    expect(callCount).toBe(2);
+    const errorLogs = logger.errors.filter(
+      (e) => e.msg === '[events-subscriber] kansei router threw',
+    );
+    expect(errorLogs.length).toBe(1);
+    // The 2nd envelope's success path logs "mint routed" via logger.info
+    const routedLogs = logger.infos.filter(
+      (l) => l.msg === '[events-subscriber] mint routed',
+    );
+    expect(routedLogs.length).toBe(1);
+
+    await sub.stop();
+  });
+});
+
+// ── kansei router stub contract ──────────────────────────────────────────────
+
+describe('DEP-1 · createKanseiRouterStub', () => {
+  test('always returns { announce: false } for DEP-1; logs through the supplied logger', async () => {
+    const logger = makeSpyLogger();
+    const router = createKanseiRouterStub(logger);
+
+    const decision = await router.route({
+      eventType: 'nft.mint.detected.mibera-shadow.v1',
+      payload: VALID_PAYLOAD,
+    });
+
+    expect(decision.announce).toBe(false);
+    expect(decision.channelId).toBeUndefined();
+
+    const stubLogs = logger.infos.filter(
+      (l) => l.msg === '[kansei-stub] DEP-1 stub — DEP-2 will wire real threshold routing',
+    );
+    expect(stubLogs.length).toBe(1);
+  });
+});

--- a/packages/persona-engine/src/events/mint-event-subscriber.ts
+++ b/packages/persona-engine/src/events/mint-event-subscriber.ts
@@ -1,0 +1,226 @@
+/**
+ * mint-event-subscriber.ts — DEP-1 of the cluster-events-pillar v1 cycle.
+ *
+ * Wires the @0xhoneyjar/events ACVP envelope subscriber at bot boot, verifies
+ * mint envelopes published by sonar-api on `nft.mint.detected.>`, and hands
+ * the typed payload to a kansei router that decides whether to announce.
+ *
+ * DEP-1 scope: subscriber + verifier wiring + kansei router invocation.
+ * DEP-2 (separate task) will replace the router stub with real threshold
+ * logic and wire the decision to a Discord channel announcement.
+ *
+ * Per cluster sovereignty doctrine (memory:cluster-no-npm-sovereignty,
+ * 2026-05-26), the events package is consumed via git-URL pinned to a
+ * commit SHA + a postinstall hook that rebuilds dist/ from source. See
+ * scripts/rebuild-events-dist.sh and the README quick-start (subscriber).
+ *
+ * Subscriber failure-mode contract (from @0xhoneyjar/events README):
+ *   - Never throws; broken envelopes surface via onVerificationFailure.
+ *   - VerificationFailureReason discriminates: envelope-schema-invalid,
+ *     payload-schema-invalid, payload-hash-mismatch, signature-invalid,
+ *     subject-mismatch, prev-hash-broken-chain, initial-anchor-policy-violation,
+ *     json-parse-error, handler-error, internal-error.
+ *
+ * Verifier choice:
+ *   - Production: JwksVerifier.fromUrl(opts.jwksUrl) — fetches cluster JWKS,
+ *     caches with TTL.
+ *   - Dev / no JWKS configured: empty StaticPubkeyVerifier — EVERY signature
+ *     fails, surfaced via onVerificationFailure. This is intentional: it's
+ *     visually loud rather than silently accepting unsigned traffic.
+ *
+ * Initial-anchor policy: default 'any' (EVT-002 backward-compat); operator
+ * can tighten to 'genesis' or a pinned hex anchor when the publisher's chain
+ * tip is known.
+ */
+
+import { connect, type NatsConnection } from 'nats';
+import {
+  subscribeEnvelope,
+  JwksVerifier,
+  StaticPubkeyVerifier,
+  InMemoryPrevHashStore,
+  NftMintDetectedSchema,
+  type Verifier,
+  type NftMintDetected,
+} from '@0xhoneyjar/events';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Decision returned by the kansei threshold router. For DEP-1 the stub
+ * always returns { announce: false } — DEP-2 wires real threshold logic and
+ * the channelId for posting.
+ */
+export interface KanseiRouteDecision {
+  announce: boolean;
+  channelId?: string;
+}
+
+export interface KanseiRouter {
+  route(input: {
+    eventType: string;
+    payload: NftMintDetected;
+  }): Promise<KanseiRouteDecision>;
+}
+
+export interface MintEventSubscriberLogger {
+  info: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+  error: (obj: unknown, msg?: string) => void;
+}
+
+export interface MintEventSubscriberOpts {
+  natsUrl: string;
+  /** Optional path to a CA cert file for NATS TLS. TLS-only in production. */
+  natsTlsCa?: string;
+  /** Cluster JWKS endpoint for verifying publisher signatures. Absent → dev mode. */
+  jwksUrl?: string;
+  kanseiRouter: KanseiRouter;
+  logger: MintEventSubscriberLogger;
+  /**
+   * Optional initial-anchor policy per EVT-002. Default 'any' for
+   * backward-compat. Set to 'genesis' to require GENESIS_PREV_HASH on the
+   * first envelope from each publisher, or pin a hex anchor.
+   */
+  initialPrevHashPolicy?: 'any' | 'genesis' | string;
+  /**
+   * Subject pattern to subscribe to. Default 'nft.mint.detected.>' (wildcard
+   * across all collections).
+   */
+  subject?: string;
+}
+
+export interface MintEventSubscriberHandle {
+  stop(): Promise<void>;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Entrypoint
+// ──────────────────────────────────────────────────────────────────────────────
+
+export async function startMintEventSubscriber(
+  opts: MintEventSubscriberOpts,
+): Promise<MintEventSubscriberHandle> {
+  const subject = opts.subject ?? 'nft.mint.detected.>';
+
+  // Connect to NATS (TLS-only in production when a CA path is configured)
+  const nc: NatsConnection = await connect({
+    servers: opts.natsUrl,
+    ...(opts.natsTlsCa ? { tls: { caFile: opts.natsTlsCa } } : {}),
+  });
+  opts.logger.info(
+    { url: opts.natsUrl, subject, tls: Boolean(opts.natsTlsCa) },
+    '[events-subscriber] NATS connected',
+  );
+
+  // Verifier: JWKS in prod, empty StaticPubkeyVerifier in dev (every sig
+  // fails — visually obvious that traffic is not being trusted).
+  let verifier: Verifier;
+  if (opts.jwksUrl) {
+    try {
+      verifier = await JwksVerifier.fromUrl(opts.jwksUrl, { timeoutMs: 5_000 });
+      opts.logger.info(
+        { jwksUrl: opts.jwksUrl },
+        '[events-subscriber] JWKS verifier loaded',
+      );
+    } catch (err) {
+      opts.logger.error(
+        { err },
+        '[events-subscriber] JWKS init failed; falling back to empty StaticPubkeyVerifier (all sigs will fail)',
+      );
+      verifier = new StaticPubkeyVerifier();
+    }
+  } else {
+    opts.logger.warn(
+      {},
+      '[events-subscriber] No JWKS_URL configured — using empty StaticPubkeyVerifier (all sigs will surface as invalid)',
+    );
+    verifier = new StaticPubkeyVerifier();
+  }
+
+  const handle = await subscribeEnvelope({
+    nats: nc,
+    subject,
+    schema: NftMintDetectedSchema,
+    verifier,
+    chainStore: new InMemoryPrevHashStore(),
+    initialPrevHashPolicy: opts.initialPrevHashPolicy ?? 'any',
+    handler: async ({ payload, envelope, subject: deliveredSubject }) => {
+      try {
+        const decision = await opts.kanseiRouter.route({
+          eventType: envelope.event_type,
+          payload,
+        });
+        opts.logger.info(
+          {
+            subject: deliveredSubject,
+            tokenId: payload.token_id,
+            contract: payload.contract,
+            chainId: payload.chain_id,
+            announce: decision.announce,
+            channelId: decision.channelId ?? null,
+          },
+          '[events-subscriber] mint routed',
+        );
+        // DEP-2 will wire decision → Discord announcement. For DEP-1 we log only.
+      } catch (err) {
+        opts.logger.error(
+          { err, subject: deliveredSubject },
+          '[events-subscriber] kansei router threw',
+        );
+      }
+    },
+    onVerificationFailure: (reason, detail) => {
+      opts.logger.warn(
+        {
+          reason,
+          subject: detail.subject,
+          emitted_by: detail.envelope?.emitted_by,
+          signing_key_id: detail.envelope?.signing_key_id,
+          error: detail.error ? String(detail.error).slice(0, 200) : undefined,
+        },
+        '[events-subscriber] envelope verification failed',
+      );
+    },
+  });
+
+  return {
+    stop: async (): Promise<void> => {
+      try {
+        handle.unsubscribe();
+      } catch (err) {
+        opts.logger.warn({ err }, '[events-subscriber] unsubscribe error');
+      }
+      try {
+        await nc.drain();
+      } catch (err) {
+        opts.logger.warn({ err }, '[events-subscriber] NATS drain error');
+      }
+    },
+  };
+}
+
+/**
+ * DEP-1 stub kansei router. Always returns { announce: false } — DEP-2 will
+ * replace this with the real threshold-based router that consults
+ * refractory + daily-cap + zone affinity.
+ */
+export function createKanseiRouterStub(
+  logger: MintEventSubscriberLogger,
+): KanseiRouter {
+  return {
+    route: async ({ eventType, payload }) => {
+      logger.info(
+        {
+          eventType,
+          tokenId: payload.token_id,
+          contract: payload.contract,
+        },
+        '[kansei-stub] DEP-1 stub — DEP-2 will wire real threshold routing',
+      );
+      return { announce: false };
+    },
+  };
+}

--- a/packages/persona-engine/src/events/mint-event-subscriber.ts
+++ b/packages/persona-engine/src/events/mint-event-subscriber.ts
@@ -115,8 +115,21 @@ export async function startMintEventSubscriber(
     '[events-subscriber] NATS connected',
   );
 
-  // Verifier: JWKS in prod, empty StaticPubkeyVerifier in dev (every sig
-  // fails — visually obvious that traffic is not being trusted).
+  // Verifier choice (BB#105 F-001 closed):
+  //   - opts.jwksUrl SET + reachable: JwksVerifier loads + caches keys.
+  //   - opts.jwksUrl SET + UNREACHABLE: THROW from startMintEventSubscriber.
+  //     The old fallback-to-empty-StaticPubkeyVerifier path was an
+  //     availability hazard: every signed envelope failed verification,
+  //     events flowed through NATS but never reached kansei, and no retry
+  //     path recovered when JWKS came back. Failing loud at startup forces
+  //     the operator to fix config / wait for JWKS / disable verifier
+  //     explicitly. Matches the bot's other boot wires (gate on NATS_URL
+  //     absent → log + skip; gate on JWKS unreachable when configured →
+  //     throw + skip).
+  //   - opts.jwksUrl UNSET: intentional dev fallback to empty
+  //     StaticPubkeyVerifier — every signature surfaces invalid via
+  //     onVerificationFailure (visually loud, never silently accepts
+  //     unsigned traffic).
   let verifier: Verifier;
   if (opts.jwksUrl) {
     try {
@@ -127,10 +140,15 @@ export async function startMintEventSubscriber(
       );
     } catch (err) {
       opts.logger.error(
-        { err },
-        '[events-subscriber] JWKS init failed; falling back to empty StaticPubkeyVerifier (all sigs will fail)',
+        { err, jwksUrl: opts.jwksUrl },
+        '[events-subscriber] JWKS init failed — refusing to start (operator must fix JWKS or remove jwksUrl)',
       );
-      verifier = new StaticPubkeyVerifier();
+      // Drain NATS before throwing so we don't leak the connection.
+      await nc.drain().catch(() => undefined);
+      throw new Error(
+        `[events-subscriber] JWKS init failed at ${opts.jwksUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     }
   } else {
     opts.logger.warn(

--- a/scripts/fixup-events-bun.sh
+++ b/scripts/fixup-events-bun.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# fixup-events-bun.sh — Bun-specific companion to rebuild-events-dist.sh.
+#
+# WHY THIS EXISTS:
+#   The verbatim rebuild-events-dist.sh template (from
+#   loa-freeside/packages/events/scripts/) was designed for pnpm's
+#   hoisted-flat layout where `node_modules/@0xhoneyjar/events` resolves
+#   to the events SUBDIR of the loa-freeside monorepo. Under bun, git-URL
+#   deps pointing at a monorepo (e.g. github:0xHoneyJar/loa-freeside#SHA)
+#   resolve to the monorepo ROOT — whose package.json has
+#   `name: "loa-freeside"`, NOT `name: "@0xhoneyjar/events"`. The import
+#   `@0xhoneyjar/events` therefore fails to resolve.
+#
+# WHAT THIS SCRIPT DOES:
+#   1. Find every bun-installed copy of the loa-freeside monorepo
+#      (workspace-pkg node_modules under packages/*/node_modules/@0xhoneyjar/).
+#   2. For each, replace the wrong symlink that points at the monorepo root
+#      with a NEW symlink that points at the `packages/events/` SUBDIR
+#      (which has the correct `name: "@0xhoneyjar/events"` + exports map).
+#   3. The verbatim rebuild-events-dist.sh handles building the dist
+#      separately — this script ONLY handles the bun symlink fixup.
+#
+# WHY NOT MODIFY THE VERBATIM TEMPLATE:
+#   The template is the cluster-canonical artifact. The bun quirk is
+#   consumer-specific (freeside-characters is bun-only). Keeping the
+#   template verbatim lets future cells (vitest/pnpm/yarn) consume it
+#   unchanged. The fixup is the local concession.
+#
+# IDEMPOTENT: re-running is a no-op when the symlink already points at
+# the right subdir.
+
+set -euo pipefail
+
+ROOT_DIR=$(pwd -P)
+TAG="[fixup-events-bun]"
+
+# Find every bun-installed events symlink under the workspace
+mapfile -t SYMLINKS < <(find "$ROOT_DIR" -type l -path "*/node_modules/@0xhoneyjar/events" 2>/dev/null || true)
+
+if [[ ${#SYMLINKS[@]} -eq 0 ]]; then
+  echo "$TAG No @0xhoneyjar/events symlinks found under $ROOT_DIR/**/node_modules — nothing to fix up"
+  exit 0
+fi
+
+fixup_count=0
+for link in ${SYMLINKS[@]+"${SYMLINKS[@]}"}; do
+  # Resolve the current symlink target (where bun put it)
+  current_target=$(readlink "$link")
+  abs_target=$(cd "$(dirname "$link")" && cd "$current_target" 2>/dev/null && pwd -P || echo "")
+  if [[ -z "$abs_target" ]]; then
+    echo "$TAG WARNING: $link points at a missing target — skipping"
+    continue
+  fi
+
+  # Check if this is already pointing at the subdir (idempotent path)
+  if [[ -f "$abs_target/package.json" ]]; then
+    name=$(node -e "try { console.log(require('$abs_target/package.json').name || '') } catch { console.log('') }" 2>/dev/null || echo "")
+    if [[ "$name" == "@0xhoneyjar/events" ]]; then
+      # Already pointing at the right place
+      continue
+    fi
+  fi
+
+  # Verify the subdir exists in the resolved monorepo root
+  subdir="$abs_target/packages/events"
+  if [[ ! -f "$subdir/package.json" ]]; then
+    echo "$TAG WARNING: $abs_target/packages/events/package.json not found — cannot fix up $link"
+    continue
+  fi
+
+  # Re-link to the subdir. Compute a relative path so the link survives
+  # filesystem moves.
+  link_dir=$(dirname "$link")
+  rel_subdir=$(node -e "console.log(require('path').relative('$link_dir', '$subdir'))" 2>/dev/null || echo "")
+  if [[ -z "$rel_subdir" ]]; then
+    echo "$TAG WARNING: failed to compute relative path for $link → $subdir"
+    continue
+  fi
+
+  rm -f "$link"
+  ln -s "$rel_subdir" "$link"
+  echo "$TAG Fixed up $link → $rel_subdir"
+  fixup_count=$((fixup_count + 1))
+done
+
+if [[ $fixup_count -gt 0 ]]; then
+  echo "$TAG Fixed up $fixup_count @0xhoneyjar/events symlink(s) to point at packages/events/ subdir"
+fi

--- a/scripts/rebuild-events-dist.sh
+++ b/scripts/rebuild-events-dist.sh
@@ -45,12 +45,29 @@ ROOT_DIR=$(pwd -P)
 COMMIT_SHA=""
 DECLARED_IN_PACKAGE_JSON=0
 if [[ -f "package.json" ]]; then
+  # BB#105 rd-2 F-001: SHA extraction reads from BOTH cluster.eventsPin.sha
+  # (the cluster sovereignty workaround for pnpm's subdir-github limitation)
+  # AND the standard dependencies/devDependencies field. Previously only the
+  # dep field was checked, so consumers using only cluster.eventsPin.sha
+  # (the canonical sonar/pnpm pattern) would always hit the declared-but-no-SHA
+  # error. Precedence: cluster.eventsPin.sha first (explicit sovereignty),
+  # then dependencies (legacy/bun-style consumers).
   COMMIT_SHA=$(node -e "
     const pkg = require('./package.json');
-    const dep = (pkg.devDependencies || {})['${PKG_NAME}'] ||
-                (pkg.dependencies || {})['${PKG_NAME}'] || '';
-    const match = dep.match(/#([0-9a-f]{7,40})\$/);
-    if (match) console.log(match[1]);
+    const SHA_RE = /^[0-9a-f]{7,40}\$/;
+    let sha = '';
+    // 1. cluster.eventsPin.sha (preferred per sovereignty doctrine)
+    const pinSha = ((pkg.cluster || {}).eventsPin || {}).sha;
+    if (pinSha && SHA_RE.test(pinSha)) {
+      sha = pinSha;
+    } else {
+      // 2. dependencies/devDependencies github:owner/repo#<sha>
+      const dep = (pkg.devDependencies || {})['${PKG_NAME}'] ||
+                  (pkg.dependencies || {})['${PKG_NAME}'] || '';
+      const match = dep.match(/#([0-9a-f]{7,40})\$/);
+      if (match) sha = match[1];
+    }
+    if (sha) console.log(sha);
   " 2>/dev/null || echo "")
   # BB#105 F-002: track whether the package is DECLARED (vs absent). When
   # declared-but-not-installed, we must fail loud below instead of silently
@@ -143,9 +160,16 @@ echo "$TAG Source SHA valid: $HAS_VALID_SOURCE_SHA"
 # Step 3: Verify git + pnpm available
 # =============================================================================
 
+# BB#105 rd-2 F-002 HIGH: once we're past the declared-but-not-found checks
+# above (package IS declared + needs rebuild), every remaining prerequisite
+# failure MUST exit 1. Silent-success at this point is a supply-chain hazard
+# — install goes green but the runtime import will throw "Cannot find package"
+# with no breadcrumb. Per BB review: "Required materialization scripts must
+# fail closed. Exit codes are an API to CI and operators."
 if ! command -v git &>/dev/null; then
-  echo "$TAG WARNING: git not available — cannot rebuild from source"
-  exit 0
+  echo "$TAG ERROR: git not available — cannot rebuild ${PKG_NAME} from source" >&2
+  echo "$TAG Install git or run rebuild-events-dist.sh from an environment with git available." >&2
+  exit 1
 fi
 
 PNPM_BIN=""
@@ -155,9 +179,9 @@ elif command -v corepack &>/dev/null; then
   # corepack will provision pnpm on first invocation
   PNPM_BIN="corepack pnpm"
 else
-  echo "$TAG WARNING: pnpm not available (and no corepack) — cannot build subdir package"
-  echo "$TAG Install pnpm or enable corepack: 'corepack enable'"
-  exit 0
+  echo "$TAG ERROR: pnpm not available (and no corepack) — cannot build ${PKG_NAME} subdir package" >&2
+  echo "$TAG Install pnpm or enable corepack: 'corepack enable'" >&2
+  exit 1
 fi
 
 # =============================================================================
@@ -179,13 +203,14 @@ git fetch --depth 1 origin "$COMMIT_SHA" 2>/dev/null || {
   cd "$BUILD_DIR"
   rm -rf repo
   git clone "$REPO" repo 2>/dev/null || {
-    echo "$TAG WARNING: git clone failed — cannot rebuild"
-    exit 0
+    # BB#105 rd-2 F-002: fail loud — declared dep cannot rebuild.
+    echo "$TAG ERROR: git clone of ${REPO} failed — cannot rebuild ${PKG_NAME}" >&2
+    exit 1
   }
   cd repo
   git checkout "$COMMIT_SHA" 2>/dev/null || {
-    echo "$TAG WARNING: Could not checkout $COMMIT_SHA — cannot rebuild"
-    exit 0
+    echo "$TAG ERROR: Could not checkout $COMMIT_SHA in ${REPO} — cannot rebuild ${PKG_NAME}" >&2
+    exit 1
   }
 }
 
@@ -210,8 +235,11 @@ echo "$TAG SHA verified: $ACTUAL_SHA"
 # =============================================================================
 
 if [[ ! -d "$SUBDIR" ]]; then
-  echo "$TAG WARNING: $SUBDIR not present in cloned loa-freeside@$COMMIT_SHA — cannot rebuild"
-  exit 0
+  # BB#105 rd-2 F-002: subdir-package SHA pinned to a commit that doesn't
+  # contain the subdir is operator-configuration broken — fail loud.
+  echo "$TAG ERROR: $SUBDIR not present in cloned loa-freeside@$COMMIT_SHA — cannot rebuild ${PKG_NAME}" >&2
+  echo "$TAG The pinned SHA may predate the subdir. Update cluster.eventsPin.sha or the github: URL #sha." >&2
+  exit 1
 fi
 
 cd "$SUBDIR"
@@ -223,15 +251,16 @@ echo "$TAG Entered subdir: $SUBDIR"
 
 echo "$TAG Installing events package deps (pnpm install --ignore-scripts)..."
 $PNPM_BIN install --ignore-scripts 2>/dev/null || {
-  echo "$TAG WARNING: pnpm install --ignore-scripts failed — cannot rebuild"
-  exit 0
+  # BB#105 rd-2 F-002: pnpm install failure leaves dist unrebuilt; fail loud.
+  echo "$TAG ERROR: pnpm install --ignore-scripts failed in $SUBDIR — cannot rebuild ${PKG_NAME}" >&2
+  exit 1
 }
 
 export SOURCE_DATE_EPOCH=0
 echo "$TAG Building events package (pnpm build, SOURCE_DATE_EPOCH=0)..."
 $PNPM_BIN build 2>/dev/null || {
-  echo "$TAG WARNING: pnpm build failed — cannot rebuild"
-  exit 0
+  echo "$TAG ERROR: pnpm build failed in $SUBDIR — cannot rebuild ${PKG_NAME}" >&2
+  exit 1
 }
 
 # =============================================================================
@@ -239,8 +268,8 @@ $PNPM_BIN build 2>/dev/null || {
 # =============================================================================
 
 if [[ ! -d "dist" ]]; then
-  echo "$TAG WARNING: No dist/ produced — cannot rebuild"
-  exit 0
+  echo "$TAG ERROR: pnpm build succeeded but produced no dist/ in $SUBDIR — cannot rebuild ${PKG_NAME}" >&2
+  exit 1
 fi
 
 if ! grep -q 'acvp-l1-v2' "dist/src/envelope.js" 2>/dev/null; then

--- a/scripts/rebuild-events-dist.sh
+++ b/scripts/rebuild-events-dist.sh
@@ -43,6 +43,7 @@ ROOT_DIR=$(pwd -P)
 # =============================================================================
 
 COMMIT_SHA=""
+DECLARED_IN_PACKAGE_JSON=0
 if [[ -f "package.json" ]]; then
   COMMIT_SHA=$(node -e "
     const pkg = require('./package.json');
@@ -51,11 +52,31 @@ if [[ -f "package.json" ]]; then
     const match = dep.match(/#([0-9a-f]{7,40})\$/);
     if (match) console.log(match[1]);
   " 2>/dev/null || echo "")
+  # BB#105 F-002: track whether the package is DECLARED (vs absent). When
+  # declared-but-not-installed, we must fail loud below instead of silently
+  # skipping (deferring the import error to runtime). Declared = either the
+  # dep is named in deps/devDeps (any value) OR cluster.eventsPin.sha is set.
+  DECLARED_IN_PACKAGE_JSON=$(node -e "
+    const pkg = require('./package.json');
+    const declared = (pkg.devDependencies || {})['${PKG_NAME}'] !== undefined
+                  || (pkg.dependencies || {})['${PKG_NAME}'] !== undefined
+                  || ((pkg.cluster || {}).eventsPin || {}).sha !== undefined;
+    console.log(declared ? '1' : '0');
+  " 2>/dev/null || echo "0")
 fi
 
 if [[ -z "$COMMIT_SHA" ]]; then
-  echo "$TAG No git commit SHA found in package.json for ${PKG_NAME} — skipping"
-  exit 0
+  # No SHA found AND package not declared → genuinely a non-consumer; skip safely.
+  if [[ "$DECLARED_IN_PACKAGE_JSON" != "1" ]]; then
+    echo "$TAG ${PKG_NAME} not declared in package.json — skipping (script is a cluster-shared template; harmless in non-consumer repos)"
+    exit 0
+  fi
+  # Declared but no SHA extractable → caller misconfigured the pin. Fail loud.
+  echo "$TAG ERROR: ${PKG_NAME} is declared in package.json but no git commit SHA can be extracted." >&2
+  echo "$TAG Expected one of:" >&2
+  echo "$TAG   - dependencies/devDependencies entry like: \"${PKG_NAME}\": \"github:owner/repo#<40-char-sha>\"" >&2
+  echo "$TAG   - cluster.eventsPin.sha block with a 40-char SHA" >&2
+  exit 1
 fi
 
 # =============================================================================
@@ -75,8 +96,18 @@ if [[ -z "$EVENTS_DIR" && -d "$ROOT_DIR/node_modules/${PKG_NAME}" ]]; then
 fi
 
 if [[ -z "$EVENTS_DIR" ]]; then
-  echo "$TAG No ${PKG_NAME} package found in node_modules — skipping"
-  exit 0
+  # BB#105 F-002: the consumer DECLARED ${PKG_NAME} (we extracted a SHA
+  # above), so a missing node_modules entry means the install layout is
+  # broken — most likely the bun-fixup script didn't run, OR pnpm bootstrap
+  # failed silently. Either way, runtime imports will throw with an opaque
+  # "Cannot find package" error. Fail loud at install time instead.
+  echo "$TAG ERROR: ${PKG_NAME} is declared with SHA ${COMMIT_SHA:0:12} but no package directory found in node_modules." >&2
+  echo "$TAG Expected one of:" >&2
+  echo "$TAG   - $ROOT_DIR/node_modules/.pnpm/@0xhoneyjar+${PKG_DIR_FILE_NAME}@*/node_modules/${PKG_NAME}" >&2
+  echo "$TAG   - $ROOT_DIR/node_modules/${PKG_NAME}" >&2
+  echo "$TAG If using bun: ensure scripts/fixup-events-bun.sh ran BEFORE this script." >&2
+  echo "$TAG If using pnpm: ensure the consumer's pnpm-lock.yaml resolves ${PKG_NAME} (you may need to clear node_modules + reinstall)." >&2
+  exit 1
 fi
 
 # =============================================================================

--- a/scripts/rebuild-events-dist.sh
+++ b/scripts/rebuild-events-dist.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# rebuild-events-dist.sh — Rebuild @0xhoneyjar/events dist from source with
+# supply-chain verification.
+#
+# Sister script to scripts/rebuild-hounfour-dist.sh (which lives in
+# loa-freeside root). Same posture, adapted for a SUBDIR package: the
+# @0xhoneyjar/events package lives at loa-freeside/packages/events/, not at
+# the repo root. The script clones loa-freeside at a pinned SHA, cds into
+# packages/events/, builds via the package's own pnpm pipeline, and copies
+# dist/ back into node_modules/@0xhoneyjar/events/dist.
+#
+# Per cluster sovereignty doctrine (memory:cluster-no-npm-sovereignty,
+# 2026-05-26), the events package is NOT published to npm. Children
+# (sonar-api, freeside-characters, future cells) consume via git-URL
+# pinned to a commit SHA, and run this script as a postinstall hook to
+# materialize the dist/ from the clone.
+#
+# Supply-chain verification (matches the rebuild-hounfour-dist.sh posture):
+#   - Isolated clone via git init + fetch --depth 1 (deterministic)
+#   - SHA verification before build
+#   - set -euo pipefail + explicit error messages
+#   - pnpm install --ignore-scripts (no post-install from transitive deps)
+#   - SOURCE_DATE_EPOCH=0 for reproducible timestamps
+#   - dist/src/SOURCE_SHA provenance file
+#   - All 8 export specifiers verified (per packages/events/package.json)
+#   - Stale-detection via SCHEMA_VERSION literal + SOURCE_SHA match
+#
+# Called automatically via "postinstall" in the consuming repo's
+# package.json. Copy this file into the consumer's scripts/ directory
+# and reference it from postinstall.
+
+set -euo pipefail
+
+REPO="https://github.com/0xHoneyJar/loa-freeside.git"
+SUBDIR="packages/events"
+PKG_NAME="@0xhoneyjar/events"
+PKG_DIR_FILE_NAME="events"
+TAG="[rebuild-events-dist]"
+ROOT_DIR=$(pwd -P)
+
+# =============================================================================
+# Step 0: Extract the commit SHA from caller's package.json
+# =============================================================================
+
+COMMIT_SHA=""
+if [[ -f "package.json" ]]; then
+  COMMIT_SHA=$(node -e "
+    const pkg = require('./package.json');
+    const dep = (pkg.devDependencies || {})['${PKG_NAME}'] ||
+                (pkg.dependencies || {})['${PKG_NAME}'] || '';
+    const match = dep.match(/#([0-9a-f]{7,40})\$/);
+    if (match) console.log(match[1]);
+  " 2>/dev/null || echo "")
+fi
+
+if [[ -z "$COMMIT_SHA" ]]; then
+  echo "$TAG No git commit SHA found in package.json for ${PKG_NAME} — skipping"
+  exit 0
+fi
+
+# =============================================================================
+# Step 1: Find the installed events package directory in node_modules
+# =============================================================================
+
+EVENTS_DIR=""
+# pnpm hoisted layout
+for candidate in "$ROOT_DIR"/node_modules/.pnpm/@0xhoneyjar+${PKG_DIR_FILE_NAME}@*/node_modules/${PKG_NAME}; do
+  if [[ -d "$candidate" ]]; then
+    EVENTS_DIR="$candidate"
+  fi
+done
+# npm / pnpm hoisted (flat) layout
+if [[ -z "$EVENTS_DIR" && -d "$ROOT_DIR/node_modules/${PKG_NAME}" ]]; then
+  EVENTS_DIR="$ROOT_DIR/node_modules/${PKG_NAME}"
+fi
+
+if [[ -z "$EVENTS_DIR" ]]; then
+  echo "$TAG No ${PKG_NAME} package found in node_modules — skipping"
+  exit 0
+fi
+
+# =============================================================================
+# Step 2: Check if dist is already up-to-date (acvp-l1-v2 fingerprint)
+# =============================================================================
+
+# Stale-detection: SCHEMA_VERSION literal in dist + SOURCE_SHA provenance
+HAS_VALID_SCHEMA_VERSION=false
+if [[ -f "$EVENTS_DIR/dist/src/envelope.js" ]]; then
+  if grep -q 'acvp-l1-v2' "$EVENTS_DIR/dist/src/envelope.js" 2>/dev/null; then
+    HAS_VALID_SCHEMA_VERSION=true
+  fi
+fi
+
+HAS_VALID_SOURCE_SHA=false
+if [[ -f "$EVENTS_DIR/dist/SOURCE_SHA" ]]; then
+  EXISTING_SOURCE_SHA=$(cat "$EVENTS_DIR/dist/SOURCE_SHA" 2>/dev/null | tr -d '[:space:]')
+  if [[ "$EXISTING_SOURCE_SHA" == "$COMMIT_SHA" ]]; then
+    HAS_VALID_SOURCE_SHA=true
+  fi
+fi
+
+if [[ "$HAS_VALID_SCHEMA_VERSION" == "true" && "$HAS_VALID_SOURCE_SHA" == "true" ]]; then
+  echo "$TAG dist/ already up-to-date (acvp-l1-v2, SOURCE_SHA=$COMMIT_SHA) — skipping"
+  exit 0
+fi
+
+echo "$TAG Rebuilding ${PKG_NAME} dist from loa-freeside@${COMMIT_SHA:0:12}..."
+echo "$TAG Schema version fingerprint present: $HAS_VALID_SCHEMA_VERSION"
+echo "$TAG Source SHA valid: $HAS_VALID_SOURCE_SHA"
+
+# =============================================================================
+# Step 3: Verify git + pnpm available
+# =============================================================================
+
+if ! command -v git &>/dev/null; then
+  echo "$TAG WARNING: git not available — cannot rebuild from source"
+  exit 0
+fi
+
+PNPM_BIN=""
+if command -v pnpm &>/dev/null; then
+  PNPM_BIN="pnpm"
+elif command -v corepack &>/dev/null; then
+  # corepack will provision pnpm on first invocation
+  PNPM_BIN="corepack pnpm"
+else
+  echo "$TAG WARNING: pnpm not available (and no corepack) — cannot build subdir package"
+  echo "$TAG Install pnpm or enable corepack: 'corepack enable'"
+  exit 0
+fi
+
+# =============================================================================
+# Step 4: Isolated clone via git init + fetch --depth 1 (deterministic)
+# =============================================================================
+
+BUILD_DIR=$(mktemp -d)
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+echo "$TAG Cloning loa-freeside at $COMMIT_SHA (isolated fetch)..."
+
+cd "$BUILD_DIR"
+git init repo >/dev/null 2>&1
+cd repo
+git remote add origin "$REPO"
+git fetch --depth 1 origin "$COMMIT_SHA" 2>/dev/null || {
+  echo "$TAG SECURITY: Failed to fetch expected SHA $COMMIT_SHA"
+  echo "$TAG Falling back to full clone + checkout..."
+  cd "$BUILD_DIR"
+  rm -rf repo
+  git clone "$REPO" repo 2>/dev/null || {
+    echo "$TAG WARNING: git clone failed — cannot rebuild"
+    exit 0
+  }
+  cd repo
+  git checkout "$COMMIT_SHA" 2>/dev/null || {
+    echo "$TAG WARNING: Could not checkout $COMMIT_SHA — cannot rebuild"
+    exit 0
+  }
+}
+
+if git rev-parse FETCH_HEAD >/dev/null 2>&1; then
+  git checkout --detach FETCH_HEAD 2>/dev/null || true
+fi
+
+# =============================================================================
+# Step 5: Verify commit SHA in the cloned repo
+# =============================================================================
+
+ACTUAL_SHA=$(git rev-parse HEAD)
+if [[ "$ACTUAL_SHA" != "$COMMIT_SHA" ]]; then
+  echo "$TAG SECURITY: SHA mismatch. Expected $COMMIT_SHA, got $ACTUAL_SHA"
+  exit 1
+fi
+
+echo "$TAG SHA verified: $ACTUAL_SHA"
+
+# =============================================================================
+# Step 6: CD into the subdir (events lives at packages/events/, not root)
+# =============================================================================
+
+if [[ ! -d "$SUBDIR" ]]; then
+  echo "$TAG WARNING: $SUBDIR not present in cloned loa-freeside@$COMMIT_SHA — cannot rebuild"
+  exit 0
+fi
+
+cd "$SUBDIR"
+echo "$TAG Entered subdir: $SUBDIR"
+
+# =============================================================================
+# Step 7: Install + build (deterministic, ignore-scripts)
+# =============================================================================
+
+echo "$TAG Installing events package deps (pnpm install --ignore-scripts)..."
+$PNPM_BIN install --ignore-scripts 2>/dev/null || {
+  echo "$TAG WARNING: pnpm install --ignore-scripts failed — cannot rebuild"
+  exit 0
+}
+
+export SOURCE_DATE_EPOCH=0
+echo "$TAG Building events package (pnpm build, SOURCE_DATE_EPOCH=0)..."
+$PNPM_BIN build 2>/dev/null || {
+  echo "$TAG WARNING: pnpm build failed — cannot rebuild"
+  exit 0
+}
+
+# =============================================================================
+# Step 8: Verify the build produced correct output
+# =============================================================================
+
+if [[ ! -d "dist" ]]; then
+  echo "$TAG WARNING: No dist/ produced — cannot rebuild"
+  exit 0
+fi
+
+if ! grep -q 'acvp-l1-v2' "dist/src/envelope.js" 2>/dev/null; then
+  echo "$TAG WARNING: built dist/src/envelope.js does NOT contain acvp-l1-v2 fingerprint — refusing to ship"
+  exit 1
+fi
+
+echo "$TAG Built dist/ (acvp-l1-v2 fingerprint present)"
+
+# =============================================================================
+# Step 9: Embed source provenance
+# =============================================================================
+
+echo "$ACTUAL_SHA" > dist/SOURCE_SHA
+echo "$TAG Embedded SOURCE_SHA: $ACTUAL_SHA"
+
+# =============================================================================
+# Step 10: Verify all export specifiers resolve from built dist
+# =============================================================================
+
+echo "$TAG Verifying export specifiers..."
+SPECIFIERS=("" "/envelope" "/jcs" "/signer" "/topics" "/publisher" "/subscriber" "/schemas/nft-mint-detected")
+for specifier in "${SPECIFIERS[@]}"; do
+  if [[ -z "$specifier" ]]; then
+    ENTRY_FILE="dist/src/index.js"
+    LABEL="root"
+  else
+    ENTRY_FILE="dist/src${specifier}.js"
+    LABEL="${specifier#/}"
+  fi
+  if [[ ! -f "$ENTRY_FILE" ]]; then
+    echo "$TAG MANIFEST: Failed to resolve specifier '${LABEL}' — $ENTRY_FILE not found"
+    exit 1
+  fi
+  echo "$TAG   [OK] ${LABEL} -> $ENTRY_FILE"
+done
+
+# =============================================================================
+# Step 11: Replace stale dist with rebuilt one
+# =============================================================================
+
+cd "$ROOT_DIR"
+rm -rf "$EVENTS_DIR/dist"
+cp -r "$BUILD_DIR/repo/$SUBDIR/dist" "$EVENTS_DIR/dist"
+
+echo "$TAG Successfully rebuilt dist (SOURCE_SHA=${ACTUAL_SHA:0:12})"


### PR DESCRIPTION
## Summary

**Sprint 2 child task** of `cluster-events-pillar-v1` (cluster-meta cycle per ADR-009 §D-7). Wires the `@0xhoneyjar/events` subscriber at bot boot — fulfills the "EVENT-DRIVEN" prophecy reserved at `packages/persona-engine/src/cron/scheduler.ts:113-119` from the cycle-008 substrate-presentation cycle.

Coord issue: #102 · coord bead: `cluster-events-pillar-coordinator-eoo`

## What ships

`packages/persona-engine/src/events/mint-event-subscriber.ts` — 226 lines:
- Connects to NATS (TLS-required in prod via `NATS_TLS_CA` cert file)
- Loads verifier: `JwksVerifier.fromUrl(jwksUrl)` in prod with 5s timeout; empty `StaticPubkeyVerifier` fallback in dev (every signature surfaces as invalid — visually loud rather than silently accepting unsigned traffic)
- `subscribeEnvelope` on `nft.mint.detected.>` wildcard, schema `NftMintDetectedSchema`, `chainStore: InMemoryPrevHashStore`, `initialPrevHashPolicy: 'any'` (backward-compat default per EVT-002)
- Handler: invokes the kansei router stub (DEP-1 scope), logs decision
- `onVerificationFailure`: logs typed reason + envelope metadata (sig-invalid, broken-chain, schema-violation, subject-mismatch, etc.) — subscriber stays alive

`apps/bot/src/index.ts:382-426` — boot wire. Gated on `NATS_URL`; absent → log warn + skip (bot boots cleanly without NATS). Stop hook chained into both shutdown paths (`config.DIGEST_CADENCE==='manual'` exit + SIGINT/SIGTERM handler).

**scheduler.ts:113-119 reserved-slot**: LEFT UNCHANGED. The "EVENT-DRIVEN" prophecy comment stays in place as a forward marker for DEP-2 (which will wire kansei stir-tier consultation per the comment text). Sacred no-touch constraint respected — cron paths untouched.

## Scope discipline (DEP-1 only)

- Subscriber + verification + kansei router stub ONLY
- Kansei stub returns `{ announce: false }` — DEP-2 will replace with real threshold logic
- NO Discord posting (DEP-2)
- NO changes to cron paths, interactions server, composer, character voice configs

## Substrate consumption — bun pattern

Per cluster sovereignty doctrine (memory `cluster-no-npm-sovereignty`), `@0xhoneyjar/events` is consumed via git-URL pinned to commit `0948a534…` (post-#227 main), NOT npm. Because the events package lives at a monorepo SUBDIR, bun resolves `github:0xHoneyJar/loa-freeside#sha` to the monorepo ROOT (whose package.json has `name: \"loa-freeside\"`), not to `packages/events/`. Workaround:

- Standard `\"@0xhoneyjar/events\": \"github:0xHoneyJar/loa-freeside#sha\"` in `packages/persona-engine/package.json` (bun accepts this directly).
- New `scripts/fixup-events-bun.sh` finds every bun-installed `node_modules/@0xhoneyjar/events` symlink and re-targets from `<bun-store>/loa-freeside/` → `<bun-store>/loa-freeside/packages/events/` (where the right `package.json` + exports map live).
- `scripts/rebuild-events-dist.sh` (verbatim cluster template from `loa-freeside/packages/events/scripts/`) handles building dist.
- Consumer also lists transitive runtime deps (`@effect/schema`, `@noble/curves`, `@noble/hashes`, `canonicalize`, `effect`, `nats`) since bun's isolated `.bun/` store means upward-walk resolution starts at the consumer's `node_modules`.

Verified end-to-end:
```
$ cd packages/persona-engine && bun -e \"import('@0xhoneyjar/events').then(m => console.log('SCHEMA_VERSION='+m.SCHEMA_VERSION))\"
OK keys= EventEnvelopeSchema,GENESIS_PREV_HASH,InMemoryPrevHashStore,JwksVerifier,LocalEd25519Signer,...
SCHEMA_VERSION=acvp-l1-v2

$ cat packages/persona-engine/node_modules/@0xhoneyjar/events/dist/SOURCE_SHA
0948a5344b21aef6a7ba7ce6e39a9258994638c0
```

Doctrine: `~/.claude/projects/.../memory/project_events-consumer-pm-patterns.md` (per-PM workarounds — sonar's pnpm variant uses `cluster.eventsPin` + node_modules bootstrap; characters' bun variant uses standard deps + symlink fixup; reconvergence path to extract events to dedicated repo would eliminate per-PM workarounds).

## Test plan

- [x] postinstall + fixup-events-bun materialize `dist/` with `acvp-l1-v2` fingerprint + valid SOURCE_SHA
- [x] 6/6 bun:test passing covering all 5 contract points from spec:
  - subscriber start + stop
  - valid envelope → kansei.route called with typed payload
  - broken-sig envelope → `signature-invalid` callback, handler NOT called
  - schema-invalid payload → `payload-schema-invalid` callback
  - handler throws → subscriber survives + processes next envelope
  - (+ 6th: kansei stub contract sanity)
- [ ] Reviewer: verify scheduler.ts:113-119 reserved comment intact (sacred no-touch)
- [ ] Reviewer: confirm bun-specific `fixup-events-bun.sh` pattern is acceptable for bun-consumer cells (vs the pnpm `cluster.eventsPin` shape sibling sonar PR uses)
- [ ] Post-merge: deploy with `NATS_URL` + `NATS_TLS_CA` + `EVENTS_JWKS_URL` env wired in characters' Railway service

## Verification pipeline (per @0xhoneyjar/events subscriber.ts)

Every envelope passes through 9 verification steps before reaching the handler. Each failure mode is typed:
1. JSON parse → `json-parse-error`
2. envelope schema (Effect.Schema strict) → `envelope-schema-invalid`
3. subject-bind (msg.subject === event_type) → `subject-mismatch`
4. payload-hash recompute → `payload-hash-mismatch`
5. signature verify (acvp-l1-v2 full-envelope binding) → `signature-invalid`
6. chain continuity + initialPrevHashPolicy → `prev-hash-broken-chain` / `initial-anchor-policy-violation`
7. per-event payload schema → `payload-schema-invalid`
8. chain advance (after payload validates — chain tracks accepted, not just signed)
9. handler dispatch → `handler-error` / `internal-error`

The subscriber NEVER throws — every failure surfaces via `onVerificationFailure` and is logged with typed reason + envelope metadata.

## Known limitations (Sprint 1 acceptable per build doc)

- **Single-process `InMemoryPrevHashStore`** — characters restart resets the subscriber's local chain view; first envelope from each publisher post-restart accepted unconditionally (per `initialPrevHashPolicy: 'any'`). Sprint 2+: tighten to `'genesis'` and/or use Redis-backed store.
- **No Discord posting yet** — DEP-2 scope (separate PR + bead `cluster-events-pillar-coordinator-zwr`).
- **Pre-existing test pollution**: `packages/persona-engine/src/voice/config-loader.test.ts` fails in full-suite run but passes in isolation; same behavior on clean origin/main. Unrelated.

## References

- Library: `loa-freeside/packages/events/` (landed in `loa-freeside#227`)
- Build doc: `loa-freeside/grimoires/loa/specs/enhance-events-pillar-v1-nft-mints.md` §3 + §4
- Sibling PR: `0xHoneyJar/sonar-api#24` (NATS publish layer) — separate PR
- Coord cycle: `cluster-events-pillar-v1` at `~/bonfire/cluster-events-pillar-coordinator/`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via headless dispatch from the cluster coordinator. Human review-gated before merge.