### PR TITLE
fix(Dockerfile): apk add bash for postinstall (Path ε hotfix unblocks bot redeploy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@
 
 FROM oven/bun:1.3-alpine
 
+# bash is required by package.json's postinstall script (rebuild-events-dist.sh
+# + fixup-events-bun.sh — both #!/usr/bin/env bash). bun:1.3-alpine ships with
+# /bin/sh only. Without bash the build fails with exit code 127 during
+# `bun install --frozen-lockfile`. Added 2026-05-26 (Path ε cluster-events-pillar
+# v1 — first canary flip).
+RUN apk add --no-cache bash
+
 WORKDIR /app
 
 # Monorepo workspace shape · root package.json declares:


### PR DESCRIPTION
## Summary

Build failed on PR #107 merge (commit 992248d) with `exit code 127`:
```
/bin/sh: bash: not found
error: postinstall script from "freeside-characters" exited with 127
```

The package.json postinstall hook calls `bash scripts/fixup-events-bun.sh && (cd packages/persona-engine && bash ../../scripts/rebuild-events-dist.sh)` but `bun:1.3-alpine` ships /bin/sh only.

**Fix**: `apk add --no-cache bash` before bun install.

## Why this matters right now

Bot is currently running OLD container (last successful build) because the post-PR-107 deploy failed. Until this lands, the bot can't pick up the mTLS client cert support → can't subscribe to NATS → no Path-ε canary flip possible.

## Test plan

- [ ] Railway picks up the merge and successfully rebuilds the bot
- [ ] Bot boot log shows the `events: NATS subscriber wired …` line
- [ ] No further `bash: not found` failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)