### PR TITLE
fix: pin loa-freeside@7db6359 + relax SOURCE_SHA check (Path ε hotfix 8 — terminal)

### DIFF
--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -31,7 +31,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#0948a5344b21aef6a7ba7ce6e39a9258994638c0",
+    "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#7db6359e98739609f8f9d24f444822ad82f597a7",
     "@0xhoneyjar/medium-registry": "^0.2.0",
     "@effect/schema": "^0.75.0",
     "@noble/curves": "^1.7.0",

--- a/scripts/rebuild-events-dist.sh
+++ b/scripts/rebuild-events-dist.sh
@@ -152,6 +152,17 @@ if [[ "$HAS_VALID_SCHEMA_VERSION" == "true" && "$HAS_VALID_SOURCE_SHA" == "true"
   exit 0
 fi
 
+# Path ε hotfix 8 (2026-05-26): if the schema-version fingerprint matches but
+# SOURCE_SHA doesn't (because dist was committed to loa-freeside upstream and
+# its SOURCE_SHA file lags by definition — it can't contain the SHA of the
+# commit that introduces it), trust the schema literal alone. Avoids the
+# pnpm-install-in-standalone-subdir failure that took 7 hotfix layers to
+# surface (PRs #108-#113 on this repo).
+if [[ "$HAS_VALID_SCHEMA_VERSION" == "true" ]]; then
+  echo "$TAG dist/ has valid acvp-l1-v2 schema fingerprint (SOURCE_SHA=$(cat "$EVENTS_DIR/dist/SOURCE_SHA" 2>/dev/null || echo "missing") vs expected $COMMIT_SHA — accepting upstream dist regardless) — skipping rebuild"
+  exit 0
+fi
+
 echo "$TAG Rebuilding ${PKG_NAME} dist from loa-freeside@${COMMIT_SHA:0:12}..."
 echo "$TAG Schema version fingerprint present: $HAS_VALID_SCHEMA_VERSION"
 echo "$TAG Source SHA valid: $HAS_VALID_SOURCE_SHA"


### PR DESCRIPTION
Two parts: (1) bump cluster.eventsPin to the loa-freeside commit that ships dist/ (#244), (2) relax rebuild-events-dist.sh's stale-detection AND clause to a schema-fingerprint-only OR. Terminates the 7-layer hotfix chain.