### PR TITLE
fix(bun.lock): regenerate for loa-freeside@7db6359 (Path ε hotfix 9)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
       "name": "@freeside-characters/persona-engine",
       "version": "0.12.0",
       "dependencies": {
-        "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#0948a5344b21aef6a7ba7ce6e39a9258994638c0",
+        "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#7db6359e98739609f8f9d24f444822ad82f597a7",
         "@0xhoneyjar/medium-registry": "^0.2.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.122",
         "@aws-sdk/client-bedrock-runtime": "^3.1048.0",
@@ -78,7 +78,7 @@
     },
   },
   "packages": {
-    "@0xhoneyjar/events": ["loa-freeside@github:0xHoneyJar/loa-freeside#0948a53", { "dependencies": { "aws-embedded-metrics": "^4.2.1" } }, "0xHoneyJar-loa-freeside-0948a53", "sha512-W1d4fsZReIo5xGDKqpOhgu0PYL036zhDPkzt0c6DtEiMEmh9ImXJCahmT3Xg0LosZRV/CYzRLz0ATYfwCbl+OA=="],
+    "@0xhoneyjar/events": ["loa-freeside@github:0xHoneyJar/loa-freeside#7db6359", { "dependencies": { "aws-embedded-metrics": "^4.2.1" } }, "0xHoneyJar-loa-freeside-7db6359", "sha512-rbbpzDSXv8ZjILEydnJc9msE7ybqjHd/z/qnkT8iBEO/4hEymCxavDHSs5XGPWCf9djq13E5/+kUkfnBtS4bng=="],
 
     "@0xhoneyjar/medium-registry": ["@0xhoneyjar/medium-registry@0.2.0", "", { "peerDependencies": { "effect": "^3.10.0" } }, "sha512-A7Kpd8UjfymCzQ6Gdod8ZcGn2LvWmgaksYhiY8M3RpUWAziJ/0VSc0SBG7PLt5dCwtWdf0xiOLG3TPJ5qitIqw=="],
 


### PR DESCRIPTION
bun.lock update for the pin bump in #114. Local bun install now succeeds with the relaxed rebuild check skipping cleanly.