### PR TITLE
Phase 35D feat(persona-engine): add Recall Wedge Dixie envelope adapter

### DIFF
--- a/docs/recall-wedge/fixtures/README.md
+++ b/docs/recall-wedge/fixtures/README.md
@@ -16,9 +16,30 @@ docs/recall-wedge/fixtures/
     operator-private-view.dto.json       operator_private projection
     public-discord-view.dto.json         public_discord projection
     character-boundary-referral.dto.json public_discord referral projection
-  validate-fixtures.mjs                  phase 33b no-leak fixture validator
+  dixie-envelope/                        phase 35d recorded dixie envelope fixtures
+    recorded-public-discord-recall-envelope.v0.json
+    recorded-referral-recall-envelope.v0.json
+    recorded-unknown-version-envelope.json
+  validate-fixtures.mjs                  phase 33b/35d no-leak fixture validator
   README.md                              this file
 ```
+
+`dixie-envelope/` is the Phase 35D home for recorded **Dixie-shaped recall
+envelope** fixtures. These envelopes feed the pure adapter at
+`packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`. The
+adapter is the only narrowing boundary from a Dixie envelope to a local
+projected DTO — the Phase 33C public renderer never reads a Dixie
+envelope directly. The envelope fixtures intentionally include
+raw / private / debug material (`raw_dixie_debug`, `raw_session_trace`,
+`source_material`, `PRIVATE_SENTINEL_*`, `session_id`, `message_id`,
+`continuity_actor_id`) so that adapter unit tests can prove none of it
+passes through to the projected DTO or the rendered public output.
+
+Recorded Dixie envelopes represent **recall responses / projected recall
+payloads**. They are not raw chat log memory and they do not constitute
+admission of any chat content into governed Straylight memory. Memory
+authority remains with Straylight; live admission is post-MVP and out of
+scope.
 
 `projected-dto/` is the neutral home for **all** projected views of the
 seed packet — operator-private and public-safe alike. Naming it
@@ -106,10 +127,11 @@ operator-private projection. The Phase 33B no-leak validator
 (`validate-fixtures.mjs`) greps the public-safe projections for these
 substrings and fails loudly if any are present.
 
-## Phase 33B no-leak fixture validator
+## Phase 33B / 35D fixture validator
 
 `validate-fixtures.mjs` is a deterministic, dependency-free, Node-
-compatible validator that locks the Phase 33B invariants in place.
+compatible validator that locks the Phase 33B invariants in place and,
+as of Phase 35D, also requires the recorded Dixie envelope fixtures.
 
 Run it:
 
@@ -117,7 +139,7 @@ Run it:
 node docs/recall-wedge/fixtures/validate-fixtures.mjs
 ```
 
-It checks:
+It checks (Phase 33B):
 
 - every fixture JSON parses;
 - the seed packet is `synthetic: true`,
@@ -140,11 +162,39 @@ It checks:
   `source_material`, `hidden estate`, `assertion_id`,
   `full assertion bodies`, `private identifiers`).
 
+It also checks (Phase 35D — required, not optional):
+
+- the `dixie-envelope/` directory exists;
+- all three required fixtures are present:
+  `recorded-public-discord-recall-envelope.v0.json`,
+  `recorded-referral-recall-envelope.v0.json`,
+  `recorded-unknown-version-envelope.json`;
+- every Dixie envelope fixture is `synthetic: true`,
+  `fixture_kind: recorded_dixie_recall_envelope`,
+  `input_envelope_kind: recorded_dixie_recall_envelope`,
+  and carries a `non_production_authorization_note`;
+- the v0 envelope fixtures use a supported `envelope_version`
+  (currently `recall_wedge.dixie_envelope.v0`);
+- the unknown-version fixture remains **syntactically valid** with an
+  `envelope_version` that is **present but intentionally unsupported**
+  — this fixture exists to drive adapter fail-closed tests, so the
+  validator confirms its non-support rather than failing on it.
+
+No leak-grep is run over raw Dixie envelope files: those intentionally
+contain raw/private/debug sentinels (`raw_dixie_debug`,
+`raw_session_trace`, `source_material`, `PRIVATE_SENTINEL_*`,
+`session_id`, `message_id`, `continuity_actor_id`) because the adapter
+in `packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`
+is responsible for stripping that material before any rendering.
+Public no-leak validation continues to gate only the public-safe
+projected DTOs above; the adapter's own unit tests cover the Dixie
+stripping behavior end-to-end.
+
 The validator exits 0 on success and nonzero on any failure. It is
 fixture-only — it does not import Straylight types, it does not call a
 live Dixie client, and it does not attempt rendering. Renderer
 implementation is Phase 33C; the cross-interface continuity demo is
-Phase 33D.
+Phase 33D; the recorded Dixie envelope adapter is Phase 35D.
 
 ## Categories that are not Recall Wedge memory
 
@@ -164,10 +214,14 @@ demo can show that the MVP keeps these categories distinct.
 ## Phase ladder (recap)
 
 - 33A — boundary decision doc (`RECALL-WEDGE-MEMORY-MVP.md`)
-- **33B — these fixtures**
+- **33B — projected-DTO + seed-memory fixtures**
 - 33C — public-safe Recall Wedge renderer + no-leak validator
 - 33D — cross-interface continuity demo
 - 34A — final MVP acceptance handoff
+- 35A — post-MVP decision map
+- 35B — operator demo runner
+- 35C — multi-surface contract spec
+- **35D — recorded Dixie envelope fixtures + adapter tests** (`dixie-envelope/`)
 
 If a later phase needs anything beyond what these fixtures shape, re-open
 the 33A doc — do not silently expand scope here.

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-public-discord-recall-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-public-discord-recall-envelope.v0.json
@@ -1,0 +1,47 @@
+{
+  "fixture_id": "recorded-public-discord-recall-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-35d.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; the projection target inside this envelope is the public discord render surface — same envelope can be projected to other surfaces by the adapter when authorized",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It contains no real user data, no live Dixie response, no live Finn output, and no governed Straylight memory. Authorized for non-production fixture use in Phase 35D only.",
+  "envelope_scope_note": "This represents a recorded Dixie-shaped recall response / projected recall payload. It is NOT raw chat log memory. It does NOT constitute admission of any chat content into governed Straylight memory. Memory authority remains with Straylight; live admission is post-MVP and out of scope.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_discord",
+    "render_surface": "discord_public_character",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "ok",
+    "public_summary": "actor is rehearsing the cross-interface continuity demo; voice preferences and participation observed across the substrate's character frames",
+    "included_count": 3,
+    "marked_count": 0,
+    "redacted_count": 1,
+    "excluded_count": 1,
+    "public_reason_counts": {
+      "redacted_for_public_surface": 1,
+      "excluded_from_public_surface": 1
+    },
+    "public_reason_labels": [
+      "redacted_for_public_surface",
+      "excluded_from_public_surface"
+    ],
+    "denied_or_refused": false
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "seed_authored_by_operator_PRIVATE_SENTINEL_DIXIE_RAW",
+      "voice_doctrine_seed_PRIVATE_SENTINEL_DIXIE_RAW",
+      "fixture_seed_context_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_SESSION_TRACE",
+    "operator_private_note": "operator-only diagnostic context for this envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "synthetic_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-referral-recall-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-referral-recall-envelope.v0.json
@@ -1,0 +1,42 @@
+{
+  "fixture_id": "recorded-referral-recall-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-35d.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; the projection target inside this envelope is a character-boundary referral on the public discord render surface",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It contains no real user data, no live Dixie response, no live Finn output, and no governed Straylight memory. Authorized for non-production fixture use in Phase 35D only.",
+  "envelope_scope_note": "This represents a recorded Dixie-shaped recall response in which the recall has been downgraded to a character-boundary referral. It is NOT raw chat log memory. It does NOT constitute admission of any chat content into governed Straylight memory.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_002",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_002",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_discord",
+    "render_surface": "discord_public_character",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "referral",
+    "public_summary": "this question lives closer to a different character frame",
+    "public_referral_message": "that lives closer to satoshi — try /satoshi for codex matters",
+    "safe_referral_target": "satoshi",
+    "included_count": 0,
+    "marked_count": 0,
+    "redacted_count": 0,
+    "excluded_count": 0,
+    "public_reason_counts": {},
+    "public_reason_labels": [],
+    "denied_or_refused": true
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "outside_ruggy_boundary_PRIVATE_SENTINEL_DIXIE_RAW",
+      "character_boundary_referral_rule_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_REFERRAL_TRACE",
+    "operator_private_note": "operator-only diagnostic context for this referral envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "character_boundary_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-unknown-version-envelope.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-unknown-version-envelope.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "recorded-unknown-version-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-35d.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v999_unknown",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It is intentionally tagged with an unknown envelope_version so the adapter must fail closed. Authorized for non-production fixture use in Phase 35D only.",
+  "envelope_scope_note": "This represents a Dixie-shaped envelope whose version is not known to the adapter. The adapter must reject it with unsupported_dixie_envelope_version and produce no projected DTO and no rendered output.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_003",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_003",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_discord",
+    "render_surface": "discord_public_character",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "ok",
+    "public_summary": "this payload is unreachable because envelope_version is unsupported",
+    "included_count": 0
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "unknown_version_envelope_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_UNKNOWN_VERSION_TRACE",
+    "operator_private_note": "operator-only diagnostic context for this unknown-version envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "unknown_version_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/recall-wedge/fixtures/validate-fixtures.mjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 // Phase 33B no-leak fixture validator for the Recall Wedge memory MVP.
+// Phase 35D extends this validator to also check recorded Dixie-safe
+// recall envelope fixtures under `dixie-envelope/`.
 // Deterministic, dependency-free, Node-compatible.
 //
-// Scope: parses the seed memory packet and the projected DTO fixtures,
-// verifies same continuity actor across frames, and grep-enforces that
-// public-safe DTOs carry no private sentinel strings or banned fields.
-// This is fixture validation only — not the renderer (33C) and not the
-// cross-interface demo (33D).
+// Scope: parses the seed memory packet, the projected DTO fixtures, and
+// the recorded Dixie envelope fixtures; verifies same continuity actor
+// across frames; grep-enforces that public-safe DTOs carry no private
+// sentinel strings or banned fields; verifies recorded Dixie envelopes
+// declare a known envelope_version (or, for the unknown-version fixture,
+// remain syntactically valid but unsupported). This is fixture
+// validation only — not the renderer (33C), not the cross-interface
+// demo (33D), and not the adapter (35D adapter unit tests cover
+// adapter behavior).
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -16,6 +22,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = __dirname;
 const SEED_DIR = join(FIXTURES_DIR, "seed-memory");
 const PROJECTED_DIR = join(FIXTURES_DIR, "projected-dto");
+const DIXIE_ENVELOPE_DIR = join(FIXTURES_DIR, "dixie-envelope");
 
 const SEED_FILE = "shared-substrate-demo.memory.json";
 const OPERATOR_PRIVATE_FILE = "operator-private-view.dto.json";
@@ -23,6 +30,17 @@ const PUBLIC_DISCORD_FILE = "public-discord-view.dto.json";
 const REFERRAL_FILE = "character-boundary-referral.dto.json";
 
 const PUBLIC_SAFE_DTOS = [PUBLIC_DISCORD_FILE, REFERRAL_FILE];
+
+const DIXIE_PUBLIC_ENVELOPE_FILE =
+  "recorded-public-discord-recall-envelope.v0.json";
+const DIXIE_REFERRAL_ENVELOPE_FILE =
+  "recorded-referral-recall-envelope.v0.json";
+const DIXIE_UNKNOWN_VERSION_ENVELOPE_FILE =
+  "recorded-unknown-version-envelope.json";
+
+const SUPPORTED_DIXIE_ENVELOPE_VERSIONS = [
+  "recall_wedge.dixie_envelope.v0",
+];
 
 const BANNED_PUBLIC_SUBSTRINGS = [
   "PRIVATE_SENTINEL",
@@ -216,11 +234,167 @@ for (const fname of PUBLIC_SAFE_DTOS) {
   ok(`${fname}: no banned public substrings`);
 }
 
+// --- 8. phase 35d recorded dixie envelope fixtures -------------------------
+//
+// As of phase 35d these fixtures are part of the recall-wedge fixture
+// contract. The validator must FAIL if the dixie-envelope directory or
+// any of the three required fixtures go missing — silently skipping
+// section 8 would let a future deletion regress the multi-surface
+// contract without warning.
+//
+// The unknown-version fixture is intentionally valid-JSON but tagged
+// with an unsupported envelope_version so adapter fail-closed tests
+// have something to bite on. Validator behavior: it must EXIST and
+// PARSE; its envelope_version must be PRESENT but NOT in the supported
+// list. Its unsupported-ness is the point — the validator does not
+// downgrade the run because of it.
+//
+// No leak-grep is run over raw Dixie envelope files: those intentionally
+// contain raw_dixie_debug / raw_session_trace / source_material /
+// PRIVATE_SENTINEL_* / session_id / message_id / continuity_actor_id
+// because the adapter is responsible for stripping that material before
+// it ever reaches a renderer. Public no-leak validation continues to
+// gate only the public-safe projected DTOs (section 7); adapter unit
+// tests cover the Dixie stripping behavior end-to-end.
+
+let dixieDirExists = false;
+try {
+  const st = statSync(DIXIE_ENVELOPE_DIR);
+  dixieDirExists = st.isDirectory();
+} catch {
+  dixieDirExists = false;
+}
+
+if (!dixieDirExists) {
+  fail(
+    `dixie-envelope: directory ${DIXIE_ENVELOPE_DIR} is required as of phase 35d but is missing`,
+  );
+} else {
+  ok("dixie-envelope: directory present");
+
+  const dixieFilesListed = listJsonFiles(DIXIE_ENVELOPE_DIR);
+  for (const f of dixieFilesListed) {
+    const loaded = loadJson(f);
+    if (loaded) ok(`parsed ${f}`);
+  }
+
+  const REQUIRED_DIXIE_FILES = [
+    DIXIE_PUBLIC_ENVELOPE_FILE,
+    DIXIE_REFERRAL_ENVELOPE_FILE,
+    DIXIE_UNKNOWN_VERSION_ENVELOPE_FILE,
+  ];
+
+  for (const fname of REQUIRED_DIXIE_FILES) {
+    const path = join(DIXIE_ENVELOPE_DIR, fname);
+    let present = false;
+    try {
+      present = statSync(path).isFile();
+    } catch {
+      present = false;
+    }
+    if (!present)
+      fail(`dixie-envelope: required fixture ${fname} is missing`);
+    else ok(`dixie-envelope: required fixture ${fname} present`);
+  }
+
+  const dixiePublic = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_PUBLIC_ENVELOPE_FILE),
+  );
+  const dixieReferral = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_REFERRAL_ENVELOPE_FILE),
+  );
+  const dixieUnknown = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_UNKNOWN_VERSION_ENVELOPE_FILE),
+  );
+
+  // Shared invariants run on ALL three fixtures (including the
+  // unknown-version one): synthetic, fixture_kind, input_envelope_kind,
+  // non_production_authorization_note. The unknown-version fixture is
+  // unsupported only on envelope_version — every other phase-35d
+  // invariant still applies.
+  const allDixie = [
+    ["dixie-public", dixiePublic],
+    ["dixie-referral", dixieReferral],
+    ["dixie-unknown-version", dixieUnknown],
+  ];
+
+  for (const [label, env] of allDixie) {
+    if (!env?.parsed) {
+      fail(`${label}: fixture failed to parse`);
+      continue;
+    }
+    const e = env.parsed;
+    if (e.synthetic !== true) fail(`${label}: synthetic must be true`);
+    else ok(`${label}: synthetic === true`);
+
+    if (e.fixture_kind !== "recorded_dixie_recall_envelope")
+      fail(
+        `${label}: fixture_kind must be recorded_dixie_recall_envelope, got ${e.fixture_kind}`,
+      );
+    else ok(`${label}: fixture_kind === recorded_dixie_recall_envelope`);
+
+    if (e.input_envelope_kind !== "recorded_dixie_recall_envelope")
+      fail(
+        `${label}: input_envelope_kind must be recorded_dixie_recall_envelope, got ${e.input_envelope_kind}`,
+      );
+    else ok(`${label}: input_envelope_kind === recorded_dixie_recall_envelope`);
+
+    if (!e.non_production_authorization_note)
+      fail(`${label}: non_production_authorization_note missing`);
+    else ok(`${label}: non_production_authorization_note present`);
+  }
+
+  // envelope_version: v0 fixtures must be SUPPORTED; the unknown-version
+  // fixture must be PRESENT but NOT SUPPORTED.
+  const supportedExpected = [
+    ["dixie-public", dixiePublic],
+    ["dixie-referral", dixieReferral],
+  ];
+  for (const [label, env] of supportedExpected) {
+    if (!env?.parsed) continue;
+    const e = env.parsed;
+    if (
+      typeof e.envelope_version !== "string" ||
+      !SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version)
+    )
+      fail(
+        `${label}: envelope_version must be one of [${SUPPORTED_DIXIE_ENVELOPE_VERSIONS.join("|")}], got ${e.envelope_version}`,
+      );
+    else ok(`${label}: envelope_version === ${e.envelope_version}`);
+  }
+
+  if (dixieUnknown?.parsed) {
+    const e = dixieUnknown.parsed;
+    if (
+      typeof e.envelope_version !== "string" ||
+      e.envelope_version.length === 0
+    )
+      fail(
+        "dixie-unknown-version: envelope_version must be present (it is meant to be syntactically valid but unsupported)",
+      );
+    else if (SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+      fail(
+        `dixie-unknown-version: envelope_version must NOT be in the supported list, got ${e.envelope_version} (it is meant to drive adapter fail-closed tests)`,
+      );
+    else
+      ok(
+        `dixie-unknown-version: envelope_version present and intentionally unsupported (${e.envelope_version})`,
+      );
+  }
+}
+
 // --- report ----------------------------------------------------------------
+
+const dixieFilesForReport = dixieDirExists
+  ? listJsonFiles(DIXIE_ENVELOPE_DIR)
+  : [];
 
 const fixtures = [
   ...seedFiles.map((f) => `  seed:      ${f.replace(FIXTURES_DIR + "/", "")}`),
   ...projectedFiles.map((f) => `  projected: ${f.replace(FIXTURES_DIR + "/", "")}`),
+  ...dixieFilesForReport.map(
+    (f) => `  dixie-env: ${f.replace(FIXTURES_DIR + "/", "")}`,
+  ),
 ].sort();
 
 console.log("recall-wedge phase 33b fixture validator");

--- a/packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts
+++ b/packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts
@@ -1,0 +1,664 @@
+// Phase 35D · adapter regression gate for recorded Dixie-safe recall envelopes.
+//
+// Drives `adaptDixieEnvelopeToPublicRecallProjection` and
+// `adaptDixieEnvelopeToRecallProjection` against the Phase 35D recorded
+// envelope fixtures shipped under `docs/recall-wedge/fixtures/dixie-envelope/`.
+// Proves:
+//
+//   1. a recorded public Dixie envelope adapts to a public_discord /
+//      discord_public_character DTO;
+//   2. that adapted DTO renders through `renderPublicRecallProjection`;
+//   3. a recorded referral envelope adapts to a referral DTO and renders
+//      through `renderPublicRecallProjection`;
+//   4. an unknown envelope_version fails closed with the
+//      `unsupported_dixie_envelope_version` code;
+//   5. non-object input fails closed;
+//   6. missing required envelope fields fail closed;
+//   7. raw / private / debug Dixie fields never appear in the adapted DTO;
+//   8. raw / private / debug Dixie fields never appear in the rendered
+//      public output;
+//   9. raw Dixie envelopes are NEVER passed directly to
+//      `renderPublicRecallProjection` (the adapter is the narrowing
+//      boundary, not the renderer);
+//  10. the adapter performs no network / Discord / Telegram / Dixie / Finn /
+//      Straylight / storage / LLM I/O — proven by import inspection;
+//  11. authorized_private_session target is rejected with a stable
+//      `authorized_private_projection_not_implemented` code (the §5a DTO
+//      gate has not been satisfied; no private renderer is authorized).
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DixieEnvelopeAdapterError,
+  adaptDixieEnvelopeToPublicRecallProjection,
+  adaptDixieEnvelopeToRecallProjection,
+  isSupportedDixieEnvelopeVersion,
+} from "./dixie-envelope-adapter.ts";
+
+import {
+  PublicRecallRenderError,
+  renderPublicRecallProjection,
+} from "./render-public-recall.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/recall-wedge/fixtures/dixie-envelope",
+);
+
+function loadFixture(name: string): unknown {
+  const path = resolve(FIXTURE_DIR, name);
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+const PUBLIC_DISCORD_ENVELOPE = loadFixture(
+  "recorded-public-discord-recall-envelope.v0.json",
+);
+const REFERRAL_ENVELOPE = loadFixture(
+  "recorded-referral-recall-envelope.v0.json",
+);
+const UNKNOWN_VERSION_ENVELOPE = loadFixture(
+  "recorded-unknown-version-envelope.json",
+);
+
+// Strings that must never appear anywhere in an adapted DTO or in rendered
+// public output. Mirrors the Phase 33C public-output guard plus the Dixie-
+// raw sentinels and operational identifiers that this adapter is explicitly
+// responsible for stripping.
+const PUBLIC_OUTPUT_BANNED_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "raw_dixie_debug",
+  "raw_session_trace",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "session_id",
+  "message_id",
+  "continuity_actor_id",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+function collectAllStrings(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectAllStrings(item, out);
+    return;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const [k, v] of Object.entries(value)) {
+      out.push(k);
+      collectAllStrings(v, out);
+    }
+  }
+}
+
+function dtoContainsBannedSubstring(dto: unknown): string | null {
+  const strings: string[] = [];
+  collectAllStrings(dto, strings);
+  for (const s of strings) {
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      if (s.includes(banned)) return banned;
+    }
+  }
+  return null;
+}
+
+describe("isSupportedDixieEnvelopeVersion", () => {
+  test("accepts the recorded v0 public envelope", () => {
+    expect(isSupportedDixieEnvelopeVersion(PUBLIC_DISCORD_ENVELOPE)).toBe(true);
+  });
+
+  test("accepts the recorded v0 referral envelope", () => {
+    expect(isSupportedDixieEnvelopeVersion(REFERRAL_ENVELOPE)).toBe(true);
+  });
+
+  test("rejects the unknown-version envelope", () => {
+    expect(isSupportedDixieEnvelopeVersion(UNKNOWN_VERSION_ENVELOPE)).toBe(
+      false,
+    );
+  });
+
+  test("rejects non-object input", () => {
+    expect(isSupportedDixieEnvelopeVersion(null)).toBe(false);
+    expect(isSupportedDixieEnvelopeVersion("nope")).toBe(false);
+    expect(isSupportedDixieEnvelopeVersion(42)).toBe(false);
+    expect(isSupportedDixieEnvelopeVersion([])).toBe(false);
+  });
+
+  test("rejects an envelope that omits envelope_version", () => {
+    const e = { ...(PUBLIC_DISCORD_ENVELOPE as Record<string, unknown>) };
+    delete e.envelope_version;
+    expect(isSupportedDixieEnvelopeVersion(e)).toBe(false);
+  });
+});
+
+describe("adaptDixieEnvelopeToPublicRecallProjection · public envelope", () => {
+  const dto = adaptDixieEnvelopeToPublicRecallProjection(
+    PUBLIC_DISCORD_ENVELOPE,
+  );
+
+  test("produces a public_discord / discord_public_character DTO", () => {
+    expect((dto as Record<string, unknown>).recall_interface).toBe(
+      "public_discord",
+    );
+    expect((dto as Record<string, unknown>).render_surface).toBe(
+      "discord_public_character",
+    );
+    expect((dto as Record<string, unknown>).outcome).toBe("ok");
+    expect((dto as Record<string, unknown>).character_frame).toBe("ruggy");
+  });
+
+  test("preserves the public counts and labels from the envelope payload", () => {
+    expect((dto as Record<string, unknown>).included_count).toBe(3);
+    expect((dto as Record<string, unknown>).redacted_count).toBe(1);
+    expect((dto as Record<string, unknown>).excluded_count).toBe(1);
+    expect((dto as Record<string, unknown>).public_reason_labels).toEqual([
+      "redacted_for_public_surface",
+      "excluded_from_public_surface",
+    ]);
+  });
+
+  test("renders successfully through the public-safe renderer", () => {
+    const text = renderPublicRecallProjection(dto);
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("[recall · public · ruggy · ok]");
+    expect(text).toContain("included=3");
+    expect(text).toContain("redacted_for_public_surface=1");
+  });
+
+  test("adapted DTO contains no raw / private / debug Dixie material", () => {
+    const banned = dtoContainsBannedSubstring(dto);
+    expect(banned).toBeNull();
+  });
+
+  test("rendered public output contains no raw / private / debug Dixie material", () => {
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("adapted DTO does not pass through session_id / message_id / continuity_actor_id", () => {
+    const obj = dto as Record<string, unknown>;
+    expect(obj.session_id).toBeUndefined();
+    expect(obj.message_id).toBeUndefined();
+    expect(obj.continuity_actor_id).toBeUndefined();
+    expect(obj.raw_dixie_debug).toBeUndefined();
+    expect(obj.raw_session_trace).toBeUndefined();
+    expect(obj.source_material).toBeUndefined();
+  });
+});
+
+describe("adaptDixieEnvelopeToPublicRecallProjection · referral envelope", () => {
+  const dto = adaptDixieEnvelopeToPublicRecallProjection(REFERRAL_ENVELOPE);
+
+  test("produces a referral DTO", () => {
+    expect((dto as Record<string, unknown>).outcome).toBe("referral");
+    expect((dto as Record<string, unknown>).safe_referral_target).toBe(
+      "satoshi",
+    );
+    expect((dto as Record<string, unknown>).public_referral_message).toContain(
+      "satoshi",
+    );
+    expect((dto as Record<string, unknown>).denied_or_refused).toBe(true);
+  });
+
+  test("renders successfully through the public-safe renderer", () => {
+    const text = renderPublicRecallProjection(dto);
+    expect(text).toContain("referral target: satoshi");
+    expect(text).toContain("referral message: that lives closer to satoshi");
+  });
+
+  test("adapted DTO and rendered text contain no raw Dixie material", () => {
+    const banned = dtoContainsBannedSubstring(dto);
+    expect(banned).toBeNull();
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+});
+
+describe("adaptDixieEnvelopeToPublicRecallProjection · fail-closed", () => {
+  test("rejects the unknown-version envelope with unsupported_dixie_envelope_version", () => {
+    expect(() =>
+      adaptDixieEnvelopeToPublicRecallProjection(UNKNOWN_VERSION_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(UNKNOWN_VERSION_ENVELOPE);
+    } catch (err) {
+      expect(err).toBeInstanceOf(DixieEnvelopeAdapterError);
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "unsupported_dixie_envelope_version",
+      );
+    }
+  });
+
+  test("rejects non-object input", () => {
+    for (const bad of [null, undefined, "nope", 7, true, []] as const) {
+      expect(() =>
+        adaptDixieEnvelopeToPublicRecallProjection(bad as unknown),
+      ).toThrow(DixieEnvelopeAdapterError);
+    }
+  });
+
+  test("rejects an envelope that omits envelope_version", () => {
+    const e = { ...(PUBLIC_DISCORD_ENVELOPE as Record<string, unknown>) };
+    delete e.envelope_version;
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      /envelope_version/,
+    );
+  });
+
+  test("rejects an envelope with the wrong input_envelope_kind", () => {
+    const e = {
+      ...(PUBLIC_DISCORD_ENVELOPE as Record<string, unknown>),
+      input_envelope_kind: "dixie_session_envelope",
+    };
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      /input_envelope_kind/,
+    );
+  });
+
+  test("rejects an envelope missing target_projection", () => {
+    const e = { ...(PUBLIC_DISCORD_ENVELOPE as Record<string, unknown>) };
+    delete e.target_projection;
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+  });
+
+  test("rejects an envelope missing public_recall_payload", () => {
+    const e = { ...(PUBLIC_DISCORD_ENVELOPE as Record<string, unknown>) };
+    delete e.public_recall_payload;
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      /public_recall_payload/,
+    );
+  });
+
+  test("rejects a referral envelope missing safe_referral_target", () => {
+    const e = JSON.parse(
+      JSON.stringify(REFERRAL_ENVELOPE),
+    ) as Record<string, unknown>;
+    const payload = e.public_recall_payload as Record<string, unknown>;
+    delete payload.safe_referral_target;
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      /safe_referral_target/,
+    );
+  });
+
+  test("rejects an envelope with an unknown outcome", () => {
+    const e = JSON.parse(
+      JSON.stringify(PUBLIC_DISCORD_ENVELOPE),
+    ) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).outcome = "exploding";
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      /outcome/,
+    );
+  });
+});
+
+describe("adaptDixieEnvelopeToRecallProjection · target options", () => {
+  test("default target picked from envelope.target_projection.recall_interface", () => {
+    const dto = adaptDixieEnvelopeToRecallProjection(PUBLIC_DISCORD_ENVELOPE);
+    expect((dto as Record<string, unknown>).recall_interface).toBe(
+      "public_discord",
+    );
+  });
+
+  test("explicit public_discord target produces a public_discord DTO", () => {
+    const dto = adaptDixieEnvelopeToRecallProjection(PUBLIC_DISCORD_ENVELOPE, {
+      target: "public_discord",
+    });
+    expect((dto as Record<string, unknown>).render_surface).toBe(
+      "discord_public_character",
+    );
+  });
+
+  test("authorized_private_session target fails closed with a stable code", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_DISCORD_ENVELOPE, {
+        target: "authorized_private_session",
+      }),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_DISCORD_ENVELOPE, {
+        target: "authorized_private_session",
+      });
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "authorized_private_projection_not_implemented",
+      );
+    }
+  });
+
+  test("public_telegram target fails closed (no shipped renderer in Phase 35D)", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_DISCORD_ENVELOPE, {
+        target: "public_telegram",
+      }),
+    ).toThrow(/public_telegram/);
+  });
+
+  test("unknown-version envelope still fails closed under adaptDixieEnvelopeToRecallProjection", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(UNKNOWN_VERSION_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(UNKNOWN_VERSION_ENVELOPE);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "unsupported_dixie_envelope_version",
+      );
+    }
+  });
+});
+
+describe("adapter is the narrowing boundary · raw envelope never reaches the renderer", () => {
+  test("renderer rejects a raw recorded Dixie envelope", () => {
+    // The renderer is bound to the projected-DTO contract, not to Dixie
+    // envelopes. Passing a raw envelope must fail closed inside the
+    // renderer, proving the adapter is the only path that can produce a
+    // renderable DTO.
+    expect(() =>
+      renderPublicRecallProjection(PUBLIC_DISCORD_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+    expect(() => renderPublicRecallProjection(REFERRAL_ENVELOPE)).toThrow(
+      PublicRecallRenderError,
+    );
+    expect(() =>
+      renderPublicRecallProjection(UNKNOWN_VERSION_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+
+  test("rendered public output from adapted public envelope has no banned substrings", () => {
+    const dto = adaptDixieEnvelopeToPublicRecallProjection(
+      PUBLIC_DISCORD_ENVELOPE,
+    );
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("rendered public output from adapted referral envelope has no banned substrings", () => {
+    const dto = adaptDixieEnvelopeToPublicRecallProjection(REFERRAL_ENVELOPE);
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+});
+
+describe("adapter is offline / pure · no live integration imports", () => {
+  test("adapter source imports nothing that could produce I/O", () => {
+    const adapterSource = readFileSync(
+      resolve(__dirname, "./dixie-envelope-adapter.ts"),
+      "utf8",
+    );
+    const FORBIDDEN_IMPORT_FRAGMENTS = [
+      "discord.js",
+      "node-telegram",
+      "telegraf",
+      "@anthropic-ai/claude-agent-sdk",
+      "@anthropic-ai/sdk",
+      "@loa/dixie",
+      "@loa/straylight",
+      "@loa/finn",
+      "fetch(",
+      "node:http",
+      "node:https",
+      "node:net",
+      "node:fs",
+      "node:child_process",
+    ];
+    for (const fragment of FORBIDDEN_IMPORT_FRAGMENTS) {
+      expect(adapterSource).not.toContain(fragment);
+    }
+  });
+});
+
+// Anti-vacuity: prove the SOURCE fixtures actually contain the planted raw /
+// private / debug sentinels before adaptation. Without this, the no-leak
+// assertions on the adapted DTO and rendered text could be vacuously true if
+// someone quietly cleaned the fixtures. These tests fail loudly in that case
+// so the rest of the proof cannot drift into vacuity.
+describe("source fixture sentinel presence · no-leak proof is non-vacuous", () => {
+  const REQUIRED_SOURCE_SENTINELS = [
+    "PRIVATE_SENTINEL",
+    "raw_dixie_debug",
+    "raw_session_trace",
+    "raw_reasons",
+    "source_material",
+    "session_id",
+    "message_id",
+    "continuity_actor_id",
+  ] as const;
+
+  function rawFixture(name: string): string {
+    return readFileSync(resolve(FIXTURE_DIR, name), "utf8");
+  }
+
+  test("recorded public Dixie envelope fixture carries every required raw/private sentinel", () => {
+    const raw = rawFixture("recorded-public-discord-recall-envelope.v0.json");
+    for (const sentinel of REQUIRED_SOURCE_SENTINELS) {
+      expect(raw).toContain(sentinel);
+    }
+  });
+
+  test("recorded referral Dixie envelope fixture carries every required raw/private sentinel", () => {
+    const raw = rawFixture("recorded-referral-recall-envelope.v0.json");
+    for (const sentinel of REQUIRED_SOURCE_SENTINELS) {
+      expect(raw).toContain(sentinel);
+    }
+  });
+
+  test("recorded unknown-version Dixie envelope fixture carries every required raw/private sentinel", () => {
+    const raw = rawFixture("recorded-unknown-version-envelope.json");
+    for (const sentinel of REQUIRED_SOURCE_SENTINELS) {
+      expect(raw).toContain(sentinel);
+    }
+  });
+});
+
+// The adapter is the narrowing boundary. Even though it only reads named
+// allowlist fields, an allowed field's STRING VALUE could still smuggle
+// banned material. The adapter must reject before returning, not delegate
+// to the renderer's defense-in-depth scan.
+describe("adapter fails closed when allowed payload fields smuggle banned material", () => {
+  function clone<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+  }
+
+  test("public_summary smuggling PRIVATE_SENTINEL trips the projection scan", () => {
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_summary =
+      "PRIVATE_SENTINEL_SHOULD_FAIL";
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("public_reason_labels containing 'raw_reasons' trips the projection scan", () => {
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_reason_labels =
+      ["redacted_for_public_surface", "raw_reasons"];
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("public_reason_counts with a key carrying 'source_material' trips the projection scan", () => {
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_reason_counts =
+      {
+        redacted_for_public_surface: 1,
+        smuggled_source_material_key: 2,
+      };
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("public_reason_counts with a contaminated STRING value trips the scan before numeric filtering", () => {
+    // Without the pre-normalization scan, the adapter's existing
+    // finite-non-negative-int filter on public_reason_counts would silently
+    // drop this entry and return a DTO with public_reason_counts: {} —
+    // erasing contamination instead of failing closed. The pre-normalization
+    // scan must catch the raw payload before that filter runs.
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_reason_counts =
+      {
+        redacted_for_public_surface: "source_material",
+      };
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("public_reason_counts contaminated string value also fails closed via adaptDixieEnvelopeToRecallProjection({ target: 'public_discord' })", () => {
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_reason_counts =
+      {
+        redacted_for_public_surface: "source_material",
+      };
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(e, { target: "public_discord" }),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(e, { target: "public_discord" });
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("public_reason_counts with PRIVATE_SENTINEL embedded in a string value also trips the scan", () => {
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_reason_counts =
+      {
+        redacted_for_public_surface: "PRIVATE_SENTINEL_LEAK",
+      };
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("character_frame smuggling actor identifier trips the projection scan", () => {
+    const e = clone(PUBLIC_DISCORD_ENVELOPE) as Record<string, unknown>;
+    (e.target_projection as Record<string, unknown>).character_frame =
+      "freeside-characters:shared-substrate";
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("referral public_referral_message smuggling debug substring trips the projection scan", () => {
+    const e = clone(REFERRAL_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_referral_message =
+      "that lives closer to satoshi — debug payload PRIVATE_SENTINEL";
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("referral safe_referral_target smuggling session_id trips the projection scan", () => {
+    const e = clone(REFERRAL_ENVELOPE) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).safe_referral_target =
+      "satoshi-session_id-leak";
+    expect(() => adaptDixieEnvelopeToPublicRecallProjection(e)).toThrow(
+      DixieEnvelopeAdapterError,
+    );
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(e);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+
+  test("scan also fires through the broader adaptDixieEnvelopeToRecallProjection entry point", () => {
+    const e = JSON.parse(
+      JSON.stringify(PUBLIC_DISCORD_ENVELOPE),
+    ) as Record<string, unknown>;
+    (e.public_recall_payload as Record<string, unknown>).public_summary =
+      "summary PRIVATE_SENTINEL_OPERATOR_ONLY";
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(e, { target: "public_discord" }),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(e, { target: "public_discord" });
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "banned_private_material_in_projection",
+      );
+    }
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts
+++ b/packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts
@@ -1,0 +1,438 @@
+// Phase 35D · pure adapter from a recorded Dixie-safe recall envelope to the
+// local Recall Wedge projected DTO consumed by the Phase 33C public-safe
+// renderer.
+//
+// Boundary (per docs/RECALL-WEDGE-MULTI-SURFACE-CONTRACT.md §9, §9a, and the
+// Phase 35D brief):
+//   - the adapter is the ONLY narrowing boundary from a Dixie-shaped envelope
+//     to a local projected DTO; renderers, runners, and surface frames never
+//     read Dixie envelopes directly;
+//   - only known recorded envelope versions are accepted; unknown / missing /
+//     malformed versions fail closed with a stable error code;
+//   - raw / private / debug Dixie material (raw_dixie_debug, raw_reasons,
+//     raw_session_trace, source_material, PRIVATE_SENTINEL_*, operator
+//     diagnostics, hidden estate, full assertion bodies) is NEVER passed
+//     through to the projected DTO;
+//   - operational/session identifiers (session_id, message_id,
+//     continuity_actor_id) are NEVER emitted on the projected DTO; the §9
+//     allowlist excludes them from the public surface and the adapter is
+//     responsible for stripping them before any rendering occurs;
+//   - authorized_private_session is gated on the §5a authorized-private DTO
+//     gate and is not authorized by this phase; the adapter fails closed on
+//     that target with a stable error code rather than inventing a private
+//     renderer;
+//   - the adapter does NOT call the network, Discord, Telegram, Dixie, Finn,
+//     Straylight, storage, or any LLM. It is a pure synchronous function over
+//     in-memory envelope data.
+//
+// This adapter is fixture-only for Phase 35D. It is not wired to any live
+// Discord command path, any live Telegram path, any live Dixie client, or any
+// memory admission path.
+
+const SUPPORTED_DIXIE_ENVELOPE_VERSIONS = [
+  "recall_wedge.dixie_envelope.v0",
+] as const;
+
+const SUPPORTED_PUBLIC_RECALL_INTERFACE = "public_discord" as const;
+const SUPPORTED_PUBLIC_RENDER_SURFACE = "discord_public_character" as const;
+
+const ALLOWED_PUBLIC_OUTCOMES = ["ok", "referral"] as const;
+type AllowedPublicOutcome = (typeof ALLOWED_PUBLIC_OUTCOMES)[number];
+
+// Adapter-level fail-closed scan. The adapter is the narrowing boundary —
+// even though it only reads named allowlist fields out of public_recall_payload
+// and target_projection, an allowed field's STRING VALUE could still carry
+// banned material (e.g. a malicious public_summary that embeds
+// PRIVATE_SENTINEL, or a public_reason_label that smuggles raw_reasons). The
+// adapter must reject before returning, not delegate that responsibility to
+// the renderer's defense-in-depth scan.
+const ADAPTER_BANNED_PROJECTION_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "raw_dixie_debug",
+  "raw_session_trace",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "session_id",
+  "message_id",
+  "continuity_actor_id",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+export type DixieEnvelopeAdapterTarget =
+  | "public_discord"
+  | "public_telegram"
+  | "authorized_private_session";
+
+export interface DixieEnvelopeAdapterOptions {
+  readonly target?: DixieEnvelopeAdapterTarget;
+}
+
+export class DixieEnvelopeAdapterError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "DixieEnvelopeAdapterError";
+    this.code = code;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Walk every key and every string value in a reconstructed projection and
+// report the first banned substring encountered, or null if clean. Cycle-safe
+// via a visited set. Numbers / booleans / nulls cannot leak text.
+function findBannedProjectionMaterial(
+  value: unknown,
+  visited: WeakSet<object> = new WeakSet(),
+): string | null {
+  if (typeof value === "string") {
+    for (const banned of ADAPTER_BANNED_PROJECTION_SUBSTRINGS) {
+      if (value.includes(banned)) return banned;
+    }
+    return null;
+  }
+  if (Array.isArray(value)) {
+    if (visited.has(value)) return null;
+    visited.add(value);
+    for (const item of value) {
+      const hit = findBannedProjectionMaterial(item, visited);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (isPlainObject(value)) {
+    if (visited.has(value)) return null;
+    visited.add(value);
+    for (const [key, sub] of Object.entries(value)) {
+      for (const banned of ADAPTER_BANNED_PROJECTION_SUBSTRINGS) {
+        if (key.includes(banned)) return banned;
+      }
+      const hit = findBannedProjectionMaterial(sub, visited);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  return null;
+}
+
+function assertProjectionIsClean(projection: unknown): void {
+  const hit = findBannedProjectionMaterial(projection);
+  if (hit !== null) {
+    throw new DixieEnvelopeAdapterError(
+      "banned_private_material_in_projection",
+      `reconstructed projected DTO contained banned private material ("${hit}"); refusing to return adapter output`,
+    );
+  }
+}
+
+// Pre-normalization scan of every RAW allowlisted source field the adapter is
+// about to read out of the envelope. This must run BEFORE any filtering /
+// type-coercion (e.g. public_reason_counts entries being filtered to finite
+// non-negative numbers, public_summary being dropped if not a non-empty
+// string), otherwise contaminated string values inside otherwise-allowed
+// fields could be silently erased instead of triggering a fail-closed throw.
+//
+// The scan is deliberately scoped to the allowlisted source fields only —
+// raw_dixie_debug, raw_session_trace, source_material, session_id,
+// message_id, and continuity_actor_id intentionally exist elsewhere in the
+// envelope and must be stripped by selective field-reading, not make every
+// fixture fail.
+function assertAllowedSourceFieldsAreClean(
+  targetProjection: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): void {
+  const allowedSourceView = {
+    character_frame: targetProjection.character_frame,
+    outcome: payload.outcome,
+    public_summary: payload.public_summary,
+    included_count: payload.included_count,
+    marked_count: payload.marked_count,
+    redacted_count: payload.redacted_count,
+    excluded_count: payload.excluded_count,
+    public_reason_labels: payload.public_reason_labels,
+    public_reason_counts: payload.public_reason_counts,
+    denied_or_refused: payload.denied_or_refused,
+    safe_referral_target: payload.safe_referral_target,
+    public_referral_message: payload.public_referral_message,
+  };
+  const hit = findBannedProjectionMaterial(allowedSourceView);
+  if (hit !== null) {
+    throw new DixieEnvelopeAdapterError(
+      "banned_private_material_in_projection",
+      `dixie envelope's allowlisted source fields contained banned private material ("${hit}") before normalization; refusing to project`,
+    );
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isFiniteNonNegativeInt(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+function asAllowedPublicOutcome(value: unknown): AllowedPublicOutcome | null {
+  return typeof value === "string" &&
+    (ALLOWED_PUBLIC_OUTCOMES as readonly string[]).includes(value)
+    ? (value as AllowedPublicOutcome)
+    : null;
+}
+
+export function isSupportedDixieEnvelopeVersion(envelope: unknown): boolean {
+  if (!isPlainObject(envelope)) return false;
+  const v = envelope.envelope_version;
+  return (
+    typeof v === "string" &&
+    (SUPPORTED_DIXIE_ENVELOPE_VERSIONS as readonly string[]).includes(v)
+  );
+}
+
+interface AdaptedPublicRecallProjection {
+  readonly recall_interface: typeof SUPPORTED_PUBLIC_RECALL_INTERFACE;
+  readonly render_surface: typeof SUPPORTED_PUBLIC_RENDER_SURFACE;
+  readonly outcome: AllowedPublicOutcome;
+  readonly character_frame?: string;
+  readonly public_summary?: string;
+  readonly included_count?: number;
+  readonly marked_count?: number;
+  readonly redacted_count?: number;
+  readonly excluded_count?: number;
+  readonly public_reason_labels?: readonly string[];
+  readonly public_reason_counts?: Readonly<Record<string, number>>;
+  readonly denied_or_refused?: boolean;
+  readonly safe_referral_target?: string;
+  readonly public_referral_message?: string;
+}
+
+function requireEnvelope(envelope: unknown): Record<string, unknown> {
+  if (!isPlainObject(envelope)) {
+    throw new DixieEnvelopeAdapterError(
+      "not_object",
+      "dixie envelope must be a plain object",
+    );
+  }
+  return envelope;
+}
+
+function requireSupportedVersion(envelope: Record<string, unknown>): void {
+  const v = envelope.envelope_version;
+  if (typeof v !== "string" || v.length === 0) {
+    throw new DixieEnvelopeAdapterError(
+      "missing_dixie_envelope_version",
+      "dixie envelope must declare an envelope_version",
+    );
+  }
+  if (!(SUPPORTED_DIXIE_ENVELOPE_VERSIONS as readonly string[]).includes(v)) {
+    throw new DixieEnvelopeAdapterError(
+      "unsupported_dixie_envelope_version",
+      `dixie envelope_version "${v}" is not supported by this adapter; refusing to project`,
+    );
+  }
+}
+
+function requireRecordedRecallKind(envelope: Record<string, unknown>): void {
+  if (envelope.input_envelope_kind !== "recorded_dixie_recall_envelope") {
+    throw new DixieEnvelopeAdapterError(
+      "wrong_input_envelope_kind",
+      "adapter expects input_envelope_kind=recorded_dixie_recall_envelope",
+    );
+  }
+}
+
+function pickTarget(
+  envelope: Record<string, unknown>,
+  options: DixieEnvelopeAdapterOptions | undefined,
+): DixieEnvelopeAdapterTarget {
+  if (options?.target) return options.target;
+  const tp = envelope.target_projection;
+  if (isPlainObject(tp)) {
+    const ri = tp.recall_interface;
+    if (ri === "public_discord") return "public_discord";
+    if (ri === "public_telegram") return "public_telegram";
+    if (ri === "authorized_private_session") {
+      return "authorized_private_session";
+    }
+  }
+  throw new DixieEnvelopeAdapterError(
+    "unknown_target_projection",
+    "dixie envelope target_projection.recall_interface is missing or unknown; refusing to project",
+  );
+}
+
+function projectPublicDiscord(
+  envelope: Record<string, unknown>,
+): AdaptedPublicRecallProjection {
+  const tp = envelope.target_projection;
+  if (!isPlainObject(tp)) {
+    throw new DixieEnvelopeAdapterError(
+      "missing_target_projection",
+      "dixie envelope is missing target_projection",
+    );
+  }
+  if (tp.recall_interface !== SUPPORTED_PUBLIC_RECALL_INTERFACE) {
+    throw new DixieEnvelopeAdapterError(
+      "wrong_recall_interface_for_target",
+      `public_discord adapter expected target_projection.recall_interface=${SUPPORTED_PUBLIC_RECALL_INTERFACE}, got "${String(tp.recall_interface)}"`,
+    );
+  }
+  if (tp.render_surface !== SUPPORTED_PUBLIC_RENDER_SURFACE) {
+    throw new DixieEnvelopeAdapterError(
+      "wrong_render_surface_for_target",
+      `public_discord adapter expected target_projection.render_surface=${SUPPORTED_PUBLIC_RENDER_SURFACE}, got "${String(tp.render_surface)}"`,
+    );
+  }
+
+  const payload = envelope.public_recall_payload;
+  if (!isPlainObject(payload)) {
+    throw new DixieEnvelopeAdapterError(
+      "missing_public_recall_payload",
+      "dixie envelope is missing public_recall_payload",
+    );
+  }
+
+  const outcome = asAllowedPublicOutcome(payload.outcome);
+  if (outcome === null) {
+    throw new DixieEnvelopeAdapterError(
+      "unknown_outcome",
+      `public_recall_payload.outcome must be one of ${ALLOWED_PUBLIC_OUTCOMES.join("|")}`,
+    );
+  }
+
+  if (outcome === "referral") {
+    if (!isNonEmptyString(payload.safe_referral_target)) {
+      throw new DixieEnvelopeAdapterError(
+        "missing_referral_target",
+        "referral outcome requires public_recall_payload.safe_referral_target",
+      );
+    }
+    if (!isNonEmptyString(payload.public_referral_message)) {
+      throw new DixieEnvelopeAdapterError(
+        "missing_referral_message",
+        "referral outcome requires public_recall_payload.public_referral_message",
+      );
+    }
+  }
+
+  // Fail closed BEFORE filtering / type coercion. If we filtered first, a
+  // contaminated string value in public_reason_counts (e.g.
+  // { redacted_for_public_surface: "source_material" }) would be silently
+  // dropped by the finite-non-negative-int filter, masking the contamination
+  // instead of surfacing it. Running the scan here forces the throw.
+  assertAllowedSourceFieldsAreClean(tp, payload);
+
+  // Reconstructed allowlist projection. Every renderer-bound field is
+  // explicitly read from the envelope's public_recall_payload and the
+  // target_projection.character_frame; nothing else from the envelope is
+  // forwarded. raw_dixie_debug, raw_session_trace, source_material,
+  // operator diagnostics, session_id, message_id, and continuity_actor_id
+  // are intentionally not read here so they cannot leak into the DTO even
+  // by accident.
+  const projection: AdaptedPublicRecallProjection = {
+    recall_interface: SUPPORTED_PUBLIC_RECALL_INTERFACE,
+    render_surface: SUPPORTED_PUBLIC_RENDER_SURFACE,
+    outcome,
+    character_frame: isNonEmptyString(tp.character_frame)
+      ? tp.character_frame
+      : undefined,
+    public_summary: isNonEmptyString(payload.public_summary)
+      ? payload.public_summary
+      : undefined,
+    included_count: isFiniteNonNegativeInt(payload.included_count)
+      ? payload.included_count
+      : undefined,
+    marked_count: isFiniteNonNegativeInt(payload.marked_count)
+      ? payload.marked_count
+      : undefined,
+    redacted_count: isFiniteNonNegativeInt(payload.redacted_count)
+      ? payload.redacted_count
+      : undefined,
+    excluded_count: isFiniteNonNegativeInt(payload.excluded_count)
+      ? payload.excluded_count
+      : undefined,
+    public_reason_labels: isStringArray(payload.public_reason_labels)
+      ? [...payload.public_reason_labels]
+      : undefined,
+    public_reason_counts: isPlainObject(payload.public_reason_counts)
+      ? Object.fromEntries(
+          Object.entries(payload.public_reason_counts).filter(
+            (entry): entry is [string, number] =>
+              isFiniteNonNegativeInt(entry[1]),
+          ),
+        )
+      : undefined,
+    denied_or_refused:
+      typeof payload.denied_or_refused === "boolean"
+        ? payload.denied_or_refused
+        : false,
+    safe_referral_target: isNonEmptyString(payload.safe_referral_target)
+      ? payload.safe_referral_target
+      : undefined,
+    public_referral_message: isNonEmptyString(payload.public_referral_message)
+      ? payload.public_referral_message
+      : undefined,
+  };
+
+  return projection;
+}
+
+export function adaptDixieEnvelopeToPublicRecallProjection(
+  envelope: unknown,
+): unknown {
+  const obj = requireEnvelope(envelope);
+  requireSupportedVersion(obj);
+  requireRecordedRecallKind(obj);
+  const projection = projectPublicDiscord(obj);
+  assertProjectionIsClean(projection);
+  return projection;
+}
+
+export function adaptDixieEnvelopeToRecallProjection(
+  envelope: unknown,
+  options?: DixieEnvelopeAdapterOptions,
+): unknown {
+  const obj = requireEnvelope(envelope);
+  requireSupportedVersion(obj);
+  requireRecordedRecallKind(obj);
+
+  const target = pickTarget(obj, options);
+
+  if (target === "authorized_private_session") {
+    throw new DixieEnvelopeAdapterError(
+      "authorized_private_projection_not_implemented",
+      "authorized_private_session target is gated on the §5a authorized-private DTO gate; no private renderer is authorized in Phase 35D",
+    );
+  }
+
+  if (target === "public_telegram") {
+    throw new DixieEnvelopeAdapterError(
+      "public_telegram_projection_not_implemented",
+      "public_telegram target has no shipped renderer in Phase 35D; refusing to project to a renderer that does not exist",
+    );
+  }
+
+  const projection = projectPublicDiscord(obj);
+  assertProjectionIsClean(projection);
+  return projection;
+}


### PR DESCRIPTION
## Summary

Phase 35D adds recorded Dixie envelope contract fixtures plus a pure Recall Wedge adapter for `freeside-characters`.

This PR remains fixture-bound and pre-live. It does not add a live Dixie client, Discord/Telegram wiring, storage, memory admission, or character voice.

The proof shape is:

```text
recorded Dixie-safe envelope fixture
        ↓
pure narrowing adapter
        ↓
local Recall Wedge projected DTO
        ↓
existing public renderer
```

Files

New:

docs/recall-wedge/fixtures/dixie-envelope/recorded-public-discord-recall-envelope.v0.json
docs/recall-wedge/fixtures/dixie-envelope/recorded-referral-recall-envelope.v0.json
docs/recall-wedge/fixtures/dixie-envelope/recorded-unknown-version-envelope.json
packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts
packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts

Modified:

docs/recall-wedge/fixtures/README.md
docs/recall-wedge/fixtures/validate-fixtures.mjs
Adapter behavior

The adapter:

accepts only recall_wedge.dixie_envelope.v0
rejects unknown versions with unsupported_dixie_envelope_version
rejects non-object input, missing fields, and wrong input_envelope_kind
adapts public Discord envelopes to public_discord / discord_public_character
adapts referral/downgrade envelopes to renderable referral DTOs
keeps authorized_private_session fail-closed
keeps public_telegram fail-closed
performs pre-normalization scans over allowlisted source fields
performs projection no-leak scans before returning adapted DTOs
never passes raw Dixie envelopes directly to the public renderer
No-leak boundary

The adapter rejects banned/private material in allowed source fields and reconstructed projections, including raw reasons, raw Dixie debug, session traces, source material, private sentinels, session/message IDs, continuity actor IDs, actor lines, private identifiers, and hidden/source/assertion material.

The raw Dixie envelope fixtures intentionally contain raw/private/debug material so tests can prove the adapter strips or rejects it. The validator therefore does not leak-grep raw envelope fixtures; adapter tests enforce stripping/fail-closed behavior.

Validator update

validate-fixtures.mjs now requires:

docs/recall-wedge/fixtures/dixie-envelope/
recorded-public-discord-recall-envelope.v0.json
recorded-referral-recall-envelope.v0.json
recorded-unknown-version-envelope.json

The unknown-version fixture remains syntactically valid but intentionally unsupported.

Validation

Claude report:

added three recorded Dixie envelope fixtures
added pure adapter and colocated tests
updated fixture README and validator
no package/lockfile/dependency changes
no Discord/Telegram wiring
no live Dixie, Straylight, Finn, storage, admission, or voice
validator: 52 passed, 0 failed
recall-wedge tests: 178 passed, 0 failed
typecheck grep found no Recall Wedge/adapter diagnostics

Codex audit:

VERDICT: ACCEPT
no exact file/line concerns
scope accepted
pre-normalization scan accepted
projection no-leak scan accepted
source-sentinel non-vacuity accepted
contaminated-payload fail-closed accepted
fixture/validator accepted
adapter behavior accepted
renderer-boundary accepted
no overclaims found

Local validation before commit:

node docs/recall-wedge/fixtures/validate-fixtures.mjs
52 passed, 0 failed
cd packages/persona-engine && bun test src/recall-wedge/
178 passed, 0 failed
bun run typecheck 2>&1 | grep -E 'recall-wedge|render-public-recall|demo-cross-interface|run-demo|dixie-envelope-adapter' || true
no output

Note: repo-wide bun run typecheck still reports pre-existing unrelated workspace dependency/type errors outside Recall Wedge files.

Non-goals

This PR intentionally does not add:

package or lockfile changes
dependencies
Discord command wiring
Telegram bot wiring
live Dixie client
@loa/straylight
@loa/dixie
Finn integration
production storage
live memory admission
production auth/consent
public_telegram renderer
authorized_private_session renderer
LLM-based recall rewriting
character-voiced recall summaries