### PR TITLE
Phase 36B test(persona-engine): expand Recall Wedge Dixie envelope fixtures

### DIFF
--- a/docs/recall-wedge/fixtures/README.md
+++ b/docs/recall-wedge/fixtures/README.md
@@ -16,19 +16,27 @@ docs/recall-wedge/fixtures/
     operator-private-view.dto.json       operator_private projection
     public-discord-view.dto.json         public_discord projection
     character-boundary-referral.dto.json public_discord referral projection
-  dixie-envelope/                        phase 35d recorded dixie envelope fixtures
+  dixie-envelope/                        recorded dixie envelope fixtures (phase 35d + phase 36b)
     recorded-public-discord-recall-envelope.v0.json
     recorded-referral-recall-envelope.v0.json
     recorded-unknown-version-envelope.json
-  validate-fixtures.mjs                  phase 33b/35d no-leak fixture validator
+    recorded-refusal-unauthorized-envelope.v0.json
+    recorded-session-bearing-public-recall-envelope.v0.json
+    recorded-authorized-private-target-envelope.v0.json
+    recorded-public-telegram-target-envelope.v0.json
+    recorded-malformed-missing-payload-envelope.v0.json
+    recorded-malformed-missing-target-envelope.v0.json
+  validate-fixtures.mjs                  phase 33b/35d/36b fixture validator
   README.md                              this file
 ```
 
-`dixie-envelope/` is the Phase 35D home for recorded **Dixie-shaped recall
-envelope** fixtures. These envelopes feed the pure adapter at
-`packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`. The
-adapter is the only narrowing boundary from a Dixie envelope to a local
-projected DTO — the Phase 33C public renderer never reads a Dixie
+`dixie-envelope/` is the home for recorded **Dixie-shaped recall
+envelope** fixtures — Phase 35D shipped the first three; Phase 36B
+expands the corpus with refusal/unauthorized, session-bearing, and four
+intentional negative fixtures. These envelopes feed the pure adapter at
+`packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`.
+The adapter is the only narrowing boundary from a Dixie envelope to a
+local projected DTO — the Phase 33C public renderer never reads a Dixie
 envelope directly. The envelope fixtures intentionally include
 raw / private / debug material (`raw_dixie_debug`, `raw_session_trace`,
 `source_material`, `PRIVATE_SENTINEL_*`, `session_id`, `message_id`,
@@ -40,6 +48,53 @@ payloads**. They are not raw chat log memory and they do not constitute
 admission of any chat content into governed Straylight memory. Memory
 authority remains with Straylight; live admission is post-MVP and out of
 scope.
+
+> **Recorded fixtures are sample v0 contract probes only.** They are
+> not production schema authority. Live envelope contract truth must
+> come later from a Dixie-side artifact, endpoint contract, or
+> cross-repo decision. Adding more recorded fixtures, version bumps,
+> or adapter dispatch entries does not promote any of those shapes to
+> "the live contract" — see
+> `docs/RECALL-WEDGE-LIVE-BOUNDARY-DECISION.md` §7a (recorded fixtures
+> are examples, not schema authority).
+
+### Positive vs negative corpus
+
+The Dixie envelope fixtures split cleanly into a **positive corpus**
+(valid v0 envelopes the adapter projects through to a public-safe DTO)
+and a **negative corpus** (intentional fail-closed shapes that drive
+specific adapter error codes).
+
+| Fixture | Class | What it proves |
+|---------|-------|----------------|
+| `recorded-public-discord-recall-envelope.v0.json` | positive · normal public | adapts to public_discord/discord_public_character DTO; renders safely; raw envelope material stripped |
+| `recorded-referral-recall-envelope.v0.json` | positive · referral | adapts to referral DTO with safe target/message; renders safely |
+| `recorded-refusal-unauthorized-envelope.v0.json` | positive · refusal/unauthorized | adapts to a public-safe generic-refusal DTO (reuses `outcome=referral` + `denied_or_refused=true` + a generic `safe_referral_target=authorized_session` and authorization-shaped `public_referral_message`); renders safely; **does not authorize a positive `authorized_private_session` projection** |
+| `recorded-session-bearing-public-recall-envelope.v0.json` | positive · session-bearing | adapts to a public_discord DTO; **proves session_id / message_id / tenant_id / community_id / session_thread_id are stripped from the projected DTO and the rendered public text** |
+| `recorded-unknown-version-envelope.json` | negative · unsupported version | adapter throws `unsupported_dixie_envelope_version` |
+| `recorded-authorized-private-target-envelope.v0.json` | negative · authorized_private_session target | adapter throws `authorized_private_projection_not_implemented` (multi-surface contract §5a authorized-private DTO gate is unsatisfied) |
+| `recorded-public-telegram-target-envelope.v0.json` | negative · public_telegram target | adapter throws `public_telegram_projection_not_implemented` (multi-surface contract §8a future-renderer warning's per-surface contract is unsatisfied for Telegram) |
+| `recorded-malformed-missing-payload-envelope.v0.json` | negative · malformed | adapter throws `missing_public_recall_payload` |
+| `recorded-malformed-missing-target-envelope.v0.json` | negative · malformed | adapter throws `missing_target_projection` (or stable-equivalent target-resolution error) |
+
+### Phase 36B-specific rules
+
+- **`session_id` / `message_id` are operational identifiers, not memory
+  identity.** The session-bearing fixture exists to prove the adapter
+  strips them; they must never appear on the adapted DTO or the
+  rendered public output. (Multi-surface contract §5.)
+- **`authorized_private_session` and `public_telegram` fixtures are
+  negative-only in this phase.** They drive the adapter's existing
+  fail-closed paths and **do not** authorize a positive
+  `authorized_private_session` projection, an `authorized_private_session`
+  renderer, or a `public_telegram` renderer. Those gates remain
+  unsatisfied — see `docs/RECALL-WEDGE-LIVE-BOUNDARY-DECISION.md` §8
+  (authorized-private remains blocked) and §9 (public surfaces remain
+  blocked).
+- **No live integration is introduced by Phase 36B.** No live Dixie
+  network call, no Discord command wiring, no Telegram bot wiring, no
+  production storage, no admission, no LLM/voice rewrite. The corpus
+  remains recorded-envelope-bound and dev/operator-gated.
 
 `projected-dto/` is the neutral home for **all** projected views of the
 seed packet — operator-private and public-safe alike. Naming it
@@ -162,23 +217,51 @@ It checks (Phase 33B):
   `source_material`, `hidden estate`, `assertion_id`,
   `full assertion bodies`, `private identifiers`).
 
-It also checks (Phase 35D — required, not optional):
+It also checks (Phase 35D + Phase 36B — required, not optional):
 
 - the `dixie-envelope/` directory exists;
-- all three required fixtures are present:
-  `recorded-public-discord-recall-envelope.v0.json`,
-  `recorded-referral-recall-envelope.v0.json`,
-  `recorded-unknown-version-envelope.json`;
-- every Dixie envelope fixture is `synthetic: true`,
+- all required Dixie envelope fixtures are present:
+  - Phase 35D — `recorded-public-discord-recall-envelope.v0.json`,
+    `recorded-referral-recall-envelope.v0.json`,
+    `recorded-unknown-version-envelope.json`;
+  - Phase 36B — `recorded-refusal-unauthorized-envelope.v0.json`,
+    `recorded-session-bearing-public-recall-envelope.v0.json`,
+    `recorded-authorized-private-target-envelope.v0.json`,
+    `recorded-public-telegram-target-envelope.v0.json`,
+    `recorded-malformed-missing-payload-envelope.v0.json`,
+    `recorded-malformed-missing-target-envelope.v0.json`;
+- every Dixie envelope fixture (positive **and** negative) carries the
+  shared metadata invariants — `synthetic: true`,
   `fixture_kind: recorded_dixie_recall_envelope`,
   `input_envelope_kind: recorded_dixie_recall_envelope`,
-  and carries a `non_production_authorization_note`;
-- the v0 envelope fixtures use a supported `envelope_version`
-  (currently `recall_wedge.dixie_envelope.v0`);
-- the unknown-version fixture remains **syntactically valid** with an
-  `envelope_version` that is **present but intentionally unsupported**
-  — this fixture exists to drive adapter fail-closed tests, so the
-  validator confirms its non-support rather than failing on it.
+  `envelope_version` present, `non_production_authorization_note`
+  present;
+- the **positive** v0 envelope fixtures (normal public, referral,
+  refusal/unauthorized, session-bearing) use a **supported**
+  `envelope_version` (currently `recall_wedge.dixie_envelope.v0`),
+  and have valid `target_projection` and `public_recall_payload`
+  objects;
+- the refusal/unauthorized fixture is shaped as
+  `target_projection.recall_interface=public_discord` with
+  `outcome=referral` and `denied_or_refused=true` so it narrows to the
+  existing public-safe contract (and **does not** authorize a positive
+  `authorized_private_session` projection);
+- the session-bearing fixture carries synthetic `session_id` and
+  `message_id` so the adapter can be exercised to strip them;
+- the **negative** fixtures are deliberately malformed/unsupported in
+  exactly **one** specific way each, and the validator confirms each
+  one is still negative in the way Phase 36B expects:
+  - unknown-version — `envelope_version` present but **not** in the
+    supported list;
+  - authorized-private-target — supported version, but
+    `target_projection.recall_interface=authorized_private_session`;
+  - public-telegram-target — supported version, but
+    `target_projection.recall_interface=public_telegram`;
+  - malformed-missing-payload — supported version, `target_projection`
+    present, but `public_recall_payload` **absent**;
+  - malformed-missing-target — supported version,
+    `public_recall_payload` present, but `target_projection`
+    **absent**.
 
 No leak-grep is run over raw Dixie envelope files: those intentionally
 contain raw/private/debug sentinels (`raw_dixie_debug`,
@@ -221,7 +304,9 @@ demo can show that the MVP keeps these categories distinct.
 - 35A — post-MVP decision map
 - 35B — operator demo runner
 - 35C — multi-surface contract spec
-- **35D — recorded Dixie envelope fixtures + adapter tests** (`dixie-envelope/`)
+- 35D — recorded Dixie envelope fixtures + adapter tests (`dixie-envelope/`)
+- 36A — live-boundary decision (`docs/RECALL-WEDGE-LIVE-BOUNDARY-DECISION.md`)
+- **36B — expanded recorded Dixie envelope corpus + adapter/validator tests** (refusal/unauthorized, session-bearing, authorized-private-target negative, public-telegram-target negative, malformed-missing-payload, malformed-missing-target)
 
 If a later phase needs anything beyond what these fixtures shape, re-open
 the 33A doc — do not silently expand scope here.

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-authorized-private-target-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-authorized-private-target-envelope.v0.json
@@ -1,0 +1,39 @@
+{
+  "fixture_id": "recorded-authorized-private-target-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-36b.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; the projection target inside this envelope is authorized_private_session — used ONLY as a negative/fail-closed fixture so the adapter can prove its existing fail-closed authorized_private_projection_not_implemented path stays in force per the Phase 36A live-boundary decision §10c boundaries",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It is intentionally tagged with target_projection.recall_interface=authorized_private_session so the adapter must fail closed. It does NOT authorize any positive authorized_private_session projection or any authorized_private_session renderer; the multi-surface contract §5a authorized-private DTO gate has not been satisfied. Authorized for non-production fixture use in Phase 36B only.",
+  "envelope_scope_note": "Negative fixture. Exists to drive the adapter's fail-closed authorized_private_projection_not_implemented path. The adapter must throw before producing any DTO; no projection is expected from this fixture.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_AUTHPRIV_NEG_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_AUTHPRIV_NEG_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "authorized_private_session",
+    "render_surface": "web_private_chat",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "ok",
+    "public_summary": "this payload is unreachable because authorized_private_session is not implemented in this phase",
+    "included_count": 0,
+    "marked_count": 0,
+    "redacted_count": 0,
+    "excluded_count": 0,
+    "public_reason_counts": {},
+    "public_reason_labels": [],
+    "denied_or_refused": false
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "authorized_private_target_negative_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_AUTHPRIV_NEG_TRACE",
+    "operator_private_note": "operator-only diagnostic context for the authorized-private negative envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "authorized_private_target_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-malformed-missing-payload-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-malformed-missing-payload-envelope.v0.json
@@ -1,0 +1,28 @@
+{
+  "fixture_id": "recorded-malformed-missing-payload-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-36b.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; the projection target inside this envelope is the public discord render surface, but the envelope is INTENTIONALLY missing public_recall_payload so the adapter can prove its fail-closed missing_public_recall_payload path stays in force",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It is INTENTIONALLY malformed in one specific way: the public_recall_payload field is omitted. The envelope_version, input_envelope_kind, and target_projection remain valid so the adapter can reach the payload-missing check. Authorized for non-production fixture use in Phase 36B only.",
+  "envelope_scope_note": "Negative fixture. Exists to drive the adapter's fail-closed missing_public_recall_payload path. The adapter must throw before producing any DTO. The validator must treat this fixture as an intentional negative and not require it to satisfy positive-envelope invariants beyond the shared metadata.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_MISSING_PAYLOAD_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_MISSING_PAYLOAD_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_discord",
+    "render_surface": "discord_public_character",
+    "character_frame": "ruggy"
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "missing_payload_negative_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_MISSING_PAYLOAD_TRACE",
+    "operator_private_note": "operator-only diagnostic context for the missing-payload negative envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "missing_payload_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-malformed-missing-target-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-malformed-missing-target-envelope.v0.json
@@ -1,0 +1,34 @@
+{
+  "fixture_id": "recorded-malformed-missing-target-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-36b.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; this envelope is INTENTIONALLY missing target_projection so the adapter can prove its fail-closed missing_target_projection / unknown_target_projection path stays in force",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It is INTENTIONALLY malformed in one specific way: the target_projection field is omitted. The envelope_version, input_envelope_kind, and public_recall_payload remain valid so the adapter can reach the target-missing check. Authorized for non-production fixture use in Phase 36B only.",
+  "envelope_scope_note": "Negative fixture. Exists to drive the adapter's fail-closed missing_target_projection (or unknown_target_projection) path. The adapter must throw before producing any DTO. The validator must treat this fixture as an intentional negative and not require it to satisfy positive-envelope invariants beyond the shared metadata.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_MISSING_TARGET_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_MISSING_TARGET_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "public_recall_payload": {
+    "outcome": "ok",
+    "public_summary": "this payload is unreachable because target_projection is missing",
+    "included_count": 0,
+    "marked_count": 0,
+    "redacted_count": 0,
+    "excluded_count": 0,
+    "public_reason_counts": {},
+    "public_reason_labels": [],
+    "denied_or_refused": false
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "missing_target_negative_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_MISSING_TARGET_TRACE",
+    "operator_private_note": "operator-only diagnostic context for the missing-target negative envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "missing_target_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-public-telegram-target-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-public-telegram-target-envelope.v0.json
@@ -1,0 +1,39 @@
+{
+  "fixture_id": "recorded-public-telegram-target-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-36b.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "telegram_group",
+  "source_surface_note": "carrier source is telegram_group; the projection target inside this envelope is public_telegram — used ONLY as a negative/fail-closed fixture so the adapter can prove its existing fail-closed public_telegram_projection_not_implemented path stays in force per the multi-surface contract §8a future-renderer warning. No Telegram renderer exists in this repo and none is added by Phase 36B.",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It is intentionally tagged with target_projection.recall_interface=public_telegram so the adapter must fail closed. It does NOT authorize any Telegram renderer; the multi-surface contract §8a future-renderer warning's per-surface no-leak / fail-closed / no-raw-debug invariants have not been independently satisfied for Telegram. Authorized for non-production fixture use in Phase 36B only.",
+  "envelope_scope_note": "Negative fixture. Exists to drive the adapter's fail-closed public_telegram_projection_not_implemented path. The adapter must throw before producing any DTO; no projection is expected from this fixture.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_TG_NEG_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_TG_NEG_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_telegram",
+    "render_surface": "telegram_group_character",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "ok",
+    "public_summary": "this payload is unreachable because public_telegram has no shipped renderer in this phase",
+    "included_count": 0,
+    "marked_count": 0,
+    "redacted_count": 0,
+    "excluded_count": 0,
+    "public_reason_counts": {},
+    "public_reason_labels": [],
+    "denied_or_refused": false
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "public_telegram_target_negative_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_TG_NEG_TRACE",
+    "operator_private_note": "operator-only diagnostic context for the public_telegram negative envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "public_telegram_target_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-refusal-unauthorized-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-refusal-unauthorized-envelope.v0.json
@@ -1,0 +1,42 @@
+{
+  "fixture_id": "recorded-refusal-unauthorized-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-36b.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; the projection target inside this envelope is a generic public-safe refusal on the public discord render surface — Dixie has indicated the caller is not authorized for any broader view than a generic refusal billboard",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It contains no real user data, no live Dixie response, and no governed Straylight memory. It is authorized for non-production fixture use in Phase 36B only. Authorization is NOT considered solved by this fixture; it represents a recorded refusal/unauthorized response shape only.",
+  "envelope_scope_note": "This represents a recorded Dixie-shaped recall response in which the caller is not authorized for the requested view. It is NOT raw chat log memory and does NOT constitute admission of any chat content into governed Straylight memory. Per the Phase 36A live-boundary decision §10c boundaries, this fixture's refusal does not authorize a positive authorized_private_session projection; it narrows to the existing public-safe referral/refusal contract by reusing outcome=referral with denied_or_refused=true and a generic refusal message.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_REFUSAL_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_REFUSAL_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_discord",
+    "render_surface": "discord_public_character",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "referral",
+    "public_summary": "this view is not available without further authorization",
+    "public_referral_message": "this question is not available on the public surface — try again from an authorized session if you have one",
+    "safe_referral_target": "authorized_session",
+    "included_count": 0,
+    "marked_count": 0,
+    "redacted_count": 0,
+    "excluded_count": 0,
+    "public_reason_counts": {},
+    "public_reason_labels": [],
+    "denied_or_refused": true
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "caller_not_authorized_PRIVATE_SENTINEL_DIXIE_RAW",
+      "missing_caller_binding_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_REFUSAL_TRACE",
+    "operator_private_note": "operator-only diagnostic context for this refusal envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "refusal_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/dixie-envelope/recorded-session-bearing-public-recall-envelope.v0.json
+++ b/docs/recall-wedge/fixtures/dixie-envelope/recorded-session-bearing-public-recall-envelope.v0.json
@@ -1,0 +1,47 @@
+{
+  "fixture_id": "recorded-session-bearing-public-recall-envelope-001",
+  "fixture_kind": "recorded_dixie_recall_envelope",
+  "fixture_version": "phase-36b.0",
+  "envelope_version": "recall_wedge.dixie_envelope.v0",
+  "input_envelope_kind": "recorded_dixie_recall_envelope",
+  "source_interface": "private_web_chat",
+  "source_surface_note": "carrier source is private web chat; the projection target inside this envelope is the public discord render surface. The envelope deliberately carries operational session metadata (session_id, message_id, tenant/community/session ids) to exercise the adapter's stripping of operational identifiers from the projected DTO — these are operational identifiers per multi-surface contract §5, never memory identity, and never permitted on a public surface per the §9 allowlist",
+  "synthetic": true,
+  "non_production_authorization_note": "This envelope is synthetic and reviewed. It contains no real user data and no live Dixie/Finn session record. Authorized for non-production fixture use in Phase 36B only.",
+  "envelope_scope_note": "This is a public-safe recorded recall envelope decorated with synthetic session-bearing metadata so the adapter test surface can prove that operational identifiers (session_id, message_id, tenant_id, community_id, session_thread_id) never reach the adapted projected DTO or the rendered public output.",
+  "session_id": "session_PRIVATE_SENTINEL_DIXIE_SESSION_ID_BEARING_001",
+  "message_id": "msg_PRIVATE_SENTINEL_DIXIE_MESSAGE_ID_BEARING_001",
+  "tenant_id": "tenant_PRIVATE_SENTINEL_DIXIE_TENANT_ID_BEARING_001",
+  "community_id": "community_PRIVATE_SENTINEL_DIXIE_COMMUNITY_ID_BEARING_001",
+  "session_thread_id": "thread_PRIVATE_SENTINEL_DIXIE_THREAD_ID_BEARING_001",
+  "continuity_actor_id": "freeside-characters:shared-substrate",
+  "target_projection": {
+    "recall_interface": "public_discord",
+    "render_surface": "discord_public_character",
+    "character_frame": "ruggy"
+  },
+  "public_recall_payload": {
+    "outcome": "ok",
+    "public_summary": "actor was observed across multiple character frames during the cross-interface continuity rehearsal",
+    "included_count": 2,
+    "marked_count": 0,
+    "redacted_count": 1,
+    "excluded_count": 0,
+    "public_reason_counts": {
+      "redacted_for_public_surface": 1
+    },
+    "public_reason_labels": [
+      "redacted_for_public_surface"
+    ],
+    "denied_or_refused": false
+  },
+  "raw_dixie_debug": {
+    "raw_reasons": [
+      "session_bearing_envelope_PRIVATE_SENTINEL_DIXIE_RAW",
+      "operational_identifier_carry_PRIVATE_SENTINEL_DIXIE_RAW"
+    ],
+    "raw_session_trace": "trace_PRIVATE_SENTINEL_DIXIE_RAW_SESSION_BEARING_TRACE",
+    "operator_private_note": "operator-only diagnostic context for the session-bearing envelope PRIVATE_SENTINEL_DIXIE_RAW"
+  },
+  "source_material": "session_bearing_envelope_source_blob_PRIVATE_SENTINEL_DIXIE_RAW"
+}

--- a/docs/recall-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/recall-wedge/fixtures/validate-fixtures.mjs
@@ -38,6 +38,20 @@ const DIXIE_REFERRAL_ENVELOPE_FILE =
 const DIXIE_UNKNOWN_VERSION_ENVELOPE_FILE =
   "recorded-unknown-version-envelope.json";
 
+// Phase 36B expanded corpus.
+const DIXIE_REFUSAL_UNAUTHORIZED_ENVELOPE_FILE =
+  "recorded-refusal-unauthorized-envelope.v0.json";
+const DIXIE_SESSION_BEARING_ENVELOPE_FILE =
+  "recorded-session-bearing-public-recall-envelope.v0.json";
+const DIXIE_AUTHORIZED_PRIVATE_TARGET_ENVELOPE_FILE =
+  "recorded-authorized-private-target-envelope.v0.json";
+const DIXIE_PUBLIC_TELEGRAM_TARGET_ENVELOPE_FILE =
+  "recorded-public-telegram-target-envelope.v0.json";
+const DIXIE_MALFORMED_MISSING_PAYLOAD_ENVELOPE_FILE =
+  "recorded-malformed-missing-payload-envelope.v0.json";
+const DIXIE_MALFORMED_MISSING_TARGET_ENVELOPE_FILE =
+  "recorded-malformed-missing-target-envelope.v0.json";
+
 const SUPPORTED_DIXIE_ENVELOPE_VERSIONS = [
   "recall_wedge.dixie_envelope.v0",
 ];
@@ -234,20 +248,38 @@ for (const fname of PUBLIC_SAFE_DTOS) {
   ok(`${fname}: no banned public substrings`);
 }
 
-// --- 8. phase 35d recorded dixie envelope fixtures -------------------------
+// --- 8. recorded dixie envelope fixtures (phase 35d + phase 36b) -----------
 //
 // As of phase 35d these fixtures are part of the recall-wedge fixture
-// contract. The validator must FAIL if the dixie-envelope directory or
-// any of the three required fixtures go missing — silently skipping
-// section 8 would let a future deletion regress the multi-surface
-// contract without warning.
+// contract. Phase 36b expands the corpus with refusal/unauthorized,
+// session-bearing, authorized_private_session-target negative,
+// public_telegram-target negative, and two malformed/missing-field
+// negative fixtures. The validator must FAIL if the dixie-envelope
+// directory or any required fixture file goes missing — silently
+// skipping section 8 would let a future deletion regress the
+// multi-surface contract without warning.
 //
-// The unknown-version fixture is intentionally valid-JSON but tagged
-// with an unsupported envelope_version so adapter fail-closed tests
-// have something to bite on. Validator behavior: it must EXIST and
-// PARSE; its envelope_version must be PRESENT but NOT in the supported
-// list. Its unsupported-ness is the point — the validator does not
-// downgrade the run because of it.
+// **Recorded fixtures are sample v0 contract probes only.** They are
+// not production schema authority. Live envelope contract truth must
+// come from a Dixie-side artifact, endpoint contract, or cross-repo
+// decision. (Phase 36A live-boundary decision §7a.)
+//
+// Positive vs negative split:
+//   - positive fixtures are valid v0 envelopes the adapter projects
+//     into a public_discord/discord_public_character DTO. They satisfy
+//     every phase-35d positive invariant: shared metadata, supported
+//     envelope_version, target_projection present, public_recall_payload
+//     present.
+//   - negative fixtures are intentional fail-closed shapes. They satisfy
+//     SHARED METADATA invariants only (synthetic, fixture_kind,
+//     input_envelope_kind, non_production_authorization_note,
+//     envelope_version present). They are deliberately malformed/
+//     unsupported in ONE specific way each, and the validator allows
+//     that one specific malformation without treating it as a regression.
+//
+// The unknown-version fixture remains in the "unsupported version"
+// negative class — it must EXIST and PARSE; its envelope_version must
+// be PRESENT but NOT in the supported list.
 //
 // No leak-grep is run over raw Dixie envelope files: those intentionally
 // contain raw_dixie_debug / raw_session_trace / source_material /
@@ -278,10 +310,17 @@ if (!dixieDirExists) {
     if (loaded) ok(`parsed ${f}`);
   }
 
+  // Required files: phase 35d + phase 36b combined corpus.
   const REQUIRED_DIXIE_FILES = [
     DIXIE_PUBLIC_ENVELOPE_FILE,
     DIXIE_REFERRAL_ENVELOPE_FILE,
     DIXIE_UNKNOWN_VERSION_ENVELOPE_FILE,
+    DIXIE_REFUSAL_UNAUTHORIZED_ENVELOPE_FILE,
+    DIXIE_SESSION_BEARING_ENVELOPE_FILE,
+    DIXIE_AUTHORIZED_PRIVATE_TARGET_ENVELOPE_FILE,
+    DIXIE_PUBLIC_TELEGRAM_TARGET_ENVELOPE_FILE,
+    DIXIE_MALFORMED_MISSING_PAYLOAD_ENVELOPE_FILE,
+    DIXIE_MALFORMED_MISSING_TARGET_ENVELOPE_FILE,
   ];
 
   for (const fname of REQUIRED_DIXIE_FILES) {
@@ -306,16 +345,39 @@ if (!dixieDirExists) {
   const dixieUnknown = loadJson(
     join(DIXIE_ENVELOPE_DIR, DIXIE_UNKNOWN_VERSION_ENVELOPE_FILE),
   );
+  const dixieRefusal = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_REFUSAL_UNAUTHORIZED_ENVELOPE_FILE),
+  );
+  const dixieSessionBearing = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_SESSION_BEARING_ENVELOPE_FILE),
+  );
+  const dixieAuthPrivateTarget = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_AUTHORIZED_PRIVATE_TARGET_ENVELOPE_FILE),
+  );
+  const dixiePublicTelegramTarget = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_PUBLIC_TELEGRAM_TARGET_ENVELOPE_FILE),
+  );
+  const dixieMalformedMissingPayload = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_MALFORMED_MISSING_PAYLOAD_ENVELOPE_FILE),
+  );
+  const dixieMalformedMissingTarget = loadJson(
+    join(DIXIE_ENVELOPE_DIR, DIXIE_MALFORMED_MISSING_TARGET_ENVELOPE_FILE),
+  );
 
-  // Shared invariants run on ALL three fixtures (including the
-  // unknown-version one): synthetic, fixture_kind, input_envelope_kind,
-  // non_production_authorization_note. The unknown-version fixture is
-  // unsupported only on envelope_version — every other phase-35d
-  // invariant still applies.
+  // Shared metadata invariants — apply to EVERY fixture, positive or
+  // negative. This is the "still a recorded Dixie envelope, not random
+  // JSON" invariant. envelope_version must be PRESENT here; whether the
+  // value is supported is checked separately below.
   const allDixie = [
     ["dixie-public", dixiePublic],
     ["dixie-referral", dixieReferral],
     ["dixie-unknown-version", dixieUnknown],
+    ["dixie-refusal-unauthorized", dixieRefusal],
+    ["dixie-session-bearing", dixieSessionBearing],
+    ["dixie-authorized-private-target", dixieAuthPrivateTarget],
+    ["dixie-public-telegram-target", dixiePublicTelegramTarget],
+    ["dixie-malformed-missing-payload", dixieMalformedMissingPayload],
+    ["dixie-malformed-missing-target", dixieMalformedMissingTarget],
   ];
 
   for (const [label, env] of allDixie) {
@@ -342,43 +404,200 @@ if (!dixieDirExists) {
     if (!e.non_production_authorization_note)
       fail(`${label}: non_production_authorization_note missing`);
     else ok(`${label}: non_production_authorization_note present`);
+
+    if (typeof e.envelope_version !== "string" || e.envelope_version.length === 0)
+      fail(`${label}: envelope_version must be present`);
+    else ok(`${label}: envelope_version present (${e.envelope_version})`);
   }
 
-  // envelope_version: v0 fixtures must be SUPPORTED; the unknown-version
-  // fixture must be PRESENT but NOT SUPPORTED.
-  const supportedExpected = [
+  // POSITIVE-fixture invariants — supported envelope_version, valid
+  // target_projection, valid public_recall_payload. These are the
+  // fixtures the adapter will project into a public_discord DTO.
+  const positiveFixtures = [
     ["dixie-public", dixiePublic],
     ["dixie-referral", dixieReferral],
+    ["dixie-refusal-unauthorized", dixieRefusal],
+    ["dixie-session-bearing", dixieSessionBearing],
   ];
-  for (const [label, env] of supportedExpected) {
+  for (const [label, env] of positiveFixtures) {
     if (!env?.parsed) continue;
     const e = env.parsed;
+    if (!SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+      fail(
+        `${label}: positive fixture envelope_version must be one of [${SUPPORTED_DIXIE_ENVELOPE_VERSIONS.join("|")}], got ${e.envelope_version}`,
+      );
+    else ok(`${label}: positive envelope_version === ${e.envelope_version}`);
+
     if (
-      typeof e.envelope_version !== "string" ||
-      !SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version)
+      typeof e.target_projection !== "object" ||
+      e.target_projection === null ||
+      Array.isArray(e.target_projection)
+    )
+      fail(`${label}: positive fixture must have target_projection object`);
+    else ok(`${label}: target_projection present`);
+
+    if (
+      typeof e.public_recall_payload !== "object" ||
+      e.public_recall_payload === null ||
+      Array.isArray(e.public_recall_payload)
     )
       fail(
-        `${label}: envelope_version must be one of [${SUPPORTED_DIXIE_ENVELOPE_VERSIONS.join("|")}], got ${e.envelope_version}`,
+        `${label}: positive fixture must have public_recall_payload object`,
       );
-    else ok(`${label}: envelope_version === ${e.envelope_version}`);
+    else ok(`${label}: public_recall_payload present`);
   }
 
+  // The refusal/unauthorized fixture must specifically be public_discord-
+  // shaped (so it renders through the existing public-safe renderer) and
+  // must mark itself denied_or_refused so the renderer's referral path
+  // takes it. Authorization is NOT considered solved by this fixture.
+  if (dixieRefusal?.parsed) {
+    const e = dixieRefusal.parsed;
+    const tp = e.target_projection;
+    if (tp && tp.recall_interface !== "public_discord")
+      fail(
+        `dixie-refusal-unauthorized: target_projection.recall_interface must be public_discord (it narrows refusal to the existing public-safe contract), got ${tp?.recall_interface}`,
+      );
+    else if (tp) ok("dixie-refusal-unauthorized: target=public_discord");
+    const p = e.public_recall_payload;
+    if (p && p.outcome !== "referral")
+      fail(
+        `dixie-refusal-unauthorized: outcome must be referral (so the existing renderer's denied_or_refused path applies), got ${p?.outcome}`,
+      );
+    else if (p) ok("dixie-refusal-unauthorized: outcome === referral");
+    if (p && p.denied_or_refused !== true)
+      fail("dixie-refusal-unauthorized: denied_or_refused must be true");
+    else if (p) ok("dixie-refusal-unauthorized: denied_or_refused === true");
+  }
+
+  // The session-bearing fixture must specifically carry session-shaped
+  // operational identifiers so the adapter test surface can prove the
+  // adapter strips them.
+  if (dixieSessionBearing?.parsed) {
+    const e = dixieSessionBearing.parsed;
+    if (typeof e.session_id !== "string" || e.session_id.length === 0)
+      fail("dixie-session-bearing: synthetic session_id must be present");
+    else ok("dixie-session-bearing: synthetic session_id present");
+    if (typeof e.message_id !== "string" || e.message_id.length === 0)
+      fail("dixie-session-bearing: synthetic message_id must be present");
+    else ok("dixie-session-bearing: synthetic message_id present");
+  }
+
+  // NEGATIVE-fixture targeted-malformation invariants. Each negative
+  // fixture is malformed/unsupported in exactly ONE specific way; the
+  // validator confirms the fixture remains intentionally negative and
+  // does not silently drift into a positive shape.
+
+  // unknown-version: envelope_version must be PRESENT but UNSUPPORTED.
   if (dixieUnknown?.parsed) {
     const e = dixieUnknown.parsed;
-    if (
-      typeof e.envelope_version !== "string" ||
-      e.envelope_version.length === 0
-    )
-      fail(
-        "dixie-unknown-version: envelope_version must be present (it is meant to be syntactically valid but unsupported)",
-      );
-    else if (SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+    if (SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
       fail(
         `dixie-unknown-version: envelope_version must NOT be in the supported list, got ${e.envelope_version} (it is meant to drive adapter fail-closed tests)`,
       );
     else
       ok(
         `dixie-unknown-version: envelope_version present and intentionally unsupported (${e.envelope_version})`,
+      );
+  }
+
+  // authorized-private-target negative: envelope_version supported, but
+  // target_projection.recall_interface=authorized_private_session.
+  if (dixieAuthPrivateTarget?.parsed) {
+    const e = dixieAuthPrivateTarget.parsed;
+    if (!SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+      fail(
+        `dixie-authorized-private-target: envelope_version must be supported, got ${e.envelope_version}`,
+      );
+    else
+      ok("dixie-authorized-private-target: envelope_version supported");
+    const tp = e.target_projection;
+    if (!tp || tp.recall_interface !== "authorized_private_session")
+      fail(
+        `dixie-authorized-private-target: target_projection.recall_interface must be authorized_private_session (it is meant to drive the adapter's fail-closed authorized_private_projection_not_implemented path), got ${tp?.recall_interface}`,
+      );
+    else
+      ok(
+        "dixie-authorized-private-target: target=authorized_private_session (negative)",
+      );
+  }
+
+  // public-telegram-target negative: envelope_version supported, but
+  // target_projection.recall_interface=public_telegram.
+  if (dixiePublicTelegramTarget?.parsed) {
+    const e = dixiePublicTelegramTarget.parsed;
+    if (!SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+      fail(
+        `dixie-public-telegram-target: envelope_version must be supported, got ${e.envelope_version}`,
+      );
+    else
+      ok("dixie-public-telegram-target: envelope_version supported");
+    const tp = e.target_projection;
+    if (!tp || tp.recall_interface !== "public_telegram")
+      fail(
+        `dixie-public-telegram-target: target_projection.recall_interface must be public_telegram (it is meant to drive the adapter's fail-closed public_telegram_projection_not_implemented path), got ${tp?.recall_interface}`,
+      );
+    else
+      ok("dixie-public-telegram-target: target=public_telegram (negative)");
+  }
+
+  // malformed-missing-payload negative: envelope_version supported,
+  // target_projection present, but public_recall_payload absent.
+  if (dixieMalformedMissingPayload?.parsed) {
+    const e = dixieMalformedMissingPayload.parsed;
+    if (!SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+      fail(
+        `dixie-malformed-missing-payload: envelope_version must be supported, got ${e.envelope_version}`,
+      );
+    else
+      ok("dixie-malformed-missing-payload: envelope_version supported");
+    if (
+      typeof e.target_projection !== "object" ||
+      e.target_projection === null ||
+      Array.isArray(e.target_projection)
+    )
+      fail(
+        "dixie-malformed-missing-payload: target_projection must remain present (the negative is in public_recall_payload only)",
+      );
+    else
+      ok("dixie-malformed-missing-payload: target_projection present");
+    if ("public_recall_payload" in e)
+      fail(
+        "dixie-malformed-missing-payload: public_recall_payload must be ABSENT (it is meant to drive the adapter's fail-closed missing_public_recall_payload path)",
+      );
+    else
+      ok(
+        "dixie-malformed-missing-payload: public_recall_payload absent (intentional)",
+      );
+  }
+
+  // malformed-missing-target negative: envelope_version supported,
+  // public_recall_payload present, but target_projection absent.
+  if (dixieMalformedMissingTarget?.parsed) {
+    const e = dixieMalformedMissingTarget.parsed;
+    if (!SUPPORTED_DIXIE_ENVELOPE_VERSIONS.includes(e.envelope_version))
+      fail(
+        `dixie-malformed-missing-target: envelope_version must be supported, got ${e.envelope_version}`,
+      );
+    else
+      ok("dixie-malformed-missing-target: envelope_version supported");
+    if (
+      typeof e.public_recall_payload !== "object" ||
+      e.public_recall_payload === null ||
+      Array.isArray(e.public_recall_payload)
+    )
+      fail(
+        "dixie-malformed-missing-target: public_recall_payload must remain present (the negative is in target_projection only)",
+      );
+    else
+      ok("dixie-malformed-missing-target: public_recall_payload present");
+    if ("target_projection" in e)
+      fail(
+        "dixie-malformed-missing-target: target_projection must be ABSENT (it is meant to drive the adapter's fail-closed missing/unknown target_projection path)",
+      );
+    else
+      ok(
+        "dixie-malformed-missing-target: target_projection absent (intentional)",
       );
   }
 }

--- a/packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts
+++ b/packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts
@@ -662,3 +662,413 @@ describe("adapter fails closed when allowed payload fields smuggle banned materi
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 36B · expanded recorded Dixie envelope corpus.
+//
+// Six new fixtures: refusal/unauthorized, session-bearing,
+// authorized_private_session-target negative, public_telegram-target
+// negative, malformed-missing-payload, malformed-missing-target. The block
+// below exercises each through the adapter and proves:
+//
+//   - positive fixtures (refusal, session-bearing) adapt and render
+//     through `renderPublicRecallProjection` without leaking;
+//   - the session-bearing fixture's session_id / message_id /
+//     tenant_id / community_id / session_thread_id never reach the
+//     adapted DTO or rendered text;
+//   - negative fixtures fail closed with their expected stable error
+//     code (authorized_private_projection_not_implemented,
+//     public_telegram_projection_not_implemented,
+//     missing_public_recall_payload, target-resolution error);
+//   - the unknown-version fixture's existing fail-closed behavior is
+//     unchanged;
+//   - raw envelopes never reach the renderer for any new fixture;
+//   - the existing Phase 35D no-leak behavior is preserved.
+// ---------------------------------------------------------------------------
+
+const REFUSAL_UNAUTHORIZED_ENVELOPE = loadFixture(
+  "recorded-refusal-unauthorized-envelope.v0.json",
+);
+const SESSION_BEARING_ENVELOPE = loadFixture(
+  "recorded-session-bearing-public-recall-envelope.v0.json",
+);
+const AUTHORIZED_PRIVATE_TARGET_ENVELOPE = loadFixture(
+  "recorded-authorized-private-target-envelope.v0.json",
+);
+const PUBLIC_TELEGRAM_TARGET_ENVELOPE = loadFixture(
+  "recorded-public-telegram-target-envelope.v0.json",
+);
+const MALFORMED_MISSING_PAYLOAD_ENVELOPE = loadFixture(
+  "recorded-malformed-missing-payload-envelope.v0.json",
+);
+const MALFORMED_MISSING_TARGET_ENVELOPE = loadFixture(
+  "recorded-malformed-missing-target-envelope.v0.json",
+);
+
+describe("phase 36b · refusal/unauthorized envelope (positive — public-safe refusal)", () => {
+  // The refusal/unauthorized envelope reuses the existing public-safe
+  // contract: outcome=referral + denied_or_refused=true + a generic
+  // safe_referral_target / public_referral_message. It is NOT a positive
+  // authorized_private_session projection; it is a public-safe billboard
+  // shaped to communicate that the requested view is unavailable on this
+  // surface. This matches the adapter's existing two-outcome contract
+  // ("ok" or "referral") without expanding the outcome enum.
+
+  const dto = adaptDixieEnvelopeToPublicRecallProjection(
+    REFUSAL_UNAUTHORIZED_ENVELOPE,
+  );
+
+  test("adapts to a public_discord referral DTO with denied_or_refused", () => {
+    expect((dto as Record<string, unknown>).recall_interface).toBe(
+      "public_discord",
+    );
+    expect((dto as Record<string, unknown>).render_surface).toBe(
+      "discord_public_character",
+    );
+    expect((dto as Record<string, unknown>).outcome).toBe("referral");
+    expect((dto as Record<string, unknown>).denied_or_refused).toBe(true);
+    expect((dto as Record<string, unknown>).safe_referral_target).toBe(
+      "authorized_session",
+    );
+  });
+
+  test("renders safely through the public-safe renderer", () => {
+    const text = renderPublicRecallProjection(dto);
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("referral");
+    expect(text).toContain("authorized_session");
+  });
+
+  test("adapted DTO contains no banned/private substrings", () => {
+    const banned = dtoContainsBannedSubstring(dto);
+    expect(banned).toBeNull();
+  });
+
+  test("rendered public output contains no banned/private substrings", () => {
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("renderer rejects the raw refusal envelope (adapter is the narrowing boundary)", () => {
+    expect(() =>
+      renderPublicRecallProjection(REFUSAL_UNAUTHORIZED_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("phase 36b · session-bearing envelope (positive — operational identifiers stripped)", () => {
+  const dto = adaptDixieEnvelopeToPublicRecallProjection(
+    SESSION_BEARING_ENVELOPE,
+  );
+
+  test("adapts to a public_discord/discord_public_character ok DTO", () => {
+    expect((dto as Record<string, unknown>).recall_interface).toBe(
+      "public_discord",
+    );
+    expect((dto as Record<string, unknown>).render_surface).toBe(
+      "discord_public_character",
+    );
+    expect((dto as Record<string, unknown>).outcome).toBe("ok");
+    expect((dto as Record<string, unknown>).included_count).toBe(2);
+    expect((dto as Record<string, unknown>).redacted_count).toBe(1);
+  });
+
+  test("source envelope ACTUALLY carries the operational identifiers (proof is non-vacuous)", () => {
+    const env = SESSION_BEARING_ENVELOPE as Record<string, unknown>;
+    expect(env.session_id).toBeDefined();
+    expect(env.message_id).toBeDefined();
+    expect(env.tenant_id).toBeDefined();
+    expect(env.community_id).toBeDefined();
+    expect(env.session_thread_id).toBeDefined();
+  });
+
+  test("session_id / message_id / tenant_id / community_id / session_thread_id do NOT appear on the adapted DTO", () => {
+    const obj = dto as Record<string, unknown>;
+    expect(obj.session_id).toBeUndefined();
+    expect(obj.message_id).toBeUndefined();
+    expect(obj.tenant_id).toBeUndefined();
+    expect(obj.community_id).toBeUndefined();
+    expect(obj.session_thread_id).toBeUndefined();
+    expect(obj.continuity_actor_id).toBeUndefined();
+    expect(obj.raw_dixie_debug).toBeUndefined();
+    expect(obj.raw_session_trace).toBeUndefined();
+    expect(obj.source_material).toBeUndefined();
+  });
+
+  test("adapted DTO contains no banned/private substrings", () => {
+    const banned = dtoContainsBannedSubstring(dto);
+    expect(banned).toBeNull();
+  });
+
+  test("rendered public output contains no banned/private substrings (and no session/message ids)", () => {
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("rendered public output does not contain the synthetic session/message id values verbatim", () => {
+    const text = renderPublicRecallProjection(dto);
+    const env = SESSION_BEARING_ENVELOPE as Record<string, unknown>;
+    for (const key of [
+      "session_id",
+      "message_id",
+      "tenant_id",
+      "community_id",
+      "session_thread_id",
+    ]) {
+      const v = env[key];
+      if (typeof v === "string" && v.length > 0) {
+        expect(text).not.toContain(v);
+      }
+    }
+  });
+
+  test("renderer rejects the raw session-bearing envelope (adapter is the narrowing boundary)", () => {
+    expect(() =>
+      renderPublicRecallProjection(SESSION_BEARING_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("phase 36b · authorized_private_session target (negative — fail-closed)", () => {
+  test("adaptDixieEnvelopeToRecallProjection fails closed with authorized_private_projection_not_implemented", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(AUTHORIZED_PRIVATE_TARGET_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(AUTHORIZED_PRIVATE_TARGET_ENVELOPE);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "authorized_private_projection_not_implemented",
+      );
+    }
+  });
+
+  test("explicit authorized_private_session target option also fails closed", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(AUTHORIZED_PRIVATE_TARGET_ENVELOPE, {
+        target: "authorized_private_session",
+      }),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(AUTHORIZED_PRIVATE_TARGET_ENVELOPE, {
+        target: "authorized_private_session",
+      });
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "authorized_private_projection_not_implemented",
+      );
+    }
+  });
+
+  test("adaptDixieEnvelopeToPublicRecallProjection on this fixture rejects on wrong target (defense in depth)", () => {
+    // The narrow public-only entry point doesn't read target_projection
+    // before validating it for the public_discord contract; an authorized
+    // private target therefore hits wrong_recall_interface_for_target
+    // there. Either way, it fails closed and never produces a positive
+    // authorized_private_session projection.
+    expect(() =>
+      adaptDixieEnvelopeToPublicRecallProjection(
+        AUTHORIZED_PRIVATE_TARGET_ENVELOPE,
+      ),
+    ).toThrow(DixieEnvelopeAdapterError);
+  });
+
+  test("renderer rejects the raw authorized-private-target envelope", () => {
+    expect(() =>
+      renderPublicRecallProjection(AUTHORIZED_PRIVATE_TARGET_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("phase 36b · public_telegram target (negative — fail-closed)", () => {
+  test("adaptDixieEnvelopeToRecallProjection fails closed with public_telegram_projection_not_implemented", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_TELEGRAM_TARGET_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_TELEGRAM_TARGET_ENVELOPE);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "public_telegram_projection_not_implemented",
+      );
+    }
+  });
+
+  test("explicit public_telegram target option also fails closed", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_TELEGRAM_TARGET_ENVELOPE, {
+        target: "public_telegram",
+      }),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(PUBLIC_TELEGRAM_TARGET_ENVELOPE, {
+        target: "public_telegram",
+      });
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "public_telegram_projection_not_implemented",
+      );
+    }
+  });
+
+  test("adaptDixieEnvelopeToPublicRecallProjection on this fixture rejects on wrong target (defense in depth)", () => {
+    expect(() =>
+      adaptDixieEnvelopeToPublicRecallProjection(
+        PUBLIC_TELEGRAM_TARGET_ENVELOPE,
+      ),
+    ).toThrow(DixieEnvelopeAdapterError);
+  });
+
+  test("renderer rejects the raw public-telegram-target envelope", () => {
+    expect(() =>
+      renderPublicRecallProjection(PUBLIC_TELEGRAM_TARGET_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("phase 36b · malformed-missing-payload (negative — fail-closed)", () => {
+  test("adaptDixieEnvelopeToPublicRecallProjection fails closed with missing_public_recall_payload", () => {
+    expect(() =>
+      adaptDixieEnvelopeToPublicRecallProjection(
+        MALFORMED_MISSING_PAYLOAD_ENVELOPE,
+      ),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(
+        MALFORMED_MISSING_PAYLOAD_ENVELOPE,
+      );
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "missing_public_recall_payload",
+      );
+    }
+  });
+
+  test("adaptDixieEnvelopeToRecallProjection also fails closed (default-target path)", () => {
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(MALFORMED_MISSING_PAYLOAD_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+  });
+
+  test("renderer rejects the raw missing-payload envelope", () => {
+    expect(() =>
+      renderPublicRecallProjection(MALFORMED_MISSING_PAYLOAD_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("phase 36b · malformed-missing-target (negative — fail-closed)", () => {
+  test("adaptDixieEnvelopeToPublicRecallProjection fails closed with missing_target_projection", () => {
+    expect(() =>
+      adaptDixieEnvelopeToPublicRecallProjection(
+        MALFORMED_MISSING_TARGET_ENVELOPE,
+      ),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(
+        MALFORMED_MISSING_TARGET_ENVELOPE,
+      );
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "missing_target_projection",
+      );
+    }
+  });
+
+  test("adaptDixieEnvelopeToRecallProjection fails closed with unknown_target_projection (target-resolution path)", () => {
+    // The broader entry point reads target_projection.recall_interface
+    // before projecting; with target_projection absent and no explicit
+    // options.target, it hits the unknown_target_projection guard.
+    expect(() =>
+      adaptDixieEnvelopeToRecallProjection(MALFORMED_MISSING_TARGET_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToRecallProjection(MALFORMED_MISSING_TARGET_ENVELOPE);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "unknown_target_projection",
+      );
+    }
+  });
+
+  test("renderer rejects the raw missing-target envelope", () => {
+    expect(() =>
+      renderPublicRecallProjection(MALFORMED_MISSING_TARGET_ENVELOPE),
+    ).toThrow(PublicRecallRenderError);
+  });
+});
+
+describe("phase 36b · expanded corpus preserves Phase 35D no-leak behavior", () => {
+  // Anti-vacuity: prove every newly-added recorded fixture still carries
+  // the planted raw / private / debug sentinels at source, so the
+  // "stripped from the adapted DTO" claims above cannot be satisfied
+  // simply by a clean fixture.
+  const REQUIRED_SOURCE_SENTINELS = [
+    "PRIVATE_SENTINEL",
+    "raw_dixie_debug",
+    "raw_session_trace",
+    "raw_reasons",
+    "source_material",
+    "session_id",
+    "message_id",
+    "continuity_actor_id",
+  ] as const;
+
+  function rawFixture(name: string): string {
+    return readFileSync(resolve(FIXTURE_DIR, name), "utf8");
+  }
+
+  const FIXTURE_FILES = [
+    "recorded-refusal-unauthorized-envelope.v0.json",
+    "recorded-session-bearing-public-recall-envelope.v0.json",
+    "recorded-authorized-private-target-envelope.v0.json",
+    "recorded-public-telegram-target-envelope.v0.json",
+    "recorded-malformed-missing-payload-envelope.v0.json",
+    "recorded-malformed-missing-target-envelope.v0.json",
+  ];
+
+  for (const fname of FIXTURE_FILES) {
+    test(`source fixture ${fname} carries every required raw/private sentinel`, () => {
+      const raw = rawFixture(fname);
+      for (const sentinel of REQUIRED_SOURCE_SENTINELS) {
+        expect(raw).toContain(sentinel);
+      }
+    });
+  }
+
+  test("Phase 35D unknown-version fail-closed behavior is unchanged", () => {
+    expect(() =>
+      adaptDixieEnvelopeToPublicRecallProjection(UNKNOWN_VERSION_ENVELOPE),
+    ).toThrow(DixieEnvelopeAdapterError);
+    try {
+      adaptDixieEnvelopeToPublicRecallProjection(UNKNOWN_VERSION_ENVELOPE);
+    } catch (err) {
+      expect((err as DixieEnvelopeAdapterError).code).toBe(
+        "unsupported_dixie_envelope_version",
+      );
+    }
+  });
+
+  test("Phase 35D normal public envelope still adapts and renders cleanly", () => {
+    const dto = adaptDixieEnvelopeToPublicRecallProjection(
+      PUBLIC_DISCORD_ENVELOPE,
+    );
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  test("Phase 35D referral envelope still adapts and renders cleanly", () => {
+    const dto = adaptDixieEnvelopeToPublicRecallProjection(REFERRAL_ENVELOPE);
+    const text = renderPublicRecallProjection(dto);
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(text).not.toContain(banned);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 36B expands the recorded Dixie envelope fixture corpus and adapter/validator test coverage for `freeside-characters`.

This PR remains recorded-envelope-bound and pre-live. It does not add live Dixie, Discord/Telegram wiring, production storage, memory admission, public Telegram rendering, authorized-private rendering, or character voice.

The purpose is to stress the existing Phase 35D Dixie envelope adapter boundary with more recorded fixture cases before any live integration work.

## Files

New recorded Dixie envelope fixtures:

- `docs/recall-wedge/fixtures/dixie-envelope/recorded-refusal-unauthorized-envelope.v0.json`
- `docs/recall-wedge/fixtures/dixie-envelope/recorded-session-bearing-public-recall-envelope.v0.json`
- `docs/recall-wedge/fixtures/dixie-envelope/recorded-authorized-private-target-envelope.v0.json`
- `docs/recall-wedge/fixtures/dixie-envelope/recorded-public-telegram-target-envelope.v0.json`
- `docs/recall-wedge/fixtures/dixie-envelope/recorded-malformed-missing-payload-envelope.v0.json`
- `docs/recall-wedge/fixtures/dixie-envelope/recorded-malformed-missing-target-envelope.v0.json`

Modified:

- `docs/recall-wedge/fixtures/validate-fixtures.mjs`
- `docs/recall-wedge/fixtures/README.md`
- `packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts`

Unchanged by design:

- `packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`

## Fixture expansion

This PR adds:

- refusal / unauthorized public-safe recorded envelope
- session-bearing public recall recorded envelope
- negative `authorized_private_session` target envelope
- negative `public_telegram` target envelope
- malformed missing-payload envelope
- malformed missing-target envelope

The fixtures remain sample v0 contract probes only. They are not production Dixie schema authority. Live envelope truth must come later from a Dixie-side artifact, endpoint contract, or cross-repo decision.

## Validator update

`validate-fixtures.mjs` now requires all nine recorded Dixie envelope fixtures and distinguishes:

- positive fixtures
- intentional negative fixtures
- unsupported-version fixture
- malformed fixture cases
- negative target cases

The validator also checks:

- shared metadata across all recorded envelope fixtures
- supported v0 shape for positive fixtures
- targeted malformation for negative fixtures
- refusal/unauthorized shape
- source session identifiers for session-bearing fixture non-vacuity

The validator still does not leak-grep raw Dixie envelope files because those fixtures intentionally contain raw/private/debug sentinels. Adapter tests enforce stripping and fail-closed behavior.

## Adapter test expansion

The new tests cover:

- refusal/unauthorized envelope adapts to safe public refusal/referral output
- session-bearing envelope adapts to public Discord and renders safely
- `session_id`, `message_id`, `tenant_id`, `community_id`, and `session_thread_id` are present at source but absent from adapted DTOs and rendered public output
- `authorized_private_session` target fails closed
- `public_telegram` target fails closed
- malformed missing-payload envelope fails closed
- malformed missing-target envelope fails closed
- unknown-version fixture still fails closed
- raw envelope direct-to-renderer remains rejected
- positive adapted DTOs and rendered public text contain no banned/private substrings
- static no-live/import guard remains in place

The optional runner work is intentionally deferred to a later phase to keep this PR focused on fixture/test proof.

## Validation

Claude report:

- added all six recommended Phase 36B fixtures
- updated validator and fixture README
- extended adapter tests
- no adapter source changes
- no package/lockfile/dependency changes
- no Discord/Telegram wiring
- no live Dixie, Straylight, Finn, storage, admission, or voice
- validator: 122 passed, 0 failed
- recall-wedge tests: 213 passed, 0 failed
- typecheck grep found no Recall Wedge/adapter diagnostics

Codex audit:

- VERDICT: ACCEPT
- no exact file/line concerns
- scope accepted
- fixture corpus accepted
- validator accepted
- README/documentation accepted
- adapter unchanged accepted
- adapter test coverage accepted
- refusal/unauthorized modeling accepted
- session identifier stripping accepted
- negative target/fail-closed behavior accepted
- optional runner deferral accepted
- no overclaims found

Local validation before commit:

- `node docs/recall-wedge/fixtures/validate-fixtures.mjs`
  - 122 passed, 0 failed
- `cd packages/persona-engine && bun test src/recall-wedge/`
  - 213 passed, 0 failed
- `bun run typecheck 2>&1 | grep -E 'recall-wedge|render-public-recall|demo-cross-interface|run-demo|dixie-envelope-adapter' || true`
  - no output

Note: repo-wide `bun run typecheck` still reports pre-existing unrelated workspace dependency/type errors outside Recall Wedge files.

## Non-goals

This PR intentionally does not add:

- package or lockfile changes
- dependencies
- live Dixie client
- Discord command wiring
- Telegram bot wiring
- `apps/bot/src/discord-interactions/*`
- delivery path changes
- production/public API surface
- `@loa/straylight`
- `@loa/dixie`
- Finn integration
- production storage
- live memory admission
- positive `authorized_private_session` projection
- `authorized_private_session` renderer
- `public_telegram` renderer
- LLM-based recall rewriting
- character-voiced recall summaries
