### PR TITLE
Phase 36C feat(persona-engine): add Recall Wedge Dixie envelope demo runner

### DIFF
--- a/docs/recall-wedge/fixtures/README.md
+++ b/docs/recall-wedge/fixtures/README.md
@@ -306,7 +306,8 @@ demo can show that the MVP keeps these categories distinct.
 - 35C — multi-surface contract spec
 - 35D — recorded Dixie envelope fixtures + adapter tests (`dixie-envelope/`)
 - 36A — live-boundary decision (`docs/RECALL-WEDGE-LIVE-BOUNDARY-DECISION.md`)
-- **36B — expanded recorded Dixie envelope corpus + adapter/validator tests** (refusal/unauthorized, session-bearing, authorized-private-target negative, public-telegram-target negative, malformed-missing-payload, malformed-missing-target)
+- 36B — expanded recorded Dixie envelope corpus + adapter/validator tests (refusal/unauthorized, session-bearing, authorized-private-target negative, public-telegram-target negative, malformed-missing-payload, malformed-missing-target)
+- **36C — dev/operator runner over the recorded Dixie envelope corpus** (`packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.ts`). Side-effect-free by default; exports `buildDixieEnvelopeDemoReport`, `formatDixieEnvelopeDemoReport`, `runDixieEnvelopeDemo`. Public sections render only positive fixtures through `renderPublicRecallProjection`; negative fixtures appear under the INTERNAL / operator-only proof section as fail-closed summaries with stable error codes. No live Dixie / Discord / Telegram / storage / admission / voice.
 
 If a later phase needs anything beyond what these fixtures shape, re-open
 the 33A doc — do not silently expand scope here.

--- a/packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.test.ts
+++ b/packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.test.ts
@@ -1,0 +1,573 @@
+// Phase 36C · regression gate for the dev/operator runner over the
+// recorded Dixie envelope corpus.
+//
+// Proves the runner module:
+//   1. processes all nine recorded Dixie envelope fixtures (4 positive +
+//      5 negative);
+//   2. positive fixtures produce rendered public output sections;
+//   3. negative fixtures produce fail-closed summaries with stable
+//      expected error codes;
+//   4. public rendered sections contain none of the Phase 36C banned
+//      substrings (incl. session_id / message_id / tenant_id /
+//      community_id / session_thread_id / continuity_actor_id /
+//      actor: / freeside-characters:shared-substrate);
+//   5. the full formatted report does not place public-sensitive
+//      operational identifiers in any public section;
+//   6. internal / fail-closed sections are clearly labeled
+//      INTERNAL / operator-only;
+//   7. fixture-bound / dev-only / non-live scope banner labels are
+//      present;
+//   8. authorized_private_session and public_telegram remain
+//      fail-closed;
+//   9. the runner does not import / invoke live / network / Discord /
+//      Telegram / Dixie / Straylight / Finn / storage / LLM behavior;
+//  10. runDixieEnvelopeDemo is side-effect-free by default and prints
+//      only through an injected sink or the CLI guard;
+//  11. existing recall-wedge test suite continues to pass (this file
+//      adds tests; nothing is removed or weakened).
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DIXIE_ENVELOPE_DEMO_REPORT_TITLE,
+  DIXIE_ENVELOPE_FIXTURE_CATALOG,
+  INTERNAL_PROOF_HEADER,
+  NON_GOALS_HEADER,
+  PUBLIC_SECTION_HEADER_PREFIX,
+  buildDixieEnvelopeDemoReport,
+  extractFormattedPublicSection,
+  formatDixieEnvelopeDemoReport,
+  loadDixieEnvelopeFixtures,
+  runDixieEnvelopeDemo,
+} from "./run-dixie-envelope-demo.ts";
+
+// Phase 36C banned-substring set, including the Phase 36B session-bearing
+// operational identifiers (tenant_id / community_id / session_thread_id).
+const PUBLIC_OUTPUT_BANNED_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "raw_dixie_debug",
+  "raw_session_trace",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "session_id",
+  "message_id",
+  "tenant_id",
+  "community_id",
+  "session_thread_id",
+  "continuity_actor_id",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/recall-wedge/fixtures/dixie-envelope",
+);
+
+function loadRawFixture(file: string): unknown {
+  return JSON.parse(readFileSync(resolve(FIXTURE_DIR, file), "utf8"));
+}
+
+describe("DIXIE_ENVELOPE_FIXTURE_CATALOG · processes all nine fixtures", () => {
+  test("catalog covers exactly the nine recorded Dixie envelope fixtures", () => {
+    expect(DIXIE_ENVELOPE_FIXTURE_CATALOG.length).toBe(9);
+    const files = DIXIE_ENVELOPE_FIXTURE_CATALOG.map((e) => e.file).sort();
+    expect(files).toEqual(
+      [
+        "recorded-public-discord-recall-envelope.v0.json",
+        "recorded-referral-recall-envelope.v0.json",
+        "recorded-refusal-unauthorized-envelope.v0.json",
+        "recorded-session-bearing-public-recall-envelope.v0.json",
+        "recorded-unknown-version-envelope.json",
+        "recorded-authorized-private-target-envelope.v0.json",
+        "recorded-public-telegram-target-envelope.v0.json",
+        "recorded-malformed-missing-payload-envelope.v0.json",
+        "recorded-malformed-missing-target-envelope.v0.json",
+      ].sort(),
+    );
+  });
+
+  test("catalog has 4 positive and 5 negative entries", () => {
+    const positive = DIXIE_ENVELOPE_FIXTURE_CATALOG.filter(
+      (e) => e.expected_class === "positive_renderable",
+    );
+    const negative = DIXIE_ENVELOPE_FIXTURE_CATALOG.filter(
+      (e) => e.expected_class === "negative_fail_closed",
+    );
+    expect(positive.length).toBe(4);
+    expect(negative.length).toBe(5);
+  });
+
+  test("every negative entry declares an expected stable error code", () => {
+    const negative = DIXIE_ENVELOPE_FIXTURE_CATALOG.filter(
+      (e) => e.expected_class === "negative_fail_closed",
+    );
+    for (const entry of negative) {
+      expect(entry.expected_error_code).toBeTruthy();
+      expect(typeof entry.expected_error_code).toBe("string");
+    }
+  });
+
+  test("loadDixieEnvelopeFixtures loads JSON for every catalog file", () => {
+    const fixtures = loadDixieEnvelopeFixtures();
+    for (const entry of DIXIE_ENVELOPE_FIXTURE_CATALOG) {
+      expect(fixtures[entry.file]).toBeDefined();
+      expect(typeof fixtures[entry.file]).toBe("object");
+    }
+  });
+});
+
+describe("buildDixieEnvelopeDemoReport · positive renderable handling", () => {
+  const report = buildDixieEnvelopeDemoReport();
+
+  test("emits one public section per positive fixture in catalog order", () => {
+    expect(report.public_sections.length).toBe(4);
+    const orderedPositiveFiles = DIXIE_ENVELOPE_FIXTURE_CATALOG.filter(
+      (e) => e.expected_class === "positive_renderable",
+    ).map((e) => e.file);
+    const reportedFiles = report.public_sections.map((s) => s.fixture_file);
+    expect(reportedFiles).toEqual(orderedPositiveFiles);
+  });
+
+  test("each positive section carries the catalog description and non-empty rendered text", () => {
+    for (const section of report.public_sections) {
+      const entry = DIXIE_ENVELOPE_FIXTURE_CATALOG.find(
+        (e) => e.file === section.fixture_file,
+      );
+      expect(entry).toBeDefined();
+      expect(section.description).toBe(entry!.description);
+      expect(typeof section.rendered_text).toBe("string");
+      expect(section.rendered_text.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("public_discord normal envelope renders the recall billboard header", () => {
+    const section = report.public_sections.find(
+      (s) =>
+        s.fixture_file === "recorded-public-discord-recall-envelope.v0.json",
+    );
+    expect(section).toBeDefined();
+    expect(section!.rendered_text).toContain("[recall · public · ruggy · ok]");
+  });
+
+  test("referral envelope renders a referral target / message", () => {
+    const section = report.public_sections.find(
+      (s) => s.fixture_file === "recorded-referral-recall-envelope.v0.json",
+    );
+    expect(section).toBeDefined();
+    expect(section!.rendered_text).toContain("referral target: satoshi");
+  });
+
+  test("refusal/unauthorized envelope renders a public-safe generic refusal billboard", () => {
+    const section = report.public_sections.find(
+      (s) =>
+        s.fixture_file ===
+        "recorded-refusal-unauthorized-envelope.v0.json",
+    );
+    expect(section).toBeDefined();
+    expect(section!.rendered_text).toContain("authorized_session");
+  });
+
+  test("session-bearing envelope renders without operational identifiers", () => {
+    const section = report.public_sections.find(
+      (s) =>
+        s.fixture_file ===
+        "recorded-session-bearing-public-recall-envelope.v0.json",
+    );
+    expect(section).toBeDefined();
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      expect(section!.rendered_text).not.toContain(banned);
+    }
+  });
+
+  test("internal proof reports all_positives_rendered_ok=true", () => {
+    expect(report.internal_proof.all_positives_rendered_ok).toBe(true);
+    expect(report.internal_proof.counts.positive_unexpected_failure).toBe(0);
+    expect(report.internal_proof.counts.positive_rendered_ok).toBe(4);
+  });
+});
+
+describe("buildDixieEnvelopeDemoReport · negative fail-closed handling", () => {
+  const report = buildDixieEnvelopeDemoReport();
+
+  test("emits one fail-closed summary per negative fixture", () => {
+    expect(report.internal_proof.fail_closed_summaries.length).toBe(5);
+  });
+
+  test("every negative fixture matched its expected stable error code", () => {
+    expect(report.internal_proof.all_negatives_matched_expected).toBe(true);
+    expect(report.internal_proof.counts.negative_unexpected_code_or_pass).toBe(
+      0,
+    );
+    expect(report.internal_proof.counts.negative_matched_expected_code).toBe(5);
+    for (const summary of report.internal_proof.fail_closed_summaries) {
+      expect(summary.matched_expected).toBe(true);
+      expect(summary.observed_error_code).toBe(summary.expected_error_code);
+    }
+  });
+
+  test("unknown-version envelope surfaces unsupported_dixie_envelope_version", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) => s.fixture_file === "recorded-unknown-version-envelope.json",
+    );
+    expect(summary?.observed_error_code).toBe(
+      "unsupported_dixie_envelope_version",
+    );
+  });
+
+  test("authorized_private_session target surfaces authorized_private_projection_not_implemented", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) =>
+        s.fixture_file ===
+        "recorded-authorized-private-target-envelope.v0.json",
+    );
+    expect(summary?.observed_error_code).toBe(
+      "authorized_private_projection_not_implemented",
+    );
+  });
+
+  test("public_telegram target surfaces public_telegram_projection_not_implemented", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) =>
+        s.fixture_file === "recorded-public-telegram-target-envelope.v0.json",
+    );
+    expect(summary?.observed_error_code).toBe(
+      "public_telegram_projection_not_implemented",
+    );
+  });
+
+  test("malformed-missing-payload surfaces missing_public_recall_payload", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) =>
+        s.fixture_file ===
+        "recorded-malformed-missing-payload-envelope.v0.json",
+    );
+    expect(summary?.observed_error_code).toBe("missing_public_recall_payload");
+  });
+
+  test("malformed-missing-target surfaces unknown_target_projection (broader entry point)", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) =>
+        s.fixture_file ===
+        "recorded-malformed-missing-target-envelope.v0.json",
+    );
+    expect(summary?.observed_error_code).toBe("unknown_target_projection");
+  });
+
+  test("negative fixtures do NOT appear in the public_sections array", () => {
+    const negativeFiles = DIXIE_ENVELOPE_FIXTURE_CATALOG.filter(
+      (e) => e.expected_class === "negative_fail_closed",
+    ).map((e) => e.file);
+    const reportedPublicFiles = report.public_sections.map(
+      (s) => s.fixture_file,
+    );
+    for (const f of negativeFiles) {
+      expect(reportedPublicFiles).not.toContain(f);
+    }
+  });
+});
+
+describe("formatDixieEnvelopeDemoReport · structural separation", () => {
+  const report = buildDixieEnvelopeDemoReport();
+  const formatted = formatDixieEnvelopeDemoReport(report);
+
+  test("title section names the fixture-bound dev/operator demo", () => {
+    expect(formatted).toContain(`# ${DIXIE_ENVELOPE_DEMO_REPORT_TITLE}`);
+  });
+
+  test("scope banner declares fixture-bound, dev/operator, not live, not admission, not schema authority", () => {
+    expect(formatted).toContain("fixture-bound");
+    expect(formatted).toContain("dev/operator only");
+    expect(formatted).toContain("not live Dixie");
+    expect(formatted).toContain("not governed memory admission");
+    expect(formatted).toContain("not production schema authority");
+  });
+
+  test("includes a public section header for each positive fixture", () => {
+    for (const section of report.public_sections) {
+      expect(formatted).toContain(
+        `## ${PUBLIC_SECTION_HEADER_PREFIX}${section.fixture_file}`,
+      );
+    }
+  });
+
+  test("internal proof section is labeled INTERNAL / operator-only", () => {
+    expect(formatted).toContain(`## ${INTERNAL_PROOF_HEADER}`);
+    expect(formatted).toContain("INTERNAL / operator-only");
+  });
+
+  test("fail-closed summaries are labeled INTERNAL / operator-only inside the internal section", () => {
+    expect(formatted).toContain(
+      "fail-closed summaries [INTERNAL / operator-only]",
+    );
+  });
+
+  test("non-goals section enumerates the live integrations not present", () => {
+    expect(formatted).toContain(`## ${NON_GOALS_HEADER}`);
+    expect(formatted).toContain("no Discord");
+    expect(formatted).toContain("no Telegram");
+    expect(formatted).toContain("no live Dixie client");
+    expect(formatted).toContain("no live memory admission");
+    expect(formatted).toContain("no LLM / voice rewrite");
+    expect(formatted).toContain(
+      "recorded fixtures are not production schema authority",
+    );
+  });
+
+  test("public sections appear before internal proof and non-goals", () => {
+    const firstPublicHeader = formatted.indexOf(
+      `## ${PUBLIC_SECTION_HEADER_PREFIX}`,
+    );
+    const internalIdx = formatted.indexOf(`## ${INTERNAL_PROOF_HEADER}`);
+    const nonGoalsIdx = formatted.indexOf(`## ${NON_GOALS_HEADER}`);
+    expect(firstPublicHeader).toBeGreaterThan(-1);
+    expect(internalIdx).toBeGreaterThan(firstPublicHeader);
+    expect(nonGoalsIdx).toBeGreaterThan(internalIdx);
+  });
+});
+
+describe("formatDixieEnvelopeDemoReport · public sections never leak banned material", () => {
+  const report = buildDixieEnvelopeDemoReport();
+  const formatted = formatDixieEnvelopeDemoReport(report);
+
+  for (const section of report.public_sections) {
+    const extracted = extractFormattedPublicSection(
+      formatted,
+      section.fixture_file,
+    );
+    for (const banned of PUBLIC_OUTPUT_BANNED_SUBSTRINGS) {
+      test(`public section for ${section.fixture_file} contains no "${banned}"`, () => {
+        expect(extracted.body).not.toContain(banned);
+      });
+    }
+
+    test(`public section for ${section.fixture_file} has no line starting with actor:`, () => {
+      for (const line of extracted.body.split("\n")) {
+        expect(line.startsWith("actor:")).toBe(false);
+      }
+    });
+  }
+});
+
+describe("formatDixieEnvelopeDemoReport · session-bearing operational ids never appear in any public section", () => {
+  // Anti-vacuity: the session-bearing source envelope MUST carry the
+  // synthetic identifier values; otherwise the leak claim below could be
+  // satisfied by an absent identifier rather than by the adapter actually
+  // stripping it.
+  const sessionBearing = loadRawFixture(
+    "recorded-session-bearing-public-recall-envelope.v0.json",
+  ) as Record<string, unknown>;
+
+  test("source envelope ACTUALLY carries operational id values (proof is non-vacuous)", () => {
+    for (const key of [
+      "session_id",
+      "message_id",
+      "tenant_id",
+      "community_id",
+      "session_thread_id",
+    ]) {
+      const v = sessionBearing[key];
+      expect(typeof v).toBe("string");
+      expect((v as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  const formatted = formatDixieEnvelopeDemoReport(
+    buildDixieEnvelopeDemoReport(),
+  );
+
+  test("synthetic identifier VALUES never appear in any public section", () => {
+    const positiveFiles = DIXIE_ENVELOPE_FIXTURE_CATALOG.filter(
+      (e) => e.expected_class === "positive_renderable",
+    ).map((e) => e.file);
+    for (const file of positiveFiles) {
+      const extracted = extractFormattedPublicSection(formatted, file);
+      for (const key of [
+        "session_id",
+        "message_id",
+        "tenant_id",
+        "community_id",
+        "session_thread_id",
+      ]) {
+        const v = sessionBearing[key];
+        if (typeof v === "string" && v.length > 0) {
+          expect(extracted.body).not.toContain(v);
+        }
+      }
+    }
+  });
+});
+
+describe("buildDixieEnvelopeDemoReport · accepts injected fixtures", () => {
+  test("passes through caller-supplied fixtures for deterministic test composition", () => {
+    const fixtures = loadDixieEnvelopeFixtures();
+    const report = buildDixieEnvelopeDemoReport({ fixtures });
+    expect(report.public_sections.length).toBe(4);
+    expect(report.internal_proof.fail_closed_summaries.length).toBe(5);
+  });
+});
+
+describe("runDixieEnvelopeDemo · invocation surface", () => {
+  test("returns the report and formatted text without printing by default", () => {
+    const result = runDixieEnvelopeDemo();
+    expect(result.report.title).toBe(DIXIE_ENVELOPE_DEMO_REPORT_TITLE);
+    expect(typeof result.formatted).toBe("string");
+    expect(result.formatted.length).toBeGreaterThan(0);
+  });
+
+  test("prints exactly once through an injected sink", () => {
+    const printed: string[] = [];
+    const result = runDixieEnvelopeDemo({
+      print: (line) => printed.push(line),
+    });
+    expect(printed.length).toBe(1);
+    expect(printed[0]).toBe(result.formatted);
+  });
+
+  test("formatted output is deterministic across invocations", () => {
+    const a = runDixieEnvelopeDemo().formatted;
+    const b = runDixieEnvelopeDemo().formatted;
+    expect(a).toBe(b);
+  });
+
+  test("does not call console.log when no print sink is provided (side-effect-free by default)", () => {
+    const original = console.log;
+    let calls = 0;
+    console.log = () => {
+      calls += 1;
+    };
+    try {
+      runDixieEnvelopeDemo();
+    } finally {
+      console.log = original;
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+describe("runDixieEnvelopeDemo · authorized_private_session and public_telegram remain fail-closed", () => {
+  const report = buildDixieEnvelopeDemoReport();
+
+  test("authorized_private_session fixture stays in fail-closed summaries with the not-implemented code", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) =>
+        s.fixture_file ===
+        "recorded-authorized-private-target-envelope.v0.json",
+    );
+    expect(summary).toBeDefined();
+    expect(summary!.observed_error_code).toBe(
+      "authorized_private_projection_not_implemented",
+    );
+    expect(summary!.matched_expected).toBe(true);
+  });
+
+  test("public_telegram fixture stays in fail-closed summaries with the not-implemented code", () => {
+    const summary = report.internal_proof.fail_closed_summaries.find(
+      (s) =>
+        s.fixture_file === "recorded-public-telegram-target-envelope.v0.json",
+    );
+    expect(summary).toBeDefined();
+    expect(summary!.observed_error_code).toBe(
+      "public_telegram_projection_not_implemented",
+    );
+    expect(summary!.matched_expected).toBe(true);
+  });
+
+  test("neither authorized_private_session nor public_telegram appears in public_sections", () => {
+    const publicFiles = report.public_sections.map((s) => s.fixture_file);
+    expect(publicFiles).not.toContain(
+      "recorded-authorized-private-target-envelope.v0.json",
+    );
+    expect(publicFiles).not.toContain(
+      "recorded-public-telegram-target-envelope.v0.json",
+    );
+  });
+});
+
+describe("runDixieEnvelopeDemo · no live integration surface (static source guard)", () => {
+  // Read the runner source directly to guard against accidental import
+  // additions. Mirrors the run-demo.test.ts pattern.
+  const moduleSource = (() => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { readFileSync: rfs } =
+      require("node:fs") as typeof import("node:fs");
+    const { dirname: dn, resolve: rs } =
+      require("node:path") as typeof import("node:path");
+    const { fileURLToPath: ftp } =
+      require("node:url") as typeof import("node:url");
+    const here = dn(ftp(import.meta.url));
+    return rfs(rs(here, "run-dixie-envelope-demo.ts"), "utf8");
+  })();
+
+  test("runner source imports no Discord client or interactions", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*discord-interactions[^"']*["']/,
+    );
+  });
+
+  test("runner source imports no Telegram client", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*node-telegram[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']telegraf["']/);
+  });
+
+  test("runner source imports no @loa/dixie / @loa/straylight / Finn", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+  });
+
+  test("runner source does not call an LLM SDK", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']@anthropic-ai\/sdk["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test("runner source does not pull in pg / production storage", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']redis["']/);
+  });
+
+  test("runner source contains no fetch( or network node imports", () => {
+    expect(moduleSource).not.toContain("fetch(");
+    expect(moduleSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:https["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:net["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:child_process["']/);
+  });
+
+  test("runner source does not register or dispatch Discord / Telegram commands", () => {
+    expect(moduleSource).not.toMatch(/registerCommand\s*\(/);
+    expect(moduleSource).not.toMatch(/applicationCommands/);
+    expect(moduleSource).not.toMatch(/sendMessage\s*\(/);
+  });
+
+  test("runner source uses node:fs only for local fixture loading", () => {
+    // node:fs is allowed (fixtures are JSON files on disk), but only
+    // through the readFileSync used by loadJson; no writes, watches, or
+    // streams.
+    expect(moduleSource).toMatch(/from\s+["']node:fs["']/);
+    expect(moduleSource).not.toMatch(/writeFileSync\s*\(/);
+    expect(moduleSource).not.toMatch(/createWriteStream\s*\(/);
+    expect(moduleSource).not.toMatch(/watchFile\s*\(/);
+    expect(moduleSource).not.toMatch(/\bunlinkSync\s*\(/);
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.ts
+++ b/packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.ts
@@ -1,0 +1,502 @@
+// Phase 36C · explicit dev/operator runner over the recorded Dixie envelope
+// fixture corpus.
+//
+// Composes the Phase 35D pure adapter
+// (`packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`) and
+// the Phase 33C public-safe renderer
+// (`packages/persona-engine/src/recall-wedge/render-public-recall.ts`) over
+// the Phase 35D + Phase 36B recorded Dixie envelope fixtures shipped under
+// `docs/recall-wedge/fixtures/dixie-envelope/`.
+//
+// Pipeline per fixture:
+//
+//   recorded Dixie envelope fixture
+//     → pure adapter (`adaptDixieEnvelopeToRecallProjection`)
+//     → local Recall Wedge projected DTO
+//     → public-safe renderer (`renderPublicRecallProjection`), if renderable
+//     → deterministic operator-readable section
+//
+// The runner clearly distinguishes:
+//   - positive renderable fixtures — public rendered output, headed with
+//     `## ${PUBLIC_SECTION_HEADER_PREFIX}<fixture_file>`;
+//   - negative fail-closed fixtures — adapter-error class + stable error
+//     code, surfaced ONLY under the INTERNAL / operator-only proof section.
+//
+// Hard non-goals (per Phase 36A live-boundary decision §10c and the Phase
+// 36C brief): no Discord client, no Telegram client, no live Dixie network
+// call, no @loa/dixie / @loa/straylight / Finn integration, no production
+// storage, no live memory admission, no LLM / voice rewrite, no character
+// voice, no `authorized_private_session` positive projection or renderer,
+// no `public_telegram` renderer. Fixture-bound, recorded-envelope-bound,
+// dev/operator-only, side-effect-free by default.
+//
+// Recorded fixtures are sample v0 contract probes only — they are not
+// production schema authority. Live envelope contract truth must come
+// later from a Dixie-side artifact, endpoint contract, or cross-repo
+// decision (live-boundary decision §7a).
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DixieEnvelopeAdapterError,
+  adaptDixieEnvelopeToRecallProjection,
+} from "./dixie-envelope-adapter.ts";
+import {
+  PublicRecallRenderError,
+  renderPublicRecallProjection,
+} from "./render-public-recall.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/recall-wedge/fixtures/dixie-envelope",
+);
+
+// -- public report shape ----------------------------------------------------
+
+export const DIXIE_ENVELOPE_DEMO_REPORT_TITLE =
+  "Dixie envelope dev/operator demo (recorded-envelope-bound, pre-live)" as const;
+
+export const PUBLIC_SECTION_HEADER_PREFIX =
+  "Public rendered output: " as const;
+
+export const INTERNAL_PROOF_HEADER =
+  "Internal proof summary [INTERNAL / operator-only]" as const;
+
+export const NON_GOALS_HEADER =
+  "Non-goals / live integration not present" as const;
+
+export const SCOPE_BANNER_LINES = [
+  "fixture-bound: recorded Dixie envelope fixtures only",
+  "dev/operator only: no public surface delivery",
+  "not live Dixie: no live Dixie network call, no live Dixie client",
+  "not governed memory admission: this runner does not write to candidate or admitted memory",
+  "not production schema authority: recorded fixtures are sample v0 contract probes",
+] as const;
+
+const NON_GOALS = [
+  "no Discord client / command registration / Discord API call",
+  "no Telegram bot / Telegram API call",
+  "no live Dixie client",
+  "no @loa/dixie or @loa/straylight integration",
+  "no Finn runtime",
+  "no production storage",
+  "no live memory admission",
+  "no LLM / voice rewrite",
+  "no character-voiced recall",
+  "recorded fixtures are not production schema authority",
+] as const;
+
+// Each recorded fixture in the Dixie envelope corpus and its expected
+// adapter behavior under `adaptDixieEnvelopeToRecallProjection` (the
+// broader entry point that respects the envelope's own target_projection).
+//
+// `expected_class` values:
+//   - "positive_renderable" — adapter projects, renderer renders
+//   - "negative_fail_closed" — adapter throws DixieEnvelopeAdapterError
+//
+// `expected_error_code` is the stable error code expected on negatives.
+// Choosing `adaptDixieEnvelopeToRecallProjection` deliberately:
+//
+//   - it surfaces `authorized_private_projection_not_implemented` and
+//     `public_telegram_projection_not_implemented` for the negative-target
+//     fixtures (the narrow public-only entry point would instead surface
+//     `wrong_recall_interface_for_target`, which is correct but generic);
+//   - for the missing-target fixture it surfaces
+//     `unknown_target_projection` because `pickTarget` runs first;
+//   - for the missing-payload fixture it surfaces
+//     `missing_public_recall_payload` after target resolution;
+//   - for the unknown-version fixture it surfaces
+//     `unsupported_dixie_envelope_version` (version check runs first).
+//
+// These expectations are a published contract for this runner and are
+// asserted by `run-dixie-envelope-demo.test.ts`.
+
+export interface DixieEnvelopeFixtureEntry {
+  readonly file: string;
+  readonly expected_class: "positive_renderable" | "negative_fail_closed";
+  readonly expected_error_code?: string;
+  readonly description: string;
+}
+
+export const DIXIE_ENVELOPE_FIXTURE_CATALOG: readonly DixieEnvelopeFixtureEntry[] =
+  [
+    {
+      file: "recorded-public-discord-recall-envelope.v0.json",
+      expected_class: "positive_renderable",
+      description: "normal public_discord recall billboard",
+    },
+    {
+      file: "recorded-referral-recall-envelope.v0.json",
+      expected_class: "positive_renderable",
+      description: "character-boundary referral on public_discord",
+    },
+    {
+      file: "recorded-refusal-unauthorized-envelope.v0.json",
+      expected_class: "positive_renderable",
+      description:
+        "refusal/unauthorized narrowed to public-safe generic-refusal billboard",
+    },
+    {
+      file: "recorded-session-bearing-public-recall-envelope.v0.json",
+      expected_class: "positive_renderable",
+      description:
+        "public_discord recall with synthetic session/message/tenant ids that the adapter must strip",
+    },
+    {
+      file: "recorded-unknown-version-envelope.json",
+      expected_class: "negative_fail_closed",
+      expected_error_code: "unsupported_dixie_envelope_version",
+      description: "envelope_version present but intentionally unsupported",
+    },
+    {
+      file: "recorded-authorized-private-target-envelope.v0.json",
+      expected_class: "negative_fail_closed",
+      expected_error_code: "authorized_private_projection_not_implemented",
+      description:
+        "target_projection.recall_interface=authorized_private_session — multi-surface contract §5a authorized-private DTO gate not satisfied",
+    },
+    {
+      file: "recorded-public-telegram-target-envelope.v0.json",
+      expected_class: "negative_fail_closed",
+      expected_error_code: "public_telegram_projection_not_implemented",
+      description:
+        "target_projection.recall_interface=public_telegram — multi-surface contract §8a future-renderer warning not satisfied for Telegram",
+    },
+    {
+      file: "recorded-malformed-missing-payload-envelope.v0.json",
+      expected_class: "negative_fail_closed",
+      expected_error_code: "missing_public_recall_payload",
+      description: "supported version + valid target, public_recall_payload absent",
+    },
+    {
+      file: "recorded-malformed-missing-target-envelope.v0.json",
+      expected_class: "negative_fail_closed",
+      expected_error_code: "unknown_target_projection",
+      description:
+        "supported version + valid payload, target_projection absent (broader entry point hits target-resolution error first)",
+    },
+  ] as const;
+
+// -- public types -----------------------------------------------------------
+
+export interface DixieEnvelopePublicSection {
+  readonly fixture_file: string;
+  readonly description: string;
+  readonly rendered_text: string;
+}
+
+export interface DixieEnvelopeFailClosedSummary {
+  readonly fixture_file: string;
+  readonly description: string;
+  readonly expected_error_code: string;
+  readonly observed_error_code: string;
+  readonly matched_expected: boolean;
+}
+
+export interface DixieEnvelopeInternalProof {
+  readonly counts: {
+    readonly total: number;
+    readonly positive_renderable: number;
+    readonly negative_fail_closed: number;
+    readonly positive_rendered_ok: number;
+    readonly positive_unexpected_failure: number;
+    readonly negative_matched_expected_code: number;
+    readonly negative_unexpected_code_or_pass: number;
+  };
+  readonly fail_closed_summaries: readonly DixieEnvelopeFailClosedSummary[];
+  readonly all_negatives_matched_expected: boolean;
+  readonly all_positives_rendered_ok: boolean;
+}
+
+export interface DixieEnvelopeDemoReport {
+  readonly title: string;
+  readonly scope_banner: readonly string[];
+  readonly public_sections: readonly DixieEnvelopePublicSection[];
+  readonly internal_proof: DixieEnvelopeInternalProof;
+  readonly non_goals: readonly string[];
+}
+
+// -- fixture loading --------------------------------------------------------
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function loadDixieEnvelopeFixtures(): Readonly<
+  Record<string, unknown>
+> {
+  const out: Record<string, unknown> = {};
+  for (const entry of DIXIE_ENVELOPE_FIXTURE_CATALOG) {
+    out[entry.file] = loadJson(resolve(FIXTURE_DIR, entry.file));
+  }
+  return out;
+}
+
+// -- adapter / renderer composition ----------------------------------------
+
+type AttemptResult =
+  | { readonly kind: "rendered"; readonly text: string }
+  | { readonly kind: "adapter_error"; readonly code: string }
+  | { readonly kind: "render_error"; readonly code: string }
+  | { readonly kind: "unknown_error" };
+
+function attemptAdaptAndRender(envelope: unknown): AttemptResult {
+  let dto: unknown;
+  try {
+    dto = adaptDixieEnvelopeToRecallProjection(envelope);
+  } catch (err) {
+    if (err instanceof DixieEnvelopeAdapterError) {
+      return { kind: "adapter_error", code: err.code };
+    }
+    return { kind: "unknown_error" };
+  }
+  try {
+    const text = renderPublicRecallProjection(dto);
+    return { kind: "rendered", text };
+  } catch (err) {
+    if (err instanceof PublicRecallRenderError) {
+      return { kind: "render_error", code: err.code };
+    }
+    return { kind: "unknown_error" };
+  }
+}
+
+// -- report builder --------------------------------------------------------
+
+export interface BuildDixieEnvelopeDemoReportOptions {
+  readonly fixtures?: Readonly<Record<string, unknown>>;
+}
+
+export function buildDixieEnvelopeDemoReport(
+  options: BuildDixieEnvelopeDemoReportOptions = {},
+): DixieEnvelopeDemoReport {
+  const fixtures = options.fixtures ?? loadDixieEnvelopeFixtures();
+
+  const publicSections: DixieEnvelopePublicSection[] = [];
+  const failClosedSummaries: DixieEnvelopeFailClosedSummary[] = [];
+
+  let positiveRenderable = 0;
+  let positiveRenderedOk = 0;
+  let positiveUnexpectedFailure = 0;
+  let negativeFailClosed = 0;
+  let negativeMatchedExpected = 0;
+  let negativeUnexpected = 0;
+
+  for (const entry of DIXIE_ENVELOPE_FIXTURE_CATALOG) {
+    const envelope = fixtures[entry.file];
+    const result = attemptAdaptAndRender(envelope);
+
+    if (entry.expected_class === "positive_renderable") {
+      positiveRenderable += 1;
+      if (result.kind === "rendered") {
+        positiveRenderedOk += 1;
+        publicSections.push({
+          fixture_file: entry.file,
+          description: entry.description,
+          rendered_text: result.text,
+        });
+      } else {
+        positiveUnexpectedFailure += 1;
+        failClosedSummaries.push({
+          fixture_file: entry.file,
+          description: `UNEXPECTED · positive fixture failed to render — ${entry.description}`,
+          expected_error_code: "(none — fixture is positive)",
+          observed_error_code:
+            result.kind === "adapter_error"
+              ? result.code
+              : result.kind === "render_error"
+                ? result.code
+                : "unknown_error",
+          matched_expected: false,
+        });
+      }
+      continue;
+    }
+
+    // negative_fail_closed
+    negativeFailClosed += 1;
+    const expected = entry.expected_error_code ?? "(unspecified)";
+    if (result.kind === "adapter_error" && result.code === expected) {
+      negativeMatchedExpected += 1;
+      failClosedSummaries.push({
+        fixture_file: entry.file,
+        description: entry.description,
+        expected_error_code: expected,
+        observed_error_code: result.code,
+        matched_expected: true,
+      });
+    } else {
+      negativeUnexpected += 1;
+      failClosedSummaries.push({
+        fixture_file: entry.file,
+        description: `UNEXPECTED · ${entry.description}`,
+        expected_error_code: expected,
+        observed_error_code:
+          result.kind === "adapter_error"
+            ? result.code
+            : result.kind === "render_error"
+              ? `(render error) ${result.code}`
+              : result.kind === "rendered"
+                ? "(rendered — negative fixture did NOT fail closed)"
+                : "unknown_error",
+        matched_expected: false,
+      });
+    }
+  }
+
+  const internalProof: DixieEnvelopeInternalProof = {
+    counts: {
+      total: DIXIE_ENVELOPE_FIXTURE_CATALOG.length,
+      positive_renderable: positiveRenderable,
+      negative_fail_closed: negativeFailClosed,
+      positive_rendered_ok: positiveRenderedOk,
+      positive_unexpected_failure: positiveUnexpectedFailure,
+      negative_matched_expected_code: negativeMatchedExpected,
+      negative_unexpected_code_or_pass: negativeUnexpected,
+    },
+    fail_closed_summaries: failClosedSummaries,
+    all_negatives_matched_expected: negativeUnexpected === 0,
+    all_positives_rendered_ok: positiveUnexpectedFailure === 0,
+  };
+
+  return {
+    title: DIXIE_ENVELOPE_DEMO_REPORT_TITLE,
+    scope_banner: SCOPE_BANNER_LINES,
+    public_sections: publicSections,
+    internal_proof: internalProof,
+    non_goals: NON_GOALS,
+  };
+}
+
+// -- formatter -------------------------------------------------------------
+
+function formatScopeBanner(banner: readonly string[]): string {
+  const lines: string[] = ["> scope (read me first):"];
+  for (const item of banner) lines.push(`> - ${item}`);
+  return lines.join("\n");
+}
+
+function formatPublicSection(section: DixieEnvelopePublicSection): string {
+  return [
+    `## ${PUBLIC_SECTION_HEADER_PREFIX}${section.fixture_file}`,
+    `description: ${section.description}`,
+    "",
+    section.rendered_text,
+  ].join("\n");
+}
+
+function formatInternalProof(proof: DixieEnvelopeInternalProof): string {
+  const lines: string[] = [
+    `## ${INTERNAL_PROOF_HEADER}`,
+    "the fields below are operator-only and must not be relayed to any",
+    "public surface; they are surfaced here for operator inspection of",
+    "the recorded-envelope-bound proof",
+    "",
+    "fixture counts:",
+    `  total fixtures:                       ${proof.counts.total}`,
+    `  positive renderable:                  ${proof.counts.positive_renderable}`,
+    `  negative fail-closed:                 ${proof.counts.negative_fail_closed}`,
+    `  positive rendered ok:                 ${proof.counts.positive_rendered_ok}`,
+    `  positive unexpected failure:          ${proof.counts.positive_unexpected_failure}`,
+    `  negative matched expected error code: ${proof.counts.negative_matched_expected_code}`,
+    `  negative unexpected code or pass:     ${proof.counts.negative_unexpected_code_or_pass}`,
+    "",
+    "proof booleans:",
+    `  all_positives_rendered_ok:       ${String(proof.all_positives_rendered_ok)}`,
+    `  all_negatives_matched_expected:  ${String(proof.all_negatives_matched_expected)}`,
+    "",
+    "fail-closed summaries [INTERNAL / operator-only]:",
+  ];
+  if (proof.fail_closed_summaries.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const s of proof.fail_closed_summaries) {
+      lines.push(`  - fixture: ${s.fixture_file}`);
+      lines.push(`    description:    ${s.description}`);
+      lines.push(`    expected_code:  ${s.expected_error_code}`);
+      lines.push(`    observed_code:  ${s.observed_error_code}`);
+      lines.push(`    matched:        ${String(s.matched_expected)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatNonGoals(nonGoals: readonly string[]): string {
+  const lines: string[] = [`## ${NON_GOALS_HEADER}`];
+  for (const item of nonGoals) lines.push(`- ${item}`);
+  return lines.join("\n");
+}
+
+export function formatDixieEnvelopeDemoReport(
+  report: DixieEnvelopeDemoReport,
+): string {
+  const parts: string[] = [
+    `# ${report.title}`,
+    formatScopeBanner(report.scope_banner),
+  ];
+  for (const section of report.public_sections) {
+    parts.push(formatPublicSection(section));
+  }
+  parts.push(formatInternalProof(report.internal_proof));
+  parts.push(formatNonGoals(report.non_goals));
+  return parts.join("\n\n");
+}
+
+// -- public-section extractor (test helper) --------------------------------
+
+export interface ExtractedDixieEnvelopePublicSection {
+  readonly header: string;
+  readonly body: string;
+}
+
+export function extractFormattedPublicSection(
+  formatted: string,
+  fixture_file: string,
+): ExtractedDixieEnvelopePublicSection {
+  const header = `## ${PUBLIC_SECTION_HEADER_PREFIX}${fixture_file}`;
+  const headerIdx = formatted.indexOf(header);
+  if (headerIdx < 0) {
+    throw new Error(
+      `run-dixie-envelope-demo: public section header not found for ${fixture_file}`,
+    );
+  }
+  const afterHeader = formatted.slice(headerIdx + header.length);
+  const nextHeaderRel = afterHeader.search(/\n## /);
+  const body =
+    nextHeaderRel < 0
+      ? afterHeader.trimStart()
+      : afterHeader.slice(0, nextHeaderRel).trimStart();
+  return { header, body };
+}
+
+// -- runner -----------------------------------------------------------------
+
+export interface RunDixieEnvelopeDemoOptions {
+  readonly fixtures?: Readonly<Record<string, unknown>>;
+  readonly print?: (text: string) => void;
+}
+
+export function runDixieEnvelopeDemo(
+  options: RunDixieEnvelopeDemoOptions = {},
+): {
+  readonly report: DixieEnvelopeDemoReport;
+  readonly formatted: string;
+} {
+  const report = buildDixieEnvelopeDemoReport({ fixtures: options.fixtures });
+  const formatted = formatDixieEnvelopeDemoReport(report);
+  if (options.print) options.print(formatted);
+  return { report, formatted };
+}
+
+// -- CLI guard --------------------------------------------------------------
+
+const isCli =
+  typeof import.meta !== "undefined" &&
+  (import.meta as { main?: boolean }).main === true;
+
+if (isCli) {
+  runDixieEnvelopeDemo({ print: (line) => console.log(line) });
+}


### PR DESCRIPTION
## Summary

Phase 36C adds a dev/operator runner over the recorded Dixie envelope corpus for `freeside-characters`.

This PR remains recorded-envelope-bound and pre-live. It makes the Phase 35D/36B recorded-envelope proof inspectable by an operator without adding live Dixie, Discord/Telegram wiring, storage, memory admission, public Telegram rendering, authorized-private rendering, or character voice.

## Files

New:

- `packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.ts`
- `packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.test.ts`

Modified:

- `docs/recall-wedge/fixtures/README.md`

Unchanged by design:

- `packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts`
- `packages/persona-engine/src/recall-wedge/render-public-recall.ts`
- `packages/persona-engine/src/recall-wedge/run-demo.ts`
- `package.json`
- lockfiles

## Runner behavior

The runner:

- catalogs all nine recorded Dixie envelope fixtures
- renders the four positive fixtures through the existing adapter and public renderer
- summarizes the five negative fixtures as fail-closed outcomes with stable error codes
- keeps public rendered output separate from internal proof/fail-closed summaries
- labels internal/fail-closed sections as `INTERNAL / operator-only`
- labels the report as fixture-bound, dev/operator-only, not live Dixie, not governed memory admission, and not production schema authority
- is side-effect-free by default
- prints only through an injected `print` callback or direct local CLI guard

## Positive fixture handling

The runner renders public output for:

- `recorded-public-discord-recall-envelope.v0.json`
- `recorded-referral-recall-envelope.v0.json`
- `recorded-refusal-unauthorized-envelope.v0.json`
- `recorded-session-bearing-public-recall-envelope.v0.json`

Public sections are produced only from the Phase 33C public renderer output.

## Negative fixture handling

The runner summarizes fail-closed behavior for:

- `recorded-unknown-version-envelope.json`
  - `unsupported_dixie_envelope_version`
- `recorded-authorized-private-target-envelope.v0.json`
  - `authorized_private_projection_not_implemented`
- `recorded-public-telegram-target-envelope.v0.json`
  - `public_telegram_projection_not_implemented`
- `recorded-malformed-missing-payload-envelope.v0.json`
  - `missing_public_recall_payload`
- `recorded-malformed-missing-target-envelope.v0.json`
  - `unknown_target_projection`

Negative fixtures never enter public rendered output sections.

## Public/internal separation

The formatted report contains:

- public rendered output sections
- internal proof summary
- fail-closed summaries marked `INTERNAL / operator-only`
- non-goals / live integration not present

Tests assert public sections do not contain private/raw/debug/source/session/actor identifiers or banned substrings.

## Validation

Claude report:

- added only the Phase 36C runner and test files plus a minimal README pointer
- no adapter source changes
- no renderer changes
- no package/lockfile/dependency changes
- no Discord/Telegram wiring
- no live Dixie, Straylight, Finn, storage, admission, or voice
- validator: 122 passed, 0 failed
- recall-wedge tests: 349 passed, 0 failed
- typecheck grep found no Recall Wedge/runner diagnostics

Codex audit:

- VERDICT: ACCEPT
- no exact file/line concerns
- scope accepted
- runner behavior accepted
- positive fixture rendering accepted
- negative fail-closed behavior accepted
- public/internal separation accepted
- public no-leak accepted
- side-effect/CLI behavior accepted
- static no-live/import guard accepted
- README change accepted
- no overclaims found

Local validation before commit:

- `node docs/recall-wedge/fixtures/validate-fixtures.mjs`
  - 122 passed, 0 failed
- `cd packages/persona-engine && bun test src/recall-wedge/`
  - 349 passed, 0 failed
- `bun run typecheck 2>&1 | grep -E 'recall-wedge|render-public-recall|demo-cross-interface|run-demo|dixie-envelope-adapter|run-dixie-envelope-demo' || true`
  - no output

Note: repo-wide `bun run typecheck` still reports pre-existing unrelated workspace dependency/type errors outside Recall Wedge files.

## Non-goals

This PR intentionally does not add:

- package or lockfile changes
- dependencies
- adapter semantic changes
- renderer changes
- live Dixie client
- Discord command wiring
- Telegram bot wiring
- `apps/bot/src/discord-interactions/*`
- delivery path changes
- production/public API surface
- `@loa/straylight`
- `@loa/dixie`
- Finn integration
- production storage
- live memory admission
- positive `authorized_private_session` projection
- `authorized_private_session` renderer
- `public_telegram` renderer
- LLM-based recall rewriting
- character-voiced recall summaries
