### PR TITLE
Phase 37C add operator live Dixie recall client

### DIFF
--- a/packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts
+++ b/packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts
@@ -1,0 +1,900 @@
+// Phase 37C · regression gate for the operator/dev-only live Dixie recall
+// client. Authority: docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md §K.
+//
+// Proves:
+//   1. config / env loader fails closed on missing or invalid env, no
+//      network call;
+//   2. request plan targets exactly POST /api/recall/intake, includes
+//      Idempotency-Key, includes the documented Dixie wire body shape,
+//      includes Bearer service auth, and never carries
+//      recorded_dixie_recall_envelope;
+//   3. unsafe Idempotency-Key reuse with different content is detected
+//      before any network call;
+//   4. response classification cleanly partitions served / denied /
+//      needs_review / ingress / service-auth / tenant-mismatch /
+//      rate-limit / upstream / network / unsupported shapes;
+//   5. raw / private / debug / source sentinels never reach the
+//      operator-public public_summary fields, even when Dixie returns a
+//      contaminated body or unknown error class;
+//   6. live client source imports no Discord / Telegram / storage / LLM /
+//      Finn / @loa/dixie / @loa/straylight runtime dependency, and does
+//      not import dixie-envelope-adapter.ts or render-public-recall.ts.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS,
+  LIVE_DIXIE_CLIENT_DEFAULT_TIMEOUT_MS,
+  LIVE_DIXIE_CLIENT_INTAKE_PATH,
+  LIVE_DIXIE_CLIENT_MAX_TIMEOUT_MS,
+  LIVE_DIXIE_DISALLOWED_ENVIRONMENT_FRAMES,
+  LIVE_DIXIE_RECALL_CLASSIFICATIONS,
+  LiveDixieClientConfigError,
+  buildLiveDixieRecallRequestPlan,
+  computeLiveDixieRequestFingerprint,
+  createIdempotencyReuseDetector,
+  findBannedPublicSubstring,
+  liveRecallViaDixie,
+  loadLiveDixieClientConfigFromEnv,
+  type LiveDixieClientConfig,
+  type LiveDixieFetchLike,
+  type LiveRecallInput,
+} from "./live-dixie-client.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WALLET = "0xabcdef0000000000000000000000000000000001";
+
+function fullEnv(
+  overrides: Partial<Record<string, string>> = {},
+): Record<string, string | undefined> {
+  return {
+    RECALL_WEDGE_DIXIE_BASE_URL: "https://dixie.example.test",
+    RECALL_WEDGE_DIXIE_SERVICE_TOKEN: "tkn-operator-dev",
+    RECALL_WEDGE_DIXIE_TENANT_ID: WALLET,
+    RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID: WALLET,
+    RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX: "p37c",
+    ...overrides,
+  };
+}
+
+function buildConfig(
+  overrides: Partial<LiveDixieClientConfig> = {},
+): LiveDixieClientConfig {
+  return {
+    baseUrl: "https://dixie.example.test",
+    serviceToken: "tkn-operator-dev",
+    tenantId: WALLET,
+    callerActorId: WALLET,
+    requestKeyPrefix: "p37c",
+    timeoutMs: LIVE_DIXIE_CLIENT_DEFAULT_TIMEOUT_MS,
+    ...overrides,
+  };
+}
+
+function buildInput(
+  overrides: Partial<LiveRecallInput> = {},
+): LiveRecallInput {
+  return {
+    recallRequestId: "rr-1",
+    task: "operator-dev-recall-spike",
+    environmentFrame: "private_chat",
+    riskProfile: "low",
+    detailLevel: "minimal",
+    receiptDetail: "minimal",
+    signature: {
+      signature_id: "sig_1",
+      signer_id: "signer_test",
+      signer_type: "actor_controller",
+      signature_type: "dev_signature",
+      signed_payload_hash:
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      signature: "devsig",
+      signed_at: "2026-05-18T00:00:00Z",
+      key_ref: "kref_test",
+    },
+    createdAt: "2026-05-18T00:00:00Z",
+    idempotencyKey: "fixed-key-1",
+    ...overrides,
+  };
+}
+
+// -- 1. config / env -------------------------------------------------------
+
+describe("loadLiveDixieClientConfigFromEnv · fail-closed env handling", () => {
+  test("loads a complete config from a valid env object", () => {
+    const cfg = loadLiveDixieClientConfigFromEnv(fullEnv());
+    expect(cfg.baseUrl).toBe("https://dixie.example.test");
+    expect(cfg.serviceToken).toBe("tkn-operator-dev");
+    expect(cfg.tenantId).toBe(WALLET);
+    expect(cfg.callerActorId).toBe(WALLET);
+    expect(cfg.requestKeyPrefix).toBe("p37c");
+    expect(cfg.timeoutMs).toBe(LIVE_DIXIE_CLIENT_DEFAULT_TIMEOUT_MS);
+  });
+
+  test("uses conservative default timeout when RECALL_WEDGE_DIXIE_TIMEOUT_MS unset", () => {
+    const cfg = loadLiveDixieClientConfigFromEnv(fullEnv());
+    expect(cfg.timeoutMs).toBe(LIVE_DIXIE_CLIENT_DEFAULT_TIMEOUT_MS);
+  });
+
+  test("respects explicit timeout when within ceiling", () => {
+    const cfg = loadLiveDixieClientConfigFromEnv(
+      fullEnv({ RECALL_WEDGE_DIXIE_TIMEOUT_MS: "2000" }),
+    );
+    expect(cfg.timeoutMs).toBe(2000);
+  });
+
+  test("rejects invalid timeout values fail-closed", () => {
+    expect(() =>
+      loadLiveDixieClientConfigFromEnv(
+        fullEnv({ RECALL_WEDGE_DIXIE_TIMEOUT_MS: "abc" }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+    expect(() =>
+      loadLiveDixieClientConfigFromEnv(
+        fullEnv({ RECALL_WEDGE_DIXIE_TIMEOUT_MS: "-1" }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+    expect(() =>
+      loadLiveDixieClientConfigFromEnv(
+        fullEnv({
+          RECALL_WEDGE_DIXIE_TIMEOUT_MS: String(
+            LIVE_DIXIE_CLIENT_MAX_TIMEOUT_MS + 1,
+          ),
+        }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+  });
+
+  test("rejects invalid base URL fail-closed", () => {
+    expect(() =>
+      loadLiveDixieClientConfigFromEnv(
+        fullEnv({ RECALL_WEDGE_DIXIE_BASE_URL: "not-a-url" }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+    expect(() =>
+      loadLiveDixieClientConfigFromEnv(
+        fullEnv({ RECALL_WEDGE_DIXIE_BASE_URL: "ftp://example.test" }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+  });
+
+  for (const required of [
+    "RECALL_WEDGE_DIXIE_BASE_URL",
+    "RECALL_WEDGE_DIXIE_SERVICE_TOKEN",
+    "RECALL_WEDGE_DIXIE_TENANT_ID",
+    "RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID",
+    "RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX",
+  ] as const) {
+    test(`missing ${required} fails closed before any network`, () => {
+      const env = fullEnv({ [required]: "" });
+      expect(() => loadLiveDixieClientConfigFromEnv(env)).toThrow(
+        LiveDixieClientConfigError,
+      );
+    });
+
+    test(`undefined ${required} fails closed before any network`, () => {
+      const env: Record<string, string | undefined> = fullEnv();
+      env[required] = undefined;
+      expect(() => loadLiveDixieClientConfigFromEnv(env)).toThrow(
+        LiveDixieClientConfigError,
+      );
+    });
+  }
+
+  test("liveRecallViaDixie reports missing_required_env without calling fetch when env incomplete", async () => {
+    const calls: number[] = [];
+    const fakeFetch: LiveDixieFetchLike = async () => {
+      calls.push(1);
+      return { status: 200, text: async () => "" };
+    };
+    // Build an obviously-invalid config (empty serviceToken) and watch the
+    // path in liveRecallViaDixie that converts buildLiveDixieRecallRequestPlan
+    // errors into a fail-closed result.
+    const result = await liveRecallViaDixie(
+      buildInput(),
+      buildConfig({ serviceToken: "" }),
+      { fetch: fakeFetch },
+    );
+    expect(result.classification).toBe("missing_required_env");
+    expect(result.public_summary.outcome).toBe("config_error");
+    expect(calls.length).toBe(0);
+  });
+});
+
+// -- 2. request building ---------------------------------------------------
+
+describe("buildLiveDixieRecallRequestPlan · request shape per Dixie Phase 32E", () => {
+  test("targets exactly POST /api/recall/intake on the configured base URL", () => {
+    const plan = buildLiveDixieRecallRequestPlan(buildInput(), buildConfig());
+    expect(plan.method).toBe("POST");
+    expect(plan.url).toBe(
+      `https://dixie.example.test${LIVE_DIXIE_CLIENT_INTAKE_PATH}`,
+    );
+    expect(LIVE_DIXIE_CLIENT_INTAKE_PATH).toBe("/api/recall/intake");
+  });
+
+  test("includes Idempotency-Key header (operator-supplied or generated)", () => {
+    const explicit = buildLiveDixieRecallRequestPlan(
+      buildInput({ idempotencyKey: "op-1" }),
+      buildConfig(),
+    );
+    expect(explicit.headers["idempotency-key"]).toBe("op-1");
+    expect(explicit.idempotencyKey).toBe("op-1");
+
+    const generated = buildLiveDixieRecallRequestPlan(
+      buildInput({ idempotencyKey: undefined }),
+      buildConfig(),
+    );
+    expect(generated.headers["idempotency-key"]).toBeTruthy();
+    expect(generated.headers["idempotency-key"].startsWith("p37c-")).toBe(
+      true,
+    );
+  });
+
+  test("attaches Bearer service auth from config (per Dixie route Authorization handling)", () => {
+    const plan = buildLiveDixieRecallRequestPlan(
+      buildInput(),
+      buildConfig({ serviceToken: "tkn-secret-x" }),
+    );
+    expect(plan.headers["authorization"]).toBe("Bearer tkn-secret-x");
+  });
+
+  test("body matches the Dixie wedge-aligned wire shape (Phase 32E §2 / route.ts ingress schema)", () => {
+    const plan = buildLiveDixieRecallRequestPlan(buildInput(), buildConfig());
+    const body = plan.body as Record<string, unknown>;
+
+    expect(body.detail_level).toBe("minimal");
+    const caller = body.caller as Record<string, unknown>;
+    expect(caller.tenant_id).toBe(WALLET);
+    expect(caller.actor_id).toBe(WALLET);
+
+    const request = body.request as Record<string, unknown>;
+    expect(request.recall_request_id).toBe("rr-1");
+    expect(request.actor_id).toBe(WALLET);
+    expect(request.estate_id).toBe(WALLET);
+    expect(request.requested_by).toBe(WALLET);
+    expect(request.task).toBe("operator-dev-recall-spike");
+    expect(request.environment_frame).toBe("private_chat");
+    expect(request.risk_profile).toBe("low");
+    expect(request.include_receipt_detail).toBe("minimal");
+
+    const sig = request.signature as Record<string, unknown>;
+    expect(sig.signature_id).toBe("sig_1");
+    expect(sig.signer_id).toBe("signer_test");
+    expect(sig.signer_type).toBe("actor_controller");
+    expect(sig.signature_type).toBe("dev_signature");
+    expect(sig.signed_at).toBe("2026-05-18T00:00:00Z");
+    expect(sig.key_ref).toBe("kref_test");
+  });
+
+  test("body never carries recorded_dixie_recall_envelope or recorded probe markers", () => {
+    const plan = buildLiveDixieRecallRequestPlan(buildInput(), buildConfig());
+    const wire = JSON.stringify(plan.body);
+    expect(wire).not.toContain("recorded_dixie_recall_envelope");
+    expect(wire).not.toContain("input_envelope_kind");
+    expect(wire).not.toContain("recall_wedge.dixie_envelope");
+    expect(wire).not.toContain("envelope_version");
+    expect(wire).not.toContain("public_recall_payload");
+    expect(wire).not.toContain("target_projection");
+  });
+
+  test("rejects mismatched tenantId / callerActorId fail-closed (Dixie §3.d authoritative-tenant rule)", () => {
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        buildInput(),
+        buildConfig({
+          tenantId: WALLET,
+          callerActorId: "0x9999999999999999999999999999999999999999",
+        }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+  });
+
+  test("rejects empty Idempotency-Key fail-closed", () => {
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        buildInput({ idempotencyKey: "" }),
+        buildConfig({ requestKeyPrefix: "" }),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+  });
+
+  test("rejects oversized Idempotency-Key fail-closed (Dixie 1-256 char ceiling)", () => {
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        buildInput({ idempotencyKey: "x".repeat(257) }),
+        buildConfig(),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+  });
+
+  test("rejects unsupported environment frame / risk / detail levels", () => {
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        // @ts-expect-error testing runtime guard
+        buildInput({ environmentFrame: "actor_private_unsupported" }),
+        buildConfig(),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        // @ts-expect-error testing runtime guard
+        buildInput({ riskProfile: "extreme" }),
+        buildConfig(),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        // @ts-expect-error testing runtime guard
+        buildInput({ detailLevel: "verbose" }),
+        buildConfig(),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+  });
+
+  test("Phase 37C non-goal: public_telegram environment frame fails closed before fetch", async () => {
+    expect(LIVE_DIXIE_DISALLOWED_ENVIRONMENT_FRAMES).toContain(
+      "public_telegram",
+    );
+    expect(() =>
+      buildLiveDixieRecallRequestPlan(
+        // @ts-expect-error public_telegram is intentionally not a typed value
+        buildInput({ environmentFrame: "public_telegram" }),
+        buildConfig(),
+      ),
+    ).toThrow(LiveDixieClientConfigError);
+
+    let calls = 0;
+    const fakeFetch: LiveDixieFetchLike = async () => {
+      calls += 1;
+      return { status: 200, text: async () => "" };
+    };
+    const r = await liveRecallViaDixie(
+      // @ts-expect-error public_telegram is intentionally not a typed value
+      buildInput({ environmentFrame: "public_telegram" }),
+      buildConfig(),
+      { fetch: fakeFetch },
+    );
+    expect(r.classification).toBe("invalid_config");
+    expect(r.public_summary.outcome).toBe("config_error");
+    expect(calls).toBe(0);
+  });
+
+  test("Phase 37C non-goal: public_telegram never appears as an accepted live request value in the wire body", () => {
+    // Sweep every successfully-built request plan body across the
+    // currently-allowed environment frames. None of them should serialize
+    // `public_telegram` as the accepted environment_frame value.
+    const allowed: readonly string[] = [
+      "private_operator",
+      "private_chat",
+      "public_discord",
+      "repo_workflow",
+      "tool_action_precheck",
+      "audit_review",
+    ];
+    for (const frame of allowed) {
+      const plan = buildLiveDixieRecallRequestPlan(
+        buildInput({ environmentFrame: frame as never }),
+        buildConfig(),
+      );
+      const wire = JSON.stringify(plan.body);
+      expect(wire).not.toContain('"environment_frame":"public_telegram"');
+    }
+  });
+});
+
+describe("idempotency · key/content fingerprinting", () => {
+  test("computeLiveDixieRequestFingerprint is deterministic for identical content", () => {
+    const a = buildLiveDixieRecallRequestPlan(buildInput(), buildConfig())
+      .body as Record<string, unknown>;
+    const b = buildLiveDixieRecallRequestPlan(buildInput(), buildConfig())
+      .body as Record<string, unknown>;
+    expect(computeLiveDixieRequestFingerprint(a)).toBe(
+      computeLiveDixieRequestFingerprint(b),
+    );
+  });
+
+  test("different content yields a different fingerprint (helper detects mismatch)", () => {
+    const a = buildLiveDixieRecallRequestPlan(
+      buildInput({ task: "task-A" }),
+      buildConfig(),
+    ).body as Record<string, unknown>;
+    const b = buildLiveDixieRecallRequestPlan(
+      buildInput({ task: "task-B" }),
+      buildConfig(),
+    ).body as Record<string, unknown>;
+    expect(computeLiveDixieRequestFingerprint(a)).not.toBe(
+      computeLiveDixieRequestFingerprint(b),
+    );
+  });
+
+  test("reuse detector flags same key + different content as unsafe", () => {
+    const det = createIdempotencyReuseDetector();
+    expect(det.observe(WALLET, WALLET, "k1", "fp-1")).toBe("ok");
+    expect(det.observe(WALLET, WALLET, "k1", "fp-1")).toBe("ok");
+    expect(det.observe(WALLET, WALLET, "k1", "fp-2")).toBe("unsafe_reuse");
+  });
+
+  test("liveRecallViaDixie surfaces unsafe_idempotency_key_reuse before any network call", async () => {
+    let calls = 0;
+    const fakeFetch: LiveDixieFetchLike = async () => {
+      calls += 1;
+      return {
+        status: 200,
+        text: async () =>
+          JSON.stringify({ outcome: "served", redacted_count: 0 }),
+      };
+    };
+    const detector = createIdempotencyReuseDetector();
+    const ok = await liveRecallViaDixie(
+      buildInput({ idempotencyKey: "shared-key", task: "first" }),
+      buildConfig(),
+      { fetch: fakeFetch, idempotencyDetector: detector },
+    );
+    expect(ok.classification).toBe("served");
+
+    const unsafe = await liveRecallViaDixie(
+      buildInput({ idempotencyKey: "shared-key", task: "second-different" }),
+      buildConfig(),
+      { fetch: fakeFetch, idempotencyDetector: detector },
+    );
+    expect(unsafe.classification).toBe("unsafe_idempotency_key_reuse");
+    expect(unsafe.public_summary.stable_reason_code).toBe(
+      "idempotency_key_content_mismatch",
+    );
+    // Only the first call hit the fake network; the second short-circuited.
+    expect(calls).toBe(1);
+  });
+});
+
+// -- 3. response classification -------------------------------------------
+
+function fakeFetchReturning(
+  status: number,
+  body: unknown,
+  bodyOverride?: string,
+): LiveDixieFetchLike {
+  return async () => ({
+    status,
+    text: async () =>
+      bodyOverride !== undefined
+        ? bodyOverride
+        : body === undefined
+          ? ""
+          : JSON.stringify(body),
+  });
+}
+
+describe("liveRecallViaDixie · response classification", () => {
+  test("served body classified as served", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(200, {
+        outcome: "served",
+        redacted_count: 0,
+        redacted_counts_by_reason: [],
+      }),
+    });
+    expect(r.classification).toBe("served");
+    expect(r.public_summary.outcome).toBe("served");
+    expect(r.public_summary.stable_reason_code).toBe("served");
+  });
+
+  test("403 privacy_scope_refusal classified as denied_or_forbidden", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(403, {
+        outcome: "denied",
+        error: "seam.privacy_scope_refusal",
+        message: "user-level recall refused",
+      }),
+    });
+    expect(r.classification).toBe("denied_or_forbidden");
+    expect(r.public_summary.stable_reason_code).toBe(
+      "seam.privacy_scope_refusal",
+    );
+  });
+
+  test("403 cross_tenant_recall_refused classified as tenant_or_session_mismatch (distinct from denied_or_forbidden)", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(403, {
+        outcome: "denied",
+        error: "seam.cross_tenant_recall_refused",
+      }),
+    });
+    expect(r.classification).toBe("tenant_or_session_mismatch");
+  });
+
+  test("401 classified as service_unauthorized (distinct from end-user denial)", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(401, {
+        outcome: "denied",
+        error: "ingress.unauthenticated",
+        message: "wallet required",
+      }),
+    });
+    expect(r.classification).toBe("service_unauthorized");
+    expect(r.public_summary.stable_reason_code).toBe("service_unauthorized");
+  });
+
+  test("400 ingress.invalid_request classified as ingress_invalid_request", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(400, {
+        outcome: "denied",
+        error: "ingress.invalid_request",
+        message: "invalid body shape",
+      }),
+    });
+    expect(r.classification).toBe("ingress_invalid_request");
+    expect(r.public_summary.stable_reason_code).toBe(
+      "ingress.invalid_request",
+    );
+  });
+
+  test("400 ingress.missing_idempotency_key classified as ingress_invalid_request", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(400, {
+        outcome: "denied",
+        error: "ingress.missing_idempotency_key",
+      }),
+    });
+    expect(r.classification).toBe("ingress_invalid_request");
+    expect(r.public_summary.stable_reason_code).toBe(
+      "ingress.missing_idempotency_key",
+    );
+  });
+
+  test("503 needs_review outcome classified as needs_review", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(503, {
+        outcome: "needs_review",
+        error: "seam.policy_unavailable",
+      }),
+    });
+    expect(r.classification).toBe("needs_review");
+  });
+
+  test("429 classified as rate_limited", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(429, {
+        outcome: "denied",
+        error: "ingress.rate_limited",
+      }),
+    });
+    expect(r.classification).toBe("rate_limited");
+  });
+
+  test("503 storage_unavailable classified as upstream_unavailable", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(503, {
+        outcome: "denied",
+        error: "seam.storage_unavailable",
+      }),
+    });
+    expect(r.classification).toBe("upstream_unavailable");
+  });
+
+  test("502/504 classified as upstream_unavailable even without an error class", async () => {
+    const r502 = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(502, {}),
+    });
+    expect(r502.classification).toBe("upstream_unavailable");
+    const r504 = await liveRecallViaDixie(
+      buildInput({ idempotencyKey: "k-504" }),
+      buildConfig(),
+      { fetch: fakeFetchReturning(504, {}) },
+    );
+    expect(r504.classification).toBe("upstream_unavailable");
+  });
+
+  test("fetch throwing classifies as network_error (no public-bound raw payload)", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    });
+    expect(r.classification).toBe("network_error");
+    expect(r.public_summary.outcome).toBe("network_error");
+  });
+
+  test("non-JSON / unparseable body classifies as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(200, undefined, "<<not json>>"),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+  });
+
+  test("200 body without served outcome classifies as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(200, {
+        outcome: "unexpected",
+      }),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+  });
+
+  test("unknown HTTP status code classifies as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(418, { hello: "teapot" }),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+  });
+
+  test("403 with empty body fails closed as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(403, {}),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+    expect(r.public_summary.stable_reason_code).toBe("unknown_403_body_shape");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("400 with empty body fails closed as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(400, {}),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+    expect(r.public_summary.stable_reason_code).toBe("unknown_400_body_shape");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("403 with unknown / hostile error class fails closed as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(403, {
+        outcome: "denied",
+        error: "seam.something_unknown_with_PRIVATE_SENTINEL",
+        message: "should not be relayed",
+      }),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+    expect(r.public_summary.stable_reason_code).toBe("unknown_403_body_shape");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("400 with unknown / hostile error class fails closed as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(400, {
+        outcome: "denied",
+        error: "ingress.something_unknown_with_session_id",
+      }),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+    expect(r.public_summary.stable_reason_code).toBe("unknown_400_body_shape");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("guard.tenant_assertion_cap classified as rate_limited (Phase 37B cap-limited mapping)", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(503, {
+        outcome: "denied",
+        error: "guard.tenant_assertion_cap",
+      }),
+    });
+    expect(r.classification).toBe("rate_limited");
+    expect(r.public_summary.stable_reason_code).toBe(
+      "guard.tenant_assertion_cap",
+    );
+  });
+
+  test("guard.tenant_byte_budget classified as rate_limited (Phase 37B cap-limited mapping)", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(503, {
+        outcome: "denied",
+        error: "guard.tenant_byte_budget",
+      }),
+    });
+    expect(r.classification).toBe("rate_limited");
+    expect(r.public_summary.stable_reason_code).toBe(
+      "guard.tenant_byte_budget",
+    );
+  });
+
+  test("guard cap refusal classified as rate_limited even on alternate carrier status (least-speculative mapping)", async () => {
+    // If Dixie ever shifts the carrier status away from 503 for these
+    // refusal classes, the documented refusal class wins — they are
+    // cap-limited regardless of HTTP status.
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(429, {
+        outcome: "denied",
+        error: "guard.tenant_assertion_cap",
+      }),
+    });
+    expect(r.classification).toBe("rate_limited");
+    expect(r.public_summary.stable_reason_code).toBe(
+      "guard.tenant_assertion_cap",
+    );
+  });
+
+  test("classification set covers every name advertised by LIVE_DIXIE_RECALL_CLASSIFICATIONS", () => {
+    // Defense-in-depth: ensures the public name list and the type stay in
+    // sync — every advertised classification has a deliberate emitter
+    // somewhere above.
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("served");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("denied_or_forbidden");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("needs_review");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain(
+      "ingress_invalid_request",
+    );
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("service_unauthorized");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain(
+      "tenant_or_session_mismatch",
+    );
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("rate_limited");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("upstream_unavailable");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain(
+      "unsupported_response_shape",
+    );
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("network_error");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("missing_required_env");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain("invalid_config");
+    expect(LIVE_DIXIE_RECALL_CLASSIFICATIONS).toContain(
+      "unsafe_idempotency_key_reuse",
+    );
+  });
+});
+
+// -- 4. no-leak ------------------------------------------------------------
+
+describe("liveRecallViaDixie · operator-public public_summary never carries banned material", () => {
+  test("contaminated denied body fails closed as unsupported_response_shape and never leaks raw refusal text", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(403, {
+        outcome: "denied",
+        // Hostile error class string carrying a banned substring. Under
+        // the post-Phase-37C-PATCH strict policy, an unknown error class
+        // on 403 fails closed to unsupported_response_shape rather than
+        // collapsing into denied_or_forbidden. Defense-in-depth: the
+        // banned substring still must not appear in public_summary.
+        error: "seam.something_with_PRIVATE_SENTINEL_in_it",
+        message: "raw_reasons present",
+        raw_reasons: ["raw_reasons:PRIVATE_SENTINEL", "source_material:leak"],
+      }),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("contaminated 503 body never leaks raw debug payload into public_summary", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(503, {
+        outcome: "denied",
+        error: "seam.totally_unknown_class_with_raw_dixie_debug",
+        raw_dixie_debug: { hidden: "estate" },
+      }),
+    });
+    expect(r.classification).toBe("upstream_unavailable");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("ingress 400 with hostile error class fails closed as unsupported_response_shape", async () => {
+    const r = await liveRecallViaDixie(buildInput(), buildConfig(), {
+      fetch: fakeFetchReturning(400, {
+        outcome: "denied",
+        error: "ingress.something_with_session_id_in_name",
+      }),
+    });
+    expect(r.classification).toBe("unsupported_response_shape");
+    expect(findBannedPublicSubstring(r.public_summary)).toBeNull();
+  });
+
+  test("findBannedPublicSubstring catches sentinels nested inside operator output payloads", () => {
+    expect(
+      findBannedPublicSubstring({ a: { b: ["ok", "hidden estate"] } }),
+    ).toBe("hidden estate");
+    expect(findBannedPublicSubstring({ session_id_value: "x" })).toBe(
+      "session_id",
+    );
+    expect(findBannedPublicSubstring({ ok: "fine" })).toBeNull();
+  });
+
+  test("LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS includes the same posture as the recorded adapter", () => {
+    for (const expected of [
+      "PRIVATE_SENTINEL",
+      "raw_reasons",
+      "raw_dixie_debug",
+      "session_id",
+      "tenant_id",
+      "freeside-characters:shared-substrate",
+    ]) {
+      expect(
+        (LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS as readonly string[]).includes(
+          expected,
+        ),
+      ).toBe(true);
+    }
+  });
+});
+
+// -- 5. static guards ------------------------------------------------------
+
+describe("live-dixie-client.ts · static source guards", () => {
+  const moduleSource = readFileSync(
+    resolve(__dirname, "live-dixie-client.ts"),
+    "utf8",
+  );
+
+  test("imports no Discord client", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*discord-interactions[^"']*["']/,
+    );
+  });
+
+  test("imports no Telegram client", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*node-telegram[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']telegraf["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']grammy["']/);
+  });
+
+  test("imports no production storage clients", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']redis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']ioredis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@aws-sdk\/client-s3["']/);
+  });
+
+  test("imports no LLM SDK", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']@anthropic-ai\/sdk["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test("imports no Finn / @loa/dixie / @loa/straylight runtime dependency", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+  });
+
+  test("does not import the recorded dixie-envelope adapter", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*dixie-envelope-adapter[^"']*["']/,
+    );
+  });
+
+  test("does not import the public renderer", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*render-public-recall[^"']*["']/,
+    );
+  });
+
+  test("does not use recorded_dixie_recall_envelope as a wire kind", () => {
+    // The string is allowed to appear in a comment that explicitly
+    // FORBIDS its use; any actual wire/value usage would also need to
+    // appear in a `recorded_dixie_recall_envelope` token outside of the
+    // comments. Defense-in-depth: the request-shape test above proves
+    // the wire body never carries it.
+    const wireBuilder = moduleSource.match(
+      /buildLiveDixieRecallRequestPlan[\s\S]*?(?=\nexport\s|\n\/\/ --|$)/,
+    );
+    expect(wireBuilder).toBeTruthy();
+    expect(wireBuilder![0]).not.toContain("recorded_dixie_recall_envelope");
+    expect(wireBuilder![0]).not.toContain("input_envelope_kind");
+  });
+
+  test("only allowed network primitive is in this live client module (one fetch site)", () => {
+    // The module has exactly one place that can call out to fetch — the
+    // injected `fetcher` invocation, plus the optional fallback to
+    // globalThis.fetch. We assert the file does NOT import any low-level
+    // network module and does NOT spawn child processes.
+    expect(moduleSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:https["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:net["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:tls["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:dgram["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:child_process["']/);
+  });
+
+  test("does not register or dispatch Discord / Telegram commands", () => {
+    expect(moduleSource).not.toMatch(/registerCommand\s*\(/);
+    expect(moduleSource).not.toMatch(/applicationCommands/);
+    expect(moduleSource).not.toMatch(/sendMessage\s*\(/);
+    expect(moduleSource).not.toMatch(/createWebhook\s*\(/);
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/live-dixie-client.ts
+++ b/packages/persona-engine/src/recall-wedge/live-dixie-client.ts
@@ -1,0 +1,1002 @@
+// Phase 37C · isolated operator/dev-only live Dixie recall-intake client.
+//
+// Authority: docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md (Phase 37B gate).
+//
+// Scope (per Phase 37B §C):
+//   - this module is the ONLY place in freeside-characters that may issue a
+//     live HTTP call to Dixie's `POST /api/recall/intake`;
+//   - it is operator/dev-only — no Discord, Telegram, storage, admission,
+//     LLM, voice, or character output is wired through here;
+//   - Phase 35D's recorded fixture adapter
+//     (`./dixie-envelope-adapter.ts`) is NOT repurposed here. The live
+//     client lives in this distinct module per gate §F / §J;
+//   - the public-safe renderer (`./render-public-recall.ts`) is not
+//     imported. The live client never feeds raw Dixie output into a
+//     public renderer.
+//
+// Hard non-goals (per Phase 37B §C, §D, §K):
+//   - no @loa/dixie / @loa/straylight / Finn import (runtime or value);
+//   - no Discord client / Telegram client / bot framework / commands;
+//   - no Postgres / Redis / object-storage / vector-index import;
+//   - no LLM SDK import;
+//   - no character voice;
+//   - no use of `recorded_dixie_recall_envelope` for live traffic;
+//   - no admission of operator-provided text as Straylight memory.
+//
+// Dixie contract evidence consulted while implementing this module:
+//   - docs/RECALL-WEDGE-DIXIE-CONTRACT-RECONCILIATION.md (Phase 37A);
+//   - docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md (Phase 37B);
+//   - ../loa-dixie/docs/integration/phase-32e-recall-wedge-route-contract.md;
+//   - ../loa-dixie/docs/integration/phase-32f-recall-wedge-readiness-checkpoint.md;
+//   - ../loa-dixie/app/src/routes/recall-intake.ts (route, ingress schema,
+//     authoritative-tenant rule, Idempotency-Key requirement);
+//   - ../loa-dixie/app/src/services/straylight-recall-intake/refusal-mapping.ts
+//     (HTTP refusal classes + raw_reasons shape);
+//   - ../loa-dixie/app/tests/integration/recall-intake/route.test.ts (proven
+//     wire shape; Bearer/wallet-bridge auth; required headers).
+
+// -- classification vocabulary ---------------------------------------------
+
+export const LIVE_DIXIE_RECALL_CLASSIFICATIONS = [
+  "served",
+  "denied_or_forbidden",
+  "needs_review",
+  "ingress_invalid_request",
+  "service_unauthorized",
+  "tenant_or_session_mismatch",
+  "rate_limited",
+  "upstream_unavailable",
+  "unsupported_response_shape",
+  "network_error",
+  "missing_required_env",
+  "invalid_config",
+  "unsafe_idempotency_key_reuse",
+] as const;
+
+export type LiveDixieRecallClassification =
+  (typeof LIVE_DIXIE_RECALL_CLASSIFICATIONS)[number];
+
+// -- config / env ----------------------------------------------------------
+
+export interface LiveDixieClientConfig {
+  readonly baseUrl: string;
+  readonly serviceToken: string;
+  readonly tenantId: string;
+  readonly callerActorId: string;
+  readonly requestKeyPrefix: string;
+  readonly timeoutMs: number;
+}
+
+export const LIVE_DIXIE_CLIENT_DEFAULT_TIMEOUT_MS = 10_000;
+export const LIVE_DIXIE_CLIENT_MAX_TIMEOUT_MS = 60_000;
+export const LIVE_DIXIE_CLIENT_MAX_REQUEST_KEY_LEN = 256;
+export const LIVE_DIXIE_CLIENT_INTAKE_PATH = "/api/recall/intake" as const;
+
+export class LiveDixieClientConfigError extends Error {
+  readonly code: LiveDixieRecallClassification;
+  readonly missingEnv?: string;
+  constructor(
+    code: "missing_required_env" | "invalid_config",
+    message: string,
+    missingEnv?: string,
+  ) {
+    super(message);
+    this.name = "LiveDixieClientConfigError";
+    this.code = code;
+    if (missingEnv !== undefined) this.missingEnv = missingEnv;
+  }
+}
+
+const REQUIRED_ENV_KEYS = [
+  "RECALL_WEDGE_DIXIE_BASE_URL",
+  "RECALL_WEDGE_DIXIE_SERVICE_TOKEN",
+  "RECALL_WEDGE_DIXIE_TENANT_ID",
+  "RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID",
+  "RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX",
+] as const;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function trimTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end -= 1;
+  return s.slice(0, end);
+}
+
+function parseTimeoutMs(raw: string | undefined): number {
+  if (raw === undefined || raw.length === 0) {
+    return LIVE_DIXIE_CLIENT_DEFAULT_TIMEOUT_MS;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `RECALL_WEDGE_DIXIE_TIMEOUT_MS must be a positive integer, got "${raw}"`,
+    );
+  }
+  if (n > LIVE_DIXIE_CLIENT_MAX_TIMEOUT_MS) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `RECALL_WEDGE_DIXIE_TIMEOUT_MS=${n} exceeds the conservative ceiling of ${LIVE_DIXIE_CLIENT_MAX_TIMEOUT_MS}ms`,
+    );
+  }
+  return n;
+}
+
+function parseBaseUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `RECALL_WEDGE_DIXIE_BASE_URL is not a valid URL: "${raw}"`,
+    );
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `RECALL_WEDGE_DIXIE_BASE_URL must be http(s); got "${parsed.protocol}"`,
+    );
+  }
+  return trimTrailingSlashes(`${parsed.origin}${parsed.pathname}`);
+}
+
+export function loadLiveDixieClientConfigFromEnv(
+  env: Record<string, string | undefined> = (
+    typeof process !== "undefined" && process && process.env
+      ? process.env
+      : {}
+  ) as Record<string, string | undefined>,
+): LiveDixieClientConfig {
+  for (const key of REQUIRED_ENV_KEYS) {
+    if (!isNonEmptyString(env[key])) {
+      throw new LiveDixieClientConfigError(
+        "missing_required_env",
+        `required env "${key}" is missing or empty`,
+        key,
+      );
+    }
+  }
+
+  const baseUrl = parseBaseUrl(env.RECALL_WEDGE_DIXIE_BASE_URL as string);
+  const timeoutMs = parseTimeoutMs(env.RECALL_WEDGE_DIXIE_TIMEOUT_MS);
+
+  return {
+    baseUrl,
+    serviceToken: env.RECALL_WEDGE_DIXIE_SERVICE_TOKEN as string,
+    tenantId: env.RECALL_WEDGE_DIXIE_TENANT_ID as string,
+    callerActorId: env.RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID as string,
+    requestKeyPrefix: env.RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX as string,
+    timeoutMs,
+  };
+}
+
+// -- request building ------------------------------------------------------
+
+// Allow-list of environment frames the operator may carry through. Per
+// Dixie Phase 32E the route accepts the wedge enum here; the live client
+// does NOT expand the vocabulary on its own. Operator picks one.
+//
+// Phase 37C explicitly has NO positive support for `public_telegram`. The
+// live client rejects it fail-closed before any network call. The string
+// is preserved only as a static-guard / non-goal phrase below; it is not
+// an accepted live request value.
+const ALLOWED_ENVIRONMENT_FRAMES = [
+  "private_operator",
+  "private_chat",
+  "public_discord",
+  "repo_workflow",
+  "tool_action_precheck",
+  "audit_review",
+] as const;
+export type LiveRecallEnvironmentFrame =
+  (typeof ALLOWED_ENVIRONMENT_FRAMES)[number];
+
+// Phase 37C non-goal: explicitly disallowed environment frames. Listed by
+// name so an operator typo or a recorded-fixture leak that resurrects a
+// disallowed frame fails closed before fetch.
+export const LIVE_DIXIE_DISALLOWED_ENVIRONMENT_FRAMES = [
+  "public_telegram",
+] as const;
+
+const ALLOWED_RISK_LEVELS = ["low", "medium", "high", "critical"] as const;
+export type LiveRecallRiskLevel = (typeof ALLOWED_RISK_LEVELS)[number];
+
+const ALLOWED_DETAIL_LEVELS = ["minimal", "standard", "debug"] as const;
+export type LiveRecallDetailLevel = (typeof ALLOWED_DETAIL_LEVELS)[number];
+
+const ALLOWED_HOST_FRAMES = ["actor_private", "public_discord"] as const;
+export type LiveRecallHostFrame = (typeof ALLOWED_HOST_FRAMES)[number];
+
+export interface LiveRecallSignatureEnvelopeInput {
+  readonly signature_id: string;
+  readonly signer_id: string;
+  readonly signer_type:
+    | "actor_controller"
+    | "operator"
+    | "runtime"
+    | "reviewer"
+    | "policy_service"
+    | "admin"
+    | "wallet"
+    | "service_key";
+  readonly signature_type:
+    | "ed25519"
+    | "secp256k1"
+    | "hmac"
+    | "dev_signature";
+  readonly signed_payload_hash: string;
+  readonly signature: string;
+  readonly signed_at: string;
+  readonly key_ref: string;
+}
+
+export interface LiveRecallInput {
+  readonly recallRequestId: string;
+  readonly task: string;
+  readonly environmentFrame: LiveRecallEnvironmentFrame;
+  readonly riskProfile: LiveRecallRiskLevel;
+  readonly detailLevel: LiveRecallDetailLevel;
+  readonly receiptDetail: LiveRecallDetailLevel;
+  readonly signature: LiveRecallSignatureEnvelopeInput;
+  readonly createdAt: string;
+  readonly hostFrame?: LiveRecallHostFrame;
+  readonly intent?: string;
+  readonly idempotencyKey?: string;
+}
+
+export interface LiveDixieRequestPlan {
+  readonly url: string;
+  readonly method: "POST";
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: Readonly<Record<string, unknown>>;
+  readonly idempotencyKey: string;
+  readonly fingerprint: string;
+}
+
+function assertConfigInvariants(config: LiveDixieClientConfig): void {
+  for (const key of REQUIRED_ENV_KEYS) {
+    const lookup: Record<string, string> = {
+      RECALL_WEDGE_DIXIE_BASE_URL: config.baseUrl,
+      RECALL_WEDGE_DIXIE_SERVICE_TOKEN: config.serviceToken,
+      RECALL_WEDGE_DIXIE_TENANT_ID: config.tenantId,
+      RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID: config.callerActorId,
+      RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX: config.requestKeyPrefix,
+    };
+    if (!isNonEmptyString(lookup[key])) {
+      throw new LiveDixieClientConfigError(
+        "missing_required_env",
+        `config field for "${key}" is missing or empty`,
+        key,
+      );
+    }
+  }
+}
+
+// Dixie's authoritative-tenant rule (route.ts §3.d) requires that
+// `request.actor_id`, `request.estate_id`, `request.requested_by`,
+// `caller.tenant_id`, and `caller.actor_id` all equal the session wallet.
+// The live client enforces this locally by binding tenantId === callerActorId.
+// Mismatches fail closed before any network call.
+function assertOperatorIdentityConsistency(config: LiveDixieClientConfig): void {
+  if (config.tenantId !== config.callerActorId) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      "Dixie route requires caller.tenant_id === caller.actor_id === session wallet; tenantId and callerActorId must match",
+    );
+  }
+}
+
+// Stable JSON serializer with sorted keys, used for request fingerprint
+// computation. Pure (no I/O). Cycle-unsafe: callers pass plain JSON-shaped
+// objects.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => stableStringify(v)).join(",")}]`;
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const parts: string[] = [];
+  for (const k of keys) {
+    const v = (value as Record<string, unknown>)[k];
+    if (v === undefined) continue;
+    parts.push(`${JSON.stringify(k)}:${stableStringify(v)}`);
+  }
+  return `{${parts.join(",")}}`;
+}
+
+// FNV-1a 64-bit (BigInt) — adequate for an in-process fingerprint used to
+// detect accidental Idempotency-Key reuse with different content. Not a
+// cryptographic identifier.
+function fingerprintForBody(body: Record<string, unknown>): string {
+  const canonical = stableStringify(body);
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < canonical.length; i += 1) {
+    hash = (hash ^ BigInt(canonical.charCodeAt(i))) & mask;
+    hash = (hash * prime) & mask;
+  }
+  return `fnv1a64:${hash.toString(16).padStart(16, "0")}`;
+}
+
+export function computeLiveDixieRequestFingerprint(
+  body: Record<string, unknown>,
+): string {
+  return fingerprintForBody(body);
+}
+
+// In-process detection of unsafe key reuse with different content. The live
+// client tracks `(tenant_id, caller_actor_id, request_key) → fingerprint`
+// across calls; a follow-up call with the same key but a different
+// fingerprint surfaces `unsafe_idempotency_key_reuse` BEFORE network.
+//
+// Operators may construct an isolated detector for tests. The default is a
+// module-private singleton.
+export interface IdempotencyReuseDetector {
+  observe(
+    tenantId: string,
+    callerActorId: string,
+    requestKey: string,
+    fingerprint: string,
+  ): "ok" | "unsafe_reuse";
+}
+
+export function createIdempotencyReuseDetector(): IdempotencyReuseDetector {
+  const seen = new Map<string, string>();
+  return {
+    observe(tenantId, callerActorId, requestKey, fingerprint) {
+      const k = JSON.stringify([tenantId, callerActorId, requestKey]);
+      const prior = seen.get(k);
+      if (prior !== undefined && prior !== fingerprint) return "unsafe_reuse";
+      if (prior === undefined) seen.set(k, fingerprint);
+      return "ok";
+    },
+  };
+}
+
+const DEFAULT_REUSE_DETECTOR = createIdempotencyReuseDetector();
+
+function generateIdempotencyKey(prefix: string): string {
+  // Operator/dev-only key: prefix + monotonic time + random tail. The live
+  // client never silently reuses across logical requests; operators may
+  // pass `idempotencyKey` explicitly for retries.
+  const t = Date.now().toString(36);
+  let r = "";
+  for (let i = 0; i < 8; i += 1) {
+    r += Math.floor(Math.random() * 36)
+      .toString(36)
+      .charAt(0);
+  }
+  return `${prefix}-${t}-${r}`;
+}
+
+// Build the deterministic request plan. Body shape is reconstructed only
+// from operator inputs and config — there is no implicit fallback. Mirrors
+// `RecallIntakeBodySchema` from `../loa-dixie/app/src/routes/recall-intake.ts`.
+export function buildLiveDixieRecallRequestPlan(
+  input: LiveRecallInput,
+  config: LiveDixieClientConfig,
+): LiveDixieRequestPlan {
+  assertConfigInvariants(config);
+  assertOperatorIdentityConsistency(config);
+
+  if (!isNonEmptyString(input.recallRequestId)) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      "input.recallRequestId is required",
+    );
+  }
+  if (!isNonEmptyString(input.task)) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      "input.task is required",
+    );
+  }
+  if (
+    (LIVE_DIXIE_DISALLOWED_ENVIRONMENT_FRAMES as readonly string[]).includes(
+      input.environmentFrame as string,
+    )
+  ) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `input.environmentFrame "${String(input.environmentFrame)}" is a Phase 37C non-goal; live client has no positive support for it`,
+    );
+  }
+  if (
+    !(ALLOWED_ENVIRONMENT_FRAMES as readonly string[]).includes(
+      input.environmentFrame,
+    )
+  ) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `input.environmentFrame must be one of ${ALLOWED_ENVIRONMENT_FRAMES.join("|")}`,
+    );
+  }
+  if (!(ALLOWED_RISK_LEVELS as readonly string[]).includes(input.riskProfile)) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `input.riskProfile must be one of ${ALLOWED_RISK_LEVELS.join("|")}`,
+    );
+  }
+  if (
+    !(ALLOWED_DETAIL_LEVELS as readonly string[]).includes(input.detailLevel)
+  ) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `input.detailLevel must be one of ${ALLOWED_DETAIL_LEVELS.join("|")}`,
+    );
+  }
+  if (
+    !(ALLOWED_DETAIL_LEVELS as readonly string[]).includes(input.receiptDetail)
+  ) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `input.receiptDetail must be one of ${ALLOWED_DETAIL_LEVELS.join("|")}`,
+    );
+  }
+  if (
+    input.hostFrame !== undefined &&
+    !(ALLOWED_HOST_FRAMES as readonly string[]).includes(input.hostFrame)
+  ) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `input.hostFrame must be one of ${ALLOWED_HOST_FRAMES.join("|")} or undefined`,
+    );
+  }
+  if (!isNonEmptyString(input.createdAt)) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      "input.createdAt is required",
+    );
+  }
+
+  const wallet = config.tenantId;
+  const requestBody: Record<string, unknown> = {
+    request: {
+      recall_request_id: input.recallRequestId,
+      actor_id: wallet,
+      estate_id: wallet,
+      requested_by: wallet,
+      task: input.task,
+      ...(input.intent !== undefined ? { intent: input.intent } : {}),
+      environment_frame: input.environmentFrame,
+      risk_profile: input.riskProfile,
+      include_receipt_detail: input.receiptDetail,
+      signature: {
+        signature_id: input.signature.signature_id,
+        signer_id: input.signature.signer_id,
+        signer_type: input.signature.signer_type,
+        signature_type: input.signature.signature_type,
+        signed_payload_hash: input.signature.signed_payload_hash,
+        signature: input.signature.signature,
+        signed_at: input.signature.signed_at,
+        key_ref: input.signature.key_ref,
+      },
+      created_at: input.createdAt,
+    },
+    detail_level: input.detailLevel,
+    caller: {
+      tenant_id: wallet,
+      actor_id: wallet,
+      ...(input.hostFrame !== undefined ? { frame: input.hostFrame } : {}),
+    },
+  };
+
+  const idempotencyKey =
+    input.idempotencyKey !== undefined && input.idempotencyKey.length > 0
+      ? input.idempotencyKey
+      : generateIdempotencyKey(config.requestKeyPrefix);
+
+  if (idempotencyKey.length === 0) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      "Idempotency-Key is required (1-256 chars) per Dixie Phase 32E §2.3",
+    );
+  }
+  if (idempotencyKey.length > LIVE_DIXIE_CLIENT_MAX_REQUEST_KEY_LEN) {
+    throw new LiveDixieClientConfigError(
+      "invalid_config",
+      `Idempotency-Key length ${idempotencyKey.length} exceeds Dixie's ${LIVE_DIXIE_CLIENT_MAX_REQUEST_KEY_LEN}-char ceiling`,
+    );
+  }
+
+  const url = `${config.baseUrl}${LIVE_DIXIE_CLIENT_INTAKE_PATH}`;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json",
+    authorization: `Bearer ${config.serviceToken}`,
+    "idempotency-key": idempotencyKey,
+  };
+
+  return {
+    url,
+    method: "POST",
+    headers,
+    body: requestBody,
+    idempotencyKey,
+    fingerprint: fingerprintForBody(requestBody),
+  };
+}
+
+// -- result types ----------------------------------------------------------
+
+export interface LiveDixieRecallPublicSummary {
+  readonly outcome:
+    | "served"
+    | "denied"
+    | "needs_review"
+    | "ingress_refused"
+    | "service_unauthorized"
+    | "rate_limited"
+    | "upstream_unavailable"
+    | "network_error"
+    | "unsupported_response_shape"
+    | "config_error"
+    | "unsafe_idempotency_key_reuse";
+  readonly classification: LiveDixieRecallClassification;
+  readonly stable_reason_code: string;
+}
+
+export interface LiveDixieRecallInternalDiagnostic {
+  readonly http_status?: number;
+  readonly observed_outcome?: string;
+  readonly observed_error_class?: string;
+  readonly idempotency_key_present: boolean;
+  readonly fingerprint?: string;
+  readonly missing_env?: string;
+  readonly network_error_kind?:
+    | "timeout"
+    | "abort"
+    | "fetch_threw"
+    | "non_response";
+}
+
+export interface LiveDixieRecallResult {
+  readonly classification: LiveDixieRecallClassification;
+  readonly public_summary: LiveDixieRecallPublicSummary;
+  readonly internal_diagnostic: LiveDixieRecallInternalDiagnostic;
+}
+
+// -- response classification ----------------------------------------------
+
+const KNOWN_INGRESS_ERRORS = new Set<string>([
+  "ingress.invalid_request",
+  "ingress.payload_too_large",
+  "ingress.missing_idempotency_key",
+]);
+
+const KNOWN_TENANT_OR_SESSION_ERRORS = new Set<string>([
+  "ingress.cross_tenant_body_mismatch",
+  "seam.cross_tenant_recall_refused",
+  "seam.tenant_resolution_failed",
+]);
+
+const KNOWN_USER_FORBIDDEN_ERRORS = new Set<string>([
+  "seam.privacy_scope_refusal",
+  "seam.signer_not_competent",
+  "seam.blocked_by_policy",
+]);
+
+const KNOWN_INVALID_REQUEST_SEAM_ERRORS = new Set<string>([
+  "seam.frame_unsupported",
+  "seam.class_validation_failed",
+]);
+
+const KNOWN_UPSTREAM_UNAVAILABLE_ERRORS = new Set<string>([
+  "seam.storage_unavailable",
+  "seam.capability_unrecognized",
+  "seam.proof_invalid",
+  "seam.capability_missing_env_key",
+]);
+
+// Phase 37B classification guidance places per-tenant cap / byte-budget
+// refusals under rate-limited / cap-limited behavior (gate §I, line 424).
+// The current classification vocabulary has `rate_limited` but no
+// `cap_limited`, so guard cap refusals collapse into `rate_limited` —
+// the least speculative mapping that preserves Dixie's "deliberately
+// bypasses cache" semantic. Dixie's source (`refusal-mapping.ts`,
+// `guardRefusal`) emits these classes with `http_status: 503`, but the
+// classifier keys on the documented refusal class first regardless of
+// the status carrier so future Dixie status-code adjustments do not
+// silently downgrade to `upstream_unavailable`.
+const KNOWN_GUARD_CAP_ERRORS = new Set<string>([
+  "guard.tenant_assertion_cap",
+  "guard.tenant_byte_budget",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface ClassifierInput {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+function classifyDixieResponse(
+  res: ClassifierInput,
+): { classification: LiveDixieRecallClassification; reason_code: string } {
+  const { status } = res;
+  const body = res.body;
+
+  if (!isPlainObject(body)) {
+    return {
+      classification: "unsupported_response_shape",
+      reason_code: "non_object_response_body",
+    };
+  }
+
+  const outcome = body.outcome;
+  const errorCls =
+    typeof body.error === "string" ? (body.error as string) : undefined;
+
+  // Guard cap refusals (per-tenant assertion cap / byte-budget) are
+  // classified as `rate_limited` regardless of the carrier HTTP status,
+  // because Dixie's documented behavior treats them as cap-limited. The
+  // class match takes priority over status-based mappings.
+  if (errorCls && KNOWN_GUARD_CAP_ERRORS.has(errorCls)) {
+    return { classification: "rate_limited", reason_code: errorCls };
+  }
+
+  if (status === 200) {
+    if (outcome === "served") {
+      return { classification: "served", reason_code: "served" };
+    }
+    return {
+      classification: "unsupported_response_shape",
+      reason_code: "200_without_served_outcome",
+    };
+  }
+
+  if (status === 401) {
+    return {
+      classification: "service_unauthorized",
+      reason_code: "service_unauthorized",
+    };
+  }
+
+  if (status === 403) {
+    if (errorCls && KNOWN_TENANT_OR_SESSION_ERRORS.has(errorCls)) {
+      return {
+        classification: "tenant_or_session_mismatch",
+        reason_code: errorCls,
+      };
+    }
+    if (errorCls && KNOWN_USER_FORBIDDEN_ERRORS.has(errorCls)) {
+      return {
+        classification: "denied_or_forbidden",
+        reason_code: errorCls,
+      };
+    }
+    // Empty / incomplete / unknown body shape on a 403 is not safely
+    // classifiable as denied_or_forbidden — Dixie's documented refusal
+    // envelopes always carry a known refusal class. Fail closed.
+    return {
+      classification: "unsupported_response_shape",
+      reason_code: "unknown_403_body_shape",
+    };
+  }
+
+  if (status === 400 || status === 413) {
+    if (errorCls && KNOWN_INGRESS_ERRORS.has(errorCls)) {
+      return {
+        classification: "ingress_invalid_request",
+        reason_code: errorCls,
+      };
+    }
+    if (errorCls && KNOWN_INVALID_REQUEST_SEAM_ERRORS.has(errorCls)) {
+      return {
+        classification: "ingress_invalid_request",
+        reason_code: errorCls,
+      };
+    }
+    // Empty / incomplete / unknown body shape on a 400/413 is not safely
+    // classifiable as ingress_invalid_request without a documented refusal
+    // class. Fail closed.
+    return {
+      classification: "unsupported_response_shape",
+      reason_code: `unknown_${status}_body_shape`,
+    };
+  }
+
+  if (status === 429) {
+    return { classification: "rate_limited", reason_code: "rate_limited" };
+  }
+
+  if (status === 503) {
+    if (outcome === "needs_review") {
+      return { classification: "needs_review", reason_code: "needs_review" };
+    }
+    if (errorCls && KNOWN_UPSTREAM_UNAVAILABLE_ERRORS.has(errorCls)) {
+      return { classification: "upstream_unavailable", reason_code: errorCls };
+    }
+    return {
+      classification: "upstream_unavailable",
+      reason_code: "upstream_unavailable_unspecified",
+    };
+  }
+
+  if (status >= 500 && status <= 599) {
+    return {
+      classification: "upstream_unavailable",
+      reason_code: `http_${status}`,
+    };
+  }
+
+  return {
+    classification: "unsupported_response_shape",
+    reason_code: `unexpected_status_${status}`,
+  };
+}
+
+// -- live call -------------------------------------------------------------
+
+export type LiveDixieFetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    signal: AbortSignal;
+  },
+) => Promise<{
+  status: number;
+  text(): Promise<string>;
+  headers?: Headers;
+}>;
+
+export interface LiveRecallViaDixieOptions {
+  readonly fetch?: LiveDixieFetchLike;
+  readonly idempotencyDetector?: IdempotencyReuseDetector;
+  readonly clock?: () => number;
+}
+
+function buildPublicSummary(
+  classification: LiveDixieRecallClassification,
+  reasonCode: string,
+): LiveDixieRecallPublicSummary {
+  const outcomeMap: Record<
+    LiveDixieRecallClassification,
+    LiveDixieRecallPublicSummary["outcome"]
+  > = {
+    served: "served",
+    denied_or_forbidden: "denied",
+    needs_review: "needs_review",
+    ingress_invalid_request: "ingress_refused",
+    service_unauthorized: "service_unauthorized",
+    tenant_or_session_mismatch: "denied",
+    rate_limited: "rate_limited",
+    upstream_unavailable: "upstream_unavailable",
+    unsupported_response_shape: "unsupported_response_shape",
+    network_error: "network_error",
+    missing_required_env: "config_error",
+    invalid_config: "config_error",
+    unsafe_idempotency_key_reuse: "unsafe_idempotency_key_reuse",
+  };
+  return {
+    outcome: outcomeMap[classification],
+    classification,
+    stable_reason_code: reasonCode,
+  };
+}
+
+export async function liveRecallViaDixie(
+  input: LiveRecallInput,
+  config: LiveDixieClientConfig,
+  options: LiveRecallViaDixieOptions = {},
+): Promise<LiveDixieRecallResult> {
+  let plan: LiveDixieRequestPlan;
+  try {
+    plan = buildLiveDixieRecallRequestPlan(input, config);
+  } catch (err) {
+    if (err instanceof LiveDixieClientConfigError) {
+      const cls = err.code;
+      const reason =
+        cls === "missing_required_env"
+          ? `missing:${err.missingEnv ?? "unknown"}`
+          : "invalid_config";
+      const diag: LiveDixieRecallInternalDiagnostic = {
+        idempotency_key_present: false,
+        ...(cls === "missing_required_env" && err.missingEnv !== undefined
+          ? { missing_env: err.missingEnv }
+          : {}),
+      };
+      return {
+        classification: cls,
+        public_summary: buildPublicSummary(cls, reason),
+        internal_diagnostic: diag,
+      };
+    }
+    throw err;
+  }
+
+  const detector = options.idempotencyDetector ?? DEFAULT_REUSE_DETECTOR;
+  const verdict = detector.observe(
+    config.tenantId,
+    config.callerActorId,
+    plan.idempotencyKey,
+    plan.fingerprint,
+  );
+  if (verdict === "unsafe_reuse") {
+    return {
+      classification: "unsafe_idempotency_key_reuse",
+      public_summary: buildPublicSummary(
+        "unsafe_idempotency_key_reuse",
+        "idempotency_key_content_mismatch",
+      ),
+      internal_diagnostic: {
+        idempotency_key_present: true,
+        fingerprint: plan.fingerprint,
+      },
+    };
+  }
+
+  const fetcher: LiveDixieFetchLike =
+    options.fetch ??
+    (async (url, init) => {
+      const g = globalThis as unknown as {
+        fetch?: (url: string, init: unknown) => Promise<Response>;
+      };
+      if (typeof g.fetch !== "function") {
+        throw new Error("globalThis.fetch is not available");
+      }
+      const r = await g.fetch(url, init);
+      return {
+        status: r.status,
+        text: () => r.text(),
+        headers: r.headers,
+      };
+    });
+
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(
+    () => controller.abort(),
+    config.timeoutMs,
+  );
+
+  let status: number;
+  let bodyText: string;
+  try {
+    const res = await fetcher(plan.url, {
+      method: plan.method,
+      headers: { ...plan.headers },
+      body: JSON.stringify(plan.body),
+      signal: controller.signal,
+    });
+    status = res.status;
+    bodyText = await res.text();
+  } catch (err) {
+    clearTimeout(timeoutHandle);
+    const aborted =
+      controller.signal.aborted ||
+      (err instanceof Error && err.name === "AbortError");
+    const kind: LiveDixieRecallInternalDiagnostic["network_error_kind"] = aborted
+      ? "timeout"
+      : err instanceof Error
+        ? "fetch_threw"
+        : "non_response";
+    return {
+      classification: "network_error",
+      public_summary: buildPublicSummary(
+        "network_error",
+        aborted ? "timeout" : "fetch_threw",
+      ),
+      internal_diagnostic: {
+        idempotency_key_present: true,
+        fingerprint: plan.fingerprint,
+        ...(kind !== undefined ? { network_error_kind: kind } : {}),
+      },
+    };
+  }
+  clearTimeout(timeoutHandle);
+
+  let parsed: unknown = null;
+  if (bodyText.length > 0) {
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (!isPlainObject(parsed)) {
+    return {
+      classification: "unsupported_response_shape",
+      public_summary: buildPublicSummary(
+        "unsupported_response_shape",
+        "non_json_body",
+      ),
+      internal_diagnostic: {
+        http_status: status,
+        idempotency_key_present: true,
+        fingerprint: plan.fingerprint,
+      },
+    };
+  }
+
+  const classified = classifyDixieResponse({ status, body: parsed });
+
+  const observedOutcome =
+    typeof parsed.outcome === "string" ? (parsed.outcome as string) : undefined;
+  const observedErrorClass =
+    typeof parsed.error === "string" ? (parsed.error as string) : undefined;
+
+  return {
+    classification: classified.classification,
+    public_summary: buildPublicSummary(
+      classified.classification,
+      classified.reason_code,
+    ),
+    internal_diagnostic: {
+      http_status: status,
+      ...(observedOutcome !== undefined
+        ? { observed_outcome: observedOutcome }
+        : {}),
+      ...(observedErrorClass !== undefined
+        ? { observed_error_class: observedErrorClass }
+        : {}),
+      idempotency_key_present: true,
+      fingerprint: plan.fingerprint,
+    },
+  };
+}
+
+// -- public-output banned substring guard ---------------------------------
+
+export const LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS = [
+  "PRIVATE_SENTINEL",
+  "raw_reasons",
+  "raw_dixie_debug",
+  "raw_session_trace",
+  "debug",
+  "operator_private",
+  "private_assertion",
+  "private assertion",
+  "private_assertion_id",
+  "assertion_id",
+  "source_material",
+  "hidden estate",
+  "full assertion bodies",
+  "private identifiers",
+  "session_id",
+  "message_id",
+  "tenant_id",
+  "community_id",
+  "session_thread_id",
+  "continuity_actor_id",
+  "actor:",
+  "freeside-characters:shared-substrate",
+] as const;
+
+// Helper for test / runner consumers — scans an arbitrary
+// operator-public-bound payload for banned substrings.
+export function findBannedPublicSubstring(value: unknown): string | null {
+  if (typeof value === "string") {
+    for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+      if (value.includes(banned)) return banned;
+    }
+    return null;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      const hit = findBannedPublicSubstring(v);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (isPlainObject(value)) {
+    for (const [k, v] of Object.entries(value)) {
+      for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+        if (k.includes(banned)) return banned;
+      }
+      const hit = findBannedPublicSubstring(v);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  return null;
+}

--- a/packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
+++ b/packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
@@ -1,0 +1,610 @@
+// Phase 37C · regression gate for the operator/dev-only runner over the
+// live Dixie recall client.
+//
+// Proves:
+//   1. runner is side-effect-free by default — no print, no network call;
+//   2. runner prints exactly once through an injected print sink;
+//   3. report includes the operator/dev-only scope banner;
+//   4. report includes the non-goals section enumerating live integrations
+//      not present;
+//   5. report does not contain banned private/debug/source substrings in
+//      public/operator-public sections, even when Dixie returns hostile
+//      payloads;
+//   6. runner source imports no Discord / Telegram / storage / LLM / Finn
+//      / @loa/dixie / @loa/straylight;
+//   7. runner source does not register or dispatch commands;
+//   8. runner source does not import the recorded adapter or the public
+//      renderer;
+//   9. runner does not use recorded_dixie_recall_envelope.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  LIVE_DIXIE_DEMO_REPORT_TITLE,
+  RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN_ENV,
+  SCOPE_BANNER_LINES,
+  buildLiveDixieDemoReport,
+  formatLiveDixieDemoReport,
+  runLiveDixieRecallDemo,
+  shouldRunLiveDixieCli,
+  type LiveDixieDemoReport,
+} from "./run-live-dixie-recall-demo.ts";
+import {
+  LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS,
+  type LiveDixieFetchLike,
+  type LiveRecallInput,
+} from "./live-dixie-client.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WALLET = "0xabcdef0000000000000000000000000000000001";
+
+function fullEnv(
+  overrides: Partial<Record<string, string>> = {},
+): Record<string, string | undefined> {
+  return {
+    RECALL_WEDGE_DIXIE_BASE_URL: "https://dixie.example.test",
+    RECALL_WEDGE_DIXIE_SERVICE_TOKEN: "tkn-operator-dev",
+    RECALL_WEDGE_DIXIE_TENANT_ID: WALLET,
+    RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID: WALLET,
+    RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX: "p37c",
+    ...overrides,
+  };
+}
+
+function makeInput(
+  overrides: Partial<LiveRecallInput> = {},
+): LiveRecallInput {
+  return {
+    recallRequestId: "rr-runner-1",
+    task: "operator-runner-test",
+    environmentFrame: "private_chat",
+    riskProfile: "low",
+    detailLevel: "minimal",
+    receiptDetail: "minimal",
+    signature: {
+      signature_id: "sig_1",
+      signer_id: "signer_test",
+      signer_type: "actor_controller",
+      signature_type: "dev_signature",
+      signed_payload_hash:
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      signature: "devsig",
+      signed_at: "2026-05-18T00:00:00Z",
+      key_ref: "kref_test",
+    },
+    createdAt: "2026-05-18T00:00:00Z",
+    idempotencyKey: "runner-test-key",
+    ...overrides,
+  };
+}
+
+function fetchReturning(
+  status: number,
+  body: unknown,
+  bodyOverride?: string,
+): LiveDixieFetchLike {
+  return async () => ({
+    status,
+    text: async () =>
+      bodyOverride !== undefined
+        ? bodyOverride
+        : body === undefined
+          ? ""
+          : JSON.stringify(body),
+  });
+}
+
+// Sections allowed to surface in the operator-public output, before the
+// internal-diagnostic header. The `runner` post-processing step never
+// strips banned substrings from the internal diagnostic; only the public
+// portion is asserted here.
+function publicPortionOf(formatted: string): string {
+  const idx = formatted.indexOf(
+    "## Internal diagnostic [INTERNAL / operator-only]",
+  );
+  return idx < 0 ? formatted : formatted.slice(0, idx);
+}
+
+// -- 1. side-effect-free invocation ----------------------------------------
+
+describe("runLiveDixieRecallDemo · invocation surface", () => {
+  test("no env supplied: returns a config_error report without printing or fetching", async () => {
+    let calls = 0;
+    const fetchSpy: LiveDixieFetchLike = async () => {
+      calls += 1;
+      return { status: 200, text: async () => "" };
+    };
+    const original = console.log;
+    let logCalls = 0;
+    console.log = () => {
+      logCalls += 1;
+    };
+    try {
+      const r = await runLiveDixieRecallDemo({ env: {}, fetch: fetchSpy });
+      expect(r.report.config_error).not.toBeNull();
+      expect(r.report.classification).toBe("missing_required_env");
+      expect(r.report.public_safe_summary.outcome).toBe("config_error");
+    } finally {
+      console.log = original;
+    }
+    expect(calls).toBe(0);
+    expect(logCalls).toBe(0);
+  });
+
+  test("prints exactly once through an injected print sink", async () => {
+    const printed: string[] = [];
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, {
+        outcome: "served",
+        redacted_count: 0,
+        redacted_counts_by_reason: [],
+      }),
+      print: (line) => printed.push(line),
+    });
+    expect(printed.length).toBe(1);
+    expect(printed[0]).toBe(r.formatted);
+  });
+
+  test("does not call console.log when no print sink is provided (side-effect-free)", async () => {
+    const original = console.log;
+    let calls = 0;
+    console.log = () => {
+      calls += 1;
+    };
+    try {
+      await runLiveDixieRecallDemo({
+        env: fullEnv(),
+        input: makeInput(),
+        fetch: fetchReturning(200, { outcome: "served" }),
+      });
+    } finally {
+      console.log = original;
+    }
+    expect(calls).toBe(0);
+  });
+
+  test("returns a report with the documented title", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    expect(r.report.title).toBe(LIVE_DIXIE_DEMO_REPORT_TITLE);
+  });
+});
+
+// -- 2. report structure ---------------------------------------------------
+
+describe("runLiveDixieRecallDemo · report structure", () => {
+  test("scope banner declares operator/dev only, live route, not Discord/Telegram, not memory admission", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    expect(r.formatted).toContain("operator/dev only");
+    expect(r.formatted).toContain("live Dixie POST /api/recall/intake");
+    expect(r.formatted).toContain("not Discord / not Telegram");
+    expect(r.formatted).toContain("not governed memory admission");
+    expect(r.formatted).toContain("not character voice");
+  });
+
+  test("non-goals section enumerates the live integrations not present", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    const formatted = r.formatted;
+    expect(formatted).toContain(
+      "## Non-goals / live integration not present",
+    );
+    expect(formatted).toContain("no Discord");
+    expect(formatted).toContain("no Telegram");
+    expect(formatted).toContain("no positive public_telegram support");
+    expect(formatted).toContain(
+      "no positive authorized_private_session support",
+    );
+    expect(formatted).toContain("no live memory admission");
+    expect(formatted).toContain("no LLM / voice rewrite / character voice");
+    expect(formatted).toContain(
+      "no use of recorded_dixie_recall_envelope on live traffic",
+    );
+  });
+
+  test("includes a request summary referencing /api/recall/intake without raw secrets", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv({ RECALL_WEDGE_DIXIE_SERVICE_TOKEN: "SECRET_TOKEN_VALUE" }),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    expect(r.formatted).toContain("## Live request summary (no secrets)");
+    expect(r.formatted).toContain("/api/recall/intake");
+    expect(r.formatted).toContain("Bearer (redacted)");
+    expect(r.formatted).not.toContain("SECRET_TOKEN_VALUE");
+  });
+
+  test("classification summary reflects the live result classification", async () => {
+    const denied = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(403, {
+        outcome: "denied",
+        error: "seam.privacy_scope_refusal",
+      }),
+    });
+    expect(denied.report.classification).toBe("denied_or_forbidden");
+    expect(denied.formatted).toContain(
+      "classification: denied_or_forbidden",
+    );
+  });
+
+  test("public/operator-safe summary section is structured separately from internal diagnostic", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    const publicIdx = r.formatted.indexOf(
+      "## Public/operator-safe summary",
+    );
+    const internalIdx = r.formatted.indexOf(
+      "## Internal diagnostic [INTERNAL / operator-only]",
+    );
+    expect(publicIdx).toBeGreaterThan(-1);
+    expect(internalIdx).toBeGreaterThan(publicIdx);
+  });
+
+  test("internal diagnostic section is labeled INTERNAL / operator-only", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    expect(r.formatted).toContain(
+      "## Internal diagnostic [INTERNAL / operator-only]",
+    );
+    expect(r.formatted).toContain(
+      "the fields below are operator-only and must not be relayed",
+    );
+  });
+
+  test("scope banner exports the documented lines", () => {
+    expect(SCOPE_BANNER_LINES.length).toBeGreaterThan(0);
+    for (const line of SCOPE_BANNER_LINES) {
+      expect(typeof line).toBe("string");
+      expect(line.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// -- 3. no-leak in public/operator-public sections -------------------------
+
+describe("runLiveDixieRecallDemo · operator-public sections never leak banned material", () => {
+  for (const scenario of [
+    {
+      name: "served body",
+      status: 200,
+      body: { outcome: "served", redacted_count: 0 },
+    },
+    {
+      name: "user-level recall denial",
+      status: 403,
+      body: { outcome: "denied", error: "seam.privacy_scope_refusal" },
+    },
+    {
+      name: "service-auth refused",
+      status: 401,
+      body: {
+        outcome: "denied",
+        error: "ingress.unauthenticated",
+        message: "wallet required",
+      },
+    },
+    {
+      name: "ingress invalid request with hostile error class",
+      status: 400,
+      body: {
+        outcome: "denied",
+        error: "ingress.something_with_session_id_in_name",
+        message: "raw_reasons should not leak",
+        raw_reasons: ["raw_reasons:PRIVATE_SENTINEL"],
+      },
+    },
+    {
+      name: "upstream 503 with raw debug payload",
+      status: 503,
+      body: {
+        outcome: "denied",
+        error: "seam.totally_unknown_class_with_raw_dixie_debug",
+        raw_dixie_debug: { hidden: "estate" },
+        raw_reasons: ["source_material:leak"],
+      },
+    },
+    {
+      name: "non-JSON body",
+      status: 200,
+      body: undefined,
+      override: "<<not json>>",
+    },
+  ] as const) {
+    test(`public portion is clean for ${scenario.name}`, async () => {
+      const r = await runLiveDixieRecallDemo({
+        env: fullEnv(),
+        input: makeInput(),
+        fetch: fetchReturning(
+          scenario.status,
+          scenario.body,
+          (scenario as { override?: string }).override,
+        ),
+      });
+      const publicPortion = publicPortionOf(r.formatted);
+      for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+        expect(publicPortion).not.toContain(banned);
+      }
+    });
+  }
+
+  test("missing-env config_error report never leaks token / env values into public portion", async () => {
+    const r = await runLiveDixieRecallDemo({
+      env: {
+        RECALL_WEDGE_DIXIE_BASE_URL: "https://dixie.example.test",
+        RECALL_WEDGE_DIXIE_SERVICE_TOKEN: "VERY_SECRET_TOKEN_123",
+        RECALL_WEDGE_DIXIE_TENANT_ID: WALLET,
+        RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID: WALLET,
+        RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX: "",
+      },
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served" }),
+    });
+    expect(r.formatted).not.toContain("VERY_SECRET_TOKEN_123");
+    const publicPortion = publicPortionOf(r.formatted);
+    for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+      expect(publicPortion).not.toContain(banned);
+    }
+  });
+});
+
+// -- 4. report builder direct test -----------------------------------------
+
+describe("buildLiveDixieDemoReport · directly", () => {
+  test("config_error null when input is well-formed", () => {
+    const result = {
+      classification: "served",
+      public_summary: {
+        outcome: "served",
+        classification: "served",
+        stable_reason_code: "served",
+      },
+      internal_diagnostic: {
+        idempotency_key_present: true,
+        http_status: 200,
+        observed_outcome: "served",
+        fingerprint: "fnv1a64:0000000000000000",
+      },
+    } as const;
+    const report: LiveDixieDemoReport = buildLiveDixieDemoReport({
+      input: makeInput(),
+      config: {
+        baseUrl: "https://dixie.example.test",
+        serviceToken: "tkn-1",
+        tenantId: WALLET,
+        callerActorId: WALLET,
+        requestKeyPrefix: "p37c",
+        timeoutMs: 10_000,
+      },
+      result,
+    });
+    expect(report.config_error).toBeNull();
+    expect(report.request_summary).not.toBeNull();
+    expect(report.request_summary!.url).toBe(
+      "https://dixie.example.test/api/recall/intake",
+    );
+    expect(report.public_safe_summary.outcome).toBe("served");
+  });
+});
+
+// -- 5. format determinism -------------------------------------------------
+
+describe("formatLiveDixieDemoReport · determinism", () => {
+  test("formatted output is deterministic across invocations with same inputs", async () => {
+    const a = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served", redacted_count: 0 }),
+    });
+    const b = await runLiveDixieRecallDemo({
+      env: fullEnv(),
+      input: makeInput(),
+      fetch: fetchReturning(200, { outcome: "served", redacted_count: 0 }),
+    });
+    expect(a.formatted).toBe(b.formatted);
+  });
+});
+
+// -- 6. static source guards ----------------------------------------------
+
+describe("run-live-dixie-recall-demo.ts · static source guards", () => {
+  const moduleSource = readFileSync(
+    resolve(__dirname, "run-live-dixie-recall-demo.ts"),
+    "utf8",
+  );
+
+  test("imports no Discord client", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*discord-interactions[^"']*["']/,
+    );
+  });
+
+  test("imports no Telegram client", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*node-telegram[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']telegraf["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']grammy["']/);
+  });
+
+  test("imports no production storage / cache clients", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']redis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']ioredis["']/);
+  });
+
+  test("imports no LLM SDK", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']@anthropic-ai\/sdk["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test("imports no Finn / @loa/dixie / @loa/straylight runtime dependency", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+  });
+
+  test("does not import the recorded dixie-envelope adapter", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*dixie-envelope-adapter[^"']*["']/,
+    );
+  });
+
+  test("does not import the public-safe renderer", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*render-public-recall[^"']*["']/,
+    );
+  });
+
+  test("does not register or dispatch Discord / Telegram commands", () => {
+    expect(moduleSource).not.toMatch(/registerCommand\s*\(/);
+    expect(moduleSource).not.toMatch(/applicationCommands/);
+    expect(moduleSource).not.toMatch(/sendMessage\s*\(/);
+    expect(moduleSource).not.toMatch(/createWebhook\s*\(/);
+  });
+
+  test("does not import low-level network or process primitives", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:https["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:net["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:tls["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:child_process["']/);
+  });
+
+  test("does not use recorded_dixie_recall_envelope as a wire kind", () => {
+    // Like the live client test, the only allowed mention is in a comment
+    // that explicitly forbids the use. Regex: token must be preceded by
+    // either "no use of " (the non-goal phrase) or a comment / scope
+    // banner phrase.
+    const all = moduleSource;
+    const hits = [...all.matchAll(/recorded_dixie_recall_envelope/g)];
+    for (const m of hits) {
+      const before = all.slice(Math.max(0, m.index - 80), m.index);
+      const commented =
+        /no use of $/.test(before) ||
+        /not the recorded fixture path/.test(before) ||
+        /\/\/ /.test(before.split("\n").pop() ?? "");
+      expect(commented).toBe(true);
+    }
+  });
+
+  test("CLI guard branch only invokes runLiveDixieRecallDemo when shouldRunLiveDixieCli is true", () => {
+    // Phase 37B requires the live runner to be explicit operator/dev opt-in.
+    // The non-opt-in branch must NOT call runLiveDixieRecallDemo and must
+    // NOT print a report skeleton.
+    //
+    // Locate the `if (isCli) { ... }` block and its inner branching, and
+    // assert structural shape: the only invocation of
+    // runLiveDixieRecallDemo inside the CLI block is gated by
+    // shouldRunLiveDixieCli(env), and there is no fallback branch that
+    // calls runLiveDixieRecallDemo without the opt-in.
+    const cliBlockMatch = moduleSource.match(
+      /if\s*\(\s*isCli\s*\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(cliBlockMatch).not.toBeNull();
+    const cliBlock = cliBlockMatch![0];
+
+    // Must reference shouldRunLiveDixieCli — the only way to reach the
+    // runner inside the CLI block.
+    expect(cliBlock).toContain("shouldRunLiveDixieCli");
+
+    // The total number of `runLiveDixieRecallDemo(` invocations in the CLI
+    // block must equal the number reached only after the opt-in helper
+    // returns true. With one gated invocation, that count is exactly 1.
+    const invocationCount = (
+      cliBlock.match(/runLiveDixieRecallDemo\s*\(/g) ?? []
+    ).length;
+    expect(invocationCount).toBe(1);
+
+    // No `else` / fallback path that prints anything in the CLI block.
+    expect(cliBlock).not.toMatch(/else\s*\{[^}]*console\.log/);
+    expect(cliBlock).not.toMatch(/else\s*\{[^}]*print/);
+    // The gated invocation must come from inside the truthy branch of
+    // shouldRunLiveDixieCli.
+    const truthyBranch = cliBlock.match(
+      /if\s*\(\s*shouldRunLiveDixieCli\([^)]*\)\s*\)\s*\{([\s\S]*?)\n {2}\}/,
+    );
+    expect(truthyBranch).not.toBeNull();
+    expect(truthyBranch![1]).toContain("runLiveDixieRecallDemo");
+  });
+});
+
+// -- 7. CLI opt-in helper -------------------------------------------------
+
+describe("shouldRunLiveDixieCli · explicit operator opt-in", () => {
+  test("env var name is the documented one", () => {
+    expect(RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN_ENV).toBe(
+      "RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN",
+    );
+  });
+
+  test('returns true ONLY when the env var equals "true" (lowercase, exact)', () => {
+    expect(
+      shouldRunLiveDixieCli({
+        RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN: "true",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when env var is absent", () => {
+    expect(shouldRunLiveDixieCli({})).toBe(false);
+  });
+
+  test("returns false when env var is empty / false / any other value", () => {
+    for (const v of [
+      "",
+      "false",
+      "FALSE",
+      "True",
+      "TRUE",
+      "1",
+      "0",
+      "yes",
+      "no",
+      " true",
+      "true ",
+      "y",
+    ]) {
+      expect(
+        shouldRunLiveDixieCli({
+          RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN: v,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("undefined env var value returns false", () => {
+    const env: Record<string, string | undefined> = {
+      RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN: undefined,
+    };
+    expect(shouldRunLiveDixieCli(env)).toBe(false);
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts
+++ b/packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts
@@ -1,0 +1,425 @@
+// Phase 37C · operator/dev-only runner over the live Dixie recall client.
+//
+// Authority: docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md §F.
+//
+// This runner is the explicit operator/dev entry point that exercises the
+// isolated live client (`./live-dixie-client.ts`). It is NOT wired to:
+//   - any Discord / Telegram surface,
+//   - the public-safe renderer (`./render-public-recall.ts`),
+//   - the recorded dixie-envelope adapter (`./dixie-envelope-adapter.ts`),
+//   - any storage / admission / LLM / character-voice path.
+//
+// Invocation discipline:
+//   - side-effect-free by default. No print, no fetch, until either the CLI
+//     guard runs (operator opts in via env), or a caller injects a print
+//     sink and a fake fetch.
+//   - the runner does NOT call live Dixie unless the operator explicitly
+//     supplies `RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN=true` AND the CLI
+//     entry point is reached. Tests always inject a fake fetch.
+
+import {
+  LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS,
+  LIVE_DIXIE_CLIENT_INTAKE_PATH,
+  LiveDixieClientConfigError,
+  buildLiveDixieRecallRequestPlan,
+  findBannedPublicSubstring,
+  liveRecallViaDixie,
+  loadLiveDixieClientConfigFromEnv,
+  type LiveDixieClientConfig,
+  type LiveDixieFetchLike,
+  type LiveDixieRecallResult,
+  type LiveRecallInput,
+} from "./live-dixie-client.ts";
+
+// -- public report shape ---------------------------------------------------
+
+export const LIVE_DIXIE_DEMO_REPORT_TITLE =
+  "Live Dixie recall dev/operator demo (operator/dev-only, post-Phase-37B gate)" as const;
+
+export const SCOPE_BANNER_LINES = [
+  "operator/dev only: no public surface delivery",
+  "live Dixie POST /api/recall/intake — operator-supplied env required",
+  "not Discord / not Telegram: no command registration, no bot dispatch",
+  "not governed memory admission: this runner does not write candidate or admitted memory",
+  "not character voice: operator-readable text only",
+  "not the recorded fixture path: this runner uses the live client module, never the recorded adapter",
+] as const;
+
+const NON_GOALS = [
+  "no Discord client / command registration / Discord API call",
+  "no Telegram bot / Telegram API call",
+  "no positive public_telegram support",
+  "no positive authorized_private_session support",
+  "no @loa/dixie / @loa/straylight / Finn integration",
+  "no production storage / admission / consent",
+  "no live memory admission",
+  "no LLM / voice rewrite / character voice",
+  "no public renderer expansion",
+  "no use of recorded_dixie_recall_envelope on live traffic",
+] as const;
+
+const REQUEST_SUMMARY_HEADER =
+  "Live request summary (no secrets)" as const;
+const CLASSIFICATION_HEADER = "Classification summary" as const;
+const PUBLIC_SAFE_HEADER = "Public/operator-safe summary" as const;
+const INTERNAL_DIAGNOSTIC_HEADER =
+  "Internal diagnostic [INTERNAL / operator-only]" as const;
+const NON_GOALS_HEADER =
+  "Non-goals / live integration not present" as const;
+
+// -- types -----------------------------------------------------------------
+
+export interface LiveDixieDemoRequestSummary {
+  readonly url: string;
+  readonly method: "POST";
+  readonly idempotency_key_present: boolean;
+  readonly idempotency_key_length: number;
+  readonly authorization_scheme: "Bearer (redacted)";
+  readonly tenant_actor_consistent: boolean;
+  readonly body_field_set: readonly string[];
+}
+
+export interface LiveDixieDemoReport {
+  readonly title: string;
+  readonly scope_banner: readonly string[];
+  readonly request_summary: LiveDixieDemoRequestSummary | null;
+  readonly classification: string;
+  readonly public_safe_summary: {
+    readonly outcome: string;
+    readonly classification: string;
+    readonly stable_reason_code: string;
+  };
+  readonly internal_diagnostic: Readonly<Record<string, unknown>>;
+  readonly non_goals: readonly string[];
+  readonly config_error: string | null;
+}
+
+// -- builders --------------------------------------------------------------
+
+// Only top-level body keys are emitted into operator-public output —
+// expanding nested objects would surface field names like `tenant_id` /
+// `actor_id` / `session_id` (which appear in Dixie's wire body but are
+// also on the public-output banned-substring list). Operators can confirm
+// shape from the top-level keys; full structural confirmation belongs in
+// internal/operator-only diagnostics, not the public summary.
+function summarizeBodyFields(
+  body: Readonly<Record<string, unknown>>,
+): readonly string[] {
+  return Object.keys(body).sort();
+}
+
+export interface BuildLiveDixieDemoReportInput {
+  readonly input: LiveRecallInput;
+  readonly config: LiveDixieClientConfig;
+  readonly result: LiveDixieRecallResult;
+}
+
+export function buildLiveDixieDemoReport(
+  args: BuildLiveDixieDemoReportInput,
+): LiveDixieDemoReport {
+  let requestSummary: LiveDixieDemoRequestSummary | null = null;
+  let configError: string | null = null;
+  try {
+    const plan = buildLiveDixieRecallRequestPlan(args.input, args.config);
+    requestSummary = {
+      url: plan.url,
+      method: plan.method,
+      idempotency_key_present: plan.headers["idempotency-key"]?.length > 0,
+      idempotency_key_length: plan.idempotencyKey.length,
+      authorization_scheme: "Bearer (redacted)",
+      tenant_actor_consistent:
+        args.config.tenantId === args.config.callerActorId,
+      body_field_set: summarizeBodyFields(plan.body),
+    };
+  } catch (err) {
+    if (err instanceof LiveDixieClientConfigError) {
+      configError = err.code;
+    } else {
+      configError = "unknown_error";
+    }
+  }
+
+  return {
+    title: LIVE_DIXIE_DEMO_REPORT_TITLE,
+    scope_banner: SCOPE_BANNER_LINES,
+    request_summary: requestSummary,
+    classification: args.result.classification,
+    public_safe_summary: {
+      outcome: args.result.public_summary.outcome,
+      classification: args.result.public_summary.classification,
+      stable_reason_code: args.result.public_summary.stable_reason_code,
+    },
+    internal_diagnostic: { ...args.result.internal_diagnostic },
+    non_goals: NON_GOALS,
+    config_error: configError,
+  };
+}
+
+// -- formatter -------------------------------------------------------------
+
+function formatScopeBanner(banner: readonly string[]): string {
+  const lines: string[] = ["> scope (read me first):"];
+  for (const item of banner) lines.push(`> - ${item}`);
+  return lines.join("\n");
+}
+
+function formatRequestSummary(
+  summary: LiveDixieDemoRequestSummary | null,
+  configError: string | null,
+): string {
+  const lines: string[] = [`## ${REQUEST_SUMMARY_HEADER}`];
+  if (summary === null) {
+    lines.push(
+      `request_plan: NOT BUILT (config_error=${configError ?? "unknown"})`,
+    );
+    lines.push("no live request was issued");
+    return lines.join("\n");
+  }
+  lines.push(`url:                   ${summary.url}`);
+  lines.push(`method:                ${summary.method}`);
+  lines.push(`route:                 ${LIVE_DIXIE_CLIENT_INTAKE_PATH}`);
+  lines.push(`authorization_scheme:  ${summary.authorization_scheme}`);
+  lines.push(
+    `idempotency_key:       present=${String(summary.idempotency_key_present)} length=${summary.idempotency_key_length}`,
+  );
+  lines.push(
+    `tenant_actor_consistent: ${String(summary.tenant_actor_consistent)}`,
+  );
+  lines.push(`body_field_set:`);
+  for (const f of summary.body_field_set) lines.push(`  - ${f}`);
+  return lines.join("\n");
+}
+
+function formatClassificationSummary(classification: string): string {
+  return [
+    `## ${CLASSIFICATION_HEADER}`,
+    `classification: ${classification}`,
+  ].join("\n");
+}
+
+function formatPublicSafe(
+  s: LiveDixieDemoReport["public_safe_summary"],
+): string {
+  return [
+    `## ${PUBLIC_SAFE_HEADER}`,
+    `outcome:             ${s.outcome}`,
+    `classification:      ${s.classification}`,
+    `stable_reason_code:  ${s.stable_reason_code}`,
+  ].join("\n");
+}
+
+function formatInternalDiagnostic(
+  diag: Readonly<Record<string, unknown>>,
+): string {
+  const lines: string[] = [
+    `## ${INTERNAL_DIAGNOSTIC_HEADER}`,
+    "the fields below are operator-only and must not be relayed to any",
+    "public surface; they are surfaced here for operator inspection of",
+    "the live spike",
+    "",
+  ];
+  const keys = Object.keys(diag).sort();
+  if (keys.length === 0) {
+    lines.push("(none)");
+  } else {
+    for (const k of keys) {
+      lines.push(`  ${k}: ${JSON.stringify(diag[k])}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatNonGoals(nonGoals: readonly string[]): string {
+  const lines: string[] = [`## ${NON_GOALS_HEADER}`];
+  for (const item of nonGoals) lines.push(`- ${item}`);
+  return lines.join("\n");
+}
+
+export function formatLiveDixieDemoReport(report: LiveDixieDemoReport): string {
+  return [
+    `# ${report.title}`,
+    formatScopeBanner(report.scope_banner),
+    formatRequestSummary(report.request_summary, report.config_error),
+    formatClassificationSummary(report.classification),
+    formatPublicSafe(report.public_safe_summary),
+    formatInternalDiagnostic(report.internal_diagnostic),
+    formatNonGoals(report.non_goals),
+  ].join("\n\n");
+}
+
+// -- runner ----------------------------------------------------------------
+
+export interface RunLiveDixieRecallDemoOptions {
+  readonly env?: Record<string, string | undefined>;
+  readonly input?: LiveRecallInput;
+  readonly fetch?: LiveDixieFetchLike;
+  readonly print?: (text: string) => void;
+}
+
+const DEFAULT_OPERATOR_INPUT: LiveRecallInput = {
+  recallRequestId: "operator-spike-1",
+  task: "operator-dev-recall-spike",
+  environmentFrame: "private_chat",
+  riskProfile: "low",
+  detailLevel: "minimal",
+  receiptDetail: "minimal",
+  signature: {
+    signature_id: "sig_1",
+    signer_id: "signer_test",
+    signer_type: "actor_controller",
+    signature_type: "dev_signature",
+    signed_payload_hash:
+      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    signature: "devsig",
+    signed_at: "2026-05-18T00:00:00Z",
+    key_ref: "kref_test",
+  },
+  createdAt: "2026-05-18T00:00:00Z",
+};
+
+export async function runLiveDixieRecallDemo(
+  options: RunLiveDixieRecallDemoOptions = {},
+): Promise<{
+  readonly report: LiveDixieDemoReport;
+  readonly formatted: string;
+}> {
+  const env = options.env ?? {};
+  const input = options.input ?? DEFAULT_OPERATOR_INPUT;
+
+  let config: LiveDixieClientConfig | null = null;
+  let configError: LiveDixieClientConfigError | null = null;
+  try {
+    config = loadLiveDixieClientConfigFromEnv(env);
+  } catch (err) {
+    if (err instanceof LiveDixieClientConfigError) {
+      configError = err;
+    } else {
+      throw err;
+    }
+  }
+
+  let result: LiveDixieRecallResult;
+  if (config === null) {
+    result = {
+      classification:
+        configError && configError.code === "missing_required_env"
+          ? "missing_required_env"
+          : "invalid_config",
+      public_summary: {
+        outcome: "config_error",
+        classification:
+          configError && configError.code === "missing_required_env"
+            ? "missing_required_env"
+            : "invalid_config",
+        stable_reason_code:
+          configError && configError.code === "missing_required_env"
+            ? `missing:${configError.missingEnv ?? "unknown"}`
+            : "invalid_config",
+      },
+      internal_diagnostic: {
+        idempotency_key_present: false,
+        ...(configError && configError.missingEnv !== undefined
+          ? { missing_env: configError.missingEnv }
+          : {}),
+      },
+    };
+  } else {
+    result = await liveRecallViaDixie(input, config, {
+      fetch: options.fetch,
+    });
+  }
+
+  const report = buildLiveDixieDemoReport({
+    input,
+    config: config ?? {
+      baseUrl: "",
+      serviceToken: "",
+      tenantId: "",
+      callerActorId: "",
+      requestKeyPrefix: "",
+      timeoutMs: 0,
+    },
+    result,
+  });
+  const formatted = formatLiveDixieDemoReport(report);
+
+  // Defense-in-depth: never let banned substrings smuggle into the
+  // public-bound sections of the formatted report. If detected, replace
+  // the public/classification/request-summary sections with a stable
+  // marker rather than printing the contaminated text.
+  const publicPortion = extractPublicPortionForScan(formatted);
+  if (findBannedPublicSubstring(publicPortion) !== null) {
+    const sanitized = formatLiveDixieDemoReport({
+      ...report,
+      public_safe_summary: {
+        outcome: "config_error",
+        classification: "unsupported_response_shape",
+        stable_reason_code: "public_section_contained_banned_material",
+      },
+      internal_diagnostic: {
+        idempotency_key_present: false,
+        sanitized: true,
+      },
+    });
+    if (options.print) options.print(sanitized);
+    return { report, formatted: sanitized };
+  }
+
+  if (options.print) options.print(formatted);
+  return { report, formatted };
+}
+
+// Inspect only the operator-public sections of the formatted report (title,
+// scope banner, request summary, classification, public-safe summary, and
+// non-goals) — exclude the internal diagnostic block, which is allowed to
+// carry classification codes whose names overlap with banned substrings
+// for downstream inspection only.
+function extractPublicPortionForScan(formatted: string): string {
+  const internalIdx = formatted.indexOf(`## ${INTERNAL_DIAGNOSTIC_HEADER}`);
+  if (internalIdx < 0) return formatted;
+  const publicHead = formatted.slice(0, internalIdx);
+  const nonGoalsIdx = formatted.indexOf(`## ${NON_GOALS_HEADER}`);
+  const nonGoalsTail =
+    nonGoalsIdx >= 0 ? formatted.slice(nonGoalsIdx) : "";
+  return `${publicHead}\n${nonGoalsTail}`;
+}
+
+// -- CLI guard -------------------------------------------------------------
+
+// Phase 37B requires the live runner to be explicitly operator/dev opt-in
+// (gate §F). The helper returns true ONLY when the env var is exactly the
+// string "true"; any other value (absent, empty, "false", "1", "TRUE", …)
+// returns false and the CLI branch must NOT call runLiveDixieRecallDemo
+// and must NOT print a report skeleton.
+export const RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN_ENV =
+  "RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN" as const;
+
+export function shouldRunLiveDixieCli(
+  env: Record<string, string | undefined>,
+): boolean {
+  return env[RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN_ENV] === "true";
+}
+
+const isCli =
+  typeof import.meta !== "undefined" &&
+  (import.meta as { main?: boolean }).main === true;
+
+if (isCli) {
+  const env: Record<string, string | undefined> =
+    typeof process !== "undefined" && process && process.env
+      ? (process.env as Record<string, string | undefined>)
+      : {};
+  if (shouldRunLiveDixieCli(env)) {
+    runLiveDixieRecallDemo({
+      env,
+      print: (line) => console.log(line),
+    });
+  }
+  // Without explicit operator opt-in, the CLI is a no-op: no fetch, no
+  // print, no skeleton. Operators must set
+  // RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN=true to invoke the live spike.
+}
+
+// Expose the banned-substring set so other operator/dev tooling in this
+// module's test surface can co-locate its no-leak posture.
+export { LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS };


### PR DESCRIPTION
## Summary

Phase 37C adds the first operator/dev-only live Dixie Recall Wedge client spike.

This PR implements the code shape authorized by Phase 37B. It adds an isolated live Dixie client module, an operator/dev-only runner, and tests/static guards. It remains intentionally pre-public-surface: no Discord command wiring, no Telegram bot wiring, no public renderer expansion, no storage/admission, no production auth/consent implementation, no direct Finn runtime/audit wiring, no LLM rewriting, and no character voice.

The live client targets only Dixie `POST /api/recall/intake`, with explicit env/config, Bearer service auth, `Idempotency-Key`, request classification/narrowing, no-leak public summaries, and fail-closed behavior for unknown shapes.

## Files

New:

- `packages/persona-engine/src/recall-wedge/live-dixie-client.ts`
- `packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts`
- `packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts`
- `packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts`

## Scope

This PR adds:

- isolated operator/dev-only live Dixie client module
- operator/dev-only runner module
- injected fetch path for tests
- default `globalThis.fetch` fallback isolated inside the live client
- explicit env/config loader
- fail-closed missing/invalid config handling
- `Idempotency-Key` construction and reuse detection
- local response classification/narrowing
- public/operator-safe summary fields
- internal/operator-only diagnostic fields
- static guards proving no forbidden imports or public-surface wiring

This PR does not modify:

- existing recorded Dixie fixture adapter
- public renderer
- Discord bot code
- Telegram bot code
- package.json
- lockfiles
- CI
- fixture JSON
- generated files

## Dixie request/auth shape

The implementation was derived from Dixie contract evidence and source:

- `../loa-dixie/app/src/routes/recall-intake.ts`
- `../loa-dixie/docs/integration/phase-32e-recall-wedge-route-contract.md`
- `../loa-dixie/app/src/middleware/jwt.ts`
- `../loa-dixie/app/src/services/straylight-recall-intake/refusal-mapping.ts`
- `../loa-dixie/app/tests/integration/recall-intake/route.test.ts`

The live client constructs:

- route: `POST /api/recall/intake`
- auth: `Authorization: Bearer <token>`
- idempotency: `Idempotency-Key`
- body shape: `{ request, detail_level, caller }`
- caller/request identity posture matching Dixie’s authenticated-wallet / authoritative-tenant rule

The client does not fake Dixie's wallet-context header. The service token must be valid for Dixie middleware to produce the authenticated wallet/session context.

## Environment/config

The live client reads:

- `RECALL_WEDGE_DIXIE_BASE_URL`
- `RECALL_WEDGE_DIXIE_SERVICE_TOKEN`
- `RECALL_WEDGE_DIXIE_TENANT_ID`
- `RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID`
- `RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX`
- optional `RECALL_WEDGE_DIXIE_TIMEOUT_MS`

Missing or empty required env fails closed before network. Invalid base URL fails closed. Timeout handling is deterministic and conservative. No secrets are committed or printed.

## Response classification

The local classification vocabulary covers:

- `served`
- `denied_or_forbidden`
- `needs_review`
- `ingress_invalid_request`
- `service_unauthorized`
- `tenant_or_session_mismatch`
- `rate_limited`
- `upstream_unavailable`
- `unsupported_response_shape`
- `network_error`
- `missing_required_env`
- `invalid_config`
- `unsafe_idempotency_key_reuse`

Service-auth failure and user/caller recall refusal are classified separately. Tenant/session mismatch is classified separately. Unknown/incomplete body shapes fail closed as `unsupported_response_shape`.

## Codex PATCH resolution

Codex initially returned PATCH. The required fixes were completed before this PR:

- `public_telegram` removed from accepted live request environment frames
- `public_telegram` now fails closed before network
- `public_telegram` remains only as a disallowed/non-goal/static-guard phrase
- `403 {}` and `400 {}` now classify as `unsupported_response_shape`
- unknown/hostile `403` and `400` error classes now classify as `unsupported_response_shape`
- hostile error strings do not become `public_summary.stable_reason_code`
- `guard.tenant_assertion_cap` maps to `rate_limited`
- `guard.tenant_byte_budget` maps to `rate_limited`
- guard cap refusals no longer map to `upstream_unavailable`
- CLI invocation is a no-op unless `RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN === "true"`
- `shouldRunLiveDixieCli(env)` returns true only for exact lowercase `"true"`
- the non-opt-in CLI branch does not call `runLiveDixieRecallDemo` and does not print a skeleton

Codex re-audit then returned ACCEPT with no required patch.

## Runner behavior

The runner is operator/dev-only.

It produces a structured report with:

- title
- operator/dev-only scope banner
- no-secrets live request summary
- classification summary
- public/operator-safe summary
- internal/operator-only diagnostic
- non-goals

It is side-effect-free by default. It prints only through an injected sink or the CLI guard. The direct CLI path only runs when:

- `RECALL_WEDGE_LIVE_DIXIE_RUNNER_OPT_IN=true`

Without that exact opt-in value, the CLI path exits without running the demo and without printing a skeleton report.

## No-leak posture

Public/operator-safe fields do not expose raw/private/debug/source fields.

Guarded banned strings include:

- `PRIVATE_SENTINEL`
- `raw_reasons`
- `raw_dixie_debug`
- `raw_session_trace`
- `debug`
- `operator_private`
- `private_assertion`
- `private assertion`
- `private_assertion_id`
- `assertion_id`
- `source_material`
- `hidden estate`
- `full assertion bodies`
- `private identifiers`
- `session_id`
- `message_id`
- `tenant_id`
- `community_id`
- `session_thread_id`
- `continuity_actor_id`
- `actor:`
- `freeside-characters:shared-substrate`

Internal diagnostics are labeled `INTERNAL / operator-only`. The runner does not dump raw Dixie JSON into public/operator-public output.

## Recorded fixture boundary

`recorded_dixie_recall_envelope` remains fixture/probe-only.

This PR does not use `recorded_dixie_recall_envelope` for live traffic. The existing `dixie-envelope-adapter.ts` remains unchanged and recorded-fixture-only. The live client is a distinct module.

## Validation

Commands run:

- git status --short --branch --untracked-files=all
- git diff --name-status
- git diff --stat
- git diff --check
- control-byte scan over the four Phase 37C files
- node docs/recall-wedge/fixtures/validate-fixtures.mjs
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.test.ts

Results:

- git diff --check: clean
- control-byte scan: clean, no NUL or illegal control bytes
- fixture validator: 122 passed, 0 failed
- Phase 37C tests: 104 passed, 0 failed, 437 expect() calls
- recorded Dixie regression tests: 215 passed, 0 failed, 700 expect() calls
- Codex re-audit: ACCEPT, no required patch

## Non-goals

This PR intentionally does not add:

- Discord command wiring
- Telegram bot wiring
- public renderer expansion
- positive `public_telegram` support
- positive `authorized_private_session` support
- production storage
- memory admission
- production auth/consent implementation
- direct Finn runtime/audit wiring
- LLM rewriting
- character-voiced recall summaries
- package changes
- lockfile changes
- dependency changes
- CI changes
- generated files
- fixture JSON changes
- changes to `dixie-envelope-adapter.ts`
- changes to `render-public-recall.ts`
- `@loa/dixie` dependency
- `@loa/straylight` runtime dependency
- live use of `recorded_dixie_recall_envelope`
