### PR TITLE
Phase 39B add dev-only Discord Recall Wedge demo

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -71,6 +71,10 @@ import {
   type DiscordInteraction,
   type DiscordInteractionResponse,
 } from './types.ts';
+import {
+  RECALL_WEDGE_DEMO_COMMAND_NAME,
+  handleRecallWedgeDemoInteraction,
+} from './recall-wedge-demo.ts';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_CHAR_LIMIT = 2000;
@@ -206,6 +210,24 @@ export async function dispatchSlashCommand(
         `(invoker=${invoker.username}/${invoker.id})`,
     );
     return ephemeralReply('characters do not respond to bot invocations.');
+  }
+
+  // ─── Phase 39B · dev-only Recall Wedge demo command ────────────────
+  // Authority: docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md (Phase
+  // 39A). The handler is self-contained (pure Phase 38A harness, no LLM, no
+  // live Dixie, no webhook, no deferred PATCH). It is async only because it
+  // lazily imports the harness AFTER its gates pass (Phase 39B patch · no
+  // harness evaluation at bot startup). It fails closed to a single generic
+  // ephemeral refusal unless the demo is
+  // enabled AND the guild + operator allowlists pass. Routed here — before
+  // character resolution / auth-bridge — because it is NOT character-bound
+  // and must not inherit the chat/imagegen async delivery path. No new
+  // logging is added: the handler enforces the §K no-raw-id posture.
+  if (!isQuest && interaction.data?.name === RECALL_WEDGE_DEMO_COMMAND_NAME) {
+    // Async: the Phase 38A harness is dynamically imported only after the
+    // handler's gates pass (no harness evaluation at bot startup). dispatch
+    // is already async, so we simply await the gated response.
+    return await handleRecallWedgeDemoInteraction(interaction);
   }
 
   // ─── Circuit breaker pre-check ─────────────────────────────────────

--- a/apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
@@ -1,0 +1,846 @@
+// Phase 39B · dev-only Recall Wedge demo command regression + static-guard
+// gate. Authority: docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md
+// (Phase 39A §D–§N).
+//
+// What these tests prove (Phase 39A §L · plus the Phase 39B Codex PATCH):
+//   - disabled by default; exact "true" enables; near-truthy values do NOT;
+//   - wrong / missing guild fails closed; non-operator fails closed; empty
+//     operator allowlist fails closed;
+//   - allowed operator in allowed guild succeeds when enabled;
+//   - every response is ephemeral (no channel-visible path);
+//   - disabled / wrong-guild / non-operator refusals share ONE generic
+//     string and pass the §I banned-substring scan;
+//   - success renders the public_discord_simulated frame + safe framing only;
+//   - success does NOT expose operator_dev diagnostics;
+//   - final output passes the banned-substring scan; contaminated output
+//     falls back to the generic ephemeral refusal;
+//   - no freeform memory / recall query option is read;
+//   - the Phase 38A harness is LAZILY loaded — refused paths never load it;
+//     the success path does; a harness load failure after the gates pass
+//     fails closed to the generic ephemeral refusal (Codex PATCH §2);
+//   - static guards: no deep app-to-package relative import; harness reached
+//     only through the authorized package subpath; no live Dixie client /
+//     runner import; no live network primitive (incl. node:tls / tls); no
+//     child_process; no Telegram / private-chat / storage / Finn / LLM
+//     import; no memory-admission / candidate-write / "remember this"
+//     strings; render-public-recall.ts + dixie-envelope-adapter.ts + the
+//     Phase 38A harness source/tests are not imported or mutated;
+//   - registration helper is gated by the exact-"true" env posture;
+//   - registration is NOT globally wired this phase.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { MessageFlags, type DiscordInteraction } from './types.ts';
+import {
+  RECALL_WEDGE_DEMO_COMMAND_NAME,
+  RECALL_WEDGE_DEMO_GENERIC_REFUSAL,
+  RECALL_WEDGE_DEMO_SELECTOR_OPTION,
+  buildRecallWedgeDemoInput,
+  handleRecallWedgeDemoInteraction,
+  isRecallWedgeDiscordDemoAllowedGuild,
+  isRecallWedgeDiscordDemoOperator,
+  parseRecallWedgeDiscordDemoOperatorIds,
+  readRecallWedgeDemoSelector,
+  recallWedgeDemoRefusal,
+  renderRecallWedgeDemoContent,
+  shouldEnableRecallWedgeDiscordDemo,
+  shouldRegisterRecallWedgeDiscordDemo,
+  type RecallWedgeHarnessModule,
+} from './recall-wedge-demo.ts';
+// Harness reached through the AUTHORIZED package subpath (Codex PATCH §1/§3) —
+// NOT a deep relative import that climbs into the package's src tree. Used
+// here only for the test's own assertions + to feed the injected harness seam.
+import {
+  MULTI_SURFACE_HARNESS_BANNED_SUBSTRINGS,
+  findMultiSurfaceBannedSubstring,
+  projectAcrossMultiSurfaceFrames,
+} from '@freeside-characters/persona-engine/recall-wedge/multi-surface-recall-harness';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const GUILD = 'guild-allowed-123';
+const OPERATOR = 'operator-user-456';
+const OTHER_GUILD = 'guild-other-999';
+const OTHER_USER = 'user-other-789';
+
+// The real Phase 38A harness surface, injected via the `loadHarness` seam so
+// success-path tests are deterministic and so we can assert load-vs-no-load.
+const REAL_HARNESS: RecallWedgeHarnessModule = {
+  projectAcrossMultiSurfaceFrames,
+  findMultiSurfaceBannedSubstring,
+};
+
+function fullEnv(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return {
+    RECALL_WEDGE_DISCORD_DEMO_ENABLED: 'true',
+    RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: GUILD,
+    RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS: OPERATOR,
+    ...overrides,
+  };
+}
+
+function interaction(
+  overrides: Partial<DiscordInteraction> = {},
+): DiscordInteraction {
+  return {
+    type: 2,
+    id: 'interaction-id',
+    application_id: 'app-id',
+    token: 'tok',
+    guild_id: GUILD,
+    channel_id: 'chan',
+    member: { user: { id: OPERATOR, username: 'op' } },
+    data: { id: 'cmd', name: RECALL_WEDGE_DEMO_COMMAND_NAME },
+    ...overrides,
+  };
+}
+
+/**
+ * A counting `loadHarness` seam: records how many times it is invoked so a
+ * test can prove a refused path never loads the harness. Returns the real
+ * harness surface so the success path renders genuine Phase 38A output.
+ */
+function countingHarnessLoader(): {
+  load: () => Promise<RecallWedgeHarnessModule>;
+  calls: () => number;
+} {
+  let calls = 0;
+  return {
+    load: async () => {
+      calls += 1;
+      return REAL_HARNESS;
+    },
+    calls: () => calls,
+  };
+}
+
+// -- 1. env gate helpers --------------------------------------------------
+
+describe('Phase 39B · env gate · enable (exact "true")', () => {
+  test('enabled only by the exact string "true"', () => {
+    expect(
+      shouldEnableRecallWedgeDiscordDemo({
+        RECALL_WEDGE_DISCORD_DEMO_ENABLED: 'true',
+      }),
+    ).toBe(true);
+  });
+
+  test('disabled by default (missing var)', () => {
+    expect(shouldEnableRecallWedgeDiscordDemo({})).toBe(false);
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', ' true', 'true ', 'truthy', ''])(
+    'near-truthy value %p does NOT enable',
+    (value) => {
+      expect(
+        shouldEnableRecallWedgeDiscordDemo({
+          RECALL_WEDGE_DISCORD_DEMO_ENABLED: value,
+        }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe('Phase 39B · env gate · register (exact "true")', () => {
+  test('registration enabled only by exact "true"', () => {
+    expect(
+      shouldRegisterRecallWedgeDiscordDemo({
+        RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: 'true',
+      }),
+    ).toBe(true);
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', undefined as unknown as string, ''])(
+    'register value %p does NOT enable',
+    (value) => {
+      expect(
+        shouldRegisterRecallWedgeDiscordDemo({
+          RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: value,
+        }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe('Phase 39B · env gate · operator allowlist parsing', () => {
+  test('missing var → empty list (fails closed)', () => {
+    expect(parseRecallWedgeDiscordDemoOperatorIds({})).toEqual([]);
+  });
+
+  test('blank var → empty list', () => {
+    expect(
+      parseRecallWedgeDiscordDemoOperatorIds({
+        RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS: '   ',
+      }),
+    ).toEqual([]);
+  });
+
+  test('comma-separated, trimmed, empties dropped', () => {
+    expect(
+      parseRecallWedgeDiscordDemoOperatorIds({
+        RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS: ' a , b ,, c ',
+      }),
+    ).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('Phase 39B · guild gate', () => {
+  test('matching guild passes', () => {
+    expect(
+      isRecallWedgeDiscordDemoAllowedGuild(interaction(), fullEnv()),
+    ).toBe(true);
+  });
+
+  test('wrong guild fails closed', () => {
+    expect(
+      isRecallWedgeDiscordDemoAllowedGuild(
+        interaction({ guild_id: OTHER_GUILD }),
+        fullEnv(),
+      ),
+    ).toBe(false);
+  });
+
+  test('missing guild_id (DM) fails closed', () => {
+    expect(
+      isRecallWedgeDiscordDemoAllowedGuild(
+        interaction({ guild_id: undefined }),
+        fullEnv(),
+      ),
+    ).toBe(false);
+  });
+
+  test('missing configured guild id fails closed', () => {
+    expect(
+      isRecallWedgeDiscordDemoAllowedGuild(
+        interaction(),
+        fullEnv({ RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: undefined }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('Phase 39B · operator gate', () => {
+  test('operator in allowlist passes', () => {
+    expect(isRecallWedgeDiscordDemoOperator(interaction(), fullEnv())).toBe(
+      true,
+    );
+  });
+
+  test('reads user.id when invoked in a DM shape', () => {
+    expect(
+      isRecallWedgeDiscordDemoOperator(
+        interaction({ member: undefined, user: { id: OPERATOR, username: 'op' } }),
+        fullEnv(),
+      ),
+    ).toBe(true);
+  });
+
+  test('non-operator fails closed', () => {
+    expect(
+      isRecallWedgeDiscordDemoOperator(
+        interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+        fullEnv(),
+      ),
+    ).toBe(false);
+  });
+
+  test('empty allowlist fails closed', () => {
+    expect(
+      isRecallWedgeDiscordDemoOperator(
+        interaction(),
+        fullEnv({ RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// -- 2. handler gating ----------------------------------------------------
+
+describe('Phase 39B · handler fail-closed gating', () => {
+  test('disabled by default → generic ephemeral refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(interaction(), {});
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', ' true'])(
+    'enabled value %p does NOT enable the handler',
+    async (value) => {
+      const res = await handleRecallWedgeDemoInteraction(
+        interaction(),
+        fullEnv({ RECALL_WEDGE_DISCORD_DEMO_ENABLED: value }),
+      );
+      expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+    },
+  );
+
+  test('wrong guild → generic refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction({ guild_id: OTHER_GUILD }),
+      fullEnv(),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('missing guild → generic refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction({ guild_id: undefined }),
+      fullEnv(),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('non-operator → generic refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+      fullEnv(),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('empty operator allowlist → generic refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction(),
+      fullEnv({ RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('disabled / wrong-guild / non-operator all share ONE generic string', async () => {
+    const disabled = await handleRecallWedgeDemoInteraction(interaction(), {});
+    const wrongGuild = await handleRecallWedgeDemoInteraction(
+      interaction({ guild_id: OTHER_GUILD }),
+      fullEnv(),
+    );
+    const nonOperator = await handleRecallWedgeDemoInteraction(
+      interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+      fullEnv(),
+    );
+    expect(disabled.data?.content).toBe(wrongGuild.data?.content);
+    expect(wrongGuild.data?.content).toBe(nonOperator.data?.content);
+  });
+
+  test('every refusal path is ephemeral', async () => {
+    for (const res of [
+      await handleRecallWedgeDemoInteraction(interaction(), {}),
+      await handleRecallWedgeDemoInteraction(
+        interaction({ guild_id: OTHER_GUILD }),
+        fullEnv(),
+      ),
+      await handleRecallWedgeDemoInteraction(
+        interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+        fullEnv(),
+      ),
+      recallWedgeDemoRefusal(),
+    ]) {
+      expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    }
+  });
+
+  test('refusal string passes the banned-substring scan', () => {
+    for (const banned of MULTI_SURFACE_HARNESS_BANNED_SUBSTRINGS) {
+      expect(RECALL_WEDGE_DEMO_GENERIC_REFUSAL).not.toContain(banned);
+    }
+  });
+});
+
+// -- 2b. lazy-load posture (Codex PATCH §2) -------------------------------
+
+describe('Phase 39B · harness is lazily loaded after gates', () => {
+  test('disabled path does NOT load the harness', async () => {
+    const loader = countingHarnessLoader();
+    await handleRecallWedgeDemoInteraction(interaction(), {}, {
+      loadHarness: loader.load,
+    });
+    expect(loader.calls()).toBe(0);
+  });
+
+  test('wrong-guild path does NOT load the harness', async () => {
+    const loader = countingHarnessLoader();
+    await handleRecallWedgeDemoInteraction(
+      interaction({ guild_id: OTHER_GUILD }),
+      fullEnv(),
+      { loadHarness: loader.load },
+    );
+    expect(loader.calls()).toBe(0);
+  });
+
+  test('non-operator path does NOT load the harness', async () => {
+    const loader = countingHarnessLoader();
+    await handleRecallWedgeDemoInteraction(
+      interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+      fullEnv(),
+      { loadHarness: loader.load },
+    );
+    expect(loader.calls()).toBe(0);
+  });
+
+  test('enabled + allowed path DOES load the harness and succeeds', async () => {
+    const loader = countingHarnessLoader();
+    const res = await handleRecallWedgeDemoInteraction(interaction(), fullEnv(), {
+      loadHarness: loader.load,
+    });
+    expect(loader.calls()).toBe(1);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    expect(res.data?.content).toContain('public_discord_simulated');
+  });
+
+  test('harness load failure after gates pass → generic ephemeral refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(interaction(), fullEnv(), {
+      loadHarness: async () => {
+        throw new Error('simulated harness load failure');
+      },
+    });
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+
+  test('default loader (real dynamic import) succeeds when gates pass', async () => {
+    // No injected loader — exercises defaultLoadHarness's dynamic import of
+    // the authorized package subpath.
+    const res = await handleRecallWedgeDemoInteraction(interaction(), fullEnv());
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    expect(res.data?.content).toContain('public_discord_simulated');
+  });
+});
+
+// -- 3. handler success ---------------------------------------------------
+
+describe('Phase 39B · handler success (enabled + allowed)', () => {
+  const env = fullEnv();
+  const withHarness = { loadHarness: async () => REAL_HARNESS };
+
+  test('allowed operator in allowed guild succeeds, ephemeral', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction(),
+      env,
+      withHarness,
+    );
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    expect(res.data?.content).toContain('public_discord_simulated');
+    expect(res.data?.content).toContain('fixture-bound dev demo');
+  });
+
+  test('success renders the public_discord_simulated frame text', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction(),
+      env,
+      withHarness,
+    );
+    expect(res.data?.content).toContain(
+      '[recall · public_discord_simulated · served]',
+    );
+  });
+
+  test('success does NOT expose operator_dev diagnostics', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction(),
+      env,
+      withHarness,
+    );
+    const content = res.data?.content ?? '';
+    expect(content).not.toContain('operator_dev');
+    expect(content).not.toContain('INTERNAL/operator-only');
+    expect(content).not.toContain('operator_diagnostic');
+  });
+
+  test('success output passes the banned-substring scan', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction(),
+      env,
+      withHarness,
+    );
+    const content = res.data?.content ?? '';
+    for (const banned of MULTI_SURFACE_HARNESS_BANNED_SUBSTRINGS) {
+      expect(content).not.toContain(banned);
+    }
+  });
+
+  test('denied selector renders a refusal frame (still ephemeral, no leak)', async () => {
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction({
+        data: {
+          id: 'cmd',
+          name: RECALL_WEDGE_DEMO_COMMAND_NAME,
+          options: [
+            { name: RECALL_WEDGE_DEMO_SELECTOR_OPTION, type: 3, value: 'denied' },
+          ],
+        },
+      }),
+      env,
+      withHarness,
+    );
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    expect(res.data?.content).toContain('public_discord_simulated');
+    const content = res.data?.content ?? '';
+    for (const banned of MULTI_SURFACE_HARNESS_BANNED_SUBSTRINGS) {
+      expect(content).not.toContain(banned);
+    }
+  });
+
+  test('contaminated success content falls back to generic ephemeral refusal', async () => {
+    const res = await handleRecallWedgeDemoInteraction(interaction(), env, {
+      loadHarness: async () => REAL_HARNESS,
+      // Inject a builder that leaks a banned substring — the final no-leak
+      // scan must catch it and fall back to the generic refusal.
+      buildSuccessContent: () => 'leak: session_id=abc123 PRIVATE_SENTINEL',
+    });
+    expect(res.data?.content).toBe(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+
+  test('clean injected content is delivered as-is (scan passes)', async () => {
+    const res = await handleRecallWedgeDemoInteraction(interaction(), env, {
+      loadHarness: async () => REAL_HARNESS,
+      buildSuccessContent: () => 'clean dev-demo content',
+    });
+    expect(res.data?.content).toBe('clean dev-demo content');
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+});
+
+// -- 4. selector / input source ------------------------------------------
+
+describe('Phase 39B · input source (fixed enum selector only)', () => {
+  test('default selector is "served"', () => {
+    expect(readRecallWedgeDemoSelector(interaction())).toBe('served');
+  });
+
+  test('valid enum selector is honored', () => {
+    expect(
+      readRecallWedgeDemoSelector(
+        interaction({
+          data: {
+            id: 'cmd',
+            name: RECALL_WEDGE_DEMO_COMMAND_NAME,
+            options: [
+              { name: RECALL_WEDGE_DEMO_SELECTOR_OPTION, type: 3, value: 'denied' },
+            ],
+          },
+        }),
+      ),
+    ).toBe('denied');
+  });
+
+  test('unknown selector value falls back to default', () => {
+    expect(
+      readRecallWedgeDemoSelector(
+        interaction({
+          data: {
+            id: 'cmd',
+            name: RECALL_WEDGE_DEMO_COMMAND_NAME,
+            options: [
+              {
+                name: RECALL_WEDGE_DEMO_SELECTOR_OPTION,
+                type: 3,
+                value: 'arbitrary-text',
+              },
+            ],
+          },
+        }),
+      ),
+    ).toBe('served');
+  });
+
+  test('freeform-query option names are ignored (no recall/memory query read)', async () => {
+    // Even if a malicious caller smuggles prompt/query/memory options, the
+    // handler only reads the fixed `case` enum option.
+    const res = await handleRecallWedgeDemoInteraction(
+      interaction({
+        data: {
+          id: 'cmd',
+          name: RECALL_WEDGE_DEMO_COMMAND_NAME,
+          options: [
+            { name: 'prompt', type: 3, value: 'remember my secret' },
+            { name: 'query', type: 3, value: 'recall everything' },
+            { name: 'memory', type: 3, value: 'PRIVATE_SENTINEL' },
+          ],
+        },
+      }),
+      fullEnv(),
+      { loadHarness: async () => REAL_HARNESS },
+    );
+    // Default ("served") rendered; smuggled values never echoed.
+    expect(res.data?.content).toContain('public_discord_simulated · served');
+    expect(res.data?.content).not.toContain('remember my secret');
+    expect(res.data?.content).not.toContain('PRIVATE_SENTINEL');
+  });
+
+  test('renderRecallWedgeDemoContent omits operator_dev frame', () => {
+    const matrix = projectAcrossMultiSurfaceFrames(
+      buildRecallWedgeDemoInput('served'),
+    );
+    const content = renderRecallWedgeDemoContent(matrix);
+    expect(content).toContain('public_discord_simulated');
+    expect(content).not.toContain('operator_only_diagnostic');
+    expect(content).not.toContain('INTERNAL/operator-only');
+  });
+});
+
+// -- 5. static source guards ---------------------------------------------
+
+// The deep-import needle is assembled from parts so this guard's OWN source
+// (which the test below reads back) does not contain the literal it forbids.
+const DEEP_PKG_NEEDLE = ['..', '..', '..', '..', 'packages', 'persona-engine'].join(
+  '/',
+);
+
+describe('Phase 39B · static source guards', () => {
+  const moduleSource = readFileSync(
+    resolve(__dirname, 'recall-wedge-demo.ts'),
+    'utf8',
+  );
+
+  test('does not deep-import across the app→package boundary (no TS6059 delta)', () => {
+    // Codex PATCH §1/§3: the deep relative import that produced a new
+    // apps/bot TS6059 rootDir error is gone. The harness is reached only
+    // through the authorized package subpath.
+    expect(moduleSource).not.toContain(DEEP_PKG_NEEDLE);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\.\.\/packages\//);
+  });
+
+  test('reaches the Phase 38A harness only via the authorized package subpath', () => {
+    // Every reference to the harness module specifier uses the package
+    // subpath, never a relative path into packages/persona-engine/src.
+    const harnessRefs =
+      moduleSource.match(
+        /["'][^"']*multi-surface-recall-harness[^"']*["']/g,
+      ) ?? [];
+    expect(harnessRefs.length).toBeGreaterThan(0);
+    for (const ref of harnessRefs) {
+      expect(ref).toContain(
+        '@freeside-characters/persona-engine/recall-wedge/multi-surface-recall-harness',
+      );
+      expect(ref).not.toContain('packages/persona-engine');
+      expect(ref).not.toContain('../');
+    }
+  });
+
+  test('only static import of the harness specifier is type-only', () => {
+    // The runtime dependency is the dynamic import() inside defaultLoadHarness;
+    // the static import of the harness subpath specifier must be `import type`
+    // so the harness is NOT evaluated at module load.
+    expect(moduleSource).toMatch(
+      /import\s+type\s*\{[^}]*\}\s*from\s+["']@freeside-characters\/persona-engine\/recall-wedge\/multi-surface-recall-harness["']/,
+    );
+    // And there is a dynamic import() of the same subpath for lazy loading.
+    expect(moduleSource).toMatch(
+      /import\(\s*[\s\n]*["']@freeside-characters\/persona-engine\/recall-wedge\/multi-surface-recall-harness["']/,
+    );
+  });
+
+  test('does not import the Phase 37C live Dixie client', () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*live-dixie-client[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*live-dixie-client[^"']*["']/,
+    );
+  });
+
+  test('does not import the Phase 37C live Dixie runner', () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+  });
+
+  test('does not import render-public-recall or dixie-envelope-adapter', () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*render-public-recall[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*dixie-envelope-adapter[^"']*["']/,
+    );
+  });
+
+  test('does not import Telegram / private-chat clients', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']telegraf["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']grammy["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*telegram[^"']*["']/i);
+  });
+
+  test('does not import or dynamic-import a private-chat module', () => {
+    // Codex PATCH §3: explicit private-chat import-syntax guards (both
+    // hyphen + underscore spellings, static and dynamic forms). Targets
+    // import/runtime syntax, NOT prose comments.
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*private[-_]chat[^"']*["']/i,
+    );
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*private[-_]chat[^"']*["']/i,
+    );
+    // No private-chat client-ish runtime identifier (call / construction).
+    expect(moduleSource).not.toMatch(/\bprivateChat[A-Za-z]*\s*\(/);
+    expect(moduleSource).not.toMatch(/\bnew\s+PrivateChat[A-Za-z]*\s*\(/);
+  });
+
+  test('does not import storage clients', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']redis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']ioredis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@aws-sdk\/[^"']+["']/);
+  });
+
+  test('does not import Finn / @loa/dixie / @loa/straylight', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+  });
+
+  test('does not import an LLM SDK / Claude Agent SDK', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@anthropic-ai\/[^"']+["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test('contains no fetch / low-level network primitives', () => {
+    expect(moduleSource).not.toMatch(/\bfetch\s*\(/);
+    expect(moduleSource).not.toMatch(/globalThis\.fetch/);
+    expect(moduleSource).not.toMatch(/\bundici\b/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:https["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:net["']/);
+  });
+
+  test('does not import TLS (node:tls / tls)', () => {
+    // Codex PATCH §3: explicit TLS guard — no socket-level crypto transport.
+    expect(moduleSource).not.toMatch(/from\s+["']node:tls["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']tls["']/);
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'](?:node:)?tls["']/,
+    );
+    expect(moduleSource).not.toMatch(/\brequire\(\s*["'](?:node:)?tls["']\)/);
+  });
+
+  test('does not import or use child_process', () => {
+    // Codex PATCH §3: explicit child_process guard — no subprocess spawning.
+    expect(moduleSource).not.toMatch(/from\s+["']node:child_process["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']child_process["']/);
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'](?:node:)?child_process["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /\brequire\(\s*["'](?:node:)?child_process["']\)/,
+    );
+    // No spawn/exec/fork call shapes (the child_process API surface).
+    expect(moduleSource).not.toMatch(/\b(spawn|exec|execFile|execSync|fork)\s*\(/);
+  });
+
+  test('does not consume RECALL_WEDGE_DIXIE_* envs (only the demo-gating envs)', () => {
+    expect(moduleSource).not.toMatch(/RECALL_WEDGE_DIXIE_/);
+  });
+
+  test('contains no memory-admission / candidate-write / "remember this" affordance', () => {
+    const lc = moduleSource.toLowerCase();
+    // Admission / candidate-write APIs (identifiers, not prose). The word
+    // "admit" alone may appear in a NON-affordance comment ("does not admit");
+    // these patterns target the actual write/enqueue call shapes.
+    expect(lc).not.toMatch(/admit(memory|candidate)\(/);
+    expect(lc).not.toMatch(/candidate[_-]?memory/);
+    expect(lc).not.toMatch(/writememory|write_memory/);
+    expect(lc).not.toMatch(/enqueueadmission|admission[_-]?job/);
+    // No "remember this" affordance phrase as a behavior in this module.
+    expect(lc).not.toContain('remember this');
+  });
+
+  test('renders only via the EPHEMERAL flag — no non-ephemeral data branch', () => {
+    // Every response data object in the module sets the EPHEMERAL flag.
+    // Guard: there is no `data: {}` (flagless) or DEFERRED response shape.
+    expect(moduleSource).toContain('MessageFlags.EPHEMERAL');
+    expect(moduleSource).not.toMatch(/DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE/);
+    // The only response builder sets flags: MessageFlags.EPHEMERAL.
+    const responseDataBlocks = moduleSource.match(/data:\s*\{[^}]*\}/g) ?? [];
+    expect(responseDataBlocks.length).toBeGreaterThan(0);
+    for (const block of responseDataBlocks) {
+      expect(block).toContain('MessageFlags.EPHEMERAL');
+    }
+  });
+});
+
+// -- 5b. test-file boundary guard ----------------------------------------
+
+describe('Phase 39B · test file crosses no app→package boundary', () => {
+  const testSource = readFileSync(
+    resolve(__dirname, 'recall-wedge-demo.test.ts'),
+    'utf8',
+  );
+
+  test('test does not deep-import across the app→package boundary', () => {
+    // Codex PATCH §1/§3: the test must also reach the harness through the
+    // authorized package subpath, not a deep relative path. The needle is
+    // assembled from parts (DEEP_PKG_NEEDLE) so this assertion does not
+    // itself plant the forbidden literal in the file it reads back.
+    expect(testSource).not.toContain(DEEP_PKG_NEEDLE);
+    expect(testSource).not.toMatch(/from\s+["'][^"']*\.\.\/packages\//);
+  });
+
+  test('test reaches the harness only via the authorized package subpath', () => {
+    const harnessRefs =
+      testSource.match(
+        /from\s+["'][^"']*multi-surface-recall-harness[^"']*["']/g,
+      ) ?? [];
+    expect(harnessRefs.length).toBeGreaterThan(0);
+    for (const ref of harnessRefs) {
+      expect(ref).toContain(
+        '@freeside-characters/persona-engine/recall-wedge/multi-surface-recall-harness',
+      );
+    }
+  });
+});
+
+// -- 6. dispatch wiring guard --------------------------------------------
+
+describe('Phase 39B · dispatch wiring', () => {
+  const dispatchSource = readFileSync(
+    resolve(__dirname, 'dispatch.ts'),
+    'utf8',
+  );
+
+  test('dispatch routes the command name to the gated handler', () => {
+    expect(dispatchSource).toContain('RECALL_WEDGE_DEMO_COMMAND_NAME');
+    expect(dispatchSource).toContain('handleRecallWedgeDemoInteraction');
+    expect(dispatchSource).toMatch(
+      /interaction\.data\?\.name\s*===\s*RECALL_WEDGE_DEMO_COMMAND_NAME/,
+    );
+  });
+
+  test('dispatch awaits the (now async) handler and returns its response', () => {
+    expect(dispatchSource).toMatch(
+      /return\s+await\s+handleRecallWedgeDemoInteraction\(interaction\)/,
+    );
+  });
+
+  test('command name is the locked Phase 39A name with no alias', () => {
+    expect(RECALL_WEDGE_DEMO_COMMAND_NAME).toBe('recall-wedge-demo');
+  });
+});
+
+// -- 7. registration guard (registration NOT wired this phase) -----------
+
+describe('Phase 39B · registration not globally wired', () => {
+  const publishSource = readFileSync(
+    resolve(__dirname, '../lib/publish-commands.ts'),
+    'utf8',
+  );
+  const publishScriptSource = readFileSync(
+    resolve(__dirname, '../../scripts/publish-commands.ts'),
+    'utf8',
+  );
+
+  test('publish-commands does not register /recall-wedge-demo', () => {
+    // Phase 39B implements handler + dispatch only; registration is NOT
+    // added (no command-set entry, no global path). A later phase that
+    // wires registration must gate on RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS
+    // and the RECALL_WEDGE_DISCORD_DEMO_GUILD_ID guild scope.
+    expect(publishSource).not.toContain('recall-wedge-demo');
+    expect(publishScriptSource).not.toContain('recall-wedge-demo');
+  });
+});

--- a/apps/bot/src/discord-interactions/recall-wedge-demo.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-demo.ts
@@ -1,0 +1,413 @@
+/**
+ * Phase 39B · dev-only Recall Wedge demo command (`/recall-wedge-demo`).
+ *
+ * Authority: docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md (Phase 39A).
+ * Phase 39A authorized ONLY a tightly gated, dev-only, guild-scoped,
+ * operator-invoked, ephemeral, harness-backed Discord slash command that
+ * renders Phase 38A multi-surface harness output. Every constraint below is
+ * binding; partial compliance does not satisfy the gate.
+ *
+ * What this module does:
+ *   - fails closed by default (disabled unless RECALL_WEDGE_DISCORD_DEMO_ENABLED
+ *     is the exact string "true");
+ *   - fails closed unless interaction.guild_id matches
+ *     RECALL_WEDGE_DISCORD_DEMO_GUILD_ID;
+ *   - fails closed unless the invoking user id is in
+ *     RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS;
+ *   - returns the SAME generic ephemeral refusal for disabled / wrong-guild /
+ *     non-operator cases (never reveals which gate tripped);
+ *   - renders ONLY the Phase 38A public_discord_simulated frame plus fixed
+ *     dev-only framing text and a compact public-safe per-frame outcome
+ *     summary;
+ *   - scans the final content with the Phase 38A harness banned-substring
+ *     posture before returning, falling back to the generic ephemeral refusal
+ *     on any hit;
+ *   - is ephemeral on every path (success and refusal).
+ *
+ * What this module does NOT do (Phase 39A §C / §G / §H / §J):
+ *   - it does NOT call live Dixie. It does not import the Phase 37C live Dixie
+ *     client (live-dixie-client) or runner (run-live-dixie-recall-demo);
+ *   - it does NOT accept freeform recall / memory query options (no prompt /
+ *     query / text / message / memory / recall option) — only a fixed enum
+ *     demo selector;
+ *   - it does NOT read Discord message history;
+ *   - it does NOT admit / write / nominate memory, and offers no
+ *     remembering affordance from Discord input;
+ *   - it does NOT invoke any LLM and emits no character voice;
+ *   - it does NOT mutate render-public-recall.ts or dixie-envelope-adapter.ts;
+ *   - it does NOT claim production auth / consent (the env allowlists are
+ *     deployment-side gates, not Straylight authority);
+ *   - it does NOT log raw harness input, the raw matrix, operator_dev
+ *     diagnostics, tokens, or any actor / operational / channel / guild / user
+ *     id.
+ */
+
+// Type-only import across the authorized package subpath (Phase 39B patch ·
+// Codex PATCH §1/§2). `import type` is fully erased at build time, so this
+// file carries NO runtime dependency on the Phase 38A harness at module load
+// — the harness runtime is pulled in lazily via `defaultLoadHarness` ONLY
+// after every gate passes (see the handler below). Importing through the
+// package export (NOT a deep relative path that climbs into the package's
+// src tree) keeps apps/bot's `rootDir: "src"` clean (no TS6059).
+import type {
+  MultiSurfaceRecallInput,
+  MultiSurfaceRecallProjectionMatrix,
+} from '@freeside-characters/persona-engine/recall-wedge/multi-surface-recall-harness';
+import {
+  InteractionResponseType,
+  MessageFlags,
+  type DiscordInteraction,
+  type DiscordInteractionResponse,
+} from './types.ts';
+
+/**
+ * The narrow runtime surface this command needs from the Phase 38A harness.
+ * Resolved lazily (dynamic import) so the harness module is never evaluated
+ * at bot startup — only after the enable / guild / operator gates pass.
+ */
+export interface RecallWedgeHarnessModule {
+  readonly projectAcrossMultiSurfaceFrames: (
+    input: MultiSurfaceRecallInput,
+  ) => MultiSurfaceRecallProjectionMatrix;
+  readonly findMultiSurfaceBannedSubstring: (value: unknown) => string | null;
+}
+
+/**
+ * Default lazy loader — dynamic-imports the Phase 38A harness through the
+ * authorized package subpath. Evaluated ONLY on the fully-gated success path;
+ * a disabled / wrong-guild / non-operator interaction never reaches it, so
+ * the harness runtime stays unloaded for refused calls.
+ */
+async function defaultLoadHarness(): Promise<RecallWedgeHarnessModule> {
+  return import(
+    '@freeside-characters/persona-engine/recall-wedge/multi-surface-recall-harness'
+  );
+}
+
+/** The single chosen command name (Phase 39A §E). No aliases. */
+export const RECALL_WEDGE_DEMO_COMMAND_NAME = 'recall-wedge-demo';
+
+/**
+ * The single, stable, generic refusal string used for EVERY fail-closed path
+ * (disabled / wrong guild / non-operator / contaminated output). It must not
+ * differ between cases and must not leak which gate tripped (Phase 39A §D, §F).
+ * Lowercase, no banned emojis, no production-recall wording.
+ */
+export const RECALL_WEDGE_DEMO_GENERIC_REFUSAL =
+  'recall-wedge-demo is not available here.';
+
+// -- env / config gate helpers (Phase 39A §D.1) ---------------------------
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Disabled by default. Enabled ONLY when the env var is the exact string
+ * "true" — "TRUE", "True", "1", "yes", and whitespace variants are all false,
+ * and a missing var is false (fail closed).
+ */
+export function shouldEnableRecallWedgeDiscordDemo(env: Env): boolean {
+  return env.RECALL_WEDGE_DISCORD_DEMO_ENABLED === 'true';
+}
+
+/**
+ * Registration gate (Phase 39A §H). Exact string "true" only; missing/other
+ * values fail closed. Phase 39B does not wire registration (see the module
+ * note in the Phase 39B report), but the helper is provided + tested so a
+ * later registration step inherits the exact-"true" posture by construction.
+ */
+export function shouldRegisterRecallWedgeDiscordDemo(env: Env): boolean {
+  return env.RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS === 'true';
+}
+
+/**
+ * Parse the comma-separated operator allowlist. Trims each entry and drops
+ * empties. A missing/blank var yields an empty list (which fails closed at
+ * the operator check).
+ */
+export function parseRecallWedgeDiscordDemoOperatorIds(env: Env): string[] {
+  const raw = env.RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS;
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Guild gate. The configured guild id (trimmed) must be non-empty AND must
+ * exactly match interaction.guild_id. A missing configured guild, or an
+ * interaction with no guild_id (e.g. a DM), fails closed.
+ */
+export function isRecallWedgeDiscordDemoAllowedGuild(
+  interaction: DiscordInteraction,
+  env: Env,
+): boolean {
+  const allowed = env.RECALL_WEDGE_DISCORD_DEMO_GUILD_ID?.trim();
+  if (!allowed) return false;
+  const guildId = interaction.guild_id;
+  if (!guildId) return false;
+  return guildId === allowed;
+}
+
+/**
+ * Operator gate. The invoking user id (member.user.id in a guild, user.id in
+ * a DM) must be present AND in the allowlist. An empty allowlist or a missing
+ * invoker id fails closed.
+ */
+export function isRecallWedgeDiscordDemoOperator(
+  interaction: DiscordInteraction,
+  env: Env,
+): boolean {
+  const operatorIds = parseRecallWedgeDiscordDemoOperatorIds(env);
+  if (operatorIds.length === 0) return false;
+  const invokerId = interaction.member?.user?.id ?? interaction.user?.id;
+  if (!invokerId) return false;
+  return operatorIds.includes(invokerId);
+}
+
+// -- deterministic demo input (Phase 39A §G) ------------------------------
+
+/**
+ * Fixed enum demo selectors. NOT freeform memory / recall queries — they map
+ * to harness-internal canned inputs only. Anything outside this set falls
+ * back to the default ("served").
+ */
+export const RECALL_WEDGE_DEMO_SELECTORS = ['served', 'denied'] as const;
+export type RecallWedgeDemoSelector =
+  (typeof RECALL_WEDGE_DEMO_SELECTORS)[number];
+
+/** The slash option name for the enum selector (NOT a freeform query name). */
+export const RECALL_WEDGE_DEMO_SELECTOR_OPTION = 'case';
+
+const DEFAULT_RECALL_WEDGE_DEMO_SELECTOR: RecallWedgeDemoSelector = 'served';
+
+/**
+ * Read the fixed enum selector from the interaction options. Reads ONLY the
+ * `case` option, validates against the allowlist, and falls back to the
+ * default on anything unknown. No freeform text is ever interpreted as a
+ * recall / memory query.
+ */
+export function readRecallWedgeDemoSelector(
+  interaction: DiscordInteraction,
+): RecallWedgeDemoSelector {
+  const opt = interaction.data?.options?.find(
+    (o) => o.name === RECALL_WEDGE_DEMO_SELECTOR_OPTION,
+  );
+  const value = typeof opt?.value === 'string' ? opt.value : undefined;
+  if (
+    value !== undefined &&
+    (RECALL_WEDGE_DEMO_SELECTORS as readonly string[]).includes(value)
+  ) {
+    return value as RecallWedgeDemoSelector;
+  }
+  return DEFAULT_RECALL_WEDGE_DEMO_SELECTOR;
+}
+
+/**
+ * Build a deterministic, built-in harness input for the chosen selector.
+ *
+ * The input intentionally carries contaminated raw/private/operational
+ * material (the same posture as the Phase 38A harness tests) so the final
+ * no-leak scan is NON-VACUOUS: the rendered output is proven clean even
+ * though the input is dirty. None of this contaminated material is ever
+ * supplied by, or derived from, the Discord interaction — it is a fixed
+ * synthetic probe.
+ */
+export function buildRecallWedgeDemoInput(
+  selector: RecallWedgeDemoSelector,
+): MultiSurfaceRecallInput {
+  const base = {
+    continuity_actor_binding: 'recall-wedge-demo-binding',
+    raw_continuity_actor_id: 'actor:freeside-characters:shared-substrate#demo',
+    recall_result_id: 'rr-recall-wedge-demo',
+    operator_diagnostic_label: 'recall_wedge_demo_operator_label',
+    // Synthetic contamination — proves the boundary holds; never rendered.
+    contaminated_internal: {
+      PRIVATE_SENTINEL: 'PRIVATE_SENTINEL',
+      raw_reasons: ['raw_reasons:PRIVATE_SENTINEL'],
+      source_material: 'source_material_demo',
+    },
+    operational_ids: {
+      session_id: 'session_id_demo',
+      message_id: 'message_id_demo',
+      tenant_id: 'tenant_id_demo',
+      community_id: 'community_id_demo',
+      session_thread_id: 'session_thread_id_demo',
+      continuityActorId: 'continuityActorId_demo',
+    },
+  } satisfies Partial<MultiSurfaceRecallInput>;
+
+  if (selector === 'served') {
+    return {
+      ...base,
+      classification: 'served',
+      safe_public_summary: 'redacted: 0 · marked: 1',
+      safe_public_reason_labels: ['public-allowlisted-label'],
+      safe_public_reason_counts: { redacted: 0, marked: 1 },
+    };
+  }
+  // "denied" demo — public surface refuses.
+  return {
+    ...base,
+    classification: 'denied_or_forbidden',
+  };
+}
+
+// -- rendering (Phase 39A §H) ---------------------------------------------
+
+const RECALL_WEDGE_DEMO_FRAMING_HEADER =
+  'recall-wedge-demo · fixture-bound dev demo (not production recall)\n' +
+  'gated · operator-only · ephemeral · phase 38a harness output';
+
+/**
+ * Build the public-bound success content from the Phase 38A matrix.
+ *
+ * Renders ONLY:
+ *   - fixed dev-only framing text;
+ *   - the public_discord_simulated frame's public text;
+ *   - a compact per-frame outcome / refusal-code summary for the other
+ *     frames (public-safe enum values only).
+ *
+ * It does NOT render operator_dev diagnostics, does NOT dump the whole
+ * matrix, and does NOT emit any field that would fail the §I no-leak scan
+ * (the caller still scans the final string as a defense-in-depth).
+ */
+export function renderRecallWedgeDemoContent(
+  matrix: MultiSurfaceRecallProjectionMatrix,
+): string {
+  const discord = matrix.frames.public_discord_simulated;
+  const lines: string[] = [RECALL_WEDGE_DEMO_FRAMING_HEADER, ''];
+
+  lines.push('[public_discord_simulated]');
+  lines.push(discord.public_text ?? '(no public text)');
+
+  // Compact, public-safe per-frame outcome summary. operator_dev is
+  // intentionally excluded — its diagnostic is operator-only and never
+  // surfaces here. Only outcome + stable refusal code (both public-safe
+  // enum strings) are listed.
+  // Frame order is derived from the matrix itself (Object.keys) rather than
+  // the harness's exported frame const, so this module needs no runtime
+  // import of the harness for rendering. operator_dev is intentionally
+  // excluded — its diagnostic is operator-only and never surfaces here.
+  lines.push('');
+  lines.push('frame outcomes:');
+  for (const frame of Object.keys(matrix.frames) as Array<
+    keyof typeof matrix.frames
+  >) {
+    if (frame === 'operator_dev') continue;
+    const r = matrix.frames[frame];
+    const code = r.refusal_code ? ` · ${r.refusal_code}` : '';
+    lines.push(`- ${frame}: ${r.outcome}${code}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Default success-content builder: project the demo input with the (already
+ * lazily-loaded) Phase 38A harness and render it. The harness module is passed
+ * in by the handler, which loads it ONLY after every gate passes.
+ */
+function defaultBuildSuccessContent(
+  selector: RecallWedgeDemoSelector,
+  harness: RecallWedgeHarnessModule,
+): string {
+  const matrix = harness.projectAcrossMultiSurfaceFrames(
+    buildRecallWedgeDemoInput(selector),
+  );
+  return renderRecallWedgeDemoContent(matrix);
+}
+
+// -- ephemeral delivery (Phase 39A §F) ------------------------------------
+
+/**
+ * Build an ephemeral interaction response. EVERY response from this module —
+ * success or refusal — goes through here, so there is no non-ephemeral path.
+ */
+function ephemeralResponse(content: string): DiscordInteractionResponse {
+  return {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: { content, flags: MessageFlags.EPHEMERAL },
+  };
+}
+
+/** The single generic refusal response (ephemeral, stable string). */
+export function recallWedgeDemoRefusal(): DiscordInteractionResponse {
+  return ephemeralResponse(RECALL_WEDGE_DEMO_GENERIC_REFUSAL);
+}
+
+/**
+ * Injectable seams (Phase 39B patch). Tests use these to prove:
+ *   - the harness is NOT loaded on refused (disabled/wrong-guild/non-operator)
+ *     paths and IS loaded on the fully-gated success path (`loadHarness`);
+ *   - a harness load failure after the gates pass still fails closed to the
+ *     generic ephemeral refusal (`loadHarness` rejecting);
+ *   - the contaminated-output fallback path (`buildSuccessContent`).
+ */
+export interface RecallWedgeDemoDeps {
+  readonly loadHarness?: () => Promise<RecallWedgeHarnessModule>;
+  readonly buildSuccessContent?: (
+    selector: RecallWedgeDemoSelector,
+    harness: RecallWedgeHarnessModule,
+  ) => string;
+}
+
+/**
+ * Handle a `/recall-wedge-demo` interaction.
+ *
+ * Fails closed (generic ephemeral refusal) unless ALL gates pass:
+ *   enabled (exact "true") + allowed guild + operator allowlist.
+ *
+ * The Phase 38A harness is loaded LAZILY — only after all three gates pass
+ * (Codex PATCH §2: no harness evaluation at bot startup). A refused
+ * interaction never loads the harness. If the harness load fails after the
+ * gates pass, we fall back to the SAME generic ephemeral refusal rather than
+ * throwing into Discord dispatch.
+ *
+ * On success, renders the Phase 38A public_discord_simulated frame plus fixed
+ * framing, then scans the final content with the harness banned-substring
+ * posture; any hit falls back to the generic ephemeral refusal.
+ *
+ * Async because the harness is dynamically imported; the dispatcher awaits
+ * the response. There is still no deferred PATCH, no follow-up, no webhook,
+ * and no live call — the harness itself is pure and in-process.
+ */
+export async function handleRecallWedgeDemoInteraction(
+  interaction: DiscordInteraction,
+  env: Env = process.env,
+  deps: RecallWedgeDemoDeps = {},
+): Promise<DiscordInteractionResponse> {
+  // Gate order is irrelevant to the user: all three fail to the SAME refusal.
+  // No harness load happens before these checks, so a refused interaction
+  // never evaluates the harness runtime.
+  if (!shouldEnableRecallWedgeDiscordDemo(env)) return recallWedgeDemoRefusal();
+  if (!isRecallWedgeDiscordDemoAllowedGuild(interaction, env)) {
+    return recallWedgeDemoRefusal();
+  }
+  if (!isRecallWedgeDiscordDemoOperator(interaction, env)) {
+    return recallWedgeDemoRefusal();
+  }
+
+  // Gates passed — NOW lazily load the harness. Any load failure fails closed
+  // to the generic refusal (never throws to dispatch).
+  const loadHarness = deps.loadHarness ?? defaultLoadHarness;
+  let harness: RecallWedgeHarnessModule;
+  try {
+    harness = await loadHarness();
+  } catch {
+    return recallWedgeDemoRefusal();
+  }
+
+  const selector = readRecallWedgeDemoSelector(interaction);
+  const build = deps.buildSuccessContent ?? defaultBuildSuccessContent;
+  const content = build(selector, harness);
+
+  // Final no-leak scan — same banned-substring posture as the Phase 38A
+  // harness (Phase 39A §H / §I). On any hit, fall back to the generic
+  // ephemeral refusal rather than emitting a leaky response.
+  if (harness.findMultiSurfaceBannedSubstring(content) !== null) {
+    return recallWedgeDemoRefusal();
+  }
+
+  return ephemeralResponse(content);
+}

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -24,7 +24,8 @@
     "./events/mst-kansei-router": "./src/events/mst-kansei-router.ts",
     "./events/announcement-dispatcher": "./src/events/announcement-dispatcher.ts",
     "./events/announce-mint": "./src/events/announce-mint.ts",
-    "./events/mint-announcement-render": "./src/events/mint-announcement-render.ts"
+    "./events/mint-announcement-render": "./src/events/mint-announcement-render.ts",
+    "./recall-wedge/multi-surface-recall-harness": "./src/recall-wedge/multi-surface-recall-harness.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Phase 39B adds the dev-only Discord Recall Wedge demo command authorized by Phase 39A.

This PR implements `/recall-wedge-demo` as a tightly gated, guild-scoped, operator-invoked, ephemeral-only Discord slash-command handler that renders Phase 38A multi-surface harness output.

It remains disabled by default, harness-backed only, and registration is intentionally not wired in this phase.

## Files

Added:

- apps/bot/src/discord-interactions/recall-wedge-demo.ts
- apps/bot/src/discord-interactions/recall-wedge-demo.test.ts

Modified:

- apps/bot/src/discord-interactions/dispatch.ts
- packages/persona-engine/package.json

Intentionally untouched:

- apps/bot/src/lib/publish-commands.ts
- apps/bot/scripts/publish-commands.ts
- apps/bot/package.json
- package.json
- bun.lock
- packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.ts
- packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- packages/persona-engine/src/recall-wedge/live-dixie-client.ts
- packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts
- packages/persona-engine/src/recall-wedge/render-public-recall.ts
- packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts
- fixture JSON
- CI/generated files

## Command

The command name is:

- /recall-wedge-demo

This is the single command authorized by Phase 39A. No aliases are added.

## Gates

The command fails closed unless all gates pass:

- RECALL_WEDGE_DISCORD_DEMO_ENABLED === "true"
- interaction.guild_id exactly matches RECALL_WEDGE_DISCORD_DEMO_GUILD_ID
- invoking user ID appears in RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS

Near-truthy values such as TRUE, True, 1, yes, leading/trailing whitespace, empty, or missing values do not enable the command.

Disabled, wrong-guild, missing-guild, empty-operator-allowlist, and non-operator paths all return the same generic ephemeral refusal and do not reveal which gate failed.

## Registration

Registration is intentionally not wired in this phase.

The helper shouldRegisterRecallWedgeDiscordDemo exists and is tested for exact-"true" behavior against RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS, but publish-command source and scripts remain untouched.

This avoids global registration risk. Registration remains a later narrow step if needed.

## Delivery

Every handler response is ephemeral.

The dispatch route returns before the existing deferred/webhook/follow-up/chat/imagegen path, so `/recall-wedge-demo` does not inherit the existing async delivery path.

This PR adds no:

- channel-visible output
- DM delivery
- follow-up broadcasts
- webhook posting
- scheduled posting
- ambient posting
- passive listening

## Input source

The command is Phase 38A harness-backed only.

Allowed input:

- deterministic built-in demo input
- fixed selector option named case
- finite selector values: served or denied

Unknown selector values fall back to the default served case.

Disallowed input:

- live Dixie calls
- Phase 37C live Dixie client
- run-live-dixie-recall-demo
- RECALL_WEDGE_DIXIE_* env consumption
- freeform recall/memory prompts
- Discord message history
- recorded_dixie_recall_envelope as live traffic
- memory admission
- candidate-memory writes
- remember-this behavior

## Output path

Success output renders only:

- fixed dev-only framing text
- the Phase 38A public_discord_simulated frame text
- compact public-safe per-frame outcome/refusal-code summaries

It does not render:

- operator_dev diagnostics
- internal/operator-only diagnostics
- raw harness input
- raw Phase 38A matrix
- operational IDs
- public renderer output from render-public-recall.ts
- Dixie envelope adapter output

## No-leak posture

Before returning success output, the handler scans the final Discord content with the Phase 38A harness banned-substring posture.

On any scan hit, the command returns the same generic ephemeral refusal.

The deterministic demo input intentionally contains contaminated synthetic raw/private/operational material so the no-leak proof is non-vacuous. That material is fixed synthetic probe data, not user-derived Discord input.

Final user-visible output must not contain raw/private/debug/source/operational material, including:

- PRIVATE_SENTINEL
- raw_reasons
- raw_dixie_debug
- raw_session_trace
- debug
- operator_private
- private_assertion
- private assertion
- private_assertion_id
- assertion_id
- source_material
- hidden estate
- full assertion bodies
- private identifiers
- session_id
- message_id
- tenant_id
- community_id
- session_thread_id
- continuity_actor_id
- actor:
- freeside-characters:shared-substrate
- sessionId
- messageId
- tenantId
- communityId
- sessionThreadId
- continuityActorId
- service token values
- Discord bot token
- raw Discord user IDs
- raw guild IDs

## Package boundary / Codex PATCH resolution

Codex initially returned PATCH because the first implementation deep-imported the Phase 38A harness from apps/bot through:

../../../../packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.ts

That created a new apps/bot TS6059 rootDir error and caused the harness runtime to be evaluated at bot startup before env gates could fail closed.

This PR resolves that by adding one explicit persona-engine export subpath:

- @freeside-characters/persona-engine/recall-wedge/multi-surface-recall-harness

The export points to:

- ./src/recall-wedge/multi-surface-recall-harness.ts

This follows the existing direct-source export convention in packages/persona-engine/package.json.

No dependency or lockfile change is introduced.

## Lazy-load posture / Codex PATCH resolution

The handler now imports the harness type-only at module load and dynamically imports the runtime harness only after all gates pass.

Refused paths do not load the harness:

- disabled path does not load harness
- wrong-guild path does not load harness
- non-operator path does not load harness

The enabled and allowed path loads the harness and succeeds.

If the harness load fails after gates pass, the command returns the same generic ephemeral refusal instead of throwing into Discord dispatch.

dispatch.ts awaits the async handler and returns its response.

## Static guards / Codex PATCH resolution

Tests guard against:

- deep app-to-package relative imports
- runtime static harness import at module load
- live-dixie-client import
- run-live-dixie-recall-demo import
- render-public-recall import
- dixie-envelope-adapter import
- Telegram/private-chat imports
- storage imports
- Finn/@loa/dixie/@loa/straylight imports
- LLM SDK imports
- fetch/globalThis.fetch/undici/node:http/node:https/node:net
- node:tls / tls import, dynamic import, or require
- node:child_process / child_process import, dynamic import, or require
- spawn/exec/execFile/execSync/fork call shapes
- RECALL_WEDGE_DIXIE_* env consumption
- memory admission/candidate-write/remember-this affordances
- non-ephemeral response branches
- global registration wiring

Private-chat guards target import/runtime syntax, not prose comments.

## Auth / consent non-claims

This PR does not implement or claim:

- production auth
- production consent
- Straylight governed authorization
- cross-user recall authorization
- production private sessions
- memory admission
- candidate-memory creation

Operator/dev allowlists are deployment gates only.

## Results

Validation commands run:

- git status --short --branch --untracked-files=all
- git diff --name-status
- git diff --stat
- git diff --check
- node docs/recall-wedge/fixtures/validate-fixtures.mjs
- bun test apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/render-public-recall.test.ts
- bun run --cwd apps/bot typecheck --pretty false
- grep typecheck output for recall-wedge-demo / multi-surface-recall-harness / TS6059 / rootDir
- git diff --cached --name-status
- git diff --cached --stat
- git diff --cached --check

Results:

- git diff --check: clean
- fixture validator: 122 passed, 0 failed
- Phase 39B Discord demo tests: 82 passed, 0 failed, 231 expect() calls
- Phase 38A harness regression: 52 passed, 0 failed, 806 expect() calls
- Phase 37C live client/runner regressions: 104 passed, 0 failed, 437 expect() calls
- recorded Dixie regressions: 215 passed, 0 failed, 700 expect() calls
- public renderer regressions: 30 passed, 0 failed, 77 expect() calls
- apps/bot typecheck: 151 errors, returned to known dirty baseline
- no Phase 39B recall-wedge-demo / harness TS6059 rootDir references found
- no deep app-to-package imports found
- publish command diff: empty
- protected file diff: empty
- staged diff check: clean
- Codex re-audit: ACCEPT
- no file/line concerns
- no required patch

## Non-goals

This PR intentionally does not add:

- command registration
- global command registration
- publish-commands changes
- package dependency changes
- lockfile changes
- fixture JSON changes
- CI changes
- generated files
- edits to Phase 38A harness source/tests
- edits to Phase 37C live Dixie client/runner
- edits to render-public-recall.ts
- edits to dixie-envelope-adapter.ts
- live Dixie-backed Discord recall
- live Dixie network calls
- public channel-visible recall
- Telegram API/bot/rendering wiring
- private chat integration
- production storage/admission
- memory admission
- candidate-memory writes
- remember-this behavior
- production auth/consent implementation
- direct Finn runtime/audit wiring
- LLM rewriting
- character voice
- public renderer expansion
- production rollout
