### PR TITLE
Phase 39C gate Discord Recall Wedge demo registration

### DIFF
--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -23,6 +23,7 @@ import {
   buildCommandSet,
   fetchApplicationId,
   publishCommands,
+  registerRecallWedgeDemoCommand,
 } from '../src/lib/publish-commands.ts';
 
 async function main(): Promise<void> {
@@ -77,6 +78,22 @@ async function main(): Promise<void> {
       for (const r of result.commands) {
         console.log(`  ✓ /${r.name} → id ${r.id}`);
       }
+    }
+
+    // Phase 39C: dev-only Recall Wedge demo registration. SEPARATE from the
+    // character command publish above — it never enters buildCommandSet (so
+    // it can never reach the global route). Skipped unless BOTH
+    // RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS === "true" AND
+    // RECALL_WEDGE_DISCORD_DEMO_GUILD_ID is set; always guild-scoped.
+    const demo = await registerRecallWedgeDemoCommand({ botToken, applicationId });
+    if (demo.registered) {
+      console.log(
+        `publish-commands: registered dev-only /recall-wedge-demo → guild ${demo.guildId} (id ${demo.command.id})`,
+      );
+    } else {
+      console.log(
+        `publish-commands: /recall-wedge-demo NOT registered (${demo.reason})`,
+      );
     }
   } catch (err) {
     console.error('publish-commands: FAILED');

--- a/apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
@@ -823,9 +823,274 @@ describe('Phase 39B · dispatch wiring', () => {
   });
 });
 
-// -- 7. registration guard (registration NOT wired this phase) -----------
+// -- 7. registration (Phase 39C · dev-only guild-scoped registration) ----
 
-describe('Phase 39B · registration not globally wired', () => {
+import {
+  RECALL_WEDGE_DEMO_COMMAND_DEFINITION,
+  resolveRecallWedgeDiscordDemoGuildId,
+} from './recall-wedge-demo.ts';
+import {
+  buildCommandSet,
+  registerRecallWedgeDemoCommand,
+} from '../lib/publish-commands.ts';
+
+// A tiny fetch capture harness so the registration tests assert the EXACT
+// Discord route used (guild-scoped) without any real network call.
+function captureFetch(
+  response: { ok: boolean; status?: number; json?: unknown } = {
+    ok: true,
+    json: { id: 'cmd-id-123', name: RECALL_WEDGE_DEMO_COMMAND_NAME },
+  },
+): { calls: Array<{ url: string; init: RequestInit }>; restore: () => void } {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init });
+    return {
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 400),
+      json: async () => response.json ?? {},
+      text: async () => JSON.stringify(response.json ?? {}),
+    } as unknown as Response;
+  }) as typeof fetch;
+  return { calls, restore: () => (globalThis.fetch = original) };
+}
+
+const REGISTER_ENABLED = {
+  RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: 'true',
+  RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: GUILD,
+};
+
+describe('Phase 39C · command definition metadata', () => {
+  test('command name is exactly recall-wedge-demo (no alias)', () => {
+    expect(RECALL_WEDGE_DEMO_COMMAND_DEFINITION.name).toBe('recall-wedge-demo');
+    expect(RECALL_WEDGE_DEMO_COMMAND_DEFINITION.name).toBe(
+      RECALL_WEDGE_DEMO_COMMAND_NAME,
+    );
+  });
+
+  test('description includes dev-only / gated / demo wording', () => {
+    const d = RECALL_WEDGE_DEMO_COMMAND_DEFINITION.description.toLowerCase();
+    expect(d).toContain('dev-only');
+    expect(d).toContain('gated');
+    expect(d).toContain('demo');
+  });
+
+  test('description makes no production memory / recall / consent claim', () => {
+    const d = RECALL_WEDGE_DEMO_COMMAND_DEFINITION.description.toLowerCase();
+    for (const banned of [
+      'your memory',
+      'remembered',
+      'saved',
+      'stored',
+      'consent',
+      'admitted',
+    ]) {
+      expect(d).not.toContain(banned);
+    }
+    // It explicitly disclaims production recall.
+    expect(d).toContain('not production recall');
+  });
+
+  test('only option is the finite `case` enum selector (no freeform query)', () => {
+    const opts = RECALL_WEDGE_DEMO_COMMAND_DEFINITION.options;
+    expect(opts.length).toBe(1);
+    const opt = opts[0]!;
+    expect(opt.name).toBe(RECALL_WEDGE_DEMO_SELECTOR_OPTION);
+    expect(opt.name).toBe('case');
+    // Finite choices, exactly the handler's selector set.
+    expect(opt.choices.map((c) => c.value).sort()).toEqual(['denied', 'served']);
+    // No freeform option name is present anywhere in the definition.
+    for (const banned of ['prompt', 'query', 'text', 'message', 'memory', 'recall']) {
+      expect(opt.name).not.toBe(banned);
+    }
+  });
+
+  test('buildCommandSet (the global-capable array) never contains the demo command', () => {
+    // The demo command must NOT flow through the shared command-set that the
+    // global registration path PUTs — that is the only way it could leak to
+    // a global payload. It is registered exclusively via the separate
+    // guild-only path below.
+    const set = buildCommandSet([
+      { id: 'ruggy', displayName: 'Ruggy' } as never,
+      { id: 'satoshi', displayName: 'Satoshi' } as never,
+    ]);
+    for (const cmd of set) {
+      expect(cmd.name).not.toBe(RECALL_WEDGE_DEMO_COMMAND_NAME);
+    }
+  });
+});
+
+describe('Phase 39C · guild-id resolution (fails closed, never global)', () => {
+  test('present non-empty guild id resolves', () => {
+    expect(
+      resolveRecallWedgeDiscordDemoGuildId({
+        RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: GUILD,
+      }),
+    ).toBe(GUILD);
+  });
+
+  test.each([undefined as unknown as string, '', '   ', '\t', ' \n '])(
+    'missing / empty / whitespace guild id %p resolves to null',
+    (value) => {
+      expect(
+        resolveRecallWedgeDiscordDemoGuildId({
+          RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: value,
+        }),
+      ).toBeNull();
+    },
+  );
+});
+
+describe('Phase 39C · registration gate (disabled by default)', () => {
+  test('disabled by default (no env) → not registered, no network call', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app',
+        env: {},
+      });
+      expect(res.registered).toBe(false);
+      expect(fetchCap.calls.length).toBe(0);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', ' true', 'true ', ''])(
+    'near-truthy register flag %p → not registered, no network call',
+    async (value) => {
+      const fetchCap = captureFetch();
+      try {
+        const res = await registerRecallWedgeDemoCommand({
+          botToken: 'tok',
+          applicationId: 'app',
+          env: {
+            RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: value,
+            RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: GUILD,
+          },
+        });
+        expect(res.registered).toBe(false);
+        if (!res.registered) expect(res.reason).toBe('gate_disabled');
+        expect(fetchCap.calls.length).toBe(0);
+      } finally {
+        fetchCap.restore();
+      }
+    },
+  );
+
+  test('exact "true" register flag enables the registration path', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app',
+        env: REGISTER_ENABLED,
+      });
+      expect(res.registered).toBe(true);
+      expect(fetchCap.calls.length).toBe(1);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test('missing guild id (register enabled) → not registered, NO global fallback', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app',
+        env: { RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: 'true' },
+      });
+      expect(res.registered).toBe(false);
+      if (!res.registered) expect(res.reason).toBe('no_guild');
+      // Crucially: no network call at all — it does NOT fall back to global.
+      expect(fetchCap.calls.length).toBe(0);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test.each(['', '   ', '\t'])(
+    'empty / whitespace guild id %p (register enabled) → not registered, no call',
+    async (value) => {
+      const fetchCap = captureFetch();
+      try {
+        const res = await registerRecallWedgeDemoCommand({
+          botToken: 'tok',
+          applicationId: 'app',
+          env: {
+            RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: 'true',
+            RECALL_WEDGE_DISCORD_DEMO_GUILD_ID: value,
+          },
+        });
+        expect(res.registered).toBe(false);
+        if (!res.registered) expect(res.reason).toBe('no_guild');
+        expect(fetchCap.calls.length).toBe(0);
+      } finally {
+        fetchCap.restore();
+      }
+    },
+  );
+});
+
+describe('Phase 39C · registration is guild-scoped ONLY', () => {
+  test('enabled path POSTs to the guild commands route with the configured guild id', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app-42',
+        env: REGISTER_ENABLED,
+      });
+      expect(res.registered).toBe(true);
+      if (res.registered) {
+        expect(res.scope).toBe('guild');
+        expect(res.guildId).toBe(GUILD);
+      }
+      expect(fetchCap.calls.length).toBe(1);
+      const { url, init } = fetchCap.calls[0]!;
+      // Guild-scoped route includes the configured guild id...
+      expect(url).toBe(
+        `https://discord.com/api/v10/applications/app-42/guilds/${GUILD}/commands`,
+      );
+      expect(url).toContain(`/guilds/${GUILD}/commands`);
+      // ...and is NEVER the global route (no `/guilds/` segment).
+      expect(url).not.toBe(
+        'https://discord.com/api/v10/applications/app-42/commands',
+      );
+      expect(init.method).toBe('POST');
+      // The payload is exactly the one demo command (no alias, no array of
+      // many commands that could smuggle a global set).
+      const body = JSON.parse(String(init.body));
+      expect(body.name).toBe(RECALL_WEDGE_DEMO_COMMAND_NAME);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test('no env path reaches the global commands route', async () => {
+    const fetchCap = captureFetch();
+    try {
+      // Across every skip reason, the global route is never touched.
+      await registerRecallWedgeDemoCommand({ botToken: 't', applicationId: 'a', env: {} });
+      await registerRecallWedgeDemoCommand({
+        botToken: 't',
+        applicationId: 'a',
+        env: { RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS: 'true' },
+      });
+      for (const { url } of fetchCap.calls) {
+        expect(url).not.toMatch(/\/applications\/[^/]+\/commands$/);
+      }
+      expect(fetchCap.calls.length).toBe(0);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+});
+
+describe('Phase 39C · registration static source guards', () => {
   const publishSource = readFileSync(
     resolve(__dirname, '../lib/publish-commands.ts'),
     'utf8',
@@ -835,12 +1100,92 @@ describe('Phase 39B · registration not globally wired', () => {
     'utf8',
   );
 
-  test('publish-commands does not register /recall-wedge-demo', () => {
-    // Phase 39B implements handler + dispatch only; registration is NOT
-    // added (no command-set entry, no global path). A later phase that
-    // wires registration must gate on RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS
-    // and the RECALL_WEDGE_DISCORD_DEMO_GUILD_ID guild scope.
-    expect(publishSource).not.toContain('recall-wedge-demo');
-    expect(publishScriptSource).not.toContain('recall-wedge-demo');
+  test('buildCommandSet body does not mention the demo command (no global-array entry)', () => {
+    // Isolate the buildCommandSet function body and prove the demo command
+    // name never appears inside it — it can only be registered via the
+    // separate guild-only POST path.
+    const start = publishSource.indexOf('export function buildCommandSet');
+    expect(start).toBeGreaterThan(-1);
+    const after = publishSource.indexOf('\nfunction buildCommand(', start);
+    const body = publishSource.slice(start, after > -1 ? after : undefined);
+    expect(body).not.toContain('recall-wedge-demo');
+    expect(body).not.toContain('RECALL_WEDGE_DEMO_COMMAND_DEFINITION');
+  });
+
+  test('publishCommands body does not reference the demo command', () => {
+    const start = publishSource.indexOf('export async function publishCommands');
+    // End at the Phase 39C banner — the publishCommands function body proper
+    // is everything before the separate registration section (whose
+    // explanatory comment legitimately names the command).
+    const end = publishSource.indexOf('// Phase 39C · dev-only Recall Wedge');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = publishSource.slice(start, end);
+    expect(body).not.toContain('recall-wedge-demo');
+    expect(body).not.toContain('RECALL_WEDGE_DEMO_COMMAND_DEFINITION');
+  });
+
+  test('the demo registration path uses ONLY the guild route, never the global route', () => {
+    const start = publishSource.indexOf(
+      'export async function registerRecallWedgeDemoCommand',
+    );
+    expect(start).toBeGreaterThan(-1);
+    const body = publishSource.slice(start);
+    // It builds a guild-scoped URL...
+    expect(body).toMatch(/\/guilds\/\$\{guildId\}\/commands/);
+    // ...and contains no bare global commands URL template.
+    expect(body).not.toMatch(/applications\/\$\{applicationId\}\/commands`/);
+  });
+
+  test('demo registration code imports no live Dixie client / runner', () => {
+    expect(publishSource).not.toMatch(
+      /from\s+["'][^"']*live-dixie-client[^"']*["']/,
+    );
+    expect(publishSource).not.toMatch(
+      /from\s+["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+  });
+
+  test('demo registration code does not import the Phase 38A harness (static or dynamic)', () => {
+    expect(publishSource).not.toMatch(
+      /multi-surface-recall-harness/,
+    );
+    // It reaches the demo module only for lightweight metadata + env gates.
+    expect(publishSource).toContain(
+      "from '../discord-interactions/recall-wedge-demo.ts'",
+    );
+  });
+
+  test('demo registration code imports no Telegram / private-chat / storage / Finn / LLM SDKs', () => {
+    expect(publishSource).not.toMatch(/from\s+["']telegraf["']/);
+    expect(publishSource).not.toMatch(/from\s+["']grammy["']/);
+    expect(publishSource).not.toMatch(/from\s+["'][^"']*private[-_]chat[^"']*["']/i);
+    expect(publishSource).not.toMatch(/from\s+["']pg["']/);
+    expect(publishSource).not.toMatch(/from\s+["']redis["']/);
+    expect(publishSource).not.toMatch(/from\s+["']ioredis["']/);
+    expect(publishSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(publishSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(publishSource).not.toMatch(/from\s+["']@anthropic-ai\/[^"']+["']/);
+    expect(publishSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test('demo registration code does not consume RECALL_WEDGE_DIXIE_* envs', () => {
+    expect(publishSource).not.toMatch(/RECALL_WEDGE_DIXIE_/);
+  });
+
+  test('demo registration code adds no memory-admission / candidate / remember-this strings', () => {
+    const lc = publishSource.toLowerCase();
+    expect(lc).not.toMatch(/candidate[_-]?memory/);
+    expect(lc).not.toMatch(/writememory|write_memory/);
+    expect(lc).not.toMatch(/admitmemory|admit_memory|admission[_-]?job/);
+    expect(lc).not.toContain('remember this');
+  });
+
+  test('CLI script registers the demo command via the gated guild-only helper', () => {
+    expect(publishScriptSource).toContain('registerRecallWedgeDemoCommand');
+    // The CLI does not hand-roll a global registration of the demo command.
+    expect(publishScriptSource).not.toMatch(
+      /applications\/\$\{[^}]+\}\/commands`/,
+    );
   });
 });

--- a/apps/bot/src/discord-interactions/recall-wedge-demo.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-demo.ts
@@ -120,6 +120,20 @@ export function shouldRegisterRecallWedgeDiscordDemo(env: Env): boolean {
 }
 
 /**
+ * Resolve the configured registration guild id (Phase 39C). Trims the value
+ * and returns null when missing / blank / whitespace-only — registration
+ * MUST fail closed (never global) when no guild is configured. This is the
+ * registration-side counterpart to the invocation-time guild gate
+ * (`isRecallWedgeDiscordDemoAllowedGuild`); it intentionally does NOT compare
+ * against an interaction, it only surfaces the single allowed guild scope for
+ * the guild-only registration path in `lib/publish-commands.ts`.
+ */
+export function resolveRecallWedgeDiscordDemoGuildId(env: Env): string | null {
+  const id = env.RECALL_WEDGE_DISCORD_DEMO_GUILD_ID?.trim();
+  return id && id.length > 0 ? id : null;
+}
+
+/**
  * Parse the comma-separated operator allowlist. Trims each entry and drops
  * empties. A missing/blank var yields an empty list (which fails closed at
  * the operator check).
@@ -180,6 +194,72 @@ export type RecallWedgeDemoSelector =
 export const RECALL_WEDGE_DEMO_SELECTOR_OPTION = 'case';
 
 const DEFAULT_RECALL_WEDGE_DEMO_SELECTOR: RecallWedgeDemoSelector = 'served';
+
+// -- registration metadata (Phase 39C) ------------------------------------
+
+/**
+ * Discord application-command option-type constants used by the registration
+ * payload (subset; mirrors `lib/publish-commands.ts`). STRING=3. Declared
+ * locally so this module carries no import dependency on publish-commands.
+ */
+const STRING_OPTION_TYPE = 3 as const;
+
+/**
+ * The single, finite, harmless demo selector option exposed at registration
+ * time (Phase 39A §E / §G). It is the `case` enum ONLY — NOT a freeform
+ * prompt / query / text / message / memory / recall option. Its choices are
+ * the same finite set the handler validates (`served` / `denied`); anything
+ * else falls back to the default selector at invocation time.
+ */
+export interface RecallWedgeDemoCommandOptionChoice {
+  readonly name: string;
+  readonly value: RecallWedgeDemoSelector;
+}
+
+export interface RecallWedgeDemoCommandOption {
+  readonly name: typeof RECALL_WEDGE_DEMO_SELECTOR_OPTION;
+  readonly description: string;
+  readonly type: typeof STRING_OPTION_TYPE;
+  readonly required: false;
+  readonly choices: readonly RecallWedgeDemoCommandOptionChoice[];
+}
+
+export interface RecallWedgeDemoCommandDefinition {
+  readonly name: typeof RECALL_WEDGE_DEMO_COMMAND_NAME;
+  readonly description: string;
+  readonly options: readonly RecallWedgeDemoCommandOption[];
+}
+
+/**
+ * The lightweight registration payload for `/recall-wedge-demo` (Phase 39C).
+ *
+ * This is plain metadata — no harness import, no runtime behavior — so it is
+ * safe to import from `lib/publish-commands.ts` without dragging in the
+ * Phase 38A harness (which is reached ONLY via the type-only import above and
+ * the gated dynamic import inside the handler).
+ *
+ * The description is explicitly dev-only / gated / demo framed and makes no
+ * production-memory / production-recall / consent claim (Phase 39A §E). The
+ * only option is the finite `case` enum selector (Phase 39A §G).
+ */
+export const RECALL_WEDGE_DEMO_COMMAND_DEFINITION: RecallWedgeDemoCommandDefinition =
+  {
+    name: RECALL_WEDGE_DEMO_COMMAND_NAME,
+    description:
+      'dev-only gated demo · renders fixture-bound harness output (not production recall)',
+    options: [
+      {
+        name: RECALL_WEDGE_DEMO_SELECTOR_OPTION,
+        description: 'demo case to render (dev-only fixture selector)',
+        type: STRING_OPTION_TYPE,
+        required: false,
+        choices: RECALL_WEDGE_DEMO_SELECTORS.map((s) => ({
+          name: s,
+          value: s,
+        })),
+      },
+    ],
+  };
 
 /**
  * Read the fixed enum selector from the interaction options. Reads ONLY the

--- a/apps/bot/src/lib/publish-commands.ts
+++ b/apps/bot/src/lib/publish-commands.ts
@@ -18,6 +18,16 @@
  */
 
 import type { CharacterConfig } from '@freeside-characters/persona-engine';
+// Phase 39C: lightweight command METADATA only (a plain object) + the two
+// registration env gates. This module-level import is safe: recall-wedge-demo.ts
+// reaches the Phase 38A harness ONLY via a type-only import (erased at build)
+// and a gated dynamic import() inside its handler, so importing its metadata
+// here adds NO harness evaluation at startup / publish time.
+import {
+  RECALL_WEDGE_DEMO_COMMAND_DEFINITION,
+  resolveRecallWedgeDiscordDemoGuildId,
+  shouldRegisterRecallWedgeDiscordDemo,
+} from '../discord-interactions/recall-wedge-demo.ts';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 
@@ -215,6 +225,115 @@ export async function publishCommands(
   }
 
   return results;
+}
+
+// =====================================================================
+// Phase 39C · dev-only Recall Wedge demo registration (guild-scoped ONLY)
+// =====================================================================
+//
+// Authority: docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md §C / §D / §L.
+//
+// This is a SEPARATE registration path, deliberately NOT routed through
+// `publishCommands` / `buildCommandSet`. Those build ONE command array that
+// is PUT to either the guild route OR (when `guildId` is undefined) the
+// GLOBAL route. `/recall-wedge-demo` must NEVER appear in a global payload,
+// so it is never added to `buildCommandSet` and never flows through that
+// global-capable code path. Instead it is registered with a single POST to
+// the guild-scoped command route, and ONLY when both env gates pass:
+//
+//   - RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS === "true" (exact); and
+//   - RECALL_WEDGE_DISCORD_DEMO_GUILD_ID is present + non-empty.
+//
+// Missing / near-truthy register flag, or a missing / blank guild id, skips
+// registration entirely (fail closed). There is no global fallback in this
+// function: if the guild id is absent the command is NOT registered anywhere.
+
+type RegistrationEnv = Record<string, string | undefined>;
+
+export interface RegisterRecallWedgeDemoOptions {
+  readonly botToken: string;
+  /** If absent, derived from `/applications/@me`. */
+  readonly applicationId?: string;
+  /** Defaults to `process.env`; the two §D.1 gates are read from here. */
+  readonly env?: RegistrationEnv;
+}
+
+export type RegisterRecallWedgeDemoResult =
+  | { readonly registered: false; readonly reason: 'gate_disabled' | 'no_guild' }
+  | {
+      readonly registered: true;
+      readonly scope: 'guild';
+      readonly guildId: string;
+      readonly command: { readonly name: string; readonly id: string };
+    };
+
+/**
+ * Register `/recall-wedge-demo` to the single configured guild, guild-scoped
+ * ONLY. Returns a skip result (without any network call) unless both env
+ * gates pass. The Discord route used is ALWAYS the guild commands route
+ * (`/applications/{app}/guilds/{guild}/commands`); there is no branch that
+ * targets the global route.
+ *
+ * POST to the guild commands route is upsert-by-name (idempotent for this one
+ * command) and does NOT replace the guild's full command set — so it composes
+ * with the separate `publishCommands` PUT without clobbering character
+ * commands. De-registration is handled per §M via Discord's command-delete
+ * mechanism, not here.
+ */
+export async function registerRecallWedgeDemoCommand(
+  opts: RegisterRecallWedgeDemoOptions,
+): Promise<RegisterRecallWedgeDemoResult> {
+  if (!opts.botToken) {
+    throw new Error('registerRecallWedgeDemoCommand: botToken is required');
+  }
+
+  const env = opts.env ?? process.env;
+
+  // Gate 1: exact-"true" register flag (near-truthy values fail closed).
+  if (!shouldRegisterRecallWedgeDiscordDemo(env)) {
+    return { registered: false, reason: 'gate_disabled' };
+  }
+
+  // Gate 2: a present, non-empty guild id. Missing / blank / whitespace-only
+  // fails closed — and crucially does NOT fall back to global registration.
+  const guildId = resolveRecallWedgeDiscordDemoGuildId(env);
+  if (!guildId) {
+    return { registered: false, reason: 'no_guild' };
+  }
+
+  const applicationId =
+    opts.applicationId ?? (await fetchApplicationId(opts.botToken));
+  if (!applicationId) {
+    throw new Error(
+      'registerRecallWedgeDemoCommand: applicationId not provided and could not be derived from /applications/@me',
+    );
+  }
+
+  // Guild-scoped route ONLY — never the global `/applications/{app}/commands`.
+  const url = `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bot ${opts.botToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(RECALL_WEDGE_DEMO_COMMAND_DEFINITION),
+  });
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => '<unreadable>');
+    throw new Error(
+      `registerRecallWedgeDemoCommand: Discord POST failed for guild=${guildId} status=${response.status} body=${txt}`,
+    );
+  }
+
+  const created = (await response.json()) as { id: string; name: string };
+  return {
+    registered: true,
+    scope: 'guild',
+    guildId,
+    command: { name: created.name, id: created.id },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 39C adds the dev-only guild-scoped registration gate for the already-merged `/recall-wedge-demo` handler.

This PR wires only safe registration for the Phase 39B Discord Recall Wedge demo command. The command remains dev-only, guild-scoped, operator-gated at invocation, ephemeral-only, harness-backed only, and disabled by default.

Registration is exact-env gated and guild-scoped only. `/recall-wedge-demo` is never added to the global-capable command array and is never routed through the global-capable publishCommands/buildCommandSet flow.

## Files

Modified:

- apps/bot/scripts/publish-commands.ts
- apps/bot/src/discord-interactions/recall-wedge-demo.ts
- apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
- apps/bot/src/lib/publish-commands.ts

Intentionally untouched:

- apps/bot/src/discord-interactions/dispatch.ts
- apps/bot/src/discord-interactions/types.ts
- apps/bot/package.json
- package.json
- bun.lock
- packages/persona-engine/package.json
- packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.ts
- packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- packages/persona-engine/src/recall-wedge/live-dixie-client.ts
- packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts
- packages/persona-engine/src/recall-wedge/render-public-recall.ts
- packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts
- fixture JSON
- config
- CI
- generated files

## Registration architecture

This PR adds a separate, additive guild-only registration function:

- registerRecallWedgeDemoCommand

It deliberately does not route `/recall-wedge-demo` through:

- buildCommandSet
- publishCommands

The reason is safety: the existing publishCommands/buildCommandSet flow builds one character command array and can publish either to a guild route or to the global route when guildId is undefined. Adding `/recall-wedge-demo` to that shared array would create a global-registration hazard.

Instead, `/recall-wedge-demo` is registered through one separate guild-only POST path.

## Command metadata

Registration metadata lives in:

- apps/bot/src/discord-interactions/recall-wedge-demo.ts

New exports:

- RECALL_WEDGE_DEMO_COMMAND_DEFINITION
- resolveRecallWedgeDiscordDemoGuildId

The metadata is a plain literal command definition. It does not import or evaluate the Phase 38A harness runtime.

Command definition:

- name: recall-wedge-demo
- description: dev-only / gated / demo framed
- no production memory, production recall, or consent claim
- one finite option: case
- allowed case choices: served, denied
- no prompt/query/text/message/memory/recall freeform option

## Registration gates

Registration is skipped without network call unless both gates pass:

- RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS === "true"
- RECALL_WEDGE_DISCORD_DEMO_GUILD_ID resolves to a non-empty trimmed guild ID

Near-truthy values do not enable registration:

- TRUE
- True
- 1
- yes
- leading/trailing whitespace
- empty
- missing

Missing, empty, or whitespace-only guild ID returns a stable skip result and makes no network call.

Skip reasons:

- gate_disabled
- no_guild

## Guild-scoped only

When enabled, registration POSTs only to:

- /applications/{applicationId}/guilds/{guildId}/commands

There is no branch targeting:

- /applications/{applicationId}/commands

Missing guild ID never falls back to global registration.

The demo command is never added to buildCommandSet, and publishCommands does not reference it.

## POST choice

The registration helper uses POST to the guild commands route for the single command.

This is intentional: POST creates or updates the guild command by name and avoids replacing the guild’s full command set. A PUT bulk-overwrite path would risk clobbering existing character commands.

## CLI wiring

apps/bot/scripts/publish-commands.ts now calls registerRecallWedgeDemoCommand after the existing character-command publication flow.

The CLI remains operator-invoked. The always-on startup auto-publish path is intentionally not touched.

The CLI prints only non-secret operational status:

- registered dev-only command and guild ID
- skipped reason

No token or secret is logged.

## Handler behavior preserved

The runtime handler behavior remains unchanged:

- disabled by default
- enabled only by RECALL_WEDGE_DISCORD_DEMO_ENABLED === "true"
- invocation guild-gated by RECALL_WEDGE_DISCORD_DEMO_GUILD_ID
- operator-gated by RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS
- ephemeral-only
- Phase 38A harness-backed only
- no live Dixie
- no freeform recall/memory input
- no Discord message history input
- no memory admission
- no candidate-memory write
- no “remember this” behavior
- no LLM
- no character voice

Phase 39B handler tests remain active and pass.

## Startup / harness-load safety

Registration code does not import or evaluate the Phase 38A harness runtime.

publish-commands.ts imports only lightweight metadata/env helpers from recall-wedge-demo.ts.

The harness remains reached only through:

- import type at module load
- gated dynamic import inside the handler after invocation gates pass

No startup-time harness-load hazard is reintroduced.

## Blocked work remains blocked

This PR does not add:

- live Dixie calls
- Phase 37C live client import
- run-live-dixie-recall-demo import
- RECALL_WEDGE_DIXIE_* env consumption
- Telegram integration
- private chat integration
- production storage
- Finn integration
- LLM SDKs
- memory admission
- candidate-memory writes
- “remember this” affordance
- render-public-recall mutation
- dixie-envelope-adapter mutation
- public rollout

## Tests and static guards

The expanded recall-wedge-demo test suite covers:

- command definition metadata
- exact command name
- dev-only/gated/demo description
- no production memory/consent claims
- finite case enum only
- no freeform option
- buildCommandSet never contains the demo command
- guild-id resolution
- disabled-by-default registration
- near-truthy register flags fail
- exact "true" register flag enables
- missing/empty/whitespace guild ID skips without network call
- enabled path POSTs to guild route
- no global route
- publishCommands body does not reference the demo command
- registration code imports no live Dixie client or runner
- registration code imports no Phase 38A harness runtime
- registration code imports no Telegram/private-chat/storage/Finn/LLM SDKs
- registration code does not consume RECALL_WEDGE_DIXIE_*
- registration code adds no memory-admission / candidate / remember-this strings
- CLI script uses the gated guild-only helper

The tests include runtime fetch capture and command-set assertions, not only comment-string checks.

## Typecheck

apps/bot typecheck remains at the known dirty baseline:

- 151 TypeScript errors

No errors mention:

- recall-wedge-demo
- multi-surface-recall-harness
- TS6059
- rootDir

No Phase 39C-introduced typecheck error was found.

## Results

Validation commands run:

- git status --short --branch --untracked-files=all
- git diff --name-status
- git diff --stat
- git diff --check
- node docs/recall-wedge/fixtures/validate-fixtures.mjs
- bun test apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.test.ts packages/persona-engine/src/recall-wedge/run-dixie-envelope-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/render-public-recall.test.ts
- bun run --cwd apps/bot typecheck --pretty false
- grep typecheck output for recall-wedge-demo / multi-surface-recall-harness / TS6059 / rootDir
- git diff --cached --name-status
- git diff --cached --stat
- git diff --cached --check

Results:

- git diff --check: clean
- fixture validator: 122 checks passed, 0 failed
- Phase 39C Discord demo registration tests: 116 passed, 0 failed, 339 expect() calls
- Phase 38A harness regression: 52 passed, 0 failed, 806 expect() calls
- Phase 37C live client/runner regressions: 104 passed, 0 failed, 437 expect() calls
- recorded Dixie regressions: 215 passed, 0 failed, 700 expect() calls
- public renderer regressions: 30 passed, 0 failed, 77 expect() calls
- apps/bot typecheck: 151 errors, known dirty baseline
- no Phase 39C recall-wedge-demo / harness TS6059 rootDir references found
- protected file diff: empty
- staged diff check: clean
- Codex audit: ACCEPT
- no file/line concerns
- no required patch

## Non-goals

This PR intentionally does not add:

- runtime recall behavior changes
- dispatch changes
- startup auto-publish wiring
- global command registration
- root package changes
- apps/bot package changes
- persona-engine package changes
- lockfile changes
- fixture JSON changes
- config changes
- CI changes
- generated files
- Phase 38A harness changes
- Phase 37C live client/runner changes
- render-public-recall changes
- dixie-envelope-adapter changes
- live Dixie-backed Discord recall
- public channel-visible recall
- Telegram API/bot/rendering wiring
- private chat integration
- production storage/admission
- memory admission
- candidate-memory writes
- remember-this behavior
- production auth/consent implementation
- direct Finn runtime/audit wiring
- LLM rewriting
- character voice
- public renderer expansion
- production rollout
