### PR TITLE
Phase 41A gate live Dixie Discord recall demo

### DIFF
--- a/docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md
+++ b/docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md
@@ -572,6 +572,20 @@ boundary.
 - **Telegram, private chat, storage / admission, production auth /
   consent, LLM rewriting, and character voice** all remain blocked.
 
+> **Phase 41A note**
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md`). Phase 41A
+> **chooses not to proceed to Phase 40C immediately** — the Phase 39D
+> runbook §L manual removal is sufficient, so the de-registration helper
+> stays deferred / only-if-needed. **This harness demo guide remains
+> valid and unchanged** — `/recall-wedge-demo` stays controlled,
+> guild-scoped, operator-gated, ephemeral, harness-backed, and
+> non-production. **Any future live Dixie Discord demo must be separate
+> from `/recall-wedge-demo`** — a distinct dev/operator-only command
+> `/recall-wedge-live-demo` under its own strict gates, never a
+> live-producer replacement of this demo. **Live Dixie-backed recall and
+> public-channel-visible recall remain blocked** until separate later
+> gates authorize implementation; Phase 41A authorizes nothing here.
+
 ---
 
 ## P. Acceptance criteria for Phase 40B
@@ -623,3 +637,7 @@ Phase 40B is acceptable if:
   (unchanged by Phase 40B).
 - `apps/bot/src/discord-interactions/dispatch.ts` — routes
   `/recall-wedge-demo` to the handler (unchanged by Phase 40B).
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` — Phase 41A
+  live-Dixie Discord decision gate; chooses a separate
+  `/recall-wedge-live-demo` command for any future live-Dixie work and
+  defers Phase 40C (see the Phase 41A note in §O).

--- a/docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md
+++ b/docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md
@@ -669,6 +669,38 @@ This note does not relax any constraint in §C–§K of this gate; it
 records continued compliance with §D, §J, and §K through the Phase
 38A / 38B work.
 
+### L.3 Phase 41A note — Discord-surface decision gate; future Discord use of the live client stays behind a separate command after Discord gates pass
+
+> Added by Phase 41A
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md`). Short
+> clarifying note, not a rewrite of this gate.
+
+- **Phase 41A is a Discord-surface decision gate, not a change to the
+  Phase 37C live client.** It does not modify
+  `live-dixie-client.ts`, `run-live-dixie-recall-demo.ts`, their tests,
+  or any constraint in §C–§K. The Phase 37C client remains the
+  operator/dev-only live Dixie seam this gate authorized.
+- **Future Discord use of the live client must remain behind a separate
+  command and must call the client only after Discord gates pass.** Phase
+  41A selects, for any future live-Dixie Discord work, a distinct
+  dev/operator-only command `/recall-wedge-live-demo` (never a mutation
+  of `/recall-wedge-demo`) that evaluates its own disabled-by-default /
+  guild-scoped / operator-gated / ephemeral-only Discord gates **before**
+  importing or calling the live client. The live client's own env / config
+  / secrets (§G) remain separate and unchanged; Phase 41A gates *whether
+  Discord may reach the client*, not *how the client authenticates to
+  Dixie*.
+- **Phase 41A does not authorize live network calls yet.** It opens a
+  future Phase 41B decision / implementation slice only; no live
+  Dixie-backed Discord recall, public-channel-visible recall, or memory
+  admission is authorized.
+- **This note does not rewrite the existing live client gate.** §C–§K
+  (allowed / disallowed scope, architecture, env / config, request /
+  idempotency, response classification, fixture relationship, required
+  tests / static guards) stand unchanged; a future Phase 41B that reaches
+  the live client must still satisfy them, plus the Discord gates the
+  Phase 41A gate doc defines.
+
 ---
 
 ## M. Acceptance criteria
@@ -738,3 +770,7 @@ Phase 37B is acceptable if:
   Phase 36C dev/operator runner over recorded Dixie envelopes
   (recorded fixtures only; Phase 37C's live runner is a distinct
   module per §F).
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` — Phase 41A
+  live-Dixie Discord decision gate; selects a separate
+  `/recall-wedge-live-demo` command, after Discord gates pass, as the
+  only future shape for Discord use of this live client (see §L.3).

--- a/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md
+++ b/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md
@@ -1,0 +1,642 @@
+# Recall Wedge — Live Dixie Discord Decision Gate
+
+> **Phase 41A** (docs / decision gate only). Companion to
+> `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` (Phase 37B live Dixie
+> client gate),
+> `docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md` (Phase 40A
+> post-smoke-test decision gate),
+> `docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md` (Phase 40B internal
+> demo guide),
+> `docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md` (Phase 39E
+> smoke-test acceptance),
+> `docs/RECALL-WEDGE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md` (Phase 39D
+> operational runbook),
+> `docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md` (Phase 39A
+> controlled-surface decision gate),
+> `docs/RECALL-WEDGE-MULTI-SURFACE-HARNESS-ACCEPTANCE.md` (Phase 38B
+> harness acceptance), and
+> `docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md` (Phase 35A option
+> matrix).
+>
+> This document is a **decision gate**. It follows Phase 40B and selects
+> the next meaningful proof boundary: whether the Discord surface may
+> ever consume a **live Dixie Recall Wedge result** under the same tight
+> gates that govern the existing harness demo. It decides the safe
+> future *shape* of that work. It does **not** implement it.
+>
+> It does not change `/recall-wedge-demo`. It does not add or authorize
+> live Dixie-backed Discord recall. It does not add or authorize public
+> channel-visible recall. It does not add memory admission,
+> candidate-memory writes, or "remember this." It adds no Telegram /
+> private chat / storage / admission / production auth / consent / LLM /
+> voice / public renderer expansion. If a step seems to require reaching
+> past those boundaries, the answer is to open the separate later gate
+> that owns it — not to relax it from this decision.
+
+---
+
+## A. Status and decision
+
+Phase 41A is **docs / decision gate only**.
+
+- Phase 41A **follows Phase 40B** (the internal demo guide).
+- It **does not implement live Dixie-backed Discord recall.** No source,
+  test, package, lockfile, fixture, config, CI, or generated change is
+  introduced by Phase 41A.
+- It **does not change `/recall-wedge-demo`.**
+- It **does not add or authorize public channel-visible recall.**
+- It **does not add memory admission.**
+- It **does not add candidate-memory writes.**
+- It **does not add "remember this."**
+- It **does not add** Telegram, private chat, storage / admission,
+  production auth / consent, LLM rewriting, character voice, or public
+  renderer expansion.
+
+### A.1 Decision sentence
+
+**Phase 41A authorizes only a future Phase 41B decision/implementation
+slice for a separate dev/operator-only `/recall-wedge-live-demo` command
+that may consume the existing Phase 37C live Dixie client after Discord
+gates pass; `/recall-wedge-demo` remains harness-backed,
+public-channel-visible recall remains blocked, and memory admission
+remains blocked.**
+
+This authorization is conditional. It selects the next decision
+boundary only — it does not implement Phase 41B, and it does not
+pre-approve any Phase 41B PR. A future Phase 41B carries its own scope
+(§F), its own required gates (§G), its own input / output boundaries
+(§H, §I), its own lazy-load / network boundary (§J), its own logging
+boundary (§K), and its own acceptance criteria (§M). Everything Phase
+39A / 39D / 39E / 40A / 40B blocked stays blocked here (§O).
+
+---
+
+## B. Source evidence
+
+This decision gate is grounded in the following artifacts. **These
+source / test files are evidence only; Phase 41A modifies none of
+them.** No new code path is introduced or authorized here.
+
+Decision-doc evidence:
+
+- `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` — Phase 37B live Dixie
+  client gate; the authority that scoped the Phase 37C operator/dev-only
+  live client and listed its required tests / static guards (its §C–§K).
+  Gains a Phase 41A note; not rewritten.
+- `docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md` — Phase 40A
+  post-smoke-test decision gate; selected Phase 40B then a possible
+  Phase 40C. Gains a Phase 41A note.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md` — Phase 40B internal
+  demo guide; the operator-facing how-to-demo-safely artifact for the
+  harness demo. Gains a Phase 41A note.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md` — Phase 39E
+  smoke-test acceptance; the redacted real-guild evidence for the
+  harness demo.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md` — Phase 39D
+  operational runbook; the governing register / enable / invoke /
+  disable / remove procedure for the harness demo.
+- `docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md` — Phase 39A
+  controlled-surface decision gate; the authority that defined the
+  dev-only / guild-only / operator-only / ephemeral / harness-backed
+  posture.
+- `docs/RECALL-WEDGE-MULTI-SURFACE-HARNESS-ACCEPTANCE.md` — Phase 38B
+  acceptance of the Phase 38A multi-surface harness that backs the
+  current demo's rendered output.
+
+Source / test evidence (read only; **Phase 41A modifies none of
+these**):
+
+- `apps/bot/src/discord-interactions/recall-wedge-demo.ts` — the Phase
+  39B handler. Source of the env gate helpers
+  (`shouldEnableRecallWedgeDiscordDemo`,
+  `isRecallWedgeDiscordDemoAllowedGuild`,
+  `isRecallWedgeDiscordDemoOperator`,
+  `shouldRegisterRecallWedgeDiscordDemo`,
+  `resolveRecallWedgeDiscordDemoGuildId`), the fixed `case` enum selector
+  (`served` / `denied`), the ephemeral-only response builder, the single
+  generic refusal string (`recall-wedge-demo is not available here.`),
+  the fixed framing header, and the final banned-substring no-leak scan.
+  It is harness-backed and **does not import the Phase 37C live client.**
+- `apps/bot/src/discord-interactions/recall-wedge-demo.test.ts` — Phase
+  39B / 39C regression / static-guard tests, including the static guard
+  that the handler never imports the live Dixie client.
+- `packages/persona-engine/src/recall-wedge/live-dixie-client.ts` — the
+  Phase 37C operator/dev-only live Dixie client. Source of the live
+  intake path constant (`LIVE_DIXIE_CLIENT_INTAKE_PATH =
+  "/api/recall/intake"`), the env config it reads (§G), and the
+  classification vocabulary it narrows responses into (§I).
+- `packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts` —
+  Phase 37C client tests proving missing-env fail-closed, unknown-shape
+  fail-closed, service-auth-vs-end-user-auth separation, idempotency-key
+  requirement, and no-leak of raw / private / debug / source fields.
+- `packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts`
+  — the Phase 37C operator/dev-only runner over the live client;
+  partitioned operator output; no Discord / Telegram / storage / LLM
+  dispatch.
+- `packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts`
+  — Phase 37C runner regression tests against fake / stub classifiers
+  (no real network) proving no public-bound leak, no command
+  registration, no storage write, and partitioned output.
+
+State clearly:
+
+- these source / test files are **evidence only**;
+- **Phase 41A modifies none of them**;
+- Phase 41A introduces no new source, test, fixture, package, lockfile,
+  config, CI, or generated file.
+
+---
+
+## C. Proven state before Phase 41A
+
+The Recall Wedge ladder is accepted through Phase 40B. Summarized so a
+future reader does not re-derive it:
+
+- **Phase 37C proved an operator/dev-only live Dixie client seam.** The
+  live client (`live-dixie-client.ts`) and its runner
+  (`run-live-dixie-recall-demo.ts`) call Dixie's
+  `POST /api/recall/intake`, classify the response into a narrow local
+  result type, and partition operator output. They are the **only** live
+  Dixie seam in the repo, and they are **not reachable from Discord**.
+- **Phase 38A / 38B proved multi-surface projection harness
+  boundaries.** The Phase 38A harness binds the same continuity actor /
+  same recall result to a taxonomy of surface frames
+  (`operator_dev`, `public_discord_simulated`,
+  `public_telegram_simulated`, `authorized_private_session_simulated`,
+  `private_chat_simulated`, `character_frame_public`) and asserts each
+  frame's allowed projection or fail-closed refusal. Phase 38B accepted
+  it. The harness consumes injected / fake `LiveDixieRecallResult`-shaped
+  values; it does not call the Phase 37C live client and makes no network
+  call.
+- **Phase 39B / 39C implemented a controlled Discord harness command and
+  registration gate.** Phase 39B added the `/recall-wedge-demo` handler
+  (guild-scoped, operator-gated, ephemeral, fixed `case` enum selector,
+  generic refusal, banned-substring no-leak scan). Phase 39C added the
+  disabled-by-default, guild-scoped-only registration gate. The handler
+  renders Phase 38A harness output and **does not import the Phase 37C
+  live client.**
+- **Phase 39E proved a real Discord smoke test for `/recall-wedge-demo`.**
+  A human operator ran the Phase 39D smoke test in one configured guild
+  (redacted observations only): guild-scoped registration with no global,
+  operator-gated ephemeral harness output for `served` and `denied`, and
+  the single generic ephemeral refusal for a non-operator.
+- **Phase 40A selected Phase 40B then a possible Phase 40C.** Phase 40B
+  added the internal demo guide; Phase 40C (a guild-scoped
+  de-registration helper) remains optional / deferred.
+- **Phase 40B added the internal demo guide** — an operator-facing
+  how-to-demo-safely artifact layered on the Phase 39D runbook.
+- **The existing `/recall-wedge-demo` is harness-backed only.** It renders
+  the Phase 38A multi-surface harness from a fixed fixture; it does not
+  call live Dixie.
+- **No current Discord command calls live Dixie.** The only live Dixie
+  path is the Phase 37C operator/dev-only client / runner, which no
+  Discord surface imports or invokes.
+
+---
+
+## D. Why not Phase 40C now
+
+Phase 40A selected Phase 40B (done) and then a *possible* Phase 40C — a
+guild-scoped de-registration helper — **only if still needed**. Phase
+41A does not do 40C now, for these reasons:
+
+- **Phase 40C is optional operational cleanup.** It would make teardown
+  less error-prone, but it does not extend the proof and is not on any
+  critical path.
+- **Manual disable / removal already exists through the Phase 39D
+  runbook.** Disable invocation (runbook §K.1), disable registration
+  (runbook §K.2), and manual removal (runbook §L — Discord Developer
+  Portal / client, a scoped `DELETE` against the specific guild command
+  ID with placeholders only, or reverting the Phase 39B / 39C commits)
+  cover teardown today. The Phase 40B guide §M points back to that
+  procedure.
+- **No current blocker requires a helper.** Nothing in the accepted state
+  is blocked on automated de-registration; the manual procedure is
+  sufficient for the controlled demo posture.
+- **The more valuable next proof is whether Discord can safely consume
+  live Dixie output under the same tight gates.** That question — not
+  teardown ergonomics — is the meaningful next boundary, so Phase 41A
+  opens that decision lane (Phase 41B) instead of doing 40C.
+- **Phase 40C remains available later.** If manual de-registration
+  becomes risky or annoying, Phase 40C can be picked up as its own phase
+  under the constraints Phase 40A §E already set (guild-scoped only, no
+  global-delete, no handler-behavior change, tests / static guards, no
+  secrets).
+
+---
+
+## E. Separate command decision
+
+- **Future live-Dixie Discord work must not silently replace the harness
+  output of `/recall-wedge-demo`.** The accepted harness demo is the
+  smoke-tested, operator-facing artifact; turning it into a live producer
+  in place would erase the boundary between fixture proof and live proof.
+- **Future implementation should use a separate command name:
+  `/recall-wedge-live-demo`.**
+- Reasons:
+  - **preserves the accepted harness demo** — `/recall-wedge-demo` stays
+    exactly what Phase 39E accepted and Phase 40B documented;
+  - **avoids confusing fixture proof with live producer proof** — two
+    names keep "this is a fixed fixture" and "this called a live
+    producer" visibly distinct to operators and reviewers;
+  - **keeps registration / runtime / env gates separable** — the live
+    command gets its own env gates (§G), so it can be registered,
+    enabled, and torn down independently;
+  - **allows disabling the live path without disabling the harness demo**
+    — turning the live command off must never affect the harness demo,
+    and vice versa;
+  - **makes audit and operator language clearer** — every log line,
+    refusal, and guide sentence can name which command and which posture
+    (harness vs live) without ambiguity.
+
+---
+
+## F. Future Phase 41B allowed scope
+
+A future Phase 41B is **possibly allowed**, and only under **all** of the
+following constraints. Phase 41A authorizes Phase 41B as a decision /
+implementation *slice*, not as an approved PR:
+
+- **dev/operator-only;**
+- **disabled by default;**
+- **guild-scoped registration only;**
+- **operator-gated invocation only;**
+- **ephemeral-only responses;**
+- **separate command `/recall-wedge-live-demo`;**
+- **no mutation to `/recall-wedge-demo`** (handler, registration,
+  dispatch, or rendering);
+- **no public channel-visible output;**
+- **no freeform recall query;**
+- **no Discord message history input;**
+- **no memory admission;**
+- **no candidate-memory writes;**
+- **no "remember this";**
+- **no production auth / consent claim;**
+- **no Telegram / private chat;**
+- **no LLM rewriting or character voice;**
+- **no public renderer expansion;**
+- **no package / lockfile changes** unless a concrete blocker appears and
+  is named in that phase;
+- **must include tests / static guards if implementation happens** (at
+  minimum the §M acceptance criteria).
+
+If Phase 41B finds itself reaching for any item Phase 41A blocks (§O), it
+has crossed this gate's boundary and must re-open the gate that owns the
+item before proceeding.
+
+---
+
+## G. Future Phase 41B required gates
+
+Phase 41B's env / config gates must be **separate live-command gates, not
+reuse of the harness command gates.** The harness demo's gates
+(`RECALL_WEDGE_DISCORD_DEMO_ENABLED`, `RECALL_WEDGE_DISCORD_DEMO_GUILD_ID`,
+`RECALL_WEDGE_DISCORD_DEMO_OPERATOR_USER_IDS`,
+`RECALL_WEDGE_DISCORD_DEMO_REGISTER_COMMANDS`) must keep governing only
+`/recall-wedge-demo`. The live command gets its own:
+
+- **`RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED`** must be the exact string
+  `"true"` to enable invocation (fail-closed on any other value, including
+  `TRUE` / `True` / `1` / `yes` / surrounding whitespace / unset).
+- **`RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS`** must be the exact
+  string `"true"` before the live command is registered.
+- **`RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID`** must be present and
+  non-empty; it scopes both registration and invocation to one guild.
+- **`RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS`** must be present
+  and non-empty; it is the operator invocation allowlist.
+
+Also:
+
+- **Phase 37C live Dixie client config / secrets remain separate** and
+  must follow the existing live Dixie client gate / runbook. The Phase
+  37C client reads its own env — `RECALL_WEDGE_DIXIE_BASE_URL`,
+  `RECALL_WEDGE_DIXIE_SERVICE_TOKEN`, `RECALL_WEDGE_DIXIE_TENANT_ID`,
+  `RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID`,
+  `RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX`, and optional
+  `RECALL_WEDGE_DIXIE_TIMEOUT_MS` — per
+  `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` §G. Phase 41B does not
+  redefine those; it gates *whether Discord may reach the client*, not
+  *how the client authenticates to Dixie*.
+- **No tokens, service credentials, app IDs, guild IDs, command IDs, or
+  user IDs may be recorded** in docs, logs, PRs, or screenshots. The
+  repo's `.env.example` may list variable **names**; it must not list
+  values.
+- **Registration must never fall back to global if the guild ID is
+  missing.** A missing or empty `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID`
+  fails closed — no registration — the same never-global posture the
+  Phase 39C registration path proves for the harness command.
+
+---
+
+## H. Live Dixie request / input decision
+
+Future Phase 41B:
+
+- **must not accept arbitrary freeform recall text;**
+- **must not read Discord message history;**
+- **must not use Discord channel content as recall input;**
+- **must not admit user text as memory** (no candidate write, no
+  admission, no "remember this");
+- **may use one of:**
+  1. **a fixed deterministic operator/dev request shape** aligned to the
+     Phase 37C live client (the same explicit operator-provided
+     tenant / caller / request-key inputs the Phase 37C client / runner
+     already construct), or
+  2. **a finite enum selector over pre-reviewed request shapes** (the
+     same shape as the harness command's fixed `served` / `denied`
+     `case` enum — a small, closed set, never a text field),
+
+  **but only if** the request source is code-reviewed and tests prove
+  **no freeform query path exists** — no Discord option that accepts
+  arbitrary text reaches the request builder, and no Discord message
+  content is read into the request.
+- **References, not invented secrets:** the Phase 37C client's request
+  construction and its config names are documented in
+  `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` §G / §H and implemented in
+  `packages/persona-engine/src/recall-wedge/live-dixie-client.ts`. Phase
+  41B references those; it does not invent secret values, and it does not
+  record any real value in docs / logs / PRs.
+
+The principle: the **only** inputs that can reach the live Dixie request
+from Discord are a fixed shape or a finite pre-reviewed enum chosen by an
+allowlisted operator — never user-authored text and never channel
+history.
+
+---
+
+## I. Live Dixie response / output decision
+
+Future Phase 41B:
+
+- **must not dump raw Dixie responses;**
+- **must narrow / classify the live Dixie result before rendering** —
+  reuse the Phase 37C classifier (the exported
+  `LIVE_DIXIE_RECALL_CLASSIFICATIONS` vocabulary in
+  `live-dixie-client.ts`: `served`, `denied_or_forbidden`,
+  `needs_review`, `ingress_invalid_request`, `service_unauthorized`,
+  `tenant_or_session_mismatch`, `rate_limited`, `upstream_unavailable`,
+  `unsupported_response_shape`, `network_error`, plus the pre-network
+  config / safety classes `missing_required_env`, `invalid_config`, and
+  `unsafe_idempotency_key_reuse`) so only the narrow local result type,
+  never raw response material, reaches the Discord render path. The three
+  pre-network classes (`missing_required_env`, `invalid_config`,
+  `unsafe_idempotency_key_reuse`) are emitted *before* any HTTP round-trip
+  and map directly onto the §J fail-closed-before-egress requirement;
+- **must run a no-leak scan over the final Discord output** — the same
+  banned-substring posture used by the harness handler's final scan and
+  by `render-public-recall.ts` / the Phase 33B no-leak validator;
+- **must expose only public-safe or operator-safe summaries;**
+- **must not expose** `raw_reasons`, debug payloads, source fields,
+  private identifiers, raw assertion IDs, service errors, stack traces,
+  tokens, or operational IDs;
+- **unknown response shapes must fail closed** — `unsupported_response_shape`
+  renders a generic ephemeral refusal, never a best-effort parse;
+- **Dixie 4xx / 5xx / network errors must fail closed** — classified
+  (`service_unauthorized`, `ingress_invalid_request`,
+  `tenant_or_session_mismatch`, `rate_limited`, `upstream_unavailable`,
+  `network_error`) and rendered as a public-safe / operator-safe summary
+  or a generic ephemeral refusal, never raw upstream text;
+- **guard / cap / rate-limit conditions must be classified safely**
+  (e.g. cap-exceeded refusals collapse into `rate_limited`) and rendered
+  without raw upstream messages;
+- **if a response cannot be safely narrowed, render a generic ephemeral
+  refusal or a public-safe operator summary** — never the raw response.
+
+The principle: between live Dixie and the Discord render path sits the
+Phase 37C classifier plus a final no-leak scan; nothing raw, private,
+debug, or upstream-error-shaped survives to the ephemeral operator
+response.
+
+---
+
+## J. Lazy-load / network boundary
+
+Future Phase 41B implementation must:
+
+- **evaluate Discord enabled / guild / operator gates before
+  importing / calling the live Dixie client** — the `enabled`,
+  `guild`, and `operator` checks run first, and only an allowlisted
+  operator in the configured guild on an enabled command reaches the
+  live path;
+- **make no live Dixie request on disabled, wrong-guild, non-operator, or
+  empty-allowlist paths** — every refused path returns the generic
+  ephemeral refusal with zero network egress;
+- **keep all live network egress isolated to the Phase 37C live Dixie
+  client or a narrow wrapper around it** — Discord code must not open its
+  own HTTP path to Dixie; the only egress is through
+  `live-dixie-client.ts`;
+- **preserve tests proving refused paths do not call Dixie** — tests must
+  assert that disabled / wrong-guild / non-operator / empty-allowlist
+  invocations perform no network call and never import / invoke the live
+  client;
+- **preserve the existing `/recall-wedge-demo` static guard that it never
+  imports live Dixie** — the Phase 39B handler's static guard (in
+  `recall-wedge-demo.test.ts`) stays intact; the harness demo must remain
+  provably harness-only even after the live command exists.
+
+The principle: the live client is loaded / called **after** the Discord
+gates pass, never before — so a refused invocation is indistinguishable
+from the harness demo's refusal and touches no network.
+
+---
+
+## K. Logging and diagnostics boundary
+
+Future Phase 41B:
+
+- **no secrets in logs** — no tokens, service credentials, app / guild /
+  command / user IDs;
+- **no raw Dixie payloads in Discord output** — only the narrowed,
+  no-leak-scanned summary reaches the operator;
+- **safe operator diagnostics only if they contain no IDs / secrets /
+  private fields** — stable reason codes are fine; raw upstream text,
+  identifiers, and payloads are not;
+- **public-facing refusal remains generic** — the same single generic
+  ephemeral refusal posture the harness command uses; the refusal never
+  reveals which gate tripped or why Dixie refused;
+- **logs must not claim production auth / consent** — the live command is
+  an operator/dev spike, not a consent system; log language must not
+  imply otherwise;
+- **errors should be classified with stable safe reason codes, not raw
+  upstream messages** — map to the Phase 37C classification vocabulary
+  (§I) and emit the code, not the upstream string / stack / payload.
+
+---
+
+## L. What Phase 41A proves / does not prove
+
+**Proves:**
+
+- only the **next decision boundary is selected** — a separate
+  `/recall-wedge-live-demo` command under strict gates is the chosen
+  shape for any future live-Dixie Discord work;
+- **live Dixie-backed Discord recall may be explored only through a
+  separate command and strict gates** — never by mutating the harness
+  demo, never freeform, never public-channel-visible;
+- the **existing harness demo remains intact** — `/recall-wedge-demo`
+  stays exactly what Phase 39E accepted and Phase 40B documented.
+
+**Does not prove:**
+
+- live Dixie works from Discord;
+- production recall;
+- production auth / consent;
+- public rollout;
+- public channel-visible recall;
+- memory admission;
+- storage / admission;
+- Telegram / private chat;
+- LLM / voice;
+- generalized agent memory solved.
+
+---
+
+## M. Future Phase 41B acceptance criteria
+
+If Phase 41B happens, it must include:
+
+- **a separate command implementation** (`/recall-wedge-live-demo`) **or a
+  decision not to implement;**
+- a **separate registration gate** (`RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS`
+  + `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID`, guild-scoped only, never
+  global);
+- a **separate invocation gate** (`RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED`
+  + `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID` +
+  `RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS`);
+- **strict guild / operator / ephemeral behavior** on every path;
+- **lazy import / call after gates** — no live client import / call
+  before the Discord gates pass (§J);
+- **fixed / finite input only** — a fixed deterministic request shape or a
+  finite pre-reviewed enum (§H);
+- **no freeform query;**
+- **no Discord history input;**
+- **live Dixie client integration only through the allowed seam** — the
+  Phase 37C client or a narrow wrapper around it (§J);
+- **response narrowing / classification** before any render (§I);
+- a **no-leak scan** over the final Discord output (§I);
+- **fail-closed unknown / error paths** (§I);
+- **tests / static guards** for: refused paths make no network call; the
+  command imports the live client only on the post-gate path; no freeform
+  query path exists; no Discord history is read; the no-leak scan holds
+  against contaminated responses; `/recall-wedge-demo`'s never-imports-live
+  static guard still passes;
+- **no source modifications outside the narrow implementation files** (the
+  new live command handler / its registration / its tests — and not
+  `recall-wedge-demo.ts`, `render-public-recall.ts`,
+  `dixie-envelope-adapter.ts`, or the Phase 38A harness);
+- **no package / lockfile changes unless justified** by a concrete named
+  blocker;
+- **no production claims.**
+
+---
+
+## N. Future Phase 41C smoke-test acceptance, if Phase 41B happens
+
+- If Phase 41B is implemented, the next acceptance should be **Phase
+  41C.**
+- Phase 41C should be a **smoke-test acceptance report similar to Phase
+  39E** (`docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md`).
+- It should **record live registration / invocation evidence with
+  redacted IDs / secrets** — guild-scoped registration with no global,
+  operator-gated ephemeral output, non-operator fail-closed.
+- It should **record success and fail-closed behavior** — a successful
+  narrowed live result on the served path, and fail-closed behavior on
+  unknown-shape / error / refusal / non-operator paths.
+- It should **not include screenshots / raw IDs / tokens.**
+- It should **not authorize public rollout** — Phase 41C is acceptance of
+  the controlled live demo only, not a launch.
+
+---
+
+## O. Blocked work remains blocked
+
+The following remain explicitly blocked. **None is authorized by Phase
+41A** (this carries forward the Phase 40A §I / Phase 39E §J / runbook §D
+blocked-work list, plus the items Phase 41A's own scope bars):
+
+- mutation of `/recall-wedge-demo` into a live command;
+- public channel-visible recall;
+- global registration;
+- production / public rollout;
+- freeform recall query input;
+- Discord message history as memory input;
+- memory admission;
+- candidate-memory writes;
+- "remember this";
+- Telegram;
+- private chat;
+- storage / admission;
+- production auth / consent;
+- direct Finn runtime / audit wiring beyond existing seams;
+- LLM rewriting;
+- character voice;
+- public renderer expansion;
+- positive `public_telegram` support;
+- positive `authorized_private_session` support.
+
+If a later phase needs any item above, it must propose a phase naming the
+item, the proof obligation it carries, and the decision artifact it
+re-opens. Phase 41A authorizes none of them, and a future Phase 41B is
+explicitly barred from all of them (§F).
+
+---
+
+## P. Acceptance criteria for Phase 41A
+
+Phase 41A is acceptable if:
+
+- the **decision doc is added** (this file);
+- the **decision map is updated** with a targeted Phase 41A addendum
+  (`docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md`);
+- the **live Dixie client gate is updated or cross-referenced**
+  (`docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` gains a Phase 41A note);
+- the **internal guide is updated or cross-referenced if useful**
+  (`docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md` gains a Phase 41A
+  note);
+- **no source / test / package / lockfile / fixture / config / CI /
+  generated changes** are made;
+- **no screenshots / images / binary files** are committed;
+- **no secrets / raw IDs** are committed;
+- **Phase 41B is only authorized as a future gated slice**, not
+  implemented;
+- **Phase 41A implements nothing.**
+
+---
+
+## Q. Cross-references
+
+- `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` — Phase 37B live Dixie
+  client gate; the live client seam, its env config, and its
+  classification vocabulary; gains a Phase 41A note.
+- `docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md` — Phase 40A
+  post-smoke-test decision gate; gains a Phase 41A note.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md` — Phase 40B internal
+  demo guide; gains a Phase 41A note.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md` — Phase 39E
+  smoke-test acceptance; the harness-demo evidence; the Phase 41C
+  template.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md` — Phase 39D
+  operational runbook; the governing register / enable / invoke /
+  disable / remove procedure.
+- `docs/RECALL-WEDGE-DISCORD-SURFACE-DECISION-GATE.md` — Phase 39A
+  controlled-surface decision gate; the authority that defined the
+  posture.
+- `docs/RECALL-WEDGE-MULTI-SURFACE-HARNESS-ACCEPTANCE.md` — Phase 38B
+  acceptance of the harness backing the current demo.
+- `docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md` — Phase 35A option matrix;
+  gains a Phase 41A addendum.
+- `apps/bot/src/discord-interactions/recall-wedge-demo.ts` — Phase 39B
+  harness handler and env gates (unchanged by Phase 41A; not mutated by a
+  future Phase 41B).
+- `apps/bot/src/discord-interactions/recall-wedge-demo.test.ts` — Phase
+  39B / 39C regression / static-guard tests, including the never-imports-
+  live-Dixie guard (unchanged by Phase 41A).
+- `packages/persona-engine/src/recall-wedge/live-dixie-client.ts` — Phase
+  37C operator/dev-only live Dixie client (unchanged by Phase 41A; the
+  only allowed live seam for a future Phase 41B).
+- `packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts` —
+  Phase 37C client tests (unchanged by Phase 41A).
+- `packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts`
+  — Phase 37C operator/dev-only runner (unchanged by Phase 41A).
+- `packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts`
+  — Phase 37C runner regression tests (unchanged by Phase 41A).

--- a/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+++ b/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
@@ -584,6 +584,61 @@ that the Phase 40A-selected internal-guide step is now fulfilled.
 
 ---
 
+### 5j. Phase 41A addendum — live-Dixie Discord decision lane opened; separate `/recall-wedge-live-demo` command, Phase 40C deferred
+
+> Added by Phase 41A
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md`).
+> Targeted addendum, not a rewrite of this section.
+
+Status as of Phase 41A:
+
+- **Phase 41A is docs / decision only.** It adds no source, test,
+  package, lockfile, fixture, config, CI, or generated change, and no
+  handler / registration / dispatch behavior change. It implements
+  nothing.
+- **Phase 40C de-registration helper is deferred / only-if-needed.** The
+  Phase 39D runbook §L manual removal remains sufficient; no current
+  blocker requires a helper. Phase 40C stays available later if manual
+  de-registration becomes risky or annoying.
+- **Future live Dixie-backed Discord work must use a separate command
+  `/recall-wedge-live-demo`.** It must not silently replace the harness
+  output of `/recall-wedge-demo`, which preserves the accepted harness
+  demo, keeps fixture proof distinct from live producer proof, keeps the
+  registration / runtime / env gates separable, and clarifies audit /
+  operator language.
+- **`/recall-wedge-demo` remains harness-backed.** It is untouched by
+  Phase 41A and must not be mutated into a live command by any future
+  phase.
+- **A future Phase 41B may be considered** only under strict
+  disabled-by-default / guild-scoped / operator-gated / ephemeral-only
+  gates, with no freeform query, no Discord message history input, no
+  memory admission, no candidate writes, no "remember this," no
+  production auth / consent, no Telegram / private chat, no LLM / voice,
+  and no public renderer expansion. It may call the Phase 37C live Dixie
+  client only after the Discord gates pass, behind separate env gates
+  (`RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED` /
+  `RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS` /
+  `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID` /
+  `RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS`), with response
+  narrowing, a no-leak scan, and fail-closed unknown / error paths.
+- **Public-channel-visible recall remains blocked** behind its own
+  separate later gate, as do memory admission, Telegram, private chat,
+  storage / admission, production auth / consent, LLM rewriting, and
+  character voice.
+- **No implementation is authorized by Phase 41A.** Phase 41B is
+  authorized only as a future gated decision / implementation slice with
+  its own scope, gates, and acceptance, defined in the Phase 41A gate
+  doc.
+
+This addendum does not duplicate the Phase 41A gate doc; it only updates
+the post-MVP option matrix's **next-decision-lane** answer from "Phase
+40B internal demo guide, then possible Phase 40C guild-scoped
+de-registration helper" to "Phase 40C deferred; the next meaningful
+proof boundary is a separate-command live-Dixie Discord decision (future
+Phase 41B), not implemented by Phase 41A."
+
+---
+
 ## 6. Decision gates before live Dixie client (Option C)
 
 Before a live Dixie client is allowed, all of the following must hold:

--- a/docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md
+++ b/docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md
@@ -417,3 +417,32 @@ Phase 40A is acceptable if:
   (unchanged by Phase 40A).
 - `apps/bot/src/discord-interactions/dispatch.ts` — routes
   `/recall-wedge-demo` to the handler (unchanged by Phase 40A).
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` — Phase 41A
+  live-Dixie Discord decision gate; opens the separate-command live-Dixie
+  decision lane (see the Phase 41A note below).
+
+---
+
+## L. Phase 41A note — Phase 40B fulfilled; 40C deferred; a separate live-Dixie Discord decision lane opened
+
+> Added by Phase 41A
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md`). Short note,
+> not a rewrite of this gate.
+
+- **Phase 40B fulfilled the internal demo guide step** selected in §E
+  (`docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md`).
+- **Phase 40C remains optional / deferred.** The Phase 39D runbook §L
+  manual removal is sufficient; no current blocker requires a helper.
+- **Phase 41A opens a separate live-Dixie Discord decision lane only as a
+  decision gate** — it selects, for any future live-Dixie Discord work, a
+  separate dev/operator-only command `/recall-wedge-live-demo` under
+  strict disabled-by-default / guild-scoped / operator-gated /
+  ephemeral / no-freeform / no-history / no-memory-admission gates that
+  may call the Phase 37C live client only after Discord gates pass. It
+  implements nothing.
+- **`/recall-wedge-demo` remains harness-backed** and is not mutated into
+  a live command.
+- **No runtime scope is added** by Phase 41A — no source / test / package
+  / lockfile / fixture / config / CI / generated change. Live
+  Dixie-backed Discord recall and public-channel-visible recall remain
+  blocked behind separate later gates (§F, §G, §I).


### PR DESCRIPTION
## Summary

Phase 41A adds the Live Dixie Discord decision gate.

This PR is docs / decision-gate only. It opens only a future, separate `/recall-wedge-live-demo` lane for possible live Dixie-backed Discord recall, while preserving the existing `/recall-wedge-demo` harness demo exactly as accepted.

It does not implement live Dixie-backed Discord recall.

## Files

New:

- docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md

Modified with targeted addenda / cross-references:

- docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
- docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md
- docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md
- docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md

Intentionally untouched:

- docs/RECALL-WEDGE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md
- docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md
- all source files
- all test files
- all package files
- all lockfiles
- fixture JSON
- config
- CI
- generated files
- screenshots/images/binary files
- Phase 39B handler
- Phase 39C registration code
- dispatch
- publish-command source/scripts
- Phase 38A harness source/tests
- Phase 37C live client/runner source/tests
- render-public-recall.ts
- dixie-envelope-adapter.ts

## Decision

Phase 41A authorizes only a future Phase 41B decision/implementation slice for a separate dev/operator-only `/recall-wedge-live-demo` command that may consume the existing Phase 37C live Dixie client after Discord gates pass; `/recall-wedge-demo` remains harness-backed, public-channel-visible recall remains blocked, and memory admission remains blocked.

## Proven state before Phase 41A

The decision gate records:

- Phase 37C proved an operator/dev-only live Dixie client seam
- Phase 38A / 38B proved multi-surface projection harness boundaries
- Phase 39B / 39C implemented a controlled Discord harness command and registration gate
- Phase 39E proved the real Discord smoke test for `/recall-wedge-demo`
- Phase 40A selected Phase 40B then possible Phase 40C
- Phase 40B added the internal demo guide
- existing `/recall-wedge-demo` is harness-backed only
- no current Discord command calls live Dixie

## Phase 40C deferral

Phase 40C remains optional / only-if-needed.

The decision gate defers Phase 40C because:

- it is operational cleanup, not the next proof boundary
- manual disable/removal already exists through the Phase 39D runbook
- no current blocker requires a helper
- the more valuable next proof is whether Discord can safely consume live Dixie output under the same tight gates
- Phase 40C remains available later if manual de-registration becomes risky or annoying

## Separate command decision

Future live-Dixie Discord work must not silently replace the harness output of `/recall-wedge-demo`.

Any future implementation should use a separate command:

- `/recall-wedge-live-demo`

Reasons:

- preserves the accepted harness demo
- avoids confusing fixture proof with live producer proof
- keeps registration/runtime/env gates separable
- allows disabling the live path without disabling the harness demo
- makes audit and operator language clearer

## Future Phase 41B allowed scope

A future Phase 41B is only possibly allowed under all of these constraints:

- dev/operator-only
- disabled by default
- guild-scoped registration only
- operator-gated invocation only
- ephemeral-only responses
- separate command `/recall-wedge-live-demo`
- no mutation to `/recall-wedge-demo`
- no public channel-visible output
- no freeform recall query
- no Discord message history input
- no memory admission
- no candidate-memory writes
- no “remember this”
- no production auth/consent claim
- no Telegram/private chat
- no LLM rewriting or character voice
- no public renderer expansion
- no package/lockfile changes unless a concrete blocker is named
- must include tests/static guards if implementation happens

## Future env/gate decision

Future live-command gates must be separate from the harness command gates:

- `RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED` must be exact `"true"`
- `RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS` must be exact `"true"` before registration
- `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID` must be present and non-empty
- `RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS` must be present and non-empty

The Phase 37C live Dixie client env/config remains separate:

- `RECALL_WEDGE_DIXIE_BASE_URL`
- `RECALL_WEDGE_DIXIE_SERVICE_TOKEN`
- `RECALL_WEDGE_DIXIE_TENANT_ID`
- `RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID`
- `RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX`
- optional `RECALL_WEDGE_DIXIE_TIMEOUT_MS`

No tokens, service credentials, app IDs, guild IDs, command IDs, or user IDs may be recorded in docs, logs, PRs, or screenshots.

Registration must never fall back to global if guild ID is missing.

## Live Dixie request/input boundary

Future Phase 41B:

- must not accept arbitrary freeform recall text
- must not read Discord message history
- must not use Discord channel content as recall input
- must not admit user text as memory
- may use either:
  - a fixed deterministic operator/dev request shape aligned to the Phase 37C live client; or
  - a finite enum selector over pre-reviewed request shapes
- must prove through tests that no freeform query path exists
- must not invent or record secret values

## Live Dixie response/output boundary

Future Phase 41B:

- must not dump raw Dixie responses
- must narrow/classify the live Dixie result before rendering
- must reuse the Phase 37C classification vocabulary accurately
- must run a no-leak scan over final Discord output
- must expose only public-safe or operator-safe summaries
- must not expose raw_reasons, debug payloads, source fields, private identifiers, raw assertion IDs, service errors, stack traces, tokens, or operational IDs
- must fail closed on unknown response shapes
- must fail closed on Dixie 4xx / 5xx / network errors
- must classify guard/cap/rate-limit conditions safely
- must render generic ephemeral refusal or public-safe operator summary if a response cannot be safely narrowed

The Phase 37C classification vocabulary recorded by this gate includes:

- `served`
- `denied_or_forbidden`
- `needs_review`
- `ingress_invalid_request`
- `service_unauthorized`
- `tenant_or_session_mismatch`
- `rate_limited`
- `upstream_unavailable`
- `unsupported_response_shape`
- `network_error`
- `missing_required_env`
- `invalid_config`
- `unsafe_idempotency_key_reuse`

## Lazy-load / network boundary

Future implementation must:

- evaluate Discord enabled/guild/operator gates before importing or calling the live Dixie client
- make no live Dixie request on disabled, wrong-guild, non-operator, or empty-allowlist paths
- keep all live network egress isolated to the Phase 37C live Dixie client or a narrow wrapper
- preserve tests proving refused paths do not call Dixie
- preserve the existing `/recall-wedge-demo` static guard that it never imports live Dixie

## Logging / diagnostics boundary

Future implementation must preserve:

- no secrets in logs
- no raw Dixie payloads in Discord output
- safe operator diagnostics only if they contain no IDs/secrets/private fields
- generic public-facing refusal
- no production auth/consent claims
- stable safe reason codes instead of raw upstream messages

## Proof / non-proof

Phase 41A proves only:

- the next decision boundary is selected
- live Dixie-backed Discord recall may be explored only through a separate command and strict gates
- the existing harness demo remains intact

Phase 41A does not prove:

- live Dixie works from Discord
- production recall
- production auth/consent
- public rollout
- public channel-visible recall
- memory admission
- storage/admission
- Telegram/private chat
- LLM/voice
- generalized agent memory solved

## Future Phase 41B / 41C acceptance

Future Phase 41B must include:

- separate command implementation or decision not to implement
- separate registration gate
- separate invocation gate
- strict guild/operator/ephemeral behavior
- lazy import/call after gates
- fixed/finite input only
- no freeform query
- no Discord history input
- live Dixie client integration only through allowed seam
- response narrowing/classification
- no-leak scan
- fail-closed unknown/error paths
- tests/static guards
- no source modifications outside narrow implementation files
- no package/lockfile changes unless justified
- no production claims

If Phase 41B is implemented, Phase 41C should be a smoke-test acceptance report similar to Phase 39E:

- redacted live registration/invocation evidence
- success and fail-closed behavior
- no screenshots/raw IDs/tokens
- no public rollout authorization

## Blocked work remains blocked

Phase 41A keeps blocked:

- mutation of `/recall-wedge-demo` into a live command
- public channel-visible recall
- global registration
- production/public rollout
- freeform recall query input
- Discord message history as memory input
- memory admission
- candidate-memory writes
- “remember this”
- Telegram
- private chat
- storage/admission
- production auth/consent
- direct Finn runtime/audit wiring beyond existing seams
- LLM rewriting
- character voice
- public renderer expansion
- positive public_telegram support
- positive authorized_private_session support

## Addenda

This PR adds:

- a Phase 41A addendum to docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
- a Phase 41A note to docs/RECALL-WEDGE-POST-SMOKE-TEST-DECISION-GATE.md
- a Phase 41A note to docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md
- a Phase 41A note to docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md

The operational runbook and smoke-test acceptance docs are intentionally untouched to avoid churn.

## Results

Validation commands run:

- git status --short --branch --untracked-files=all
- git diff --name-status
- git diff --stat
- git diff --check
- node docs/recall-wedge/fixtures/validate-fixtures.mjs
- bun test apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
- bun run --cwd apps/bot typecheck --pretty false
- grep typecheck output for recall-wedge-demo / multi-surface-recall-harness / live-dixie / TS6059 / rootDir
- secret/raw-ID scan on changed docs
- git diff --cached --name-status
- git diff --cached --stat
- git diff --cached --check

Results:

- git diff --check: clean
- fixture validator: 122 passed, 0 failed
- Phase 39C Discord demo registration tests: 116 passed, 0 failed, 339 expect() calls
- Phase 38A harness regression: 52 passed, 0 failed, 806 expect() calls
- Phase 37C live Dixie client + runner regressions: 104 passed, 0 failed, 437 expect() calls
- apps/bot typecheck: 151 errors, known dirty baseline
- no Phase 41A recall-wedge-demo / harness / live-dixie TS6059 rootDir references found
- no source/test/package/fixture/config/CI/generated files touched
- no raw Discord IDs, command IDs, app IDs, user IDs, tokens, screenshots, images, or binary evidence added
- staged diff check: clean
- Codex audit: ACCEPT
- no file/line concerns
- no required patch

## Non-goals

This PR intentionally does not add:

- source code changes
- test changes
- package changes
- lockfile changes
- fixture JSON changes
- config changes
- CI changes
- generated files
- screenshots/images/binary files
- handler behavior changes
- registration behavior changes
- dispatch changes
- publish-command source/script changes
- Phase 38A harness changes
- Phase 37C live client/runner changes
- render-public-recall changes
- dixie-envelope-adapter changes
- live Dixie calls
- live Dixie-backed Discord recall
- public channel-visible recall
- global registration
- Telegram API/bot/rendering wiring
- private chat integration
- production storage/admission
- memory admission
- candidate-memory writes
- remember-this behavior
- production auth/consent implementation
- direct Finn runtime/audit wiring beyond existing seams
- LLM rewriting
- character voice
- public renderer expansion
- production rollout
- Phase 40C de-registration helper implementation
- Phase 41B implementation
- Phase 41C smoke-test acceptance
