### PR TITLE
Phase 41B add gated live Dixie Discord recall demo

### DIFF
--- a/apps/bot/scripts/publish-commands.ts
+++ b/apps/bot/scripts/publish-commands.ts
@@ -24,6 +24,7 @@ import {
   fetchApplicationId,
   publishCommands,
   registerRecallWedgeDemoCommand,
+  registerRecallWedgeLiveDemoCommand,
 } from '../src/lib/publish-commands.ts';
 
 async function main(): Promise<void> {
@@ -93,6 +94,26 @@ async function main(): Promise<void> {
     } else {
       console.log(
         `publish-commands: /recall-wedge-demo NOT registered (${demo.reason})`,
+      );
+    }
+
+    // Phase 41B: dev/operator-only LIVE Dixie demo registration. SEPARATE from
+    // both the character publish above and the Phase 39C harness-demo POST — it
+    // never enters buildCommandSet (so it can never reach the global route).
+    // Skipped unless BOTH RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS ===
+    // "true" AND RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID is set; always
+    // guild-scoped.
+    const liveDemo = await registerRecallWedgeLiveDemoCommand({
+      botToken,
+      applicationId,
+    });
+    if (liveDemo.registered) {
+      console.log(
+        `publish-commands: registered dev-only /recall-wedge-live-demo → guild ${liveDemo.guildId} (id ${liveDemo.command.id})`,
+      );
+    } else {
+      console.log(
+        `publish-commands: /recall-wedge-live-demo NOT registered (${liveDemo.reason})`,
       );
     }
   } catch (err) {

--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -75,6 +75,10 @@ import {
   RECALL_WEDGE_DEMO_COMMAND_NAME,
   handleRecallWedgeDemoInteraction,
 } from './recall-wedge-demo.ts';
+import {
+  RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+  handleRecallWedgeLiveDemoInteraction,
+} from './recall-wedge-live-demo.ts';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_CHAR_LIMIT = 2000;
@@ -228,6 +232,25 @@ export async function dispatchSlashCommand(
     // handler's gates pass (no harness evaluation at bot startup). dispatch
     // is already async, so we simply await the gated response.
     return await handleRecallWedgeDemoInteraction(interaction);
+  }
+
+  // ─── Phase 41B · dev/operator-only LIVE Dixie Recall Wedge demo ────
+  // Authority: docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md (Phase
+  // 41A). SEPARATE command from `/recall-wedge-demo` — it never mutates or
+  // aliases the harness command. The handler evaluates its own enable / guild
+  // / operator gates FIRST and only then lazily imports the Phase 37C live
+  // Dixie client (the sole live-egress seam); a refused interaction loads no
+  // client and makes no network request. It fails closed to a single generic
+  // ephemeral refusal on every refused / unknown / unsafe / error path. Routed
+  // here — before character resolution / auth-bridge — because it is NOT
+  // character-bound and must not inherit the chat/imagegen async delivery
+  // path. No new logging is added: the handler enforces the §K no-raw-id /
+  // no-secret posture.
+  if (
+    !isQuest &&
+    interaction.data?.name === RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME
+  ) {
+    return await handleRecallWedgeLiveDemoInteraction(interaction);
   }
 
   // ─── Circuit breaker pre-check ─────────────────────────────────────

--- a/apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
@@ -1,0 +1,1367 @@
+// Phase 41B · dev/operator-only LIVE Dixie Recall Wedge demo command
+// (`/recall-wedge-live-demo`) regression + static-guard gate.
+// Authority: docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md (Phase 41A
+// §F–§M) under docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md (Phase 37B).
+//
+// What these tests prove:
+//   A. env gate exactness — ENABLED exact "true" only; near-truthy fail;
+//      missing/blank/non-matching guild fail; missing/blank operator allowlist
+//      fail; non-operator fails; allowlist parsing trims + drops empties.
+//   B. refused paths — disabled / wrong-guild / missing-guild / non-operator /
+//      empty-allowlist all return the SAME generic ephemeral refusal; every
+//      refused path is ephemeral; refused paths neither load nor call the live
+//      Dixie client.
+//   C. lazy live-client load/call — load + call happen only after gates pass;
+//      the injected seam counts loads + recall calls; a load failure after
+//      gates fails closed; a thrown live client fails closed; no network-like
+//      call occurs except via the injected fake (the one real-loader test
+//      throws on config before any egress).
+//   D. input source — no freeform query; no message-history inspection; the
+//      fixed synthetic probe (not interaction options) reaches the live client
+//      even when freeform-like options are smuggled in.
+//   E. success render — a served classification renders ephemeral live-demo
+//      output with dev framing + only safe classification/summary, no raw
+//      payload, passing the no-leak scan.
+//   F. error / classification render — every Phase 37C classification renders
+//      a safe summary or the generic refusal; unsupported_response_shape /
+//      network_error / unsafe_idempotency_key_reuse fail closed; config classes
+//      render a safe summary with no env values; contaminated summary falls
+//      back to the generic refusal.
+//   G. registration — disabled by default; exact "true" enables; near-truthy
+//      do not register; missing/blank guild does not register; enabled path
+//      POSTs ONLY to the guild route, never global; name is exactly
+//      recall-wedge-live-demo; description is dev-only/live-Dixie/gated/demo
+//      with no production claim; no freeform option; buildCommandSet never
+//      contains it.
+//   H. static guards — no Telegram/private-chat/storage/Finn/LLM imports; no
+//      render-public-recall / dixie-envelope-adapter import; no recorded
+//      fixture / recorded_dixie_recall_envelope use; no memory-admission /
+//      candidate-write / "remember this"; no child_process / TLS; no raw
+//      fetch; live client reached only via the authorized package subpath
+//      (type-only static + gated dynamic import); `/recall-wedge-demo` still
+//      never imports live Dixie; registration code imports neither the live
+//      client nor the harness; the global publish set excludes the live
+//      command; dispatch routes the live command to the gated handler.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { MessageFlags, type DiscordInteraction } from './types.ts';
+import {
+  RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION,
+  RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+  RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL,
+  handleRecallWedgeLiveDemoInteraction,
+  isRecallWedgeLiveDiscordDemoAllowedGuild,
+  isRecallWedgeLiveDiscordDemoOperator,
+  parseRecallWedgeLiveDiscordDemoOperatorIds,
+  recallWedgeLiveDemoRefusal,
+  renderRecallWedgeLiveDemoContent,
+  resolveRecallWedgeLiveDiscordDemoGuildId,
+  shouldEnableRecallWedgeLiveDiscordDemo,
+  shouldRegisterRecallWedgeLiveDiscordDemo,
+  type RecallWedgeLiveDixieClientModule,
+} from './recall-wedge-live-demo.ts';
+// Live Dixie client reached through the AUTHORIZED package subpath (Phase 41B
+// added `./recall-wedge/live-dixie-client` to persona-engine exports) — NOT a
+// deep relative import that climbs into the package's src tree. Used here only
+// for the test's own assertions + to feed the injected client seam.
+import {
+  LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS,
+  findBannedPublicSubstring,
+  type LiveDixieClientConfig,
+  type LiveDixieRecallClassification,
+  type LiveDixieRecallResult,
+  type LiveRecallInput,
+} from '@freeside-characters/persona-engine/recall-wedge/live-dixie-client';
+import {
+  buildCommandSet,
+  registerRecallWedgeLiveDemoCommand,
+} from '../lib/publish-commands.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const GUILD = 'guild-allowed-123';
+const OPERATOR = 'operator-user-456';
+const OTHER_GUILD = 'guild-other-999';
+const OTHER_USER = 'user-other-789';
+
+function fullEnv(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return {
+    RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED: 'true',
+    RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: GUILD,
+    RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: OPERATOR,
+    ...overrides,
+  };
+}
+
+function interaction(
+  overrides: Partial<DiscordInteraction> = {},
+): DiscordInteraction {
+  return {
+    type: 2,
+    id: 'interaction-id',
+    application_id: 'app-id',
+    token: 'tok',
+    guild_id: GUILD,
+    channel_id: 'chan',
+    member: { user: { id: OPERATOR, username: 'op' } },
+    data: { id: 'cmd', name: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME },
+    ...overrides,
+  };
+}
+
+// A dummy live Dixie config — the injected client never uses it for a real
+// call, so its field values are inert placeholders (no secrets).
+const DUMMY_CONFIG = {
+  baseUrl: 'https://dixie.example.test',
+  serviceToken: 'inert',
+  tenantId: '0xinert',
+  callerActorId: '0xinert',
+  requestKeyPrefix: 'p41b',
+  timeoutMs: 10_000,
+} satisfies LiveDixieClientConfig;
+
+function liveResult(
+  classification: LiveDixieRecallClassification,
+  reasonCode: string = classification,
+  outcome: string = classification,
+): LiveDixieRecallResult {
+  return {
+    classification,
+    public_summary: {
+      // The render path reads only these three fields; cast the outcome to the
+      // client's outcome union for the type — value content is what matters.
+      outcome: outcome as LiveDixieRecallResult['public_summary']['outcome'],
+      classification,
+      stable_reason_code: reasonCode,
+    },
+    // A deliberately dirty internal diagnostic — proves the renderer never
+    // surfaces raw payload / fingerprint / http_status material.
+    internal_diagnostic: {
+      http_status: 200,
+      idempotency_key_present: true,
+      fingerprint: 'fnv1a64:deadbeefdeadbeef',
+    },
+  };
+}
+
+/**
+ * A counting live-client module seam. Returns the real banned-substring helper
+ * so the no-leak scan is genuine, a configurable config loader, and a recall
+ * fn that records call count + captured input.
+ */
+function countingClient(
+  result: LiveDixieRecallResult,
+  opts: {
+    loadConfig?: (env: Record<string, string | undefined>) => LiveDixieClientConfig;
+    throwOnRecall?: boolean;
+  } = {},
+): {
+  module: RecallWedgeLiveDixieClientModule;
+  recallCalls: () => number;
+  capturedInput: () => LiveRecallInput | undefined;
+} {
+  let recallCalls = 0;
+  let captured: LiveRecallInput | undefined;
+  const module: RecallWedgeLiveDixieClientModule = {
+    loadLiveDixieClientConfigFromEnv: opts.loadConfig ?? (() => DUMMY_CONFIG),
+    liveRecallViaDixie: async (input) => {
+      recallCalls += 1;
+      captured = input;
+      if (opts.throwOnRecall) throw new Error('simulated live client failure');
+      return result;
+    },
+    findBannedPublicSubstring,
+  };
+  return {
+    module,
+    recallCalls: () => recallCalls,
+    capturedInput: () => captured,
+  };
+}
+
+/**
+ * A counting loader seam: records how many times the live client is loaded so a
+ * test can prove a refused path never loads it.
+ */
+function countingLoader(module: RecallWedgeLiveDixieClientModule): {
+  load: () => Promise<RecallWedgeLiveDixieClientModule>;
+  loads: () => number;
+} {
+  let loads = 0;
+  return {
+    load: async () => {
+      loads += 1;
+      return module;
+    },
+    loads: () => loads,
+  };
+}
+
+// =====================================================================
+// A. env gate exactness
+// =====================================================================
+
+describe('Phase 41B · env gate · enable (exact "true")', () => {
+  test('enabled only by the exact string "true"', () => {
+    expect(
+      shouldEnableRecallWedgeLiveDiscordDemo({
+        RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED: 'true',
+      }),
+    ).toBe(true);
+  });
+
+  test('disabled by default (missing var)', () => {
+    expect(shouldEnableRecallWedgeLiveDiscordDemo({})).toBe(false);
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', ' true', 'true ', 'truthy', ''])(
+    'near-truthy value %p does NOT enable',
+    (value) => {
+      expect(
+        shouldEnableRecallWedgeLiveDiscordDemo({
+          RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED: value,
+        }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe('Phase 41B · env gate · register (exact "true")', () => {
+  test('registration enabled only by exact "true"', () => {
+    expect(
+      shouldRegisterRecallWedgeLiveDiscordDemo({
+        RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: 'true',
+      }),
+    ).toBe(true);
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', undefined as unknown as string, ''])(
+    'register value %p does NOT enable',
+    (value) => {
+      expect(
+        shouldRegisterRecallWedgeLiveDiscordDemo({
+          RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: value,
+        }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe('Phase 41B · env gate · operator allowlist parsing', () => {
+  test('missing var → empty list (fails closed)', () => {
+    expect(parseRecallWedgeLiveDiscordDemoOperatorIds({})).toEqual([]);
+  });
+
+  test('blank var → empty list', () => {
+    expect(
+      parseRecallWedgeLiveDiscordDemoOperatorIds({
+        RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '   ',
+      }),
+    ).toEqual([]);
+  });
+
+  test('comma-separated, trimmed, empties dropped', () => {
+    expect(
+      parseRecallWedgeLiveDiscordDemoOperatorIds({
+        RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: ' a , b ,, c ',
+      }),
+    ).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('Phase 41B · guild gate', () => {
+  test('matching guild passes', () => {
+    expect(
+      isRecallWedgeLiveDiscordDemoAllowedGuild(interaction(), fullEnv()),
+    ).toBe(true);
+  });
+
+  test('wrong guild fails closed', () => {
+    expect(
+      isRecallWedgeLiveDiscordDemoAllowedGuild(
+        interaction({ guild_id: OTHER_GUILD }),
+        fullEnv(),
+      ),
+    ).toBe(false);
+  });
+
+  test('missing guild_id (DM) fails closed', () => {
+    expect(
+      isRecallWedgeLiveDiscordDemoAllowedGuild(
+        interaction({ guild_id: undefined }),
+        fullEnv(),
+      ),
+    ).toBe(false);
+  });
+
+  test.each([undefined as unknown as string, '', '   ', '\t'])(
+    'missing / blank configured guild id %p fails closed',
+    (value) => {
+      expect(
+        isRecallWedgeLiveDiscordDemoAllowedGuild(
+          interaction(),
+          fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: value }),
+        ),
+      ).toBe(false);
+    },
+  );
+});
+
+describe('Phase 41B · operator gate', () => {
+  test('operator in allowlist passes', () => {
+    expect(isRecallWedgeLiveDiscordDemoOperator(interaction(), fullEnv())).toBe(
+      true,
+    );
+  });
+
+  test('reads user.id when invoked in a DM shape', () => {
+    expect(
+      isRecallWedgeLiveDiscordDemoOperator(
+        interaction({ member: undefined, user: { id: OPERATOR, username: 'op' } }),
+        fullEnv(),
+      ),
+    ).toBe(true);
+  });
+
+  test('non-operator fails closed', () => {
+    expect(
+      isRecallWedgeLiveDiscordDemoOperator(
+        interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+        fullEnv(),
+      ),
+    ).toBe(false);
+  });
+
+  test('empty allowlist fails closed', () => {
+    expect(
+      isRecallWedgeLiveDiscordDemoOperator(
+        interaction(),
+        fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// =====================================================================
+// B. refused paths (generic ephemeral refusal · no client load/call)
+// =====================================================================
+
+describe('Phase 41B · handler fail-closed gating', () => {
+  test('disabled by default → generic ephemeral refusal', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), {});
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', ' true'])(
+    'enabled value %p does NOT enable the handler',
+    async (value) => {
+      const res = await handleRecallWedgeLiveDemoInteraction(
+        interaction(),
+        fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED: value }),
+      );
+      expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+    },
+  );
+
+  test('wrong guild → generic refusal', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction({ guild_id: OTHER_GUILD }),
+      fullEnv(),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('missing guild → generic refusal', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction({ guild_id: undefined }),
+      fullEnv(),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('non-operator → generic refusal', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+      fullEnv(),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('empty operator allowlist → generic refusal', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+    );
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+  });
+
+  test('disabled / wrong-guild / missing-guild / non-operator / empty-allowlist share ONE generic string', async () => {
+    const refusals = [
+      await handleRecallWedgeLiveDemoInteraction(interaction(), {}),
+      await handleRecallWedgeLiveDemoInteraction(
+        interaction({ guild_id: OTHER_GUILD }),
+        fullEnv(),
+      ),
+      await handleRecallWedgeLiveDemoInteraction(
+        interaction({ guild_id: undefined }),
+        fullEnv(),
+      ),
+      await handleRecallWedgeLiveDemoInteraction(
+        interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+        fullEnv(),
+      ),
+      await handleRecallWedgeLiveDemoInteraction(
+        interaction(),
+        fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+      ),
+    ];
+    for (const r of refusals) {
+      expect(r.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+      expect(r.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    }
+  });
+
+  test('refusal string passes the live-client banned-substring scan', () => {
+    for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+      expect(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL).not.toContain(banned);
+    }
+    expect(findBannedPublicSubstring(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL)).toBeNull();
+  });
+
+  test('recallWedgeLiveDemoRefusal() is ephemeral and the generic string', () => {
+    const r = recallWedgeLiveDemoRefusal();
+    expect(r.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+    expect(r.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+});
+
+describe('Phase 41B · refused paths never load or call the live Dixie client', () => {
+  for (const [label, build] of [
+    ['disabled', () => ({ int: interaction(), env: {} as Record<string, string | undefined> })],
+    ['wrong-guild', () => ({ int: interaction({ guild_id: OTHER_GUILD }), env: fullEnv() })],
+    ['missing-guild', () => ({ int: interaction({ guild_id: undefined }), env: fullEnv() })],
+    [
+      'non-operator',
+      () => ({
+        int: interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+        env: fullEnv(),
+      }),
+    ],
+    [
+      'empty-allowlist',
+      () => ({
+        int: interaction(),
+        env: fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+      }),
+    ],
+  ] as const) {
+    test(`${label} path loads NO client and makes NO call`, async () => {
+      const client = countingClient(liveResult('served'));
+      const loader = countingLoader(client.module);
+      const { int, env } = build();
+      const res = await handleRecallWedgeLiveDemoInteraction(int, env, {
+        loadLiveClient: loader.load,
+      });
+      expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+      expect(loader.loads()).toBe(0);
+      expect(client.recallCalls()).toBe(0);
+    });
+  }
+});
+
+// =====================================================================
+// C. lazy live-client load/call
+// =====================================================================
+
+describe('Phase 41B · live client is loaded + called only after gates pass', () => {
+  test('enabled + allowed path loads the client once and calls recall once', async () => {
+    const client = countingClient(liveResult('served'));
+    const loader = countingLoader(client.module);
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv(),
+      { loadLiveClient: loader.load },
+    );
+    expect(loader.loads()).toBe(1);
+    expect(client.recallCalls()).toBe(1);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    expect(res.data?.content).toContain('classification: served');
+  });
+
+  test('client load failure after gates pass → generic ephemeral refusal', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => {
+        throw new Error('simulated client load failure');
+      },
+    });
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+
+  test('thrown live client (recall throws) → generic ephemeral refusal', async () => {
+    const client = countingClient(liveResult('served'), { throwOnRecall: true });
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    expect(client.recallCalls()).toBe(1);
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+
+  test('default loader (real dynamic import) + missing live env → safe config summary, NO network egress', async () => {
+    // No injected loader — exercises defaultLoadLiveClient's dynamic import of
+    // the authorized package subpath AND the real config loader. With the live
+    // Dixie env absent, config load throws missing_required_env BEFORE any
+    // network egress, so we spy on globalThis.fetch and assert zero calls.
+    const original = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async (_url: string, _init?: RequestInit) => {
+      fetchCalls += 1;
+      return { ok: true, status: 200, text: async () => '' } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv());
+      expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+      // Safe config-error summary (no env values) OR generic refusal — both
+      // are fail-closed-acceptable per Phase 41A §I.
+      const content = res.data?.content ?? '';
+      const okShape =
+        content === RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL ||
+        content.includes('classification: missing_required_env');
+      expect(okShape).toBe(true);
+      // Crucially: no network egress on the missing-env path.
+      expect(fetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+// =====================================================================
+// D. input source (fixed synthetic probe · no freeform query)
+// =====================================================================
+
+describe('Phase 41B · input source is the fixed synthetic probe (no freeform query)', () => {
+  test('the live client receives the FIXED probe, never interaction options', async () => {
+    const client = countingClient(liveResult('served'));
+    await handleRecallWedgeLiveDemoInteraction(
+      interaction({
+        // Smuggle freeform-like options; the handler must ignore them entirely.
+        data: {
+          id: 'cmd',
+          name: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+          options: [
+            { name: 'prompt', type: 3, value: 'remember my secret' },
+            { name: 'query', type: 3, value: 'recall everything' },
+            { name: 'memory', type: 3, value: 'PRIVATE_SENTINEL' },
+            { name: 'case', type: 3, value: 'served' },
+          ],
+        },
+      }),
+      fullEnv(),
+      { loadLiveClient: async () => client.module },
+    );
+    const captured = client.capturedInput();
+    expect(captured).toBeDefined();
+    // Fixed probe identity — not derived from any option.
+    expect(captured!.recallRequestId).toBe('recall-wedge-live-demo-1');
+    expect(captured!.task).toContain('operator/dev probe');
+    expect(captured!.environmentFrame).toBe('private_operator');
+    // None of the smuggled freeform values reached the request.
+    const serialized = JSON.stringify(captured);
+    expect(serialized).not.toContain('remember my secret');
+    expect(serialized).not.toContain('recall everything');
+    expect(serialized).not.toContain('PRIVATE_SENTINEL');
+  });
+
+  test('smuggled freeform option values never appear in the rendered output', async () => {
+    const client = countingClient(liveResult('served'));
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction({
+        data: {
+          id: 'cmd',
+          name: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+          options: [{ name: 'prompt', type: 3, value: 'leak me PRIVATE_SENTINEL' }],
+        },
+      }),
+      fullEnv(),
+      { loadLiveClient: async () => client.module },
+    );
+    const content = res.data?.content ?? '';
+    expect(content).not.toContain('leak me');
+    expect(content).not.toContain('PRIVATE_SENTINEL');
+    expect(content).toContain('classification: served');
+  });
+
+  test('handler module source reads no interaction options / message history', () => {
+    const moduleSource = readFileSync(
+      resolve(__dirname, 'recall-wedge-live-demo.ts'),
+      'utf8',
+    );
+    // No option/text readers, no interaction.data access (the request is fixed).
+    expect(moduleSource).not.toContain('interaction.data');
+    expect(moduleSource).not.toMatch(/readStringOption|readBooleanOption/);
+    expect(moduleSource).not.toMatch(/\.options\?\./);
+    expect(moduleSource).not.toMatch(/message[_-]?history/i);
+    expect(moduleSource).not.toMatch(/getMessages|fetchMessages|channel\.messages/);
+  });
+});
+
+// =====================================================================
+// E. success render
+// =====================================================================
+
+describe('Phase 41B · success render (served)', () => {
+  const withServed = {
+    loadLiveClient: async () => countingClient(liveResult('served')).module,
+  };
+
+  test('served renders ephemeral live-demo output', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv(),
+      withServed,
+    );
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    expect(res.data?.content).toContain('classification: served');
+  });
+
+  test('output includes the live-demo dev framing', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv(),
+      withServed,
+    );
+    const content = res.data?.content ?? '';
+    expect(content).toContain('live Dixie dev demo (not production recall)');
+    expect(content).toContain('phase 37c live Dixie client output');
+  });
+
+  test('output includes only the safe classification / summary fields', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv(),
+      withServed,
+    );
+    const content = res.data?.content ?? '';
+    expect(content).toContain('classification: served');
+    expect(content).toContain('route:          /api/recall/intake');
+    expect(content).toContain('reason:');
+  });
+
+  test('output does NOT include raw Dixie payload / diagnostic fields', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv(),
+      withServed,
+    );
+    const content = res.data?.content ?? '';
+    expect(content).not.toContain('internal_diagnostic');
+    expect(content).not.toContain('http_status');
+    expect(content).not.toContain('fingerprint');
+    expect(content).not.toContain('idempotency_key');
+  });
+
+  test('output passes the live-client no-leak scan', async () => {
+    const res = await handleRecallWedgeLiveDemoInteraction(
+      interaction(),
+      fullEnv(),
+      withServed,
+    );
+    const content = res.data?.content ?? '';
+    for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+      expect(content).not.toContain(banned);
+    }
+    expect(findBannedPublicSubstring(content)).toBeNull();
+  });
+});
+
+// =====================================================================
+// F. error / classification render
+// =====================================================================
+
+describe('Phase 41B · classification render', () => {
+  // Classifications that render a safe ephemeral summary.
+  const SAFE: LiveDixieRecallClassification[] = [
+    'served',
+    'denied_or_forbidden',
+    'needs_review',
+    'ingress_invalid_request',
+    'service_unauthorized',
+    'tenant_or_session_mismatch',
+    'rate_limited',
+    'upstream_unavailable',
+  ];
+
+  for (const classification of SAFE) {
+    test(`${classification} renders a safe ephemeral summary (no leak)`, async () => {
+      const client = countingClient(liveResult(classification));
+      const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+        loadLiveClient: async () => client.module,
+      });
+      expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+      const content = res.data?.content ?? '';
+      // Either a safe summary naming the classification, or the generic refusal
+      // — both are §I-acceptable. The safe-summary branch must pass no-leak.
+      const isRefusal = content === RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL;
+      if (!isRefusal) {
+        expect(content).toContain(`classification: ${classification}`);
+        for (const banned of LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS) {
+          expect(content).not.toContain(banned);
+        }
+      }
+    });
+  }
+
+  // Classifications that ALWAYS fail closed to the generic refusal.
+  for (const classification of [
+    'unsupported_response_shape',
+    'network_error',
+    'unsafe_idempotency_key_reuse',
+  ] as LiveDixieRecallClassification[]) {
+    test(`${classification} fails closed to the generic refusal`, async () => {
+      const client = countingClient(liveResult(classification));
+      const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+        loadLiveClient: async () => client.module,
+      });
+      expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+      expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    });
+  }
+
+  test('missing_required_env config throw → safe summary with NO env name / value', async () => {
+    const loadConfig = () => {
+      const e = new Error(
+        'required env "RECALL_WEDGE_DIXIE_SERVICE_TOKEN" is missing or empty',
+      ) as Error & { code: string; missingEnv: string };
+      e.code = 'missing_required_env';
+      e.missingEnv = 'RECALL_WEDGE_DIXIE_SERVICE_TOKEN';
+      throw e;
+    };
+    const client = countingClient(liveResult('served'), { loadConfig });
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    const content = res.data?.content ?? '';
+    const okShape =
+      content === RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL ||
+      content.includes('classification: missing_required_env');
+    expect(okShape).toBe(true);
+    // Never leaks the env NAME or the underlying message, and never calls recall.
+    expect(content).not.toContain('RECALL_WEDGE_DIXIE_SERVICE_TOKEN');
+    expect(content).not.toContain('RECALL_WEDGE_DIXIE_');
+    expect(client.recallCalls()).toBe(0);
+  });
+
+  test('invalid_config config throw → safe summary with NO env values', async () => {
+    const loadConfig = () => {
+      const e = new Error('RECALL_WEDGE_DIXIE_BASE_URL is not a valid URL') as Error & {
+        code: string;
+      };
+      e.code = 'invalid_config';
+      throw e;
+    };
+    const client = countingClient(liveResult('served'), { loadConfig });
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+    const content = res.data?.content ?? '';
+    const okShape =
+      content === RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL ||
+      content.includes('classification: invalid_config');
+    expect(okShape).toBe(true);
+    expect(content).not.toContain('RECALL_WEDGE_DIXIE_BASE_URL');
+    expect(client.recallCalls()).toBe(0);
+  });
+
+  test('contaminated stable_reason_code falls back to the generic refusal', async () => {
+    // A safe-summary classification but with a reason code that carries a
+    // banned substring — the final no-leak scan must catch it.
+    const client = countingClient(
+      liveResult('denied_or_forbidden', 'leak:raw_reasons:PRIVATE_SENTINEL', 'denied'),
+    );
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+    expect(res.data?.flags).toBe(MessageFlags.EPHEMERAL);
+  });
+});
+
+describe('Phase 41B · renderRecallWedgeLiveDemoContent (direct)', () => {
+  test('served renders content', () => {
+    const out = renderRecallWedgeLiveDemoContent({
+      classification: 'served',
+      outcome: 'served',
+      stable_reason_code: 'served',
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain('classification: served');
+    expect(out).toContain('/api/recall/intake');
+  });
+
+  test.each([
+    'unsupported_response_shape',
+    'network_error',
+    'unsafe_idempotency_key_reuse',
+  ] as LiveDixieRecallClassification[])('%s renders null (fail closed)', (classification) => {
+    expect(
+      renderRecallWedgeLiveDemoContent({
+        classification,
+        outcome: 'x',
+        stable_reason_code: 'x',
+      }),
+    ).toBeNull();
+  });
+
+  test('config classes force the reason to the bare class name (no env leak)', () => {
+    const out = renderRecallWedgeLiveDemoContent({
+      classification: 'missing_required_env',
+      outcome: 'config_error',
+      stable_reason_code: 'missing:RECALL_WEDGE_DIXIE_SERVICE_TOKEN',
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain('reason:         missing_required_env');
+    expect(out).not.toContain('RECALL_WEDGE_DIXIE_SERVICE_TOKEN');
+  });
+
+  test('unknown classification renders null (fail closed)', () => {
+    expect(
+      renderRecallWedgeLiveDemoContent({
+        classification: 'totally_unknown' as LiveDixieRecallClassification,
+        outcome: 'x',
+        stable_reason_code: 'x',
+      }),
+    ).toBeNull();
+  });
+});
+
+// =====================================================================
+// G. registration (guild-scoped ONLY · never global)
+// =====================================================================
+
+function captureFetch(
+  response: { ok: boolean; status?: number; json?: unknown } = {
+    ok: true,
+    json: { id: 'cmd-id-live', name: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME },
+  },
+): { calls: Array<{ url: string; init: RequestInit }>; restore: () => void } {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init });
+    return {
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 400),
+      json: async () => response.json ?? {},
+      text: async () => JSON.stringify(response.json ?? {}),
+    } as unknown as Response;
+  }) as typeof fetch;
+  return { calls, restore: () => (globalThis.fetch = original) };
+}
+
+const REGISTER_ENABLED = {
+  RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: 'true',
+  RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: GUILD,
+};
+
+describe('Phase 41B · command definition metadata', () => {
+  test('command name is exactly recall-wedge-live-demo (no alias)', () => {
+    expect(RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION.name).toBe(
+      'recall-wedge-live-demo',
+    );
+    expect(RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION.name).toBe(
+      RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+    );
+  });
+
+  test('description includes dev-only / live Dixie / gated / demo wording', () => {
+    const d = RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION.description.toLowerCase();
+    expect(d).toContain('dev-only');
+    expect(d).toContain('live dixie');
+    expect(d).toContain('gated');
+    expect(d).toContain('demo');
+  });
+
+  test('description makes no production memory / recall / consent claim', () => {
+    const d = RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION.description.toLowerCase();
+    for (const banned of [
+      'your memory',
+      'remembered',
+      'saved',
+      'stored',
+      'consent',
+      'admitted',
+    ]) {
+      expect(d).not.toContain(banned);
+    }
+    expect(d).toContain('not production recall');
+  });
+
+  test('command has NO options (no freeform query path)', () => {
+    expect(RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION.options.length).toBe(0);
+  });
+
+  test('buildCommandSet (the global-capable array) never contains the live command', () => {
+    const set = buildCommandSet([
+      { id: 'ruggy', displayName: 'Ruggy' } as never,
+      { id: 'satoshi', displayName: 'Satoshi' } as never,
+    ]);
+    for (const cmd of set) {
+      expect(cmd.name).not.toBe(RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME);
+    }
+  });
+});
+
+describe('Phase 41B · guild-id resolution (fails closed, never global)', () => {
+  test('present non-empty guild id resolves', () => {
+    expect(
+      resolveRecallWedgeLiveDiscordDemoGuildId({
+        RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: GUILD,
+      }),
+    ).toBe(GUILD);
+  });
+
+  test.each([undefined as unknown as string, '', '   ', '\t', ' \n '])(
+    'missing / empty / whitespace guild id %p resolves to null',
+    (value) => {
+      expect(
+        resolveRecallWedgeLiveDiscordDemoGuildId({
+          RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: value,
+        }),
+      ).toBeNull();
+    },
+  );
+});
+
+describe('Phase 41B · registration gate (disabled by default)', () => {
+  test('disabled by default (no env) → not registered, no network call', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeLiveDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app',
+        env: {},
+      });
+      expect(res.registered).toBe(false);
+      expect(fetchCap.calls.length).toBe(0);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test.each(['TRUE', 'True', '1', 'yes', ' true', 'true ', ''])(
+    'near-truthy register flag %p → not registered, no network call',
+    async (value) => {
+      const fetchCap = captureFetch();
+      try {
+        const res = await registerRecallWedgeLiveDemoCommand({
+          botToken: 'tok',
+          applicationId: 'app',
+          env: {
+            RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: value,
+            RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: GUILD,
+          },
+        });
+        expect(res.registered).toBe(false);
+        if (!res.registered) expect(res.reason).toBe('gate_disabled');
+        expect(fetchCap.calls.length).toBe(0);
+      } finally {
+        fetchCap.restore();
+      }
+    },
+  );
+
+  test('exact "true" register flag enables the registration path', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeLiveDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app',
+        env: REGISTER_ENABLED,
+      });
+      expect(res.registered).toBe(true);
+      expect(fetchCap.calls.length).toBe(1);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test('missing guild id (register enabled) → not registered, NO global fallback', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeLiveDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app',
+        env: { RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: 'true' },
+      });
+      expect(res.registered).toBe(false);
+      if (!res.registered) expect(res.reason).toBe('no_guild');
+      expect(fetchCap.calls.length).toBe(0);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test.each(['', '   ', '\t'])(
+    'empty / whitespace guild id %p (register enabled) → not registered, no call',
+    async (value) => {
+      const fetchCap = captureFetch();
+      try {
+        const res = await registerRecallWedgeLiveDemoCommand({
+          botToken: 'tok',
+          applicationId: 'app',
+          env: {
+            RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: 'true',
+            RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: value,
+          },
+        });
+        expect(res.registered).toBe(false);
+        if (!res.registered) expect(res.reason).toBe('no_guild');
+        expect(fetchCap.calls.length).toBe(0);
+      } finally {
+        fetchCap.restore();
+      }
+    },
+  );
+});
+
+describe('Phase 41B · registration is guild-scoped ONLY', () => {
+  test('enabled path POSTs to the guild commands route with the configured guild id', async () => {
+    const fetchCap = captureFetch();
+    try {
+      const res = await registerRecallWedgeLiveDemoCommand({
+        botToken: 'tok',
+        applicationId: 'app-77',
+        env: REGISTER_ENABLED,
+      });
+      expect(res.registered).toBe(true);
+      if (res.registered) {
+        expect(res.scope).toBe('guild');
+        expect(res.guildId).toBe(GUILD);
+      }
+      expect(fetchCap.calls.length).toBe(1);
+      const { url, init } = fetchCap.calls[0]!;
+      expect(url).toBe(
+        `https://discord.com/api/v10/applications/app-77/guilds/${GUILD}/commands`,
+      );
+      expect(url).toContain(`/guilds/${GUILD}/commands`);
+      expect(url).not.toBe(
+        'https://discord.com/api/v10/applications/app-77/commands',
+      );
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(String(init.body));
+      expect(body.name).toBe(RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME);
+      // No freeform option smuggled into the registered payload.
+      expect(body.options ?? []).toEqual([]);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+
+  test('no env path reaches the global commands route', async () => {
+    const fetchCap = captureFetch();
+    try {
+      await registerRecallWedgeLiveDemoCommand({ botToken: 't', applicationId: 'a', env: {} });
+      await registerRecallWedgeLiveDemoCommand({
+        botToken: 't',
+        applicationId: 'a',
+        env: { RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS: 'true' },
+      });
+      for (const { url } of fetchCap.calls) {
+        expect(url).not.toMatch(/\/applications\/[^/]+\/commands$/);
+      }
+      expect(fetchCap.calls.length).toBe(0);
+    } finally {
+      fetchCap.restore();
+    }
+  });
+});
+
+// =====================================================================
+// H. static source guards
+// =====================================================================
+
+// Assembled from parts so this guard's OWN source does not contain the literal
+// it forbids (the test reads its sibling sources back).
+const DEEP_PKG_NEEDLE = ['..', '..', '..', '..', 'packages', 'persona-engine'].join(
+  '/',
+);
+
+describe('Phase 41B · static source guards (handler module)', () => {
+  const moduleSource = readFileSync(
+    resolve(__dirname, 'recall-wedge-live-demo.ts'),
+    'utf8',
+  );
+
+  test('does not deep-import across the app→package boundary (no TS6059 delta)', () => {
+    expect(moduleSource).not.toContain(DEEP_PKG_NEEDLE);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\.\.\/packages\//);
+  });
+
+  test('reaches the live Dixie client only via the authorized package subpath', () => {
+    const refs =
+      moduleSource.match(/["'][^"']*live-dixie-client[^"']*["']/g) ?? [];
+    expect(refs.length).toBeGreaterThan(0);
+    for (const ref of refs) {
+      expect(ref).toContain(
+        '@freeside-characters/persona-engine/recall-wedge/live-dixie-client',
+      );
+      expect(ref).not.toContain('packages/persona-engine');
+      expect(ref).not.toContain('../');
+    }
+  });
+
+  test('only static import of the client specifier is type-only; a dynamic import() exists', () => {
+    expect(moduleSource).toMatch(
+      /import\s+type\s*\{[^}]*\}\s*from\s+["']@freeside-characters\/persona-engine\/recall-wedge\/live-dixie-client["']/,
+    );
+    expect(moduleSource).toMatch(
+      /import\(\s*[\s\n]*["']@freeside-characters\/persona-engine\/recall-wedge\/live-dixie-client["']/,
+    );
+  });
+
+  test('does not import the Phase 37C live Dixie runner', () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+  });
+
+  test('does not import render-public-recall or dixie-envelope-adapter', () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*render-public-recall[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*dixie-envelope-adapter[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*(render-public-recall|dixie-envelope-adapter)[^"']*["']/,
+    );
+  });
+
+  test('does not import the Phase 38A multi-surface harness', () => {
+    expect(moduleSource).not.toMatch(/multi-surface-recall-harness/);
+  });
+
+  test('does not use recorded_dixie_recall_envelope or recorded fixtures', () => {
+    expect(moduleSource).not.toMatch(/recorded_dixie_recall_envelope/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*fixtures?[^"']*["']/);
+  });
+
+  test('does not import Telegram / private-chat clients', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']telegraf["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']grammy["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*telegram[^"']*["']/i);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*private[-_]chat[^"']*["']/i);
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*private[-_]chat[^"']*["']/i,
+    );
+  });
+
+  test('does not import storage clients', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']redis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']ioredis["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@aws-sdk\/[^"']+["']/);
+  });
+
+  test('does not import Finn / @loa/dixie / @loa/straylight', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+  });
+
+  test('does not import an LLM SDK / Claude Agent SDK', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@anthropic-ai\/[^"']+["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+  });
+
+  test('contains no raw fetch / low-level network primitives (egress stays in the client)', () => {
+    expect(moduleSource).not.toMatch(/\bfetch\s*\(/);
+    expect(moduleSource).not.toMatch(/globalThis\.fetch/);
+    expect(moduleSource).not.toMatch(/\bundici\b/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:https["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']node:net["']/);
+  });
+
+  test('does not import TLS (node:tls / tls)', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']node:tls["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']tls["']/);
+    expect(moduleSource).not.toMatch(/import\(\s*[\s\n]*["'](?:node:)?tls["']/);
+    expect(moduleSource).not.toMatch(/\brequire\(\s*["'](?:node:)?tls["']\)/);
+  });
+
+  test('does not import or use child_process', () => {
+    expect(moduleSource).not.toMatch(/from\s+["']node:child_process["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']child_process["']/);
+    expect(moduleSource).not.toMatch(
+      /import\(\s*[\s\n]*["'](?:node:)?child_process["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /\brequire\(\s*["'](?:node:)?child_process["']\)/,
+    );
+    expect(moduleSource).not.toMatch(/\b(spawn|exec|execFile|execSync|fork)\s*\(/);
+  });
+
+  test('contains no memory-admission / candidate-write / "remember this" affordance', () => {
+    const lc = moduleSource.toLowerCase();
+    expect(lc).not.toMatch(/admit(memory|candidate)\(/);
+    expect(lc).not.toMatch(/candidate[_-]?memory/);
+    expect(lc).not.toMatch(/writememory|write_memory/);
+    expect(lc).not.toMatch(/enqueueadmission|admission[_-]?job/);
+    expect(lc).not.toContain('remember this');
+  });
+
+  test('renders only via the EPHEMERAL flag — no non-ephemeral / deferred branch', () => {
+    expect(moduleSource).toContain('MessageFlags.EPHEMERAL');
+    expect(moduleSource).not.toMatch(/DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE/);
+    const responseDataBlocks = moduleSource.match(/data:\s*\{[^}]*\}/g) ?? [];
+    expect(responseDataBlocks.length).toBeGreaterThan(0);
+    for (const block of responseDataBlocks) {
+      expect(block).toContain('MessageFlags.EPHEMERAL');
+    }
+  });
+});
+
+describe('Phase 41B · test file crosses no app→package boundary', () => {
+  const testSource = readFileSync(
+    resolve(__dirname, 'recall-wedge-live-demo.test.ts'),
+    'utf8',
+  );
+
+  test('test does not deep-import across the app→package boundary', () => {
+    expect(testSource).not.toContain(DEEP_PKG_NEEDLE);
+    expect(testSource).not.toMatch(/from\s+["'][^"']*\.\.\/packages\//);
+  });
+
+  test('test reaches the live client only via the authorized package subpath', () => {
+    const refs =
+      testSource.match(/from\s+["'][^"']*live-dixie-client[^"']*["']/g) ?? [];
+    expect(refs.length).toBeGreaterThan(0);
+    for (const ref of refs) {
+      expect(ref).toContain(
+        '@freeside-characters/persona-engine/recall-wedge/live-dixie-client',
+      );
+    }
+  });
+});
+
+// =====================================================================
+// `/recall-wedge-demo` preservation guard (Phase 41A §J · §O)
+// =====================================================================
+
+describe('Phase 41B · /recall-wedge-demo still never imports live Dixie', () => {
+  const harnessSource = readFileSync(
+    resolve(__dirname, 'recall-wedge-demo.ts'),
+    'utf8',
+  );
+
+  test('harness handler imports no live Dixie client / runner (static or dynamic)', () => {
+    expect(harnessSource).not.toMatch(
+      /from\s+["'][^"']*live-dixie-client[^"']*["']/,
+    );
+    expect(harnessSource).not.toMatch(
+      /import\(\s*[\s\n]*["'][^"']*live-dixie-client[^"']*["']/,
+    );
+    expect(harnessSource).not.toMatch(
+      /from\s+["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+  });
+
+  test('harness command name is unchanged (no alias collision with live)', () => {
+    expect(harnessSource).toContain("RECALL_WEDGE_DEMO_COMMAND_NAME = 'recall-wedge-demo'");
+    expect(RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME).not.toBe('recall-wedge-demo');
+  });
+});
+
+// =====================================================================
+// dispatch wiring + registration-code static guards
+// =====================================================================
+
+describe('Phase 41B · dispatch wiring', () => {
+  const dispatchSource = readFileSync(resolve(__dirname, 'dispatch.ts'), 'utf8');
+
+  test('dispatch routes the live command name to the gated handler', () => {
+    expect(dispatchSource).toContain('RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME');
+    expect(dispatchSource).toContain('handleRecallWedgeLiveDemoInteraction');
+    expect(dispatchSource).toMatch(
+      /interaction\.data\?\.name\s*===\s*RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME/,
+    );
+    expect(dispatchSource).toMatch(
+      /return\s+await\s+handleRecallWedgeLiveDemoInteraction\(interaction\)/,
+    );
+  });
+
+  test('dispatch still routes the harness command independently', () => {
+    expect(dispatchSource).toContain('handleRecallWedgeDemoInteraction');
+    expect(dispatchSource).toContain('RECALL_WEDGE_DEMO_COMMAND_NAME');
+  });
+});
+
+describe('Phase 41B · registration-code static guards (publish-commands.ts)', () => {
+  const publishSource = readFileSync(
+    resolve(__dirname, '../lib/publish-commands.ts'),
+    'utf8',
+  );
+  const publishScriptSource = readFileSync(
+    resolve(__dirname, '../../scripts/publish-commands.ts'),
+    'utf8',
+  );
+
+  test('registration code imports no live Dixie client / runner / harness', () => {
+    expect(publishSource).not.toMatch(
+      /from\s+["'][^"']*live-dixie-client[^"']*["']/,
+    );
+    expect(publishSource).not.toMatch(
+      /from\s+["'][^"']*run-live-dixie-recall-demo[^"']*["']/,
+    );
+    expect(publishSource).not.toMatch(/multi-surface-recall-harness/);
+    // It reaches the live command module only for lightweight metadata + gates.
+    expect(publishSource).toContain(
+      "from '../discord-interactions/recall-wedge-live-demo.ts'",
+    );
+  });
+
+  test('the live registration path uses ONLY the guild route, never the global route', () => {
+    const start = publishSource.indexOf(
+      'export async function registerRecallWedgeLiveDemoCommand',
+    );
+    expect(start).toBeGreaterThan(-1);
+    const after = publishSource.indexOf('\nexport function buildCommandSet', start);
+    const body = publishSource.slice(start, after > -1 ? after : undefined);
+    expect(body).toMatch(/\/guilds\/\$\{guildId\}\/commands/);
+    expect(body).not.toMatch(/applications\/\$\{applicationId\}\/commands`/);
+  });
+
+  test('buildCommandSet body does not mention the live command (no global-array entry)', () => {
+    const start = publishSource.indexOf('export function buildCommandSet');
+    expect(start).toBeGreaterThan(-1);
+    const after = publishSource.indexOf('\nfunction buildCommand(', start);
+    const body = publishSource.slice(start, after > -1 ? after : undefined);
+    expect(body).not.toContain('recall-wedge-live-demo');
+    expect(body).not.toContain('RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION');
+  });
+
+  test('registration code consumes no RECALL_WEDGE_DIXIE_* secret envs', () => {
+    expect(publishSource).not.toMatch(/RECALL_WEDGE_DIXIE_/);
+  });
+
+  test('CLI script registers the live command via the gated guild-only helper', () => {
+    expect(publishScriptSource).toContain('registerRecallWedgeLiveDemoCommand');
+    expect(publishScriptSource).not.toMatch(/applications\/\$\{[^}]+\}\/commands`/);
+  });
+});

--- a/apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
@@ -1,0 +1,509 @@
+/**
+ * Phase 41B · dev/operator-only LIVE Dixie Recall Wedge demo command
+ * (`/recall-wedge-live-demo`).
+ *
+ * Authority: docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md (Phase 41A)
+ * under the Phase 37B live Dixie client gate
+ * (docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md). Phase 41A locked the SHAPE of
+ * this work; Phase 41B implements that locked shape and nothing past it. Every
+ * constraint below is binding; partial compliance does not satisfy the gate.
+ *
+ * This is a SEPARATE command from the Phase 39B `/recall-wedge-demo`. It does
+ * NOT alias it, does NOT mutate it, and does NOT replace its harness output.
+ * `/recall-wedge-demo` stays harness-backed and provably never imports the
+ * live Dixie client (its Phase 39B static guard is preserved and re-asserted
+ * by this command's test).
+ *
+ * What this module does (Phase 41A §F / §G / §J / §I / §K):
+ *   - fails closed by default — disabled unless
+ *     RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED is the exact string "true";
+ *   - fails closed unless interaction.guild_id matches
+ *     RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID;
+ *   - fails closed unless the invoking user id is in
+ *     RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS;
+ *   - returns the SAME generic ephemeral refusal for disabled / wrong-guild /
+ *     missing-guild / non-operator / empty-allowlist (never reveals which gate
+ *     tripped, never reveals why Dixie refused);
+ *   - evaluates ALL Discord gates BEFORE importing or calling the live Dixie
+ *     client — a refused interaction never loads the client and makes NO
+ *     network request;
+ *   - after the gates pass, lazily imports the Phase 37C live Dixie client
+ *     (the ONLY live-egress seam) through the authorized package subpath and
+ *     drives it with a FIXED deterministic operator/dev request shape;
+ *   - narrows the live result through the Phase 37C classifier vocabulary and
+ *     renders only a public/operator-safe summary (classification + outcome +
+ *     route + stable reason code) — never the raw Dixie response;
+ *   - fails closed (generic ephemeral refusal) on unknown / unsafe / error
+ *     classifications, on a thrown live client, and on any no-leak hit;
+ *   - scans the final content with the Phase 37C client's exported
+ *     banned-substring helper before returning;
+ *   - is ephemeral on every path (success and refusal).
+ *
+ * What this module does NOT do (Phase 41A §F / §H / §O):
+ *   - NO freeform recall / memory query — it reads NO interaction options at
+ *     all; the request shape is a fixed synthetic operator/dev probe;
+ *   - NO Discord message history / channel content as recall input;
+ *   - NO memory admission, NO candidate writes, NO remembering affordance;
+ *   - NO Telegram / private-chat surface, NO storage, NO LLM, NO character
+ *     voice, NO production auth / consent claim;
+ *   - NO raw network egress — all of it stays inside the Phase 37C live Dixie
+ *     client (this module never opens its own HTTP path);
+ *   - NO public channel-visible output;
+ *   - does NOT mutate render-public-recall.ts or dixie-envelope-adapter.ts, and
+ *     does NOT use recorded recall envelopes or any recorded fixture as live
+ *     traffic.
+ */
+
+// Type-only import across the authorized package subpath (Phase 41B added a
+// narrow recall-wedge client subpath to the persona-engine package exports to
+// avoid an app to package deep relative import that would trip the apps/bot
+// rootDir src TS6059, exactly as the Phase 39B harness command reaches the
+// Phase 38A harness). import type is fully erased at build time, so this file
+// carries NO runtime dependency on the live client at module load — the client
+// runtime is pulled in lazily via defaultLoadLiveClient ONLY after every
+// Discord gate passes (see the handler below).
+import type {
+  LiveDixieClientConfig,
+  LiveDixieRecallClassification,
+  LiveDixieRecallResult,
+  LiveRecallInput,
+} from '@freeside-characters/persona-engine/recall-wedge/live-dixie-client';
+import {
+  InteractionResponseType,
+  MessageFlags,
+  type DiscordInteraction,
+  type DiscordInteractionResponse,
+} from './types.ts';
+
+/** The single chosen command name (Phase 41A §E). No aliases. */
+export const RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME = 'recall-wedge-live-demo';
+
+/**
+ * The single, stable, generic refusal string used for EVERY fail-closed path
+ * (disabled / wrong guild / missing guild / non-operator / empty allowlist /
+ * load failure / unsafe classification / contaminated output). It must not
+ * differ between cases and must not leak which gate tripped or why Dixie
+ * refused (Phase 41A §K). Lowercase, no banned emojis, no production claim.
+ */
+export const RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL =
+  'recall-wedge-live-demo is not available here.';
+
+// -- runtime invocation env gates (Phase 41A §G · separate live gates) -----
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Disabled by default. Enabled ONLY when the env var is the exact string
+ * "true" — "TRUE", "True", "1", "yes", and whitespace variants are all false,
+ * and a missing var is false (fail closed). These are the LIVE command's own
+ * gates and never reuse the harness command's `RECALL_WEDGE_DISCORD_DEMO_*`
+ * gates (Phase 41A §G).
+ */
+export function shouldEnableRecallWedgeLiveDiscordDemo(env: Env): boolean {
+  return env.RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED === 'true';
+}
+
+/**
+ * Registration gate (Phase 41A §M). Exact string "true" only; missing/other
+ * values fail closed. Consumed by the guild-only registration helper in
+ * `lib/publish-commands.ts`.
+ */
+export function shouldRegisterRecallWedgeLiveDiscordDemo(env: Env): boolean {
+  return env.RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS === 'true';
+}
+
+/**
+ * Resolve the configured guild id. Trims the value and returns null when
+ * missing / blank / whitespace-only — registration MUST fail closed (never
+ * global) when no guild is configured (Phase 41A §G). The single allowed
+ * guild scope is shared by registration (`lib/publish-commands.ts`) and the
+ * invocation-time guild gate below.
+ */
+export function resolveRecallWedgeLiveDiscordDemoGuildId(
+  env: Env,
+): string | null {
+  const id = env.RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID?.trim();
+  return id && id.length > 0 ? id : null;
+}
+
+/**
+ * Parse the comma-separated operator allowlist. Trims each entry and drops
+ * empties. A missing/blank var yields an empty list (which fails closed at
+ * the operator check).
+ */
+export function parseRecallWedgeLiveDiscordDemoOperatorIds(env: Env): string[] {
+  const raw = env.RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS;
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Guild gate. The configured guild id (trimmed) must be non-empty AND must
+ * exactly match interaction.guild_id. A missing configured guild, or an
+ * interaction with no guild_id (e.g. a DM), fails closed.
+ */
+export function isRecallWedgeLiveDiscordDemoAllowedGuild(
+  interaction: DiscordInteraction,
+  env: Env,
+): boolean {
+  const allowed = resolveRecallWedgeLiveDiscordDemoGuildId(env);
+  if (!allowed) return false;
+  const guildId = interaction.guild_id;
+  if (!guildId) return false;
+  return guildId === allowed;
+}
+
+/**
+ * Operator gate. The invoking user id (member.user.id in a guild, user.id in
+ * a DM) must be present AND in the allowlist. An empty allowlist or a missing
+ * invoker id fails closed.
+ */
+export function isRecallWedgeLiveDiscordDemoOperator(
+  interaction: DiscordInteraction,
+  env: Env,
+): boolean {
+  const operatorIds = parseRecallWedgeLiveDiscordDemoOperatorIds(env);
+  if (operatorIds.length === 0) return false;
+  const invokerId = interaction.member?.user?.id ?? interaction.user?.id;
+  if (!invokerId) return false;
+  return operatorIds.includes(invokerId);
+}
+
+// -- fixed deterministic operator/dev request shape (Phase 41A §H) ---------
+
+/**
+ * The ONLY input that reaches the live Dixie request from Discord — a FIXED
+ * synthetic operator/dev probe (Phase 41A §H option 1). It is a code-reviewed
+ * constant, NOT derived from the interaction: no option is read, no message
+ * history is read, no channel content is read, and there is no fallback to
+ * interaction text. Its shape mirrors the Phase 37C runner's
+ * `DEFAULT_OPERATOR_INPUT` (operator-supplied tenant / caller / request-key
+ * inputs the live client already constructs). It carries no real secret value
+ * — secrets live only in the Phase 37C client's own `RECALL_WEDGE_DIXIE_*`
+ * env (§G), which this module does not read. No fixed idempotencyKey is set,
+ * so the live client mints a fresh key per call (no reuse).
+ */
+const RECALL_WEDGE_LIVE_DEMO_FIXED_INPUT: LiveRecallInput = {
+  recallRequestId: 'recall-wedge-live-demo-1',
+  task: 'recall-wedge-live-demo operator/dev probe',
+  environmentFrame: 'private_operator',
+  riskProfile: 'low',
+  detailLevel: 'minimal',
+  receiptDetail: 'minimal',
+  signature: {
+    signature_id: 'recall-wedge-live-demo-sig',
+    signer_id: 'recall-wedge-live-demo-signer',
+    signer_type: 'operator',
+    signature_type: 'dev_signature',
+    signed_payload_hash:
+      'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+    signature: 'devsig',
+    signed_at: '2026-05-18T00:00:00Z',
+    key_ref: 'recall-wedge-live-demo-kref',
+  },
+  createdAt: '2026-05-18T00:00:00Z',
+};
+
+// -- live Dixie client seam (Phase 41A §J · lazy after gates) --------------
+
+/**
+ * The narrow runtime surface this command needs from the Phase 37C live Dixie
+ * client. Resolved lazily (dynamic import) so the client module is never
+ * evaluated at bot startup — only after the enable / guild / operator gates
+ * pass. All live network egress lives inside `liveRecallViaDixie` (the client),
+ * never in this module.
+ */
+export interface RecallWedgeLiveDixieClientModule {
+  readonly loadLiveDixieClientConfigFromEnv: (
+    env: Env,
+  ) => LiveDixieClientConfig;
+  readonly liveRecallViaDixie: (
+    input: LiveRecallInput,
+    config: LiveDixieClientConfig,
+  ) => Promise<LiveDixieRecallResult>;
+  readonly findBannedPublicSubstring: (value: unknown) => string | null;
+}
+
+/**
+ * Default lazy loader — dynamic-imports the Phase 37C live Dixie client
+ * through the authorized package subpath. Evaluated ONLY on the fully-gated
+ * path; a disabled / wrong-guild / non-operator interaction never reaches it,
+ * so the client runtime (and its network egress) stays unloaded for refused
+ * calls.
+ */
+async function defaultLoadLiveClient(): Promise<RecallWedgeLiveDixieClientModule> {
+  return import(
+    '@freeside-characters/persona-engine/recall-wedge/live-dixie-client'
+  );
+}
+
+// -- classification → render decision (Phase 41A §I) -----------------------
+
+/**
+ * Classifications that may render a public/operator-safe summary. Their
+ * `stable_reason_code` is classifier-controlled in the Phase 37C client (never
+ * an echoed raw upstream string), and the config classes' reason codes are
+ * overridden to the bare class name below so no env name can ride along.
+ */
+const SAFE_SUMMARY_CLASSIFICATIONS = new Set<LiveDixieRecallClassification>([
+  'served',
+  'denied_or_forbidden',
+  'needs_review',
+  'ingress_invalid_request',
+  'service_unauthorized',
+  'tenant_or_session_mismatch',
+  'rate_limited',
+  'upstream_unavailable',
+  'missing_required_env',
+  'invalid_config',
+]);
+
+/**
+ * Classifications that ALWAYS fail closed to the generic refusal (Phase 41A
+ * §I): an unsafely-narrowable response shape, a transport failure, or unsafe
+ * idempotency-key reuse. Any classification not in `SAFE_SUMMARY_*` also fails
+ * closed by default (the renderer treats unknown classes as fail-closed).
+ */
+const FAIL_CLOSED_CLASSIFICATIONS = new Set<LiveDixieRecallClassification>([
+  'unsupported_response_shape',
+  'network_error',
+  'unsafe_idempotency_key_reuse',
+]);
+
+/**
+ * The fixed, public-safe Dixie route string surfaced in the operator summary
+ * (Phase 41A §I allows a safe non-secret route/path summary). Declared as a
+ * local literal so this module imports no client value at runtime; it matches
+ * the Phase 37C client's `LIVE_DIXIE_CLIENT_INTAKE_PATH`.
+ */
+const RECALL_WEDGE_LIVE_DEMO_ROUTE = '/api/recall/intake';
+
+const RECALL_WEDGE_LIVE_DEMO_FRAMING_HEADER =
+  'recall-wedge-live-demo · live Dixie dev demo (not production recall)\n' +
+  'gated · operator-only · ephemeral · phase 37c live Dixie client output';
+
+/**
+ * The minimal public/operator-safe slice of a live result the renderer reads.
+ * Only the narrowed classification / outcome / stable reason code — never the
+ * raw Dixie response, never `internal_diagnostic`, never raw_reasons / source
+ * fields / IDs / tokens.
+ */
+interface RenderableLiveSummary {
+  readonly classification: LiveDixieRecallClassification;
+  readonly outcome: string;
+  readonly stable_reason_code: string;
+}
+
+/**
+ * Render the public/operator-safe live-demo content from a narrowed summary,
+ * or return null to signal "fail closed to the generic refusal".
+ *
+ * Renders ONLY: the fixed dev-only framing, the classification, the public-safe
+ * outcome enum, the fixed safe route, and a stable reason code. For the config
+ * classes (`missing_required_env` / `invalid_config`) the reason is forced to
+ * the bare class name so a `missing:<ENV_NAME>`-style reason code can never
+ * surface an env name. Unknown / fail-closed classifications return null. The
+ * caller still runs the no-leak scan over this string as defense-in-depth.
+ */
+export function renderRecallWedgeLiveDemoContent(
+  summary: RenderableLiveSummary,
+): string | null {
+  if (FAIL_CLOSED_CLASSIFICATIONS.has(summary.classification)) return null;
+  if (!SAFE_SUMMARY_CLASSIFICATIONS.has(summary.classification)) return null;
+
+  const reason =
+    summary.classification === 'missing_required_env' ||
+    summary.classification === 'invalid_config'
+      ? summary.classification
+      : summary.stable_reason_code;
+
+  return [
+    RECALL_WEDGE_LIVE_DEMO_FRAMING_HEADER,
+    '',
+    `classification: ${summary.classification}`,
+    `outcome:        ${summary.outcome}`,
+    `route:          ${RECALL_WEDGE_LIVE_DEMO_ROUTE}`,
+    `reason:         ${reason}`,
+  ].join('\n');
+}
+
+/**
+ * Map a thrown live-client config error to a classification WITHOUT importing
+ * the client's error class as a runtime value (the static import stays
+ * type-only). Duck-types on the error's `code` field; anything unrecognized
+ * collapses to the conservative `invalid_config`.
+ */
+function configErrorClassification(
+  err: unknown,
+): 'missing_required_env' | 'invalid_config' {
+  const code =
+    err && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+  return code === 'missing_required_env' ? 'missing_required_env' : 'invalid_config';
+}
+
+// -- ephemeral delivery (Phase 41A §F · ephemeral-only) --------------------
+
+/**
+ * Build an ephemeral interaction response. EVERY response from this module —
+ * success or refusal — goes through here, so there is no non-ephemeral path
+ * and no public channel-visible output.
+ */
+function ephemeralResponse(content: string): DiscordInteractionResponse {
+  return {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: { content, flags: MessageFlags.EPHEMERAL },
+  };
+}
+
+/** The single generic refusal response (ephemeral, stable string). */
+export function recallWedgeLiveDemoRefusal(): DiscordInteractionResponse {
+  return ephemeralResponse(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+}
+
+/**
+ * Injectable seam (Phase 41B). Tests use `loadLiveClient` to prove:
+ *   - the live client is NOT loaded on refused (disabled/wrong-guild/
+ *     non-operator/empty-allowlist) paths and IS loaded only after the gates
+ *     pass;
+ *   - the injected client's `liveRecallViaDixie` is invoked exactly when
+ *     expected (call counting) and never on refused paths;
+ *   - a load failure after the gates pass fails closed to the generic refusal;
+ *   - a thrown live client fails closed;
+ *   - contaminated summaries fall back to the generic refusal (the injected
+ *     module supplies the real banned-substring helper).
+ * There is no network seam here: live egress is the client's responsibility,
+ * and tests inject the whole client module rather than a network primitive.
+ */
+export interface RecallWedgeLiveDemoDeps {
+  readonly loadLiveClient?: () => Promise<RecallWedgeLiveDixieClientModule>;
+}
+
+/**
+ * Handle a `/recall-wedge-live-demo` interaction.
+ *
+ * Fails closed (generic ephemeral refusal) unless ALL Discord gates pass:
+ *   enabled (exact "true") + allowed guild + operator allowlist.
+ *
+ * The Phase 37C live Dixie client is loaded LAZILY — only after all three
+ * gates pass (Phase 41A §J: no client evaluation, and crucially no network
+ * egress, on refused paths). After the gates pass, the handler:
+ *   1. lazily imports the live client seam (load failure → generic refusal);
+ *   2. loads the live client's own `RECALL_WEDGE_DIXIE_*` config (a config
+ *      throw is mapped to a safe `missing_required_env` / `invalid_config`
+ *      classification — never echoing an env name);
+ *   3. calls `liveRecallViaDixie` with the FIXED operator/dev probe (a thrown
+ *      client → generic refusal);
+ *   4. narrows the result and renders a public/operator-safe summary, or fails
+ *      closed for unknown / unsafe / transport classifications;
+ *   5. runs the client's banned-substring no-leak scan over the final content
+ *      and falls back to the generic refusal on any hit.
+ *
+ * Async because the client is dynamically imported and called; the dispatcher
+ * awaits the response. The only network egress is inside the client.
+ */
+export async function handleRecallWedgeLiveDemoInteraction(
+  interaction: DiscordInteraction,
+  env: Env = process.env,
+  deps: RecallWedgeLiveDemoDeps = {},
+): Promise<DiscordInteractionResponse> {
+  // Gate order is irrelevant to the user: all gates fail to the SAME refusal.
+  // No client load — and therefore no network egress — happens before these
+  // checks, so a refused interaction never reaches the live path.
+  if (!shouldEnableRecallWedgeLiveDiscordDemo(env)) {
+    return recallWedgeLiveDemoRefusal();
+  }
+  if (!isRecallWedgeLiveDiscordDemoAllowedGuild(interaction, env)) {
+    return recallWedgeLiveDemoRefusal();
+  }
+  if (!isRecallWedgeLiveDiscordDemoOperator(interaction, env)) {
+    return recallWedgeLiveDemoRefusal();
+  }
+
+  // Gates passed — NOW lazily load the live client. Any load failure fails
+  // closed to the generic refusal (never throws to dispatch).
+  const loadLiveClient = deps.loadLiveClient ?? defaultLoadLiveClient;
+  let client: RecallWedgeLiveDixieClientModule;
+  try {
+    client = await loadLiveClient();
+  } catch {
+    return recallWedgeLiveDemoRefusal();
+  }
+
+  // Resolve the live result. Config errors are mapped to safe classes; a
+  // thrown live call fails closed. NOTE: the request shape is the fixed
+  // synthetic probe above — the interaction's options are never read.
+  let summary: RenderableLiveSummary;
+  try {
+    const config = client.loadLiveDixieClientConfigFromEnv(env);
+    let result: LiveDixieRecallResult;
+    try {
+      result = await client.liveRecallViaDixie(
+        RECALL_WEDGE_LIVE_DEMO_FIXED_INPUT,
+        config,
+      );
+    } catch {
+      // A thrown live client fails closed (Phase 41A §I / §J).
+      return recallWedgeLiveDemoRefusal();
+    }
+    summary = {
+      classification: result.public_summary.classification,
+      outcome: result.public_summary.outcome,
+      stable_reason_code: result.public_summary.stable_reason_code,
+    };
+  } catch (err) {
+    // Missing / invalid live Dixie env/config fails closed to a SAFE classified
+    // summary (no env values, no env names) per Phase 41A §I.
+    const classification = configErrorClassification(err);
+    summary = {
+      classification,
+      outcome: 'config_error',
+      stable_reason_code: classification,
+    };
+  }
+
+  const content = renderRecallWedgeLiveDemoContent(summary);
+  if (content === null) return recallWedgeLiveDemoRefusal();
+
+  // Final no-leak scan — the Phase 37C client's exported banned-substring
+  // posture (Phase 41A §I). On any hit, fall back to the generic ephemeral
+  // refusal rather than emitting a leaky response.
+  if (client.findBannedPublicSubstring(content) !== null) {
+    return recallWedgeLiveDemoRefusal();
+  }
+
+  return ephemeralResponse(content);
+}
+
+// -- registration metadata (Phase 41A §M · guild-scoped only) --------------
+
+/**
+ * The `/recall-wedge-live-demo` registration payload (Phase 41A §M).
+ *
+ * Plain metadata — no client import, no runtime behavior — so it is safe to
+ * import from `lib/publish-commands.ts` without dragging in the live Dixie
+ * client (which is reached ONLY via the type-only import above and the gated
+ * dynamic import inside the handler).
+ *
+ * The description is explicitly dev-only / gated / live-Dixie / demo framed and
+ * makes NO production memory / recall / consent claim (it disclaims "not
+ * production recall"). There are NO options at all — the request shape is the
+ * fixed synthetic probe, so no freeform query path can exist (Phase 41A §H).
+ */
+export interface RecallWedgeLiveDemoCommandDefinition {
+  readonly name: typeof RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME;
+  readonly description: string;
+  readonly options: readonly never[];
+}
+
+export const RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION: RecallWedgeLiveDemoCommandDefinition =
+  {
+    name: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+    description:
+      'dev-only gated live Dixie demo (not production recall) · operator-only',
+    options: [],
+  };

--- a/apps/bot/src/lib/publish-commands.ts
+++ b/apps/bot/src/lib/publish-commands.ts
@@ -28,6 +28,17 @@ import {
   resolveRecallWedgeDiscordDemoGuildId,
   shouldRegisterRecallWedgeDiscordDemo,
 } from '../discord-interactions/recall-wedge-demo.ts';
+// Phase 41B: lightweight live-command METADATA only (a plain object) + the two
+// live registration env gates. Same posture as the Phase 39C import above —
+// recall-wedge-live-demo.ts reaches the Phase 37C live Dixie client ONLY via a
+// type-only import (erased at build) and a gated dynamic import() inside its
+// handler, so importing its metadata here adds NO live-client evaluation (and
+// no network egress) at startup / publish time.
+import {
+  RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION,
+  resolveRecallWedgeLiveDiscordDemoGuildId,
+  shouldRegisterRecallWedgeLiveDiscordDemo,
+} from '../discord-interactions/recall-wedge-live-demo.ts';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 
@@ -324,6 +335,112 @@ export async function registerRecallWedgeDemoCommand(
     const txt = await response.text().catch(() => '<unreadable>');
     throw new Error(
       `registerRecallWedgeDemoCommand: Discord POST failed for guild=${guildId} status=${response.status} body=${txt}`,
+    );
+  }
+
+  const created = (await response.json()) as { id: string; name: string };
+  return {
+    registered: true,
+    scope: 'guild',
+    guildId,
+    command: { name: created.name, id: created.id },
+  };
+}
+
+// =====================================================================
+// Phase 41B · dev/operator-only LIVE Dixie demo registration (guild-scoped ONLY)
+// =====================================================================
+//
+// Authority: docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md §G / §M.
+//
+// SEPARATE registration path for `/recall-wedge-live-demo`, posture-identical
+// to the Phase 39C `registerRecallWedgeDemoCommand` helper above but using the
+// LIVE command's own env names + command definition. Like the harness helper,
+// it is deliberately NOT routed through `publishCommands` / `buildCommandSet`
+// (the global-capable PUT path), so the live command can NEVER appear in a
+// global payload. It registers with a single POST to the guild-scoped command
+// route, and ONLY when both live env gates pass:
+//
+//   - RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS === "true" (exact); and
+//   - RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID is present + non-empty.
+//
+// Missing / near-truthy register flag, or a missing / blank guild id, skips
+// registration entirely (fail closed). There is NO global fallback: if the
+// guild id is absent the command is NOT registered anywhere (Phase 41A §G).
+
+export interface RegisterRecallWedgeLiveDemoOptions {
+  readonly botToken: string;
+  /** If absent, derived from `/applications/@me`. */
+  readonly applicationId?: string;
+  /** Defaults to `process.env`; the two §G gates are read from here. */
+  readonly env?: RegistrationEnv;
+}
+
+export type RegisterRecallWedgeLiveDemoResult =
+  | { readonly registered: false; readonly reason: 'gate_disabled' | 'no_guild' }
+  | {
+      readonly registered: true;
+      readonly scope: 'guild';
+      readonly guildId: string;
+      readonly command: { readonly name: string; readonly id: string };
+    };
+
+/**
+ * Register `/recall-wedge-live-demo` to the single configured guild,
+ * guild-scoped ONLY. Returns a skip result (without any network call) unless
+ * both live env gates pass. The Discord route used is ALWAYS the guild commands
+ * route (`/applications/{app}/guilds/{guild}/commands`); there is no branch
+ * that targets the global route.
+ *
+ * POST to the guild commands route is upsert-by-name (idempotent for this one
+ * command) and does NOT replace the guild's full command set — so it composes
+ * with both the separate `publishCommands` PUT and the Phase 39C harness-demo
+ * POST without clobbering other commands.
+ */
+export async function registerRecallWedgeLiveDemoCommand(
+  opts: RegisterRecallWedgeLiveDemoOptions,
+): Promise<RegisterRecallWedgeLiveDemoResult> {
+  if (!opts.botToken) {
+    throw new Error('registerRecallWedgeLiveDemoCommand: botToken is required');
+  }
+
+  const env = opts.env ?? process.env;
+
+  // Gate 1: exact-"true" register flag (near-truthy values fail closed).
+  if (!shouldRegisterRecallWedgeLiveDiscordDemo(env)) {
+    return { registered: false, reason: 'gate_disabled' };
+  }
+
+  // Gate 2: a present, non-empty guild id. Missing / blank / whitespace-only
+  // fails closed — and crucially does NOT fall back to global registration.
+  const guildId = resolveRecallWedgeLiveDiscordDemoGuildId(env);
+  if (!guildId) {
+    return { registered: false, reason: 'no_guild' };
+  }
+
+  const applicationId =
+    opts.applicationId ?? (await fetchApplicationId(opts.botToken));
+  if (!applicationId) {
+    throw new Error(
+      'registerRecallWedgeLiveDemoCommand: applicationId not provided and could not be derived from /applications/@me',
+    );
+  }
+
+  // Guild-scoped route ONLY — never the global `/applications/{app}/commands`.
+  const url = `${DISCORD_API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bot ${opts.botToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION),
+  });
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => '<unreadable>');
+    throw new Error(
+      `registerRecallWedgeLiveDemoCommand: Discord POST failed for guild=${guildId} status=${response.status} body=${txt}`,
     );
   }
 

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -25,7 +25,8 @@
     "./events/announcement-dispatcher": "./src/events/announcement-dispatcher.ts",
     "./events/announce-mint": "./src/events/announce-mint.ts",
     "./events/mint-announcement-render": "./src/events/mint-announcement-render.ts",
-    "./recall-wedge/multi-surface-recall-harness": "./src/recall-wedge/multi-surface-recall-harness.ts"
+    "./recall-wedge/multi-surface-recall-harness": "./src/recall-wedge/multi-surface-recall-harness.ts",
+    "./recall-wedge/live-dixie-client": "./src/recall-wedge/live-dixie-client.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Phase 41B implements the tightly gated dev/operator-only Discord live Dixie Recall Wedge demo command authorized by Phase 41A.

This PR adds a separate command:

- `/recall-wedge-live-demo`

It does not mutate `/recall-wedge-demo`.

The live command is disabled by default, guild-scoped, operator-gated, ephemeral-only, fixed-input only, and lazy-loads/calls the existing Phase 37C live Dixie client only after Discord gates pass.

## Files

New:

- apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
- apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts

Modified:

- apps/bot/src/discord-interactions/dispatch.ts
- apps/bot/src/lib/publish-commands.ts
- apps/bot/scripts/publish-commands.ts
- packages/persona-engine/package.json

Intentionally untouched:

- apps/bot/src/discord-interactions/recall-wedge-demo.ts
- apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
- packages/persona-engine/src/recall-wedge/live-dixie-client.ts
- packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts
- packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.ts
- packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
- packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.ts
- packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- packages/persona-engine/src/recall-wedge/render-public-recall.ts
- packages/persona-engine/src/recall-wedge/dixie-envelope-adapter.ts
- all docs
- fixture JSON
- config
- CI
- generated files
- lockfiles
- screenshots/images/binary files

## Package export

This PR adds one narrow persona-engine export subpath:

- `./recall-wedge/live-dixie-client`: `./src/recall-wedge/live-dixie-client.ts`

Reason:

- apps/bot has `rootDir: "src"`;
- a deep relative app-to-package import would climb outside rootDir and risk TS6059;
- this mirrors the existing Phase 39B harness export pattern;
- no dependency changes;
- no lockfile changes.

## Command separation

The new command name is exactly:

- `recall-wedge-live-demo`

There is no alias.

`/recall-wedge-demo` remains unchanged, harness-backed, and separately routed.

Dispatch now routes:

- `/recall-wedge-demo` to the existing harness demo handler
- `/recall-wedge-live-demo` to the new live Dixie demo handler

The live command is routed before character resolution / auth-bridge / chat-imagegen paths because it is not character-bound.

## Runtime invocation gates

The live command uses separate runtime env gates:

- `RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED`
- `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID`
- `RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS`

Rules:

- enabled only when `RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED === "true"`
- missing, empty, whitespace, or near-truthy values fail closed
- configured guild ID must be present and non-empty
- interaction guild ID must exactly match the configured guild
- operator allowlist must be present and non-empty
- comma-separated allowlist trims spaces and drops empties
- invoking user must be allowlisted

Disabled / wrong-guild / missing-guild / non-operator / empty-allowlist paths all return the same generic ephemeral refusal:

- `recall-wedge-live-demo is not available here.`

Refused paths:

- do not reveal which gate failed
- do not load the live Dixie client
- do not call the live Dixie client
- make no network request
- are ephemeral

## Registration gates

The live command uses separate registration env gates:

- `RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS`
- `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID`

Rules:

- register only when `RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS === "true"`
- missing, empty, whitespace, or near-truthy values do not register
- missing/blank/whitespace guild ID does not register
- no network call happens when registration gates fail
- no global fallback exists

Enabled path POSTs only to the guild command route:

- `/applications/{applicationId}/guilds/{guildId}/commands`

It never targets the global command route:

- `/applications/{applicationId}/commands`

The live command is not added to `buildCommandSet` or any global-capable command array.

## Command input

The live command has no options:

- `options: []`

There is no:

- freeform recall query
- text option
- Discord message history input
- channel content input
- hidden fallback to interaction text
- user memory input

The handler reads no `interaction.data.options`.

It uses a fixed deterministic operator/dev probe aligned to the Phase 37C `LiveRecallInput` contract.

The fixed input:

- uses `environmentFrame: "private_operator"`
- uses low/minimal detail posture
- includes no real secret
- includes no fixed idempotency key, so the Phase 37C client can mint a fresh key per call
- does not use `recorded_dixie_recall_envelope`
- does not import recorded fixtures
- does not use Discord channel/user content

## Live Dixie client boundary

The handler uses the existing Phase 37C live Dixie client seam:

- `packages/persona-engine/src/recall-wedge/live-dixie-client.ts`

The static import is type-only through the authorized package subpath.

Runtime import is dynamic and happens only after all Discord gates pass.

All live network egress remains inside the Phase 37C live client. The Discord handler does not create a raw fetch/HTTP path.

The handler calls:

- `loadLiveDixieClientConfigFromEnv`
- `liveRecallViaDixie`
- `findBannedPublicSubstring`

through an injectable loaded-client seam.

Tests prove:

- refused paths do not load the client
- refused paths do not call the client
- load/call happen only after gates pass
- load failure after gates pass fails closed
- thrown live client fails closed
- default loader with missing live env produces no network egress

## Live Dixie env/config boundary

Discord env gates only decide whether Discord may reach the client.

The Phase 37C live Dixie client keeps its own env/config:

- `RECALL_WEDGE_DIXIE_BASE_URL`
- `RECALL_WEDGE_DIXIE_SERVICE_TOKEN`
- `RECALL_WEDGE_DIXIE_TENANT_ID`
- `RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID`
- `RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX`
- optional `RECALL_WEDGE_DIXIE_TIMEOUT_MS`

The new registration code consumes no `RECALL_WEDGE_DIXIE_*` secret envs.

Missing/invalid live Dixie config returns either generic refusal or a safe config summary with no env names/values.

## Output rendering

Every response is ephemeral.

The live output framing is:

- `recall-wedge-live-demo · live Dixie dev demo (not production recall)`
- `gated · operator-only · ephemeral · phase 37c live Dixie client output`

Rendered fields are limited to:

- classification
- outcome
- fixed safe route: `/api/recall/intake`
- stable reason

The output does not render:

- raw Dixie response
- `internal_diagnostic`
- `http_status`
- fingerprint
- idempotency key
- request body
- headers
- tenant/caller IDs
- app/guild/user/command IDs
- `raw_reasons`
- debug payloads
- source fields
- private identifiers
- raw assertion IDs
- service errors
- stack traces
- tokens
- operational IDs

Final content is scanned with the Phase 37C `findBannedPublicSubstring`.

Contaminated output falls back to generic refusal.

## Classification handling

The classification set aligns to Phase 37C:

- `served`
- `denied_or_forbidden`
- `needs_review`
- `ingress_invalid_request`
- `service_unauthorized`
- `tenant_or_session_mismatch`
- `rate_limited`
- `upstream_unavailable`
- `unsupported_response_shape`
- `network_error`
- `missing_required_env`
- `invalid_config`
- `unsafe_idempotency_key_reuse`

Safe summaries are allowed for:

- `served`
- `denied_or_forbidden`
- `needs_review`
- `ingress_invalid_request`
- `service_unauthorized`
- `tenant_or_session_mismatch`
- `rate_limited`
- `upstream_unavailable`
- `missing_required_env`
- `invalid_config`

Always fail closed for:

- `unsupported_response_shape`
- `network_error`
- `unsafe_idempotency_key_reuse`
- unknown classifications

Config classes force the reason to the bare class name, preventing env-name leaks.

## Fail-closed behavior

Generic ephemeral refusal is returned on:

- disabled gate
- near-truthy enable gate
- missing/blank guild
- wrong guild
- missing/blank operator allowlist
- non-operator
- client load failure
- thrown client
- unsupported response shape
- network error
- unsafe idempotency reuse
- unknown classification
- no-leak scan hit

Gate failures and unsafe paths do not reveal internals.

## `/recall-wedge-demo` preservation

`/recall-wedge-demo` remains harness-backed and unchanged.

Evidence:

- `apps/bot/src/discord-interactions/recall-wedge-demo.ts` untouched
- `apps/bot/src/discord-interactions/recall-wedge-demo.test.ts` untouched
- Phase 39C regression tests still pass
- new static guard reasserts the harness command imports no live Dixie client or runner
- command name remains `recall-wedge-demo`
- dispatch routes both commands independently
- registration paths are separate
- `/recall-wedge-demo` still does not consume live Dixie env

## Static guards

The new tests cover:

- no Telegram/private-chat imports
- no storage clients
- no Finn imports
- no `@loa/dixie` or `@loa/straylight` runtime imports
- no LLM/Claude SDK imports
- no `render-public-recall` import
- no `dixie-envelope-adapter` import
- no recorded fixture import
- no `recorded_dixie_recall_envelope`
- no memory-admission/candidate-write/remember-this affordance
- no `child_process`
- no `node:tls` / `tls`
- no raw fetch or low-level network primitive in the Discord handler
- registration code imports no live client/runner/harness
- global publish command set excludes live command

## Publish script behavior

`apps/bot/scripts/publish-commands.ts` calls `registerRecallWedgeLiveDemoCommand` after existing command publishing and the harness demo helper.

Missing gates print:

- `/recall-wedge-live-demo NOT registered (...)`

Enabled path prints successful guild registration.

This does not alter startup auto-publish. `apps/bot/src/index.ts` still calls only the existing global-capable publish path.

## Results

Validation commands run:

- git status --short --branch --untracked-files=all
- git diff --name-status
- git diff --stat
- git diff --check
- node docs/recall-wedge/fixtures/validate-fixtures.mjs
- bun test apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
- bun test apps/bot/src/discord-interactions/recall-wedge-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts
- bun run --cwd apps/bot typecheck --pretty false
- grep typecheck output for recall-wedge-live-demo / recall-wedge-demo / multi-surface-recall-harness / live-dixie / TS6059 / rootDir
- git diff --cached --name-status
- git diff --cached --stat
- git diff --cached --check

Results:

- git diff --check: clean
- fixture validator: 122 passed, 0 failed
- Phase 41B live Discord demo tests: 134 passed, 0 failed, 530 expect() calls
- Phase 39C harness Discord demo regression: 116 passed, 0 failed, 339 expect() calls
- Phase 37C live Dixie client + runner regressions: 104 passed, 0 failed, 437 expect() calls
- Phase 38A harness regression: 52 passed, 0 failed, 806 expect() calls
- apps/bot typecheck: 151 errors, known dirty baseline
- no Phase 41B live/harness/recall-wedge TS6059 rootDir references found
- no docs/fixtures/config/CI/generated unexpected files touched
- staged diff check: clean
- Codex audit: ACCEPT
- no file/line concerns
- no required patch

## Non-goals

This PR intentionally does not add:

- docs changes
- fixture JSON changes
- config changes
- CI changes
- generated files
- lockfile changes
- dependency changes
- screenshots/images/binary files
- changes to `/recall-wedge-demo`
- changes to the Phase 37C live Dixie client source/tests
- changes to the Phase 37C live Dixie runner source/tests
- changes to the Phase 38A harness source/tests
- changes to `render-public-recall.ts`
- changes to `dixie-envelope-adapter.ts`
- public channel-visible recall
- global registration
- freeform recall query input
- Discord message history input
- memory admission
- candidate-memory writes
- remember-this behavior
- Telegram API/bot/rendering wiring
- private chat integration
- production storage/admission
- production auth/consent implementation
- direct Finn runtime/audit wiring beyond existing seams
- LLM rewriting
- character voice
- public renderer expansion
- production rollout
- Phase 41C smoke-test acceptance
