### PR TITLE
feat(bot): wire inventoryApiBaseUrl into announce-mint dispatcher (#139 gate 2a)

### DIFF
--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -386,6 +386,14 @@ async function main(): Promise<void> {
       const mstCanaryChannelId = process.env.MST_CANARY_CHANNEL_ID?.trim() ?? '';
       const identityApiBaseUrl =
         process.env.IDENTITY_API_URL?.trim() ?? 'https://identity.0xhoneyjar.xyz';
+      // inventory-api (Hyper Bun HTTP+MCP service) — the mint-image/traits
+      // enrichment source. Consumed over the wire via the persona-engine HTTP
+      // client (announce-mint → fetchNftMetadataHttp). Defaults to the live
+      // Railway deployment; override per-env with INVENTORY_API_URL. Unset →
+      // announce-mint fail-softs to imageless (dormant-until-configured).
+      const inventoryApiBaseUrl =
+        process.env.INVENTORY_API_URL?.trim() ??
+        'https://inventory-api-production-3f25.up.railway.app';
 
       // Build the dispatcher only when the bot client is available — it's
       // the discord.js Client carrying the Bot token for the Components-V2 REST
@@ -396,6 +404,7 @@ async function main(): Promise<void> {
         botClient && mstCanaryEnabled && mstCanaryChannelId
           ? createAnnouncementDispatcher({
               identityApiBaseUrl,
+              inventoryApiBaseUrl,
               discordSendFn: async (msg) => {
                 await postToChannel(botClient, msg.channelId, {
                   content: msg.contentFallback ?? '',


### PR DESCRIPTION
the last hop of MST image enrichment. #141 threaded `inventoryApiBaseUrl` through `createAnnouncementDispatcher → announce-mint → fetchNftMetadataHttp`, but `apps/bot/src/index.ts` never passed it — so the value stayed `undefined` and the image path fail-softed to imageless.

**change** (`index.ts`): read `INVENTORY_API_URL` (default the live Railway deploy `https://inventory-api-production-3f25.up.railway.app`) + pass `inventoryApiBaseUrl` into `createAnnouncementDispatcher` alongside `identityApiBaseUrl`.

**live-verified upstream:** inventory-api redeployed today (`831123c`) and serves MST — `GET /nfts/0x0483…c008/234` → `200` + `assets…/Mibera/generated/234.webp` + 19 traits (image byte `200 image/webp ~0.4MB`).

**still gated** (intended): image renders only when the MST canary is on (`MST_CANARY_ENABLED=1` + `MST_CANARY_CHANNEL_ID`) AND cycle-009 reaches prod. typecheck clean.

Refs #139 · activation gate 2a
🤖 Generated with [Claude Code](https://claude.com/claude-code)