### PR TITLE
feat(events): MST mint image+traits via inventory-api HTTP — decoupled to main

### DIFF
--- a/apps/bot/scripts/smoke-mint-announce.ts
+++ b/apps/bot/scripts/smoke-mint-announce.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * smoke-mint-announce.ts — offline visual smoke for the shadow-mint announcement.
+ *
+ * Drives ONE synthetic Mibera Shadow (MST) mint through the real DEP-2 pipeline
+ * — announceMint() -> enrichment fail-soft -> buildEnrichedMintAnnouncement ->
+ * captured Discord send — and PRINTS the Components-V2 payload + plain-text
+ * fallback to stdout. No NATS, no JWKS, no live creds: every external surface
+ * is supplied via announceMint's public test seams (metadataFetchFn, fetchFn,
+ * discordWebhookSendFn).
+ *
+ * Why this exists: the go-live brief (cluster-events-pillar-v1, 2026-05-28)
+ * flagged that there was NO standalone way to eyeball a rendered mint
+ * announcement before wiring Railway. This closes that gap for repeatable
+ * voice/format iteration — the FEEL surface for the canary.
+ *
+ * It renders BOTH variants so the contrast is visible in one run:
+ *   1. ENRICHED  — nym + image + traits (the TARGET state once inventory-api
+ *      is deployed and inventoryApiBaseUrl is configured; see brief §3 Gap #3).
+ *   2. FAIL-SOFT — shortAddress + NO image + NO traits (what the canary posts
+ *      when inventoryApiBaseUrl is unset / inventory-api is unreachable).
+ *
+ * Read-only. Additive dev harness (mirrors apps/bot/scripts/verify-score-events.ts).
+ *
+ * Run:        bun run apps/bot/scripts/smoke-mint-announce.ts
+ * Token id:   bun run apps/bot/scripts/smoke-mint-announce.ts 1337
+ * One variant: SMOKE_VARIANT=enriched|failsoft bun run apps/bot/scripts/smoke-mint-announce.ts
+ */
+
+import {
+  announceMint,
+  type DiscordMessagePayload,
+} from '@freeside-characters/persona-engine/events/announce-mint';
+import type { MintEventSubscriberLogger } from '@freeside-characters/persona-engine/events/mint-event-subscriber';
+
+// Mibera Shadow (MST) canonical contract — matches announce-mint.ts MST_CONTRACT.
+const MST_CONTRACT = '0x048327a187b944ddac61c6e202bfccd20d17c008';
+
+// Structural shape of the events package's NftMintDetected (type-only import in
+// the lib is erased at runtime, so we build the object structurally here to keep
+// the harness independent of the @0xhoneyjar/events dist being present).
+interface SyntheticMint {
+  chain_id: number;
+  contract: string;
+  token_id: string;
+  minter: string;
+  block_number: number;
+  transaction_hash: string;
+  timestamp: string;
+}
+
+const tokenId = (process.argv[2] ?? '234').replace(/[^\d]/g, '') || '234';
+const variantFilter = process.env.SMOKE_VARIANT?.trim().toLowerCase();
+
+const PAYLOAD: SyntheticMint = {
+  chain_id: 80094, // Berachain mainnet
+  contract: MST_CONTRACT,
+  token_id: tokenId,
+  minter: '0x000000000000000000000000000000000000abcd',
+  block_number: 12_345_678,
+  transaction_hash: '0x' + 'ab'.repeat(32),
+  timestamp: '2026-05-28T18:30:00Z',
+};
+
+// Quiet logger — the harness prints its own structured output. Flip VERBOSE=1 to
+// see the lib's fail-soft warnings (useful when debugging enrichment timeouts).
+const verbose = process.env.VERBOSE === '1';
+const logger: MintEventSubscriberLogger = {
+  info: (obj, msg) => verbose && console.error('  · info', msg ?? '', obj),
+  warn: (obj, msg) => verbose && console.error('  · warn', msg ?? '', obj),
+  error: (obj, msg) => console.error('  · error', msg ?? '', obj),
+};
+
+/** identity-api stub. nym!=null → enriched display; null → simulate the live 400 (fail-soft to shortAddress). */
+function makeIdentityFetch(nym: string | null): typeof fetch {
+  return (async () => {
+    if (nym == null) {
+      return new Response('phase-2-not-built', { status: 400 });
+    }
+    return new Response(
+      JSON.stringify({ identity: { world_identities: [{ world_slug: 'mibera', nym }] } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+/**
+ * inventory-api stub — fakes the HTTP route GET /nfts/{contract}/{tokenId}.
+ * inventory-api is a deployed Hyper service consumed over the wire; this stub
+ * stands in for it so the smoke runs fully offline (no network, no deploy).
+ *   withImage=true  → 200 with a representative MST metadata document.
+ *   withImage=false → 404 (unknown token) → client fail-softs to no image.
+ */
+function makeInventoryFetch(withImage: boolean): typeof fetch {
+  return (async (url: string | URL) => {
+    if (!withImage) {
+      return new Response(JSON.stringify({ error: { status: 404, message: 'not found' } }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    // tokenId is the last path segment of /nfts/{contract}/{tokenId}
+    const tid = String(url).split('/').pop() ?? tokenId;
+    return new Response(
+      JSON.stringify({
+        name: `Mibera Shadow #${tid}`,
+        description: 'a shadow',
+        // representative MST asset URL shape (metadata.0xhoneyjar.xyz per recon).
+        image: `https://metadata.0xhoneyjar.xyz/mibera-shadow/${tid}.png`,
+        attributes: [
+          { trait_type: 'Element', value: 'Shadow' },
+          { trait_type: 'Archetype', value: 'Wanderer' },
+          { trait_type: 'Era', value: 'Owsley' },
+          { trait_type: 'Swag', value: 'A' },
+        ],
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+async function renderVariant(
+  label: string,
+  desc: string,
+  opts: { nym: string | null; withImage: boolean },
+): Promise<void> {
+  const captured: DiscordMessagePayload[] = [];
+  const result = await announceMint({
+    payload: PAYLOAD as never, // structural match to NftMintDetected
+    identityApiBaseUrl: 'https://identity.0xhoneyjar.xyz',
+    inventoryApiBaseUrl: 'https://inventory.0xhoneyjar.xyz',
+    discordWebhookSendFn: async (msg) => {
+      captured.push(msg);
+    },
+    channelId: 'C_SMOKE_TEST',
+    logger,
+    fetchFn: makeIdentityFetch(opts.nym),
+    metadataFetchFn: makeInventoryFetch(opts.withImage),
+  });
+
+  console.log(`\n${'━'.repeat(72)}`);
+  console.log(`  ${label}`);
+  console.log(`  ${desc}`);
+  console.log('━'.repeat(72));
+  console.log(`  posted=${result.posted}${result.reason ? ` reason=${result.reason}` : ''}`);
+
+  const msg = captured[0];
+  if (!msg) {
+    console.log('  (no payload captured)');
+    return;
+  }
+  console.log('\n  ── plain-text fallback (embeds-disabled clients) ──');
+  console.log(
+    (msg.contentFallback ?? '(none)')
+      .split('\n')
+      .map((l) => `  │ ${l}`)
+      .join('\n'),
+  );
+  console.log('\n  ── Components V2 payload (IS_COMPONENTS_V2 flag) ──');
+  console.log(
+    JSON.stringify(msg.components, null, 2)
+      .split('\n')
+      .map((l) => `  ${l}`)
+      .join('\n'),
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(`\n🌒 shadow-mint announcement smoke · MST #${tokenId} · Berachain`);
+  console.log('   (offline — all enrichment via announceMint test seams, no NATS/JWKS/network)');
+
+  const variants: Array<[string, string, { nym: string | null; withImage: boolean }]> = [
+    [
+      '1 · ENRICHED  (target state — once inventory-api is deployed + configured, brief §3)',
+      'nym + image (full-bleed MediaGallery) + traits',
+      { nym: 'velvetfang', withImage: true },
+    ],
+    [
+      '2 · FAIL-SOFT (what the canary posts when inventoryApiBaseUrl is unset / unreachable)',
+      'shortAddress + NO image + NO traits',
+      { nym: null, withImage: false },
+    ],
+  ];
+
+  for (const [label, desc, opts] of variants) {
+    if (variantFilter === 'enriched' && !label.startsWith('1')) continue;
+    if (variantFilter === 'failsoft' && !label.startsWith('2')) continue;
+    await renderVariant(label, desc, opts);
+  }
+
+  console.log(`\n${'━'.repeat(72)}`);
+  console.log('  what this proves: the DEP-2 render + fail-soft contract is sound.');
+  console.log('  what it does NOT prove: live image resolution (blocked — see brief Gap #3),');
+  console.log('  signature verification (Gap #1 JWKS), or sonar emission (Gap #2).');
+  console.log('━'.repeat(72) + '\n');
+}
+
+main().catch((err) => {
+  console.error('smoke failed:', err);
+  process.exit(1);
+});

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -385,6 +385,14 @@ async function main(): Promise<void> {
       const mstCanaryChannelId = process.env.MST_CANARY_CHANNEL_ID?.trim() ?? '';
       const identityApiBaseUrl =
         process.env.IDENTITY_API_URL?.trim() ?? 'https://identity.0xhoneyjar.xyz';
+      // inventory-api (Hyper Bun HTTP+MCP service) — the mint-image/traits
+      // enrichment source. Consumed over the wire via the persona-engine HTTP
+      // client (announce-mint → fetchNftMetadataHttp). Defaults to the live
+      // Railway deployment; override per-env with INVENTORY_API_URL. Unset →
+      // announce-mint fail-softs to imageless (dormant-until-configured).
+      const inventoryApiBaseUrl =
+        process.env.INVENTORY_API_URL?.trim() ??
+        'https://inventory-api-production-3f25.up.railway.app';
 
       // Build the dispatcher only when the bot client is available — it's
       // the discord.js Client carrying the Bot token for the Components-V2 REST
@@ -395,6 +403,7 @@ async function main(): Promise<void> {
         botClient && mstCanaryEnabled && mstCanaryChannelId
           ? createAnnouncementDispatcher({
               identityApiBaseUrl,
+              inventoryApiBaseUrl,
               discordSendFn: async (msg) => {
                 await postToChannel(botClient, msg.channelId, {
                   content: msg.contentFallback ?? '',

--- a/packages/persona-engine/src/events/announce-mint.test.ts
+++ b/packages/persona-engine/src/events/announce-mint.test.ts
@@ -9,9 +9,11 @@
  *   - discordWebhookSendFn throws → returns { posted: false, reason } (subscriber stays alive)
  *   - Timeout: identity fetch exceeds fetchTimeoutMs → treated as failure
  *
- * Bypasses the lazy-import path for @0xhoneyjar/inventory via the
- * inventoryModule option (test seam). identity-api uses the injectable
- * fetchFn (test seam). No real network I/O.
+ * Both enrichment paths are HTTP. identity-api uses the injectable `fetchFn`
+ * seam; inventory-api (GET /nfts/{contract}/{tokenId}) uses the dedicated
+ * `metadataFetchFn` seam so the two stay independently mockable. No real
+ * network I/O. The `@0xhoneyjar/inventory` dynamic import (phantom dep) is
+ * gone — inventory-api is consumed over the wire, never as a package.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -112,6 +114,42 @@ function makeFakeFetch(opts: {
   }) as unknown as typeof fetch;
 }
 
+/**
+ * Build a fake fetch for the inventory-api endpoint
+ * (GET /nfts/{contract}/{tokenId} → metadata document, unwrapped).
+ *   - `metadata` set → 200 with that body (image + attributes).
+ *   - `status` (e.g. 404) → non-OK → client fail-softs to null.
+ *   - `throwError` → network failure.
+ *   - `delayMs` → slow response (honors abort signal for timeout testing).
+ */
+function makeInventoryFetch(opts: {
+  metadata?: { image?: string | null; attributes?: Array<{ trait_type?: string; value?: string | number }> } | null;
+  status?: number;
+  throwError?: boolean;
+  delayMs?: number;
+}): typeof fetch {
+  return (async (_url: string | URL, init?: RequestInit) => {
+    if (opts.throwError) {
+      throw new Error('inventory unreachable');
+    }
+    if (opts.delayMs) {
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, opts.delayMs);
+        init?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new Error('aborted'));
+        });
+      });
+    }
+    const status = opts.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => opts.metadata ?? { error: { status, message: 'not found' } },
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
 // ── helper exports tests ─────────────────────────────────────────────────────
 
 describe('DEP-2 · helpers', () => {
@@ -181,19 +219,20 @@ describe('DEP-2 · announceMint · happy path', () => {
     const result = await announceMint({
       payload: PAYLOAD,
       identityApiBaseUrl: 'https://identity.test',
+      inventoryApiBaseUrl: 'https://inventory.test',
       discordWebhookSendFn: sender.send,
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: {
-        getNftMetadata: async () => ({
+      metadataFetchFn: makeInventoryFetch({
+        metadata: {
           image: 'https://cdn.test/shadow-234.png',
           attributes: [
             { trait_type: 'Background', value: 'Void' },
             { trait_type: 'Eyes', value: 'Glowing' },
           ],
-        }),
-      },
+        },
+      }),
     });
 
     expect(result.posted).toBe(true);
@@ -221,9 +260,10 @@ describe('DEP-2 · announceMint · identity-api fail-soft', () => {
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: {
-        getNftMetadata: async () => ({ image: 'https://cdn.test/x.png', attributes: [] }),
-      },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({
+        metadata: { image: 'https://cdn.test/x.png', attributes: [] },
+      }),
     });
 
     expect(result.posted).toBe(true);
@@ -247,7 +287,8 @@ describe('DEP-2 · announceMint · identity-api fail-soft', () => {
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: { getNftMetadata: async () => null },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ status: 404 }),
     });
 
     expect(result.posted).toBe(true);
@@ -266,7 +307,8 @@ describe('DEP-2 · announceMint · identity-api fail-soft', () => {
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: { getNftMetadata: async () => null },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ status: 404 }),
     });
 
     expect(result.posted).toBe(true);
@@ -287,11 +329,8 @@ describe('DEP-2 · announceMint · inventory-api fail-soft', () => {
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: {
-        getNftMetadata: async () => {
-          throw new Error('inventory unhealthy');
-        },
-      },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ throwError: true }),
     });
 
     expect(result.posted).toBe(true);
@@ -300,7 +339,7 @@ describe('DEP-2 · announceMint · inventory-api fail-soft', () => {
     expect(fallback).toContain('shadowmaker');
     expect(fallback).not.toContain('https://cdn.');
     const warns = logger.warns.filter((w) =>
-      w.msg?.includes('inventory module unavailable'),
+      w.msg?.includes('inventory-api unavailable'),
     );
     expect(warns.length).toBe(1);
   });
@@ -317,7 +356,8 @@ describe('DEP-2 · announceMint · inventory-api fail-soft', () => {
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: { getNftMetadata: async () => null },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ status: 404 }),
     });
 
     expect(result.posted).toBe(true);
@@ -326,24 +366,32 @@ describe('DEP-2 · announceMint · inventory-api fail-soft', () => {
     expect(fallback).not.toContain('https://cdn.');
   });
 
-  test('inventory module missing getNftMetadata function → fail-soft', async () => {
+  test('inventoryApiBaseUrl unset (pre-deploy / CI) → no fetch, fail-soft no image', async () => {
     const logger = makeSpyLogger();
     const sender = makeSpySender();
     const fetchFn = makeFakeFetch({ nym: 'shadowmaker' });
+    let inventoryCalled = false;
+    const metadataFetchFn = (async () => {
+      inventoryCalled = true;
+      throw new Error('should not be called when baseUrl is unset');
+    }) as unknown as typeof fetch;
 
     const result = await announceMint({
       payload: PAYLOAD,
       identityApiBaseUrl: 'https://identity.test',
+      // inventoryApiBaseUrl intentionally omitted — the dormant-until-deploy case
       discordWebhookSendFn: sender.send,
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: {}, // no getNftMetadata
+      metadataFetchFn,
     });
 
     expect(result.posted).toBe(true);
+    expect(inventoryCalled).toBe(false); // no baseUrl → no fetch at all
     const fallback = sender.calls[0]!.contentFallback ?? '';
     expect(fallback).toContain('shadowmaker');
+    expect(fallback).not.toContain('https://cdn.');
   });
 });
 
@@ -360,11 +408,8 @@ describe('DEP-2 · announceMint · both fail-soft (canary-safe minimal post)', (
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: {
-        getNftMetadata: async () => {
-          throw new Error('inventory down');
-        },
-      },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ throwError: true }),
     });
 
     expect(result.posted).toBe(true);
@@ -390,7 +435,8 @@ describe('DEP-2 · announceMint · discord send failure', () => {
       channelId: 'CHAN_123',
       logger,
       fetchFn,
-      inventoryModule: { getNftMetadata: async () => null },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ status: 404 }),
     });
 
     expect(result.posted).toBe(false);
@@ -417,11 +463,107 @@ describe('DEP-2 · announceMint · timeout', () => {
       logger,
       fetchFn,
       fetchTimeoutMs: 30,
-      inventoryModule: { getNftMetadata: async () => null },
+      inventoryApiBaseUrl: 'https://inventory.test',
+      metadataFetchFn: makeInventoryFetch({ status: 404 }),
     });
 
     expect(result.posted).toBe(true);
     // timed-out identity fetch → fell back to shortAddress
     expect(sender.calls[0]!.contentFallback).toContain('0x0000…abcd');
+  });
+
+  test('inventory fetch exceeds fetchTimeoutMs → no image, announcement still ships', async () => {
+    const logger = makeSpyLogger();
+    const sender = makeSpySender();
+    const fetchFn = makeFakeFetch({ nym: 'shadowmaker' });
+    // slow inventory-api: 200ms response, timeout 30ms → AbortController aborts
+    const metadataFetchFn = makeInventoryFetch({
+      metadata: { image: 'https://cdn.test/slow.png', attributes: [] },
+      delayMs: 200,
+    });
+
+    const result = await announceMint({
+      payload: PAYLOAD,
+      identityApiBaseUrl: 'https://identity.test',
+      inventoryApiBaseUrl: 'https://inventory.test',
+      discordWebhookSendFn: sender.send,
+      channelId: 'CHAN_123',
+      logger,
+      fetchFn,
+      fetchTimeoutMs: 30,
+      metadataFetchFn,
+    });
+
+    expect(result.posted).toBe(true);
+    const fallback = sender.calls[0]!.contentFallback ?? '';
+    expect(fallback).toContain('shadowmaker'); // identity still resolved
+    expect(fallback).not.toContain('https://cdn.'); // image timed out → omitted
+  });
+});
+
+describe('DEP-2 · announceMint · inventory-api HTTP contract', () => {
+  test('inventory fetch hits GET {base}/nfts/{contract}/{tokenId} and renders the image', async () => {
+    const logger = makeSpyLogger();
+    const sender = makeSpySender();
+    const fetchFn = makeFakeFetch({ nym: 'shadowmaker' });
+
+    const seenUrls: string[] = [];
+    const metadataFetchFn = (async (url: string | URL) => {
+      seenUrls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          name: 'Shadow #234',
+          description: 'a shadow',
+          image: 'https://metadata.0xhoneyjar.xyz/mibera-shadow/234.png',
+          attributes: [{ trait_type: 'Element', value: 'Shadow' }],
+        }),
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    const result = await announceMint({
+      payload: PAYLOAD,
+      identityApiBaseUrl: 'https://identity.test',
+      inventoryApiBaseUrl: 'https://inventory.test/', // trailing slash → stripped
+      discordWebhookSendFn: sender.send,
+      channelId: 'CHAN_123',
+      logger,
+      fetchFn,
+      metadataFetchFn,
+    });
+
+    expect(result.posted).toBe(true);
+    // URL shape: trailing slash stripped, contract + tokenId path-encoded
+    expect(seenUrls.length).toBe(1);
+    expect(seenUrls[0]).toBe(
+      `https://inventory.test/nfts/${encodeURIComponent(MST_CONTRACT)}/${encodeURIComponent('234')}`,
+    );
+    // image flowed through to the fallback (and thus the MediaGallery)
+    expect(sender.calls[0]!.contentFallback).toContain(
+      'https://metadata.0xhoneyjar.xyz/mibera-shadow/234.png',
+    );
+  });
+
+  test('inventory 400 (bad input) → fail-soft no image, warn logged', async () => {
+    const logger = makeSpyLogger();
+    const sender = makeSpySender();
+    const fetchFn = makeFakeFetch({ nym: 'shadowmaker' });
+
+    const result = await announceMint({
+      payload: PAYLOAD,
+      identityApiBaseUrl: 'https://identity.test',
+      inventoryApiBaseUrl: 'https://inventory.test',
+      discordWebhookSendFn: sender.send,
+      channelId: 'CHAN_123',
+      logger,
+      fetchFn,
+      metadataFetchFn: makeInventoryFetch({ status: 400 }),
+    });
+
+    expect(result.posted).toBe(true);
+    expect(sender.calls[0]!.contentFallback).not.toContain('https://cdn.');
+    const warns = logger.warns.filter((w) => w.msg?.includes('inventory-api non-OK'));
+    expect(warns.length).toBe(1);
   });
 });

--- a/packages/persona-engine/src/events/announce-mint.ts
+++ b/packages/persona-engine/src/events/announce-mint.ts
@@ -8,7 +8,7 @@
  * Pipeline:
  *   1. Parallel-fetch enrichment (Promise.allSettled, fail-soft):
  *      - identity-api `/v1/profile?world=mibera&wallet=<minter>` → nym
- *      - inventory-api `getNftMetadata(contract, token_id)` → image + traits
+ *      - inventory-api `GET /nfts/{contract}/{tokenId}` → image + traits
  *   2. Derive display name: identity nym → shortenAddress (NEVER ENS).
  *   3. Build Components V2 payload via buildEnrichedMintAnnouncement.
  *   4. discordWebhookSendFn(payload) — wrapped in try/catch; never throws.
@@ -20,13 +20,17 @@
  *     + no traits (canary-safe minimal post; visible rather than silent).
  *   - Either enrichment fetch exceeds `fetchTimeoutMs` (default 3000ms) → treated
  *     as failure (matches the resolve-nft-pfp.ts pattern).
+ *   - `inventoryApiBaseUrl` unset (CI / dev / pre-deploy) → no image / no traits,
+ *     announcement still ships. Image enrichment is dormant-until-deploy.
  *   - discordWebhookSendFn throws → returns { posted: false, reason } without
  *     bubbling — the subscriber must stay alive for the next envelope.
  *
- * Lazy-import shape for @0xhoneyjar/inventory mirrors
- * `packages/persona-engine/src/orchestrator/inventory/resolve-nft-pfp.ts`:
- * dynamic specifier so the package builds without the dependency present;
- * runtime resolves via the deploy/gateway. CI + dev without it fail-soft.
+ * inventory-api is a deployed Hyper (Bun) HTTP+MCP service, consumed over the
+ * wire via the thin typed client in
+ * `packages/persona-engine/src/orchestrator/inventory/inventory-http-client.ts`
+ * — NEVER as an npm package (the earlier `@0xhoneyjar/inventory` dynamic-import
+ * plan was a phantom dep; dead). The image path mirrors the identity-api fetch
+ * posture exactly: bounded fetch, fail-soft to null.
  *
  * Identity API: plain HTTP fetch (no SDK exists yet). The endpoint
  * `/v1/profile?world=<slug>&wallet=<addr>` returns
@@ -40,6 +44,7 @@ import {
   buildEnrichedMintAnnouncement,
   type MintTraitInput,
 } from './mint-announcement-render.ts';
+import { fetchNftMetadataHttp } from '../orchestrator/inventory/inventory-http-client.ts';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Public types
@@ -62,7 +67,12 @@ export interface AnnounceMintOpts {
   payload: NftMintDetected;
   /** identity-api base URL — e.g. https://identity.0xhoneyjar.xyz */
   identityApiBaseUrl: string;
-  /** Optional dev override for inventory-api; prod uses gateway-routed @0xhoneyjar/inventory. */
+  /**
+   * inventory-api base URL — e.g. https://inventory.0xhoneyjar.xyz. When set,
+   * the image/traits enrichment fetches `GET {base}/nfts/{contract}/{tokenId}`.
+   * When unset (CI / dev / pre-deploy), the announcement ships imageless +
+   * traitless (fail-soft). Plumbed from announcement-dispatcher.
+   */
   inventoryApiBaseUrl?: string;
   /** Injectable Discord send — keeps announceMint substrate-clean for tests. */
   discordWebhookSendFn: DiscordSendFn;
@@ -79,14 +89,16 @@ export interface AnnounceMintOpts {
    */
   collectionDisplayOverride?: string;
   /**
-   * Test seam: override the @0xhoneyjar/inventory dynamic import. Used by
-   * the bun:test suite to avoid the lazy-import path entirely.
-   */
-  inventoryModule?: InventoryModule;
-  /**
    * Test seam: override the global fetch (for identity-api requests).
    */
   fetchFn?: typeof fetch;
+  /**
+   * Test seam: override the fetch used for inventory-api metadata requests.
+   * Kept distinct from `fetchFn` so the two enrichment paths stay
+   * independently mockable (mirrors the identity-api fetchFn seam). Defaults
+   * to `fetchFn ?? fetch` when unset.
+   */
+  metadataFetchFn?: typeof fetch;
 }
 
 export interface AnnounceMintResult {
@@ -98,18 +110,11 @@ export interface AnnounceMintResult {
 // internal types
 // ──────────────────────────────────────────────────────────────────────────────
 
-interface InventoryModule {
-  /**
-   * Optional in the deployed gateway-routed module — present in v2 when the
-   * token-entity gap closes. Today returns null if not implemented; we
-   * fail-soft to null on absence.
-   */
-  getNftMetadata?: (
-    contract: string,
-    tokenId: string,
-  ) => Promise<NftMetadata | null>;
-}
-
+/**
+ * Renderer-facing metadata shape (image + attributes are all the renderer
+ * consumes). Returned by the inventory-api HTTP client; mapped from the
+ * `GET /nfts/{contract}/{tokenId}` 200 body.
+ */
 interface NftMetadata {
   image?: string | null;
   attributes?: Array<{ trait_type?: string; value?: string | number }> | null;
@@ -137,6 +142,7 @@ export async function announceMint(
 ): Promise<AnnounceMintResult> {
   const timeoutMs = opts.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
   const doFetch = opts.fetchFn ?? fetch;
+  const metadataFetch = opts.metadataFetchFn ?? doFetch;
 
   // 1. Parallel-fetch enrichment, both bounded by timeoutMs, both fail-soft.
   const [identityRes, metadataRes] = await Promise.allSettled([
@@ -149,11 +155,12 @@ export async function announceMint(
       logger: opts.logger,
     }),
     fetchNftMetadata({
+      baseUrl: opts.inventoryApiBaseUrl,
       contract: opts.payload.contract,
       tokenId: opts.payload.token_id,
       timeoutMs,
+      doFetch: metadataFetch,
       logger: opts.logger,
-      moduleOverride: opts.inventoryModule,
     }),
   ]);
 
@@ -330,46 +337,47 @@ async function fetchIdentityProfile(opts: {
   }
 }
 
+/**
+ * Fetch token metadata (image + traits) from inventory-api over HTTP.
+ *
+ * Delegates to the thin typed client (inventory-http-client.ts) which mirrors
+ * fetchIdentityProfile's posture (AbortController + timeout, accept JSON,
+ * non-OK → null, fail-soft). When `baseUrl` is unset (pre-deploy), the client
+ * returns null without fetching → announcement ships imageless.
+ *
+ * The outer try/catch is a defense-in-depth fail-soft seam: the client already
+ * fails soft internally, but a malformed JSON body (`res.json()` throws) or any
+ * unexpected error here must NEVER bubble past enrichment — the canary stays
+ * visible. Mirrors the Promise.allSettled rejection handling in announceMint.
+ */
 async function fetchNftMetadata(opts: {
+  baseUrl: string | undefined;
   contract: string;
   tokenId: string;
   timeoutMs: number;
+  doFetch: typeof fetch;
   logger: MintEventSubscriberLogger;
-  moduleOverride?: InventoryModule;
 }): Promise<NftMetadata | null> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    let mod: InventoryModule;
-    if (opts.moduleOverride) {
-      mod = opts.moduleOverride;
-    } else {
-      // Dynamic specifier — package builds without @0xhoneyjar/inventory
-      // present; runtime resolves at the gateway. Mirrors resolve-nft-pfp.ts.
-      mod = (await import('@0xhoneyjar/inventory' as string)) as unknown as InventoryModule;
-    }
-    if (typeof mod.getNftMetadata !== 'function') {
-      // Token-entity gap: per-token lookup may not be present yet in the
-      // deployed inventory-api module. Fail-soft.
-      return null;
-    }
-    return await Promise.race([
-      mod.getNftMetadata(opts.contract, opts.tokenId),
-      new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), opts.timeoutMs);
-      }),
-    ]);
+    if (!opts.baseUrl) return null; // pre-deploy / unconfigured → no image, fail-soft
+    return await fetchNftMetadataHttp({
+      baseUrl: opts.baseUrl,
+      contract: opts.contract,
+      tokenId: opts.tokenId,
+      timeoutMs: opts.timeoutMs,
+      doFetch: opts.doFetch,
+      logger: opts.logger,
+    });
   } catch (err) {
-    // Building unavailable / errored — fail-soft to no metadata.
+    // inventory-api unavailable / errored / malformed body — fail-soft to no metadata.
     opts.logger.warn(
       {
         err: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
         contract: opts.contract,
         tokenId: opts.tokenId,
       },
-      '[announce-mint] inventory module unavailable',
+      '[announce-mint] inventory-api unavailable',
     );
     return null;
-  } finally {
-    if (timer) clearTimeout(timer);
   }
 }

--- a/packages/persona-engine/src/events/mint-announcement-render.test.ts
+++ b/packages/persona-engine/src/events/mint-announcement-render.test.ts
@@ -21,7 +21,9 @@ import {
 const TYPE_CONTAINER = 17;
 const TYPE_TEXT_DISPLAY = 10;
 const TYPE_SEPARATOR = 14;
-const TYPE_SECTION = 9;
+// Full-bleed HERO image — MediaGallery (type 12), replacing the prior
+// Section(9)+Thumbnail(11) 80px accessory.
+const TYPE_MEDIA_GALLERY = 12;
 
 const BASE_CTX: MintAnnouncementContext = {
   displayName: 'shadowmaker',
@@ -48,8 +50,8 @@ function countSeparators(blocks: unknown[]): number {
   return blocks.filter((b) => (b as { type: number }).type === TYPE_SEPARATOR).length;
 }
 
-function findSection(blocks: unknown[]): unknown | null {
-  return blocks.find((b) => (b as { type: number }).type === TYPE_SECTION) ?? null;
+function findMediaGallery(blocks: unknown[]): unknown | null {
+  return blocks.find((b) => (b as { type: number }).type === TYPE_MEDIA_GALLERY) ?? null;
 }
 
 function textContents(blocks: unknown[]): string[] {
@@ -65,15 +67,15 @@ describe('DEP-2 · buildEnrichedMintAnnouncement · happy path', () => {
     const out = buildEnrichedMintAnnouncement(BASE_CTX);
     const blocks = extractBlocks(out.components);
 
-    // header (text) + sep + image-section (section) + sep + traits (text) + sep + footer (text)
+    // header (text) + sep + image-gallery (type 12) + sep + traits (text) + sep + footer (text)
     expect(countSeparators(blocks)).toBe(3);
 
-    // image section present
-    const section = findSection(blocks);
-    expect(section).not.toBeNull();
-    expect((section as { accessory: { media: { url: string } } }).accessory.media.url).toBe(
-      'https://cdn.test/shadow-234.png',
-    );
+    // image HERO present as a full-bleed MediaGallery (type 12), not a thumbnail
+    const gallery = findMediaGallery(blocks);
+    expect(gallery).not.toBeNull();
+    expect(
+      (gallery as { items: Array<{ media: { url: string } }> }).items[0]!.media.url,
+    ).toBe('https://cdn.test/shadow-234.png');
 
     // text contents
     const texts = textContents(blocks);
@@ -116,12 +118,12 @@ describe('DEP-2 · buildEnrichedMintAnnouncement · happy path', () => {
 });
 
 describe('DEP-2 · buildEnrichedMintAnnouncement · image omitted', () => {
-  test('imageUrl null → no image section; header + traits + footer remain', () => {
+  test('imageUrl null → no image gallery; header + traits + footer remain', () => {
     const out = buildEnrichedMintAnnouncement({ ...BASE_CTX, imageUrl: null });
     const blocks = extractBlocks(out.components);
 
-    // section type 9 should NOT appear
-    expect(findSection(blocks)).toBeNull();
+    // MediaGallery (type 12) should NOT appear
+    expect(findMediaGallery(blocks)).toBeNull();
 
     // traits still rendered
     const traitsText = textContents(blocks).find((t) => t.includes('Traits'));
@@ -142,8 +144,8 @@ describe('DEP-2 · buildEnrichedMintAnnouncement · traits omitted', () => {
     // no "Traits" text content
     expect(textContents(blocks).some((t) => t.includes('Traits'))).toBe(false);
 
-    // image section still present
-    expect(findSection(blocks)).not.toBeNull();
+    // image gallery still present
+    expect(findMediaGallery(blocks)).not.toBeNull();
   });
 
   test('traits empty array → treated like null (no traits text)', () => {
@@ -162,7 +164,7 @@ describe('DEP-2 · buildEnrichedMintAnnouncement · both image + traits omitted 
     });
     const blocks = extractBlocks(out.components);
 
-    expect(findSection(blocks)).toBeNull();
+    expect(findMediaGallery(blocks)).toBeNull();
     const texts = textContents(blocks);
     // header + footer = 2 text displays
     expect(texts.length).toBe(2);

--- a/packages/persona-engine/src/events/mint-announcement-render.ts
+++ b/packages/persona-engine/src/events/mint-announcement-render.ts
@@ -12,7 +12,7 @@
  * Layout (top → bottom):
  *   Container (accent: Mibera Shadows purple)
  *     ├── Header  (## emoji collection · -# subtitle "<displayName> minted #<tokenId>")
- *     ├── Image   (Section + thumbnail) — OMITTED when imageUrl is null
+ *     ├── Image   (MediaGallery type 12 · full-bleed HERO) — OMITTED when imageUrl is null
  *     ├── Traits  (TextDisplay · two-column rows) — OMITTED when traits is null/empty
  *     └── Footer  (TextDisplay · "[tx](berascan link)" + chain marker)
  *
@@ -37,8 +37,10 @@ import { escapeDiscordMarkdown } from '../deliver/sanitize.ts';
 const COMPONENT_TEXT_DISPLAY = 10;
 const COMPONENT_CONTAINER = 17;
 const COMPONENT_SEPARATOR = 14;
-const SECTION_TYPE = 9;
-const THUMBNAIL_TYPE = 11;
+// MediaGallery (type 12) — full-bleed HERO image, the headline of the card.
+// Replaces the prior Section(9)+Thumbnail(11) 80px accessory so the minted
+// shadow renders large rather than as a sidebar thumbnail.
+const MEDIA_GALLERY_TYPE = 12;
 
 /** Mibera Shadows accent — matches the owsley-lab purple in enriched-render's ZONE_ACCENT. */
 const MST_ACCENT = 0x6f4ea1;
@@ -94,15 +96,14 @@ export function buildEnrichedMintAnnouncement(
     { type: COMPONENT_TEXT_DISPLAY, content: `${headerLine}\n${subtitleLine}` },
   ];
 
-  // Image section (omit if enrichment failed)
+  // Image HERO — full-bleed MediaGallery (type 12). Omit if enrichment failed.
+  // No caption: the header already says "<displayName> minted #<tokenId>", so
+  // the image is the hero rather than a thumbnail beside a token-id line.
   if (ctx.imageUrl) {
     blocks.push({ type: COMPONENT_SEPARATOR });
     blocks.push({
-      type: SECTION_TYPE,
-      components: [
-        { type: COMPONENT_TEXT_DISPLAY, content: `-# Token #${ctx.tokenId}` },
-      ],
-      accessory: { type: THUMBNAIL_TYPE, media: { url: ctx.imageUrl } },
+      type: MEDIA_GALLERY_TYPE,
+      items: [{ media: { url: ctx.imageUrl } }],
     });
   }
 

--- a/packages/persona-engine/src/orchestrator/inventory/inventory-http-client.ts
+++ b/packages/persona-engine/src/orchestrator/inventory/inventory-http-client.ts
@@ -1,0 +1,98 @@
+/**
+ * inventory-http-client — thin typed HTTP client for inventory-api's
+ * single-token metadata route.
+ *
+ * inventory-api is a deployed Hyper (Bun) HTTP+MCP SERVICE, consumed over the
+ * wire — NEVER as an npm package (its own beacon + src/app.ts say so; the
+ * earlier `@0xhoneyjar/inventory` / `@freeside/inventory` dynamic-import plan
+ * was a phantom dep and is dead). This module is the lightweight consumer-owned
+ * SDK: one call, one route, no cross-repo package.
+ *
+ * Route (verified against inventory-api@831123c src/routes.ts):
+ *   GET {baseUrl}/nfts/{contract}/{tokenId}
+ *     200 → { name, description, image, attributes: [{ trait_type, value }] }
+ *     400/404 → { error: { status, message, code? } }
+ *   The 200 body is the metadata document directly (NOT wrapped).
+ *
+ * FAIL-SOFT (mirrors fetchIdentityProfile in announce-mint.ts EXACTLY): missing
+ * baseUrl, non-OK status, timeout, or any throw → returns null. The caller
+ * (announce-mint) then ships the announcement imageless + traitless — the
+ * canary stays visible, never silently suppressed, never throws past this seam.
+ *
+ * End-to-end image rendering only activates once inventory-api is DEPLOYED and
+ * `inventoryApiBaseUrl` is configured in the bot. Absent (CI/dev) → dormant
+ * fail-soft, by design.
+ */
+
+import type { MintEventSubscriberLogger } from '../../events/mint-event-subscriber.ts';
+
+/**
+ * The renderer-facing metadata shape. Matches the `NftMetadata` internal type
+ * in announce-mint.ts (image + attributes are the only fields the renderer
+ * consumes; name/description are carried for completeness/future use).
+ */
+export interface InventoryNftMetadata {
+  name?: string | null;
+  description?: string | null;
+  image?: string | null;
+  attributes?: Array<{ trait_type?: string; value?: string | number }> | null;
+}
+
+/** Raw 200 body shape from inventory-api GET /nfts/:contract/:tokenId. */
+interface InventoryMetadataResponse {
+  name?: string | null;
+  description?: string | null;
+  image?: string | null;
+  attributes?: Array<{ trait_type?: string; value?: string | number }> | null;
+}
+
+/**
+ * Fetch a single token's metadata from inventory-api over HTTP.
+ *
+ * Mirrors fetchIdentityProfile's posture: AbortController + setTimeout(abort),
+ * `accept: application/json`, non-OK → logger.warn + null, fail-soft on any
+ * throw, clearTimeout in finally.
+ */
+export async function fetchNftMetadataHttp(opts: {
+  /** inventory-api base URL — e.g. https://inventory.0xhoneyjar.xyz */
+  baseUrl: string;
+  /** 0x-prefixed contract address. */
+  contract: string;
+  /** Decimal token id string (NftMintDetectedSchema enforces `^\d+$`). */
+  tokenId: string;
+  timeoutMs: number;
+  doFetch: typeof fetch;
+  logger: MintEventSubscriberLogger;
+}): Promise<InventoryNftMetadata | null> {
+  // Defensive: missing baseUrl → no-op fail-soft (deploy hasn't configured it).
+  if (!opts.baseUrl || opts.baseUrl.trim().length === 0) return null;
+  const trimmed = opts.baseUrl.replace(/\/+$/, '');
+  const url = `${trimmed}/nfts/${encodeURIComponent(opts.contract)}/${encodeURIComponent(opts.tokenId)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  try {
+    const res = await opts.doFetch(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      // 400/404 (unknown token / bad input) and 5xx all fail-soft to no image.
+      opts.logger.warn(
+        { status: res.status, contract: opts.contract, tokenId: opts.tokenId },
+        '[announce-mint] inventory-api non-OK → fail-soft (no image / no traits)',
+      );
+      return null;
+    }
+    const body = (await res.json()) as InventoryMetadataResponse;
+    return {
+      name: body.name ?? null,
+      description: body.description ?? null,
+      image: typeof body.image === 'string' ? body.image : null,
+      attributes: Array.isArray(body.attributes) ? body.attributes : null,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
**decoupled** the MST image enrichment from the cycle-009 onboarding draft (#138) so it ships independently. These two commits already merged + passed CI on `cycle-009` (#141, #142); cherry-picked here onto `main` clean.

**what** (mirrors the DEP-2 mint path, builds on it):
- new `orchestrator/inventory/inventory-http-client.ts` — thin typed client, `GET {inventoryApiBaseUrl}/nfts/{contract}/{tokenId}` → `{image,attributes}`, fail-soft (mirrors `fetchIdentityProfile`).
- `announce-mint.ts` — replace the phantom `@0xhoneyjar/inventory` dynamic import with the HTTP client; thread `inventoryApiBaseUrl`.
- `index.ts` — read `INVENTORY_API_URL` (default the live Railway deploy) + pass `inventoryApiBaseUrl` into `createAnnouncementDispatcher`.
- `mint-announcement-render.ts` — HERO: `Thumbnail(11)` → full-bleed `MediaGallery(12)`.

**live-verified upstream:** inventory-api redeployed (`831123c`), `GET /nfts/0x0483…c008/234` → `200` + `assets…/Mibera/generated/234.webp` + 19 traits. MST canary already ON in prod (`MST_CANARY_ENABLED=1` + channel). So once this is on main + the bot redeploys, **MST shadow-mints render with the HERO image**.

scope: mint image only. spotlight PFP → bead `…img-spotlight-pfp-http-9pc`. no new deps; `package.json` untouched. (cycle-009 keeps the same changes; it'll see them as already-applied on its next main-sync.)

Refs #139
🤖 Generated with [Claude Code](https://claude.com/claude-code)