### PR TITLE
fix(inventory-client): self-catch fail-soft + image-URL allowlist guard

### DIFF
--- a/packages/persona-engine/src/events/announce-mint.test.ts
+++ b/packages/persona-engine/src/events/announce-mint.test.ts
@@ -226,7 +226,7 @@ describe('DEP-2 · announceMint · happy path', () => {
       fetchFn,
       metadataFetchFn: makeInventoryFetch({
         metadata: {
-          image: 'https://cdn.test/shadow-234.png',
+          image: 'https://assets.0xhoneyjar.xyz/Mibera/generated/234.webp',
           attributes: [
             { trait_type: 'Background', value: 'Void' },
             { trait_type: 'Eyes', value: 'Glowing' },
@@ -243,7 +243,36 @@ describe('DEP-2 · announceMint · happy path', () => {
     // ensure plain-text fallback carries the nym
     expect(msg.contentFallback).toContain('shadowmaker');
     expect(msg.contentFallback).toContain('#234');
-    expect(msg.contentFallback).toContain('https://cdn.test/shadow-234.png');
+    expect(msg.contentFallback).toContain('https://assets.0xhoneyjar.xyz/Mibera/generated/234.webp');
+  });
+
+  test('off-domain / non-allowlisted image URL is dropped (no injection into the card)', async () => {
+    const logger = makeSpyLogger();
+    const sender = makeSpySender();
+    const fetchFn = makeFakeFetch({ nym: 'shadowmaker' });
+
+    const result = await announceMint({
+      payload: PAYLOAD,
+      identityApiBaseUrl: 'https://identity.test',
+      inventoryApiBaseUrl: 'https://inventory.test',
+      discordWebhookSendFn: sender.send,
+      channelId: 'CHAN_123',
+      logger,
+      fetchFn,
+      metadataFetchFn: makeInventoryFetch({
+        // off-domain host — an injection vector if rendered. The client's
+        // allowlist guard must drop it; traits still flow.
+        metadata: {
+          image: 'https://cdn.evil/pwn.png',
+          attributes: [{ trait_type: 'Background', value: 'Void' }],
+        },
+      }),
+    });
+
+    expect(result.posted).toBe(true);
+    const msg = sender.calls[0]!;
+    expect(msg.contentFallback).not.toContain('cdn.evil'); // image omitted
+    expect(msg.contentFallback).toContain('shadowmaker'); // announcement still ships
   });
 });
 
@@ -262,7 +291,7 @@ describe('DEP-2 · announceMint · identity-api fail-soft', () => {
       fetchFn,
       inventoryApiBaseUrl: 'https://inventory.test',
       metadataFetchFn: makeInventoryFetch({
-        metadata: { image: 'https://cdn.test/x.png', attributes: [] },
+        metadata: { image: 'https://assets.0xhoneyjar.xyz/Mibera/generated/234.webp', attributes: [] },
       }),
     });
 
@@ -338,8 +367,10 @@ describe('DEP-2 · announceMint · inventory-api fail-soft', () => {
     const fallback = sender.calls[0]!.contentFallback ?? '';
     expect(fallback).toContain('shadowmaker');
     expect(fallback).not.toContain('https://cdn.');
+    // F2: the HTTP client self-catches the throw (honors "never throws past this
+    // seam") and logs here, rather than propagating to announce-mint's outer catch.
     const warns = logger.warns.filter((w) =>
-      w.msg?.includes('inventory-api unavailable'),
+      w.msg?.includes('inventory-api fetch errored'),
     );
     expect(warns.length).toBe(1);
   });

--- a/packages/persona-engine/src/orchestrator/inventory/inventory-http-client.ts
+++ b/packages/persona-engine/src/orchestrator/inventory/inventory-http-client.ts
@@ -46,6 +46,33 @@ interface InventoryMetadataResponse {
   attributes?: Array<{ trait_type?: string; value?: string | number }> | null;
 }
 
+/** Image hosts allowed into a rendered Discord card (THJ sovereign assets). */
+const ALLOWED_IMAGE_HOSTS = new Set([
+  'assets.0xhoneyjar.xyz',
+  'metadata.0xhoneyjar.xyz',
+]);
+
+/**
+ * Allowlist guard for the upstream `image` before it lands in a Discord card.
+ * The 200 body is untrusted (inventory-api → storage-api JSON): reject anything
+ * that isn't `https` on a known THJ asset host, so a compromised/buggy upstream
+ * can't inject an arbitrary-scheme (`javascript:`, `data:`) or off-domain URL
+ * into the announcement card or its plain-text fallback. null → render omits the
+ * image (fail-soft), exactly as for missing metadata.
+ */
+function safeImageUrl(raw: unknown): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:') return null;
+  if (!ALLOWED_IMAGE_HOSTS.has(u.hostname)) return null;
+  return raw;
+}
+
 /**
  * Fetch a single token's metadata from inventory-api over HTTP.
  *
@@ -89,9 +116,22 @@ export async function fetchNftMetadataHttp(opts: {
     return {
       name: body.name ?? null,
       description: body.description ?? null,
-      image: typeof body.image === 'string' ? body.image : null,
+      image: safeImageUrl(body.image),
       attributes: Array.isArray(body.attributes) ? body.attributes : null,
     };
+  } catch (err) {
+    // Honor this seam's contract ("never throws past this seam"): a network
+    // failure, timeout-abort, or malformed JSON fail-softs to null rather than
+    // propagating. (announce-mint's outer catch is then belt-and-suspenders.)
+    opts.logger.warn(
+      {
+        err: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+        contract: opts.contract,
+        tokenId: opts.tokenId,
+      },
+      '[announce-mint] inventory-api fetch errored → fail-soft (no image / no traits)',
+    );
+    return null;
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
Post-ship hardening of the MST image consumer (shipped #143), from a **FAGAN multimodel review** (Opus-skeptic + GPT-5.5 + Composer — both findings independently confirmed by the panel) + self-review. Behavior unchanged for the happy path; persona-engine 1544 pass, typechecks clean.

- **client self-catches (honors its own contract).** The docstring promised *"never throws past this seam"* but the client had only `try/finally` — a network throw, timeout-abort, or malformed JSON propagated, relying on `announce-mint`'s outer catch. Now it catches → warn → null, so future callers can't let an enrichment throw escape. *(FAGAN `inventory-http-client.ts:68` + self-flagged F2.)*
- **image-URL allowlist guard.** The upstream `image` (untrusted inventory-api→storage-api JSON) is now validated — `https` on a known THJ asset host (`assets`/`metadata.0xhoneyjar.xyz`) — before it can reach a Discord card. Closes content/link-injection (`javascript:`/`data:`/off-domain). null → image omitted (fail-soft). *(FAGAN `inventory-http-client.ts:92` + self-flagged F3.)*

Tests: fixtures moved to the real allowlisted host (what prod returns) + an off-domain-image-is-dropped test. The "inventory throws → fail-soft" test now asserts the client-side warn (the path F2 cleaned up).

context: companion to inventory-api#10 (resolver-side hardening). Closes out the MST mint-image enrichment.
🤖 Generated with [Claude Code](https://claude.com/claude-code)