### PR TITLE
Phase 41D docs: accept live Dixie Discord smoke test

### DIFF
--- a/docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md
+++ b/docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md
@@ -598,6 +598,19 @@ boundary.
 > **The live Dixie smoke-test acceptance is a future Phase 41D** (after a
 > controlled live run), not part of this guide.
 
+> **Phase 41D note**
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md`).
+> The future Phase 41D has now occurred: a controlled live-Dixie run of
+> `/recall-wedge-live-demo` was accepted (docs-only) for **safe wiring +
+> fail-closed rendering only** — the live path reached the Dixie
+> `/api/recall/intake` seam and fail-closed on `seam.storage_unavailable`
+> (unseeded estate / storage), with no served recall, no memory
+> admission, and no leak. **This harness `/recall-wedge-demo` guide is
+> unaffected** — it still governs only the fixture-bound harness demo.
+> **Served recall, public recall, and public-channel-visible recall
+> remain blocked**; served recall is blocked on the unseeded estate /
+> storage state.
+
 ---
 
 ## P. Acceptance criteria for Phase 40B

--- a/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md
+++ b/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md
@@ -95,6 +95,33 @@ boundary (§K), and its own acceptance criteria (§M). Everything Phase
   future Phase 41D add no runtime scope; everything §O blocks stays
   blocked.
 
+### A.3 Phase 41D note — controlled live-Dixie Discord smoke test accepted; safe wiring only
+
+> Added by Phase 41D
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md`),
+> 2026-05-30.
+
+- **The future Phase 41D anticipated in §A.2 / §N has occurred and is
+  accepted (docs-only).** A human operator deployed Dixie live (Railway,
+  healthy service + Postgres), wired the **Freeside Characters** service
+  with the live Dixie env, registered `/recall-wedge-live-demo` to one
+  configured guild, and invoked it as an allowlisted operator.
+- **Accepted scope: safe live wiring + fail-closed rendering, not served
+  recall.** The authenticated `/api/recall/intake` call reached the
+  Straylight seam and returned `seam.storage_unavailable` (unseeded live
+  estate / storage); the command classified it as `upstream_unavailable`
+  and rendered an ephemeral operator-safe summary with no raw reasons,
+  payload, IDs, or tokens — exactly the §I output / §J lazy-load / §K
+  logging boundaries this gate set.
+- **No new authorization.** Phase 41D adds no runtime scope. It claims no
+  production rollout, no public recall, no served memory, no healthy Finn
+  integration, and no cross-user auth / consent. Everything §O blocks
+  stays blocked; served recall is blocked on the unseeded estate /
+  storage state.
+- **Ladder note:** §N below (written before Phase 41B landed) calls this
+  acceptance "Phase 41C"; read it as **Phase 41D**, consistent with the
+  §A.2 ladder reconciliation.
+
 ---
 
 ## B. Source evidence
@@ -631,6 +658,13 @@ Phase 41A is acceptable if:
 
 ## Q. Cross-references
 
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md` — Phase
+  41D smoke-test acceptance; the redacted report for the controlled
+  live-Dixie Discord run (safe wiring + fail-closed, no served recall);
+  §A.3 records its acceptance note.
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md` —
+  Phase 41C operational runbook; the governing procedure the Phase 41D
+  run followed.
 - `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` — Phase 37B live Dixie
   client gate; the live client seam, its env config, and its
   classification vocabulary; gains a Phase 41A note.

--- a/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md
+++ b/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md
@@ -777,6 +777,61 @@ Concise triage. Keep secrets and raw IDs out of chat and docs throughout.
   public-channel-visible recall, Telegram / private chat, LLM / voice, or
   production auth / consent.
 
+> ### Phase 41D acceptance note — done (2026-05-30)
+>
+> Added by Phase 41D
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md`).
+>
+> - **A controlled live run of this procedure has occurred and is
+>   accepted.** A human operator deployed Dixie live (Railway, healthy
+>   service + Postgres, `GET /api/health` → 200), wired the **Freeside
+>   Characters** service with the live Dixie env (§D / §I), registered
+>   `/recall-wedge-live-demo` to the configured guild, and invoked it as
+>   an allowlisted operator.
+> - **The live path reached the Dixie `/api/recall/intake` seam and
+>   fail-closed safely.** The authenticated intake returned
+>   `seam.storage_unavailable` (unseeded live estate / storage); the
+>   command classified it as `upstream_unavailable` and rendered the
+>   ephemeral §J.1 category-2 safe summary — **no `raw_reasons`, no raw
+>   payload, no bounded-store scope, no tenant / debug / JWT / token /
+>   stack-trace / private-ID exposure.**
+> - **Accepted scope: safe live wiring + fail-closed rendering, not
+>   served recall.** Served recall is blocked on the unseeded estate /
+>   storage state (acceptance §J). The run claims no production rollout,
+>   no public recall, no served memory, no healthy Finn integration
+>   (Finn was intentionally unreachable), and no cross-user auth /
+>   consent.
+> - **The two operational caveats in §R.1 below were load-bearing in the
+>   run:** the startup auto-publish path can erase the dev-only live
+>   command (register after restart, do not restart before invocation),
+>   and the manually minted Dixie JWT is short-lived (refresh + restart
+>   if expired). They are now confirmed against a real run, not just
+>   anticipated.
+> - **This runbook still records no acceptance itself** — the acceptance
+>   lives in the Phase 41D report; this note only points to it.
+
+### R.1 Operational caveats confirmed by the Phase 41D run
+
+The Phase 41D run confirmed two operational caveats are load-bearing.
+Restated together here for anyone repeating the smoke test:
+
+- **R.1.a — startup auto-publish can remove the dev-only live command.**
+  The startup auto-publish path bulk-syncs the normal command set and
+  **can remove `/recall-wedge-live-demo`** from the configured guild —
+  this is a newly-surfaced caveat from the Phase 41D run, not previously
+  called out in this runbook. For smoke: **register the live command
+  after the restart (§H), and do not restart Freeside Characters again
+  before invocation.** In the Phase 41D run the command was manually
+  re-registered after restart for exactly this reason.
+- **R.1.b — the manually minted Dixie JWT is short-lived.** The service
+  token / JWT used to reach the seam (the `RECALL_WEDGE_DIXIE_SERVICE_TOKEN`
+  material in §D.4 / §I) is short-lived and manually minted. **Before
+  repeating the smoke test, refresh the token and restart Freeside
+  Characters if it has expired.** An expired token surfaces as a safe
+  classification (e.g. `service_unauthorized`) or the generic refusal —
+  never a leak — but it will not exercise the seam reach. Disable /
+  rotation handling is in §O.
+
 ---
 
 ## S. Blocked work remains blocked
@@ -832,6 +887,10 @@ Phase 41C is acceptable if:
 
 ## U. Cross-references
 
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md` — Phase
+  41D smoke-test acceptance; the redacted report for the controlled live
+  run of this procedure (safe wiring + fail-closed, no served recall).
+  This runbook's §R gains the Phase 41D acceptance note.
 - `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` — Phase 41A
   decision gate; gains a Phase 41C note.
 - `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` — Phase 37B live Dixie

--- a/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md
+++ b/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md
@@ -1,0 +1,568 @@
+# Recall Wedge — Live Dixie Discord Smoke-Test Acceptance
+
+> **Phase 41D** (docs / smoke-test acceptance only). Date: 2026-05-30.
+> Companion to
+> `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md`
+> (Phase 41C operational runbook — the governing procedure this
+> acceptance records a run of),
+> `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` (Phase 41A
+> decision gate — the authority this acceptance preserves without
+> expanding),
+> `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` (Phase 37B live Dixie
+> client gate — the live client seam, its env, and its classification
+> vocabulary),
+> `docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md` (Phase 39E
+> harness-demo smoke-test acceptance — the redacted-evidence template
+> this report follows), and
+> `docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md` (Phase 35A option matrix).
+>
+> This document records the controlled operator smoke test that was run
+> **after** Phase 41C, against a real Discord guild, with the live
+> `/recall-wedge-live-demo` command wired to a live Dixie deployment. It
+> does **not** add or authorize new code. It is the acceptance record for
+> a single, controlled dev / operator demo run — nothing more.
+>
+> It does not expand the Phase 41A authorization. Anything Phase 41A /
+> 41C blocked stays blocked here (see §K). This acceptance is for
+> **controlled live-Dixie Discord wiring and safe fail-closed
+> rendering** — it is **not** acceptance of served recall memory (see
+> §G, §H). If a step seems to require reaching past those boundaries, the
+> answer is to stop and open the next decision gate (§N) — not to relax
+> it from this acceptance.
+
+---
+
+## A. Status and decision
+
+Phase 41D is **docs / smoke-test acceptance only**.
+
+- It **records the controlled operator smoke test** run after Phase 41C,
+  in one configured Discord guild, against a live Dixie deployment.
+- It **does not add or authorize new code.** No source, test, package,
+  lockfile, fixture, config, CI, or generated change is introduced by
+  Phase 41D.
+- It **does not authorize production rollout.**
+- It **does not claim public recall.**
+- It **does not claim served memory** — the live run reached the Dixie
+  seam and fail-closed safely; no recall content was served (§G, §H).
+- It **does not claim Finn integration is healthy** — Finn was
+  intentionally unreachable during the run (§D).
+- It **does not authorize public channel-visible recall.**
+- It **does not authorize** memory admission, candidate-memory writes,
+  "remember this," Telegram, private chat, storage / admission,
+  production auth / consent, LLM rewriting, character voice, or public
+  renderer expansion.
+
+### A.1 Decision sentence
+
+**Phase 41D accepts `/recall-wedge-live-demo` as successfully
+smoke-tested for controlled dev / operator Discord use against a live
+Dixie deployment: guild-scoped operator-gated invocation, authenticated
+live reach to the Dixie `/api/recall/intake` seam, ephemeral
+safe-classified output, and fail-closed rendering when the upstream
+estate / storage state is unseeded — with no served recall content, no
+memory admission, no public rollout, and no raw-material leak.**
+
+This acceptance is conditional on the boundaries restated in §H (what
+Phase 41D does not prove) and §K (blocked work remains blocked). Partial
+compliance does not satisfy this acceptance.
+
+### A.2 Naming note (binding for this document)
+
+- **"Freeside Characters"** is the current Discord app / this repo / the
+  Railway project and service that runs the bot. The current bot
+  identity is **"loa."**
+- **"Dixie"** is the upstream live Recall Wedge service this run reached.
+- **"Finn"** (`loa_finn`) is the upstream Dixie depends on for a healthy
+  overall state; it was intentionally pointed at a placeholder URL for
+  this run, so the overall Dixie health was degraded by design (§D).
+- The bare word **"Freeside"** is **not** used here to name the current
+  app. "Freeside platform" is reserved for the future broader platform
+  and is out of scope for this acceptance.
+
+---
+
+## B. Source evidence
+
+This acceptance is grounded in the following artifacts (the same set the
+Phase 41C runbook operationalizes — no new code path is introduced or
+accepted here):
+
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md` —
+  Phase 41C operational runbook; the governing operating procedure for
+  every step performed in this smoke test (its §F–§N).
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` — Phase 41A
+  decision gate; the authority the smoke test preserves without
+  expanding.
+- `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` — Phase 37B live Dixie
+  client gate; the live client's env config and classification
+  vocabulary the rendered output narrows into.
+- `apps/bot/src/discord-interactions/recall-wedge-live-demo.ts` — the
+  Phase 41B live command handler. Source of the env gate helpers, the
+  fixed deterministic input, the lazy live-client loader (only after the
+  Discord gates pass), the classification → render decision, the single
+  generic refusal string (`recall-wedge-live-demo is not available
+  here.`), the ephemeral-only response builder, and the final
+  banned-substring no-leak scan.
+- `apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts` —
+  Phase 41B regression / static-guard tests; the local evidence behind
+  the static posture.
+- `apps/bot/src/lib/publish-commands.ts` —
+  `registerRecallWedgeLiveDemoCommand` (guild-scoped-only registration,
+  fail-closed on both env gates, never global).
+- `apps/bot/scripts/publish-commands.ts` — the publish CLI entry point.
+- `apps/bot/src/discord-interactions/dispatch.ts` — routes
+  `recall-wedge-live-demo` as a distinct command name, with bot-author
+  and webhook-author drop guards.
+- `packages/persona-engine/src/recall-wedge/live-dixie-client.ts` — the
+  Phase 37C operator/dev-only live Dixie client; the only live-egress
+  seam reached during this run.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md` — Phase 39E
+  harness-demo smoke-test acceptance; the redacted-evidence template
+  this report follows.
+
+---
+
+## C. Test environment and redaction posture
+
+- The test was performed in **one configured Discord guild** using the
+  existing **Freeside Characters** shell bot application (identity
+  "loa"); no new application, token, or identity was introduced.
+- Dixie was deployed to **Railway** and reachable at its public Railway
+  URL; the **Freeside Characters service** received the live Dixie env
+  (§E) on the same Railway project.
+- The raw Discord **bot token, guild ID, command ID, application ID, and
+  user IDs are intentionally not recorded** in this document.
+- The raw **Dixie base URL, service token, tenant ID, caller actor ID,
+  request-key prefix, the minted Dixie JWT, the dev wallet, any admin /
+  allowlist key, the Postgres connection string, and all Railway service
+  / project identifiers are intentionally not recorded.**
+- **Raw Dixie response bodies are not pasted** — only the narrowed,
+  classifier-controlled summary shape is recorded (§F). In particular,
+  no `raw_reasons`, no bounded-store scope detail, no tenant / debug
+  material, and no upstream payload appear here.
+- **Screenshots / images are not committed** with this acceptance.
+- Evidence is recorded as **redacted operator observations** — what was
+  seen, not the operational identifiers or secrets that produced it.
+- **No secrets were pasted** into this report (consistent with the Phase
+  41C runbook §M / §Q no-secrets posture and the handler's no-leak
+  scan).
+
+This redaction posture is deliberate: it mirrors the runbook's
+evidence-capture rules (runbook §M) and the no-leak banned-substring
+posture the handler enforces. The acceptance is meaningful *because* the
+operator observed the gated, fail-closed behavior — not because raw IDs,
+tokens, or payloads were copied here.
+
+---
+
+## D. Live Dixie deployment preconditions (redacted)
+
+Recorded (redacted) deployment observations, in the order they occurred:
+
+- Dixie was **deployed to Railway** and became reachable at its public
+  Railway URL.
+- `GET /api/health` returned **HTTP 200**.
+- the **Dixie service and its Postgres were healthy.**
+- the **overall health was reported degraded / unhealthy only because
+  the Finn dependency (`loa_finn`) was intentionally unreachable** via a
+  placeholder Finn URL — a deliberate precondition of this run, not a
+  defect. This run does **not** claim Finn integration is healthy.
+- `POST /api/recall/intake` **without auth returned HTTP 401
+  "Authentication required."**
+- a **dev wallet was allowlisted in Dixie** (the wallet value is not
+  recorded).
+- a **short-lived Dixie JWT was minted locally, not printed**, and
+  **verified against Dixie with HTTP 200** (the token is not recorded).
+- an **authenticated direct `POST /api/recall/intake` reached the
+  Straylight seam** and returned a **`seam.storage_unavailable`**
+  condition, because the live estate / storage state is **unseeded**.
+
+These preconditions establish that the live Dixie deployment was real,
+healthy at the service / Postgres layer, correctly rejecting
+unauthenticated calls, and reachable with a valid short-lived token —
+while the **served-recall path was not yet available** because the
+estate / storage state is unseeded (§G). The degraded overall health is
+attributable solely to the intentionally-unreachable Finn placeholder.
+
+---
+
+## E. Freeside Characters live-Dixie wiring (redacted)
+
+The **Freeside Characters** service "freeside characters" received the
+live Dixie env (placeholder names only; **no values recorded**):
+
+- `RECALL_WEDGE_DIXIE_BASE_URL`
+- `RECALL_WEDGE_DIXIE_SERVICE_TOKEN`
+- `RECALL_WEDGE_DIXIE_TENANT_ID`
+- `RECALL_WEDGE_DIXIE_CALLER_ACTOR_ID`
+- `RECALL_WEDGE_DIXIE_REQUEST_KEY_PREFIX`
+- `RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED`
+- `RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID`
+- `RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS`
+
+This is the env shape the Phase 41C runbook §D / §I documents: the
+`RECALL_WEDGE_LIVE_DISCORD_DEMO_*` Discord gates plus the separate Phase
+37C `RECALL_WEDGE_DIXIE_*` client config. The Discord gates govern
+*whether Discord may reach the client*; the `RECALL_WEDGE_DIXIE_*` env
+governs *how the client authenticates to Dixie*. No value of either set
+is recorded here.
+
+---
+
+## F. Live invocation result — safe fail-closed classification
+
+Recorded (redacted) observations for the operator invocation:
+
+- `/recall-wedge-live-demo` was registered to the configured guild and
+  **manually re-registered after restart** (see §L caveat) so the
+  dev-only live command was present.
+- the operator invoked `/recall-wedge-live-demo` in the configured
+  Discord guild.
+- the response was **ephemeral / operator-visible** (only the operator
+  saw it).
+- the Discord output returned a **safe classification**:
+  - `classification: upstream_unavailable`
+  - `outcome:        upstream_unavailable`
+  - `route:          /api/recall/intake`
+  - `reason:         seam.storage_unavailable`
+- the Discord output **did not expose**:
+  - `raw_reasons`;
+  - the raw Dixie payload / response body;
+  - bounded-store scope detail;
+  - tenant / debug material;
+  - JWT / token / service-token material;
+  - stack traces;
+  - private identifiers / raw IDs.
+
+This is the runbook §J.1 category-2 shape: the fixed dev-only live
+framing plus a narrowed `classification` / `outcome` / `route` / `reason`
+summary, with a stable classifier-controlled reason code and no raw
+upstream material. The upstream seam's `storage_unavailable` condition
+was classified into the Phase 37C `upstream_unavailable` vocabulary and
+rendered as a public-safe / operator-safe summary — exactly the
+fail-closed behavior the Phase 41A §I output decision and the runbook
+§J.2 require.
+
+### F.1 Observed safe Discord output shape (illustrative, redacted)
+
+The observed output matched this narrowed shape (illustrative — the
+framing is fixed in code; the four data lines are classifier-controlled):
+
+```
+recall-wedge-live-demo · live Dixie dev demo (not production recall)
+gated · operator-only · ephemeral · phase 37c live Dixie client output
+
+classification: upstream_unavailable
+outcome:        upstream_unavailable
+route:          /api/recall/intake
+reason:         seam.storage_unavailable
+```
+
+Nothing beyond this narrowed shape was visible: no served recall body,
+no raw reasons, no payload, no IDs, no tokens, no stack trace.
+
+---
+
+## G. What Phase 41D proves
+
+Phase 41D proves, from the controlled operator smoke test, that:
+
+- **Dixie can be deployed live** (Railway, public URL) with a healthy
+  service and Postgres, returning **HTTP 200** on `GET /api/health`;
+- the Dixie intake seam **rejects unauthenticated calls** (`HTTP 401`)
+  and **accepts a valid short-lived token** (verified `HTTP 200`),
+  proving the auth boundary works at the seam;
+- the **Freeside Characters live command can be wired to live Dixie**
+  via the `RECALL_WEDGE_DIXIE_*` + `RECALL_WEDGE_LIVE_DISCORD_DEMO_*`
+  env (§E);
+- an **allowlisted operator can invoke `/recall-wedge-live-demo` in the
+  configured guild** and the live path reaches the Dixie
+  `/api/recall/intake` seam;
+- when the upstream estate / storage state is unseeded, the seam's
+  `seam.storage_unavailable` condition is **classified safely as
+  `upstream_unavailable`** and **rendered fail-closed** as an ephemeral
+  operator-safe summary;
+- the **user-visible output avoids `raw_reasons`, raw Dixie payload,
+  bounded-store scope detail, tenant / debug material, JWT / token
+  material, stack traces, and private IDs**;
+- the run **served no recall content**, **admitted no memory**, **made no
+  production auth / consent claim**, and **produced no public-channel
+  output**.
+
+These are observations about *this controlled run*. They confirm the
+Phase 41C runbook procedure works end-to-end against a real Dixie
+deployment under the gates, and that the seam fails closed safely when
+recall content is unavailable. They do not extend the proof past §H.
+
+---
+
+## H. What Phase 41D does not prove
+
+Phase 41D does **not** prove any of the following. These remain in scope
+only for later, separately authorized phases:
+
+- **served recall memory** — the run reached the seam and fail-closed on
+  `seam.storage_unavailable`; **no recall content was served**;
+- production readiness;
+- public rollout readiness;
+- public recall / public channel-visible recall;
+- production auth / consent;
+- cross-user recall authorization / consent;
+- live memory admission;
+- candidate-memory admission;
+- persistent production storage / admission (the live estate / storage
+  state is unseeded — see §J);
+- a healthy Finn integration (Finn was intentionally unreachable — §D);
+- Telegram support;
+- private chat support;
+- LLM rewriting;
+- character voice;
+- broad Discord UX readiness;
+- long-running operational stability;
+- de-registration automation;
+- a long-lived or production-grade Dixie service-token / JWT path (the
+  token used was short-lived and manually minted — §L).
+
+If a later phase needs proof of any item above, it must propose a phase
+that *names* the proof it intends to deliver and the gate it must clear
+— it must not stretch this smoke-test acceptance to cover that ground.
+
+---
+
+## I. Security / no-leak assessment
+
+- **No secrets recorded.** No bot token, Dixie service token, minted
+  JWT, dev wallet, admin / allowlist key, or Postgres connection string
+  appears in this document or in any committed artifact for this phase.
+- **No raw IDs recorded.** No guild, app, command, user, tenant, caller
+  actor, or Railway service / project identifier, and no request-key
+  prefix, appears here.
+- **No raw upstream material recorded.** No `raw_reasons`, no raw Dixie
+  response body, no bounded-store scope detail, no headers, and no
+  request body appear here.
+- **The minted Dixie JWT was not printed** during the run; it was minted
+  locally and verified by HTTP status only.
+- **Discord output was fail-closed and narrowed.** The operator-visible
+  output exposed only the four classifier-controlled summary lines
+  (§F) — no payload, no IDs, no tokens, no stack trace — consistent with
+  the handler's final banned-substring no-leak scan
+  (`recall-wedge-live-demo.ts`) and the Phase 41A §I / §K output and
+  logging boundaries.
+- **Ephemeral only.** Every observed response was ephemeral
+  (operator-visible), consistent with the runbook §N pass criteria.
+- **No screenshots / images committed.**
+
+The assessment: this run produced **no leak** of secrets, raw IDs, or
+raw upstream material, and the Discord surface fail-closed safely. The
+redaction posture of this document matches the no-leak posture the
+handler enforces at runtime.
+
+---
+
+## J. Current blocker for served recall
+
+- **The live estate / storage state is unseeded.** The authenticated
+  intake call reached the Straylight seam and returned
+  `seam.storage_unavailable`; the live command classified this as
+  `upstream_unavailable` and fail-closed.
+- **This is the current blocker for served recall:** until the live
+  estate / storage state is seeded (and the seeding / admission path is
+  itself designed and gated — see decision-map §7), the live command can
+  prove **safe reach and safe fail-closed**, but it cannot prove **served
+  recall content**.
+- **This blocker is expected and safe.** Fail-closing on an unseeded
+  upstream is the designed behavior, not a defect. Acceptance of *this*
+  run is acceptance of the wiring and the fail-closed render — not of
+  served memory.
+
+---
+
+## K. Blocked work remains blocked
+
+The following remain explicitly blocked. None is authorized by Phase
+41D (this restates the Phase 41A §O / Phase 41C §S blocked-work list,
+carried forward unchanged):
+
+- mutation of `/recall-wedge-demo` into a live command;
+- public channel-visible recall;
+- public recall;
+- served recall memory as an accepted capability;
+- global registration;
+- production / public rollout;
+- freeform recall query input;
+- Discord message history as memory input;
+- memory admission;
+- candidate-memory writes;
+- "remember this";
+- Telegram;
+- private chat;
+- storage / admission (the unseeded estate / storage blocker — §J);
+- production auth / consent;
+- cross-user auth / consent;
+- direct Finn runtime / audit wiring beyond existing seams;
+- LLM rewriting;
+- character voice;
+- public renderer expansion;
+- positive `public_telegram` support;
+- positive `authorized_private_session` support.
+
+If a later phase needs any item above, it must propose a phase naming
+the item, the proof obligation it carries, and the decision artifact it
+re-opens.
+
+---
+
+## L. Operational caveats
+
+These are load-bearing for anyone repeating the smoke test.
+
+### L.1 Startup auto-publish can remove the dev-only live command
+
+- The startup auto-publish path **bulk-syncs the normal command set**,
+  which **can remove the dev-only live command** (`/recall-wedge-live-demo`)
+  from the configured guild.
+- **For the smoke test: register `/recall-wedge-live-demo` after the
+  restart, and do not restart Freeside Characters again before
+  invocation.** A restart between registration and invocation can erase
+  the dev-only command, leaving nothing to invoke.
+- In this run, the command was **manually re-registered after restart**
+  for exactly this reason (§F).
+
+### L.2 The manually minted Dixie JWT is short-lived
+
+- The Dixie service token / JWT used for the live reach was **manually
+  minted and short-lived.**
+- **Before repeating the smoke test, refresh the token and restart
+  Freeside Characters if the token has expired.** An expired token will
+  surface as a safe classification (e.g. `service_unauthorized`) or the
+  generic refusal — never a leak — but it will not exercise the seam
+  reach this run demonstrated.
+- A longer-lived / safer dev service-token path is **not** solved by
+  this run (§H) and is offered as a next-decision option (§N.e).
+
+---
+
+## M. Operator acceptance checklist
+
+The operator confirmed every item below during the smoke test:
+
+- [x] Dixie deployed to Railway and reachable at its public URL;
+- [x] `GET /api/health` returned HTTP 200;
+- [x] Dixie service and Postgres healthy;
+- [x] overall health degraded only due to the intentional Finn
+      placeholder (no Finn-healthy claim);
+- [x] unauthenticated `POST /api/recall/intake` returned HTTP 401;
+- [x] dev wallet allowlisted in Dixie;
+- [x] short-lived Dixie JWT minted locally, not printed, verified HTTP
+      200;
+- [x] authenticated intake reached the Straylight seam and returned
+      `seam.storage_unavailable` (unseeded estate / storage);
+- [x] Freeside Characters service wired with the live Dixie env (§E);
+- [x] `/recall-wedge-live-demo` manually re-registered after restart;
+- [x] operator invocation returned the safe classification
+      (`upstream_unavailable` / `seam.storage_unavailable`);
+- [x] response ephemeral / operator-visible;
+- [x] no raw_reasons / raw payload / bounded-store scope / tenant /
+      debug / JWT / token / stack-trace / private-ID exposure;
+- [x] no served recall content;
+- [x] no memory admission language;
+- [x] no production auth / consent claim;
+- [x] no public-channel-visible output;
+- [x] screenshots not committed;
+- [x] secrets / raw IDs / tokens not recorded.
+
+---
+
+## N. Next decision options
+
+Phase 41D itself authorizes none of the following — it only accepts the
+controlled live-Dixie Discord smoke-test result. Each option carries its
+own proof obligation and re-opens its own decision artifact:
+
+- **a. Stop and preserve this as controlled smoke acceptance.** Treat
+  this run as the accepted state and take no further live action.
+- **b. Docs-only runbook hardening for repeatable smoke.** Tighten the
+  Phase 41C runbook so the §L caveats (auto-publish erasure, short-lived
+  token) are checklist steps, with no runtime change.
+- **c. Tiny operational patch so live dev command registration is not
+  erased by startup auto-publish** when the registration gate is true —
+  a narrow change to the publish / startup path so a true
+  `RECALL_WEDGE_LIVE_DISCORD_DEMO_REGISTER_COMMANDS` gate survives the
+  bulk sync. This is a code change and would carry its own gate / tests
+  (it is **not** authorized here).
+- **d. Design a seeded live estate / storage path** so the seam can
+  serve recall content — gated by decision-map §7 (admission / storage)
+  and §6 (live Dixie client), since served recall is the current blocker
+  (§J).
+- **e. Design a longer-lived / safer dev service-token path** so the
+  smoke test does not depend on a short-lived manually minted JWT (§L.2).
+- **f. Keep public rollout blocked.** The default and recommended
+  posture: public recall, served memory, and public-channel-visible
+  output stay blocked behind separate later gates (§K).
+
+**Recommended:** option **a** or **b** now (preserve + optionally harden
+docs), with options **c / d / e** sequenced later under their own gates,
+and option **f** held throughout. Phase 41D authorizes none of them; the
+next phase is the place to weigh them.
+
+---
+
+## O. Acceptance criteria for Phase 41D
+
+Phase 41D is acceptable if:
+
+- the **live-Dixie Discord smoke-test acceptance report is added** (this
+  file);
+- the **decision map is updated** with a targeted Phase 41D addendum
+  (`docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md`);
+- the **Phase 41C runbook is updated / referenced** with a Phase 41D
+  acceptance note
+  (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md`);
+- the **Phase 41A gate is updated / referenced** with a Phase 41D note
+  (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md`);
+- **no source / test / package / lockfile / fixture / config / CI /
+  generated changes** are made;
+- **no secrets / raw IDs / tokens / screenshots / images** are
+  committed;
+- **no raw Dixie response bodies** (including `raw_reasons`) are pasted;
+- **no production rollout, public recall, or served-memory claim** is
+  made;
+- **all blocked work remains blocked** (§K).
+
+---
+
+## P. Cross-references
+
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md` —
+  Phase 41C operational runbook; the governing procedure for this run;
+  gains a Phase 41D acceptance note.
+- `docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md` — Phase 41A
+  decision gate; the authority this acceptance preserves; gains a Phase
+  41D note.
+- `docs/RECALL-WEDGE-LIVE-DIXIE-CLIENT-GATE.md` — Phase 37B live Dixie
+  client gate; the live client seam, env config, and classification
+  vocabulary the output narrows into.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-SMOKE-TEST-ACCEPTANCE.md` — Phase 39E
+  harness-demo smoke-test acceptance; the redacted-evidence template
+  this report follows.
+- `docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md` — Phase 40B internal
+  demo guide for the harness demo (separate command; gains a Phase 41D
+  cross-reference).
+- `docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md` — Phase 35A option matrix;
+  gains a Phase 41D addendum.
+- `apps/bot/src/discord-interactions/recall-wedge-live-demo.ts` — Phase
+  41B live handler, env gates, fixed input, lazy load, render, no-leak
+  scan (unchanged by Phase 41D).
+- `apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts` —
+  Phase 41B regression / static-guard tests (unchanged by Phase 41D).
+- `apps/bot/src/lib/publish-commands.ts` —
+  `registerRecallWedgeLiveDemoCommand` (guild-scoped-only registration;
+  unchanged by Phase 41D).
+- `apps/bot/scripts/publish-commands.ts` — publish CLI entry point
+  (unchanged by Phase 41D).
+- `apps/bot/src/discord-interactions/dispatch.ts` — routes the live
+  command as a distinct name (unchanged by Phase 41D).
+- `packages/persona-engine/src/recall-wedge/live-dixie-client.ts` — Phase
+  37C live Dixie client; the only live-egress seam reached during this
+  run (unchanged by Phase 41D).

--- a/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+++ b/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
@@ -680,6 +680,62 @@ This addendum does not duplicate the Phase 41C runbook; it only records
 that the Phase 41B live command now has an operational runbook and that
 the next acceptance step is a future Phase 41D, not Phase 41C.
 
+### 5l. Phase 41D addendum — controlled live-Dixie Discord smoke test accepted; safe wiring + fail-closed only, no served recall
+
+> Added by Phase 41D
+> (`docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md`).
+> Targeted addendum, not a rewrite of this section.
+
+Status as of Phase 41D (2026-05-30):
+
+- **Phase 41D records controlled operator smoke-test acceptance for the
+  live command.** A human operator deployed Dixie live (Railway, healthy
+  service + Postgres, `GET /api/health` → 200), wired the **Freeside
+  Characters** service with the live Dixie env, and invoked
+  `/recall-wedge-live-demo` in one configured guild. The live path
+  reached the Dixie `/api/recall/intake` seam and **fail-closed safely**.
+- **It is docs-only.** It adds no source, test, package, lockfile,
+  fixture, config, CI, or generated change, and no handler /
+  registration / dispatch behavior change.
+- **It accepts safe wiring + fail-closed rendering, not served recall.**
+  The authenticated intake reached the Straylight seam and returned
+  `seam.storage_unavailable`; the command classified it as
+  `upstream_unavailable` and rendered an ephemeral operator-safe summary
+  (`classification` / `outcome` / `route` / `reason`) with **no
+  `raw_reasons`, no raw payload, no IDs / tokens / tenant / debug
+  material**.
+- **The current blocker for served recall is the unseeded live estate /
+  storage state.** Until it is seeded (and the seeding / admission path
+  is itself designed and gated — §7), the live command can prove safe
+  reach + safe fail-closed, not served recall content.
+- **No production / public claim, no Finn-healthy claim.** The run does
+  not claim production rollout, public recall, served memory, healthy
+  Finn integration (Finn was intentionally unreachable), persistent
+  production storage / admission, or cross-user auth / consent.
+- **Two documented operational caveats.** Startup auto-publish can remove
+  the dev-only live command (register after restart; do not restart
+  before invocation); and the manually minted Dixie JWT is short-lived
+  (refresh + restart before re-running if expired).
+- **Next decision options are recorded, none authorized here:** preserve
+  as controlled smoke acceptance; harden the runbook (docs-only); a tiny
+  operational patch so startup auto-publish does not erase the gated dev
+  command; design a seeded live estate / storage path; design a
+  longer-lived / safer dev service-token path; keep public rollout
+  blocked.
+- **Public-channel-visible recall, public recall, served memory, memory
+  admission, storage / admission, production / public rollout, Telegram /
+  private chat, LLM / voice, candidate writes, "remember this," cross-user
+  auth / consent, direct Finn runtime / audit wiring beyond existing
+  seams, and public renderer expansion all remain blocked** behind
+  separate later gates.
+
+This addendum does not duplicate the Phase 41D acceptance report; it only
+records that a controlled live-Dixie Discord run was accepted for safe
+wiring + fail-closed rendering, that served recall remains blocked on the
+unseeded estate / storage state, and that the **recommended next phase**
+answer is preserve / harden docs now, with seeded-storage and
+safer-token work sequenced later under their own gates.
+
 ---
 
 ## 6. Decision gates before live Dixie client (Option C)


### PR DESCRIPTION
## Summary

Phase 41D records the controlled live Dixie Discord smoke-test acceptance for Freeside Characters.

This is docs-only acceptance for the live /recall-wedge-live-demo smoke path. It records that the current Freeside Characters Discord app identity, loa, can invoke the gated live Dixie demo command, call the live Dixie recall-intake path, and render the upstream seam unavailability safely.

The report accepts live command wiring, auth path, upstream Dixie reach, fail-closed classification, and no-leak Discord rendering. It does not accept served recall memory.

## Files

Added:

- docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-SMOKE-TEST-ACCEPTANCE.md

Modified:

- docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
- docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md
- docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md
- docs/RECALL-WEDGE-DISCORD-DEMO-INTERNAL-GUIDE.md

## What the report records

- Dixie public endpoint was reachable.
- Health returned HTTP 200.
- Dixie and Postgres were healthy.
- Overall health was degraded only because the Finn dependency was intentionally placeholder/unreachable for this smoke.
- Unauthenticated recall-intake failed closed with HTTP 401.
- The allowlist and short-lived Dixie JWT verification path worked.
- Direct authenticated recall-intake reached the Straylight seam and returned seam.storage_unavailable because live estate/storage is unseeded.
- Freeside Characters service received the live Dixie env.
- The loa Discord app registered /recall-wedge-live-demo to the controlled guild after restart.
- Operator invocation in Discord was ephemeral and rendered a safe upstream_unavailable classification with reason seam.storage_unavailable.
- Discord output did not expose raw upstream payloads, raw reasons, bounded-store scope details, tenant/debug material, token material, stack traces, or private IDs.

## Results

Local validation:

- docs-only scope: passed
- required acceptance report exists: passed
- git diff --check: passed
- high-confidence value-shaped leak scan: passed
- raw upstream/debug detail scan: passed
- screenshot/image/binary working-tree scan: passed
- positive content checks for upstream_unavailable, seam.storage_unavailable, Freeside Characters, loa, and not-served-memory claims: passed

Codex audit:

- VERDICT: ACCEPT
- Scope accepted as docs-only.
- Acceptance claim accepted as live wiring and safe fail-closed rendering only.
- Served recall, production rollout, Finn integration, storage/admission, and broader auth/consent remain unaccepted.
- Redaction/no-leak assessment accepted.
- Terminology accepted: Freeside Characters is the current app/repo/Railway service, loa is the bot identity, and Freeside platform remains future/broader platform.

## Operational caveats recorded

- Startup auto-publish can erase the dev-only live command; repeat smoke runs must register the live command after restart and avoid restarting before invocation.
- The manually minted Dixie JWT is short-lived; repeat smoke runs must refresh the token and restart Freeside Characters if the token expires.
- Served recall remains blocked by unseeded live estate/storage state.

## Non-goals

This PR does not:

- change source code
- change tests
- change package or lockfiles
- change config or CI
- add screenshots, images, binaries, or generated files
- record raw Discord IDs, Railway IDs, tokens, JWTs, admin keys, service tokens, Postgres URLs, or secret values
- record raw Dixie response bodies or raw upstream/debug details
- claim served recall memory
- claim production rollout
- claim public recall
- claim Finn integration is healthy
- claim durable storage/admission is solved
- claim cross-user auth or consent is solved
