### PR TITLE
Phase 42B chore: add live recall demo refusal diagnostics

### DIFF
--- a/apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
@@ -43,7 +43,7 @@
 //      client nor the harness; the global publish set excludes the live
 //      command; dispatch routes the live command to the gated handler.
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, spyOn } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -53,6 +53,7 @@ import {
   RECALL_WEDGE_LIVE_DEMO_COMMAND_DEFINITION,
   RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
   RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL,
+  computeRecallWedgeLiveDemoGateDiagnostics,
   handleRecallWedgeLiveDemoInteraction,
   isRecallWedgeLiveDiscordDemoAllowedGuild,
   isRecallWedgeLiveDiscordDemoOperator,
@@ -62,6 +63,7 @@ import {
   resolveRecallWedgeLiveDiscordDemoGuildId,
   shouldEnableRecallWedgeLiveDiscordDemo,
   shouldRegisterRecallWedgeLiveDiscordDemo,
+  type RecallWedgeLiveDemoGateDiagnostics,
   type RecallWedgeLiveDixieClientModule,
 } from './recall-wedge-live-demo.ts';
 // Live Dixie client reached through the AUTHORIZED package subpath (Phase 41B
@@ -470,6 +472,377 @@ describe('Phase 41B · refused paths never load or call the live Dixie client', 
         loadLiveClient: loader.load,
       });
       expect(res.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+      expect(loader.loads()).toBe(0);
+      expect(client.recallCalls()).toBe(0);
+    });
+  }
+});
+
+// =====================================================================
+// B2. Phase 42B · pre-Dixie gate diagnostics (safe booleans + reason code)
+//
+// Authority: docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DECISION-GATE.md §K — "safe
+// operator diagnostics only if they contain no IDs / secrets / private fields
+// — stable reason codes are fine." Phase 42B adds a booleans-only operator log
+// line on the pre-Dixie refusal path WITHOUT changing the generic refusal or
+// reaching the live client. These tests prove:
+//   - the pure diagnostics computer derives the right refusal_code + booleans
+//     for each gate failure (and null when all gates pass);
+//   - the public/ephemeral refusal string is UNCHANGED;
+//   - the emitted log line carries NO configured guild ID, NO interaction guild
+//     ID, NO invoker user ID, NO operator allowlist raw value, NO Discord token,
+//     NO Dixie token/URL, NO channel/message ID, NO env names/values, and NO
+//     stack traces — only booleans + the stable reason code;
+//   - refused paths still neither load nor call the live Dixie client even with
+//     the diagnostic in place.
+// =====================================================================
+
+// Distinctive sentinels (NOT the generic GUILD/OPERATOR constants) so a leak of
+// any of them into the log line is unmistakable. By DEFAULT secretInteraction()
+// + secretEnv() pass every gate (interaction guild == configured guild, invoker
+// is in the allowlist), so each refusal test drives a SINGLE gate failure via an
+// explicit override — and the secret values stay loaded on every refused path so
+// we can prove the diagnostic copies none of them out.
+const SENTINEL_GUILD = 'SENTINEL-CONFIGURED-GUILD-aaaa';
+const SENTINEL_INVOKER = 'SENTINEL-INVOKER-ID-dddd';
+const SENTINEL_ALLOWLIST = `${SENTINEL_INVOKER},SENTINEL-OP-2-ffff`;
+const SENTINEL_BOT_TOKEN = 'SENTINEL-DISCORD-BOT-TOKEN-gggg';
+const SENTINEL_DIXIE_TOKEN = 'SENTINEL-DIXIE-SERVICE-TOKEN-hhhh';
+const SENTINEL_DIXIE_URL = 'https://SENTINEL-DIXIE-BASE-URL-iiii.example.test';
+const SENTINEL_CHANNEL = 'SENTINEL-CHANNEL-ID-jjjj';
+const SENTINEL_TOKEN = 'SENTINEL-INTERACTION-TOKEN-kkkk';
+const SENTINEL_OTHER_GUILD = 'SENTINEL-OTHER-GUILD-zzzz';
+const SENTINEL_OTHER_USER = 'SENTINEL-OTHER-USER-yyyy';
+
+// Every sentinel that must NEVER appear in a diagnostic log line.
+const ALL_SENTINELS = [
+  SENTINEL_GUILD,
+  SENTINEL_INVOKER,
+  SENTINEL_ALLOWLIST,
+  'SENTINEL-OP-2-ffff',
+  SENTINEL_BOT_TOKEN,
+  SENTINEL_DIXIE_TOKEN,
+  SENTINEL_DIXIE_URL,
+  SENTINEL_CHANNEL,
+  SENTINEL_TOKEN,
+  SENTINEL_OTHER_GUILD,
+  SENTINEL_OTHER_USER,
+];
+
+// A "secret-loaded" env: the live + Dixie secret vars all present with
+// distinctive values. The diagnostic must surface none of them. Defaults pass
+// every gate (so refusal cases override exactly one var).
+function secretEnv(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return {
+    RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED: 'true',
+    RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: SENTINEL_GUILD,
+    RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: SENTINEL_ALLOWLIST,
+    DISCORD_BOT_TOKEN: SENTINEL_BOT_TOKEN,
+    RECALL_WEDGE_DIXIE_BASE_URL: SENTINEL_DIXIE_URL,
+    RECALL_WEDGE_DIXIE_SERVICE_TOKEN: SENTINEL_DIXIE_TOKEN,
+    ...overrides,
+  };
+}
+
+// A secret-loaded interaction: distinctive channel / token, allowlisted invoker,
+// and (by default) the configured guild so every gate passes unless overridden.
+function secretInteraction(
+  overrides: Partial<DiscordInteraction> = {},
+): DiscordInteraction {
+  return interaction({
+    guild_id: SENTINEL_GUILD,
+    channel_id: SENTINEL_CHANNEL,
+    token: SENTINEL_TOKEN,
+    member: { user: { id: SENTINEL_INVOKER, username: 'op' } },
+    ...overrides,
+  });
+}
+
+/** Run `fn` with console.warn captured; returns all warn lines (joined args). */
+async function captureWarn(fn: () => Promise<unknown> | unknown): Promise<string[]> {
+  const captured: string[] = [];
+  const spy = spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    captured.push(args.map((a) => String(a)).join(' '));
+  });
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return captured;
+}
+
+describe('Phase 42B · pre-Dixie gate diagnostics (pure computer)', () => {
+  test('disabled → refusal_code "disabled", enabled_gate false', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(interaction(), {});
+    expect(d.command).toBe(RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME);
+    expect(d.stage).toBe('pre_dixie_gate');
+    expect(d.enabled_gate).toBe(false);
+    expect(d.refusal_code).toBe('disabled');
+  });
+
+  test('wrong guild → "missing_or_wrong_guild" (configured + interaction guild both present)', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(
+      interaction({ guild_id: OTHER_GUILD }),
+      fullEnv(),
+    );
+    expect(d.enabled_gate).toBe(true);
+    expect(d.guild_gate).toBe(false);
+    expect(d.has_configured_guild).toBe(true);
+    expect(d.has_interaction_guild).toBe(true);
+    expect(d.refusal_code).toBe('missing_or_wrong_guild');
+  });
+
+  test('missing interaction guild (DM) → "missing_or_wrong_guild", has_interaction_guild false', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(
+      interaction({ guild_id: undefined }),
+      fullEnv(),
+    );
+    expect(d.guild_gate).toBe(false);
+    expect(d.has_interaction_guild).toBe(false);
+    expect(d.has_configured_guild).toBe(true);
+    expect(d.refusal_code).toBe('missing_or_wrong_guild');
+  });
+
+  test('missing configured guild → "missing_or_wrong_guild", has_configured_guild false', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(
+      interaction(),
+      fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_GUILD_ID: '' }),
+    );
+    expect(d.guild_gate).toBe(false);
+    expect(d.has_configured_guild).toBe(false);
+    expect(d.has_interaction_guild).toBe(true);
+    expect(d.refusal_code).toBe('missing_or_wrong_guild');
+  });
+
+  test('empty allowlist → "empty_allowlist", has_operator_allowlist false', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(
+      interaction(),
+      fullEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+    );
+    expect(d.enabled_gate).toBe(true);
+    expect(d.guild_gate).toBe(true);
+    expect(d.operator_gate).toBe(false);
+    expect(d.has_operator_allowlist).toBe(false);
+    expect(d.refusal_code).toBe('empty_allowlist');
+  });
+
+  test('non-operator → "non_operator" (allowlist present, invoker present, not listed)', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(
+      interaction({ member: { user: { id: OTHER_USER, username: 'x' } } }),
+      fullEnv(),
+    );
+    expect(d.operator_gate).toBe(false);
+    expect(d.has_operator_allowlist).toBe(true);
+    expect(d.has_invoker_id).toBe(true);
+    expect(d.refusal_code).toBe('non_operator');
+  });
+
+  test('missing invoker (allowlist present, no member/user) → "missing_invoker"', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(
+      interaction({ member: undefined, user: undefined }),
+      fullEnv(),
+    );
+    expect(d.operator_gate).toBe(false);
+    expect(d.has_operator_allowlist).toBe(true);
+    expect(d.has_invoker_id).toBe(false);
+    expect(d.refusal_code).toBe('missing_invoker');
+  });
+
+  test('all gates pass → refusal_code null (handler proceeds to gated live path)', () => {
+    const d = computeRecallWedgeLiveDemoGateDiagnostics(interaction(), fullEnv());
+    expect(d.enabled_gate).toBe(true);
+    expect(d.guild_gate).toBe(true);
+    expect(d.operator_gate).toBe(true);
+    expect(d.refusal_code).toBeNull();
+  });
+
+  test('diagnostics carry only booleans + the stable enums (no id-shaped fields)', () => {
+    const d: RecallWedgeLiveDemoGateDiagnostics =
+      computeRecallWedgeLiveDemoGateDiagnostics(secretInteraction(), secretEnv());
+    // Every field is a boolean, the fixed command/stage literals, or the
+    // reason-code enum — there is no slot for an id / value / token / payload.
+    const booleanKeys = [
+      'enabled_gate',
+      'guild_gate',
+      'operator_gate',
+      'has_configured_guild',
+      'has_interaction_guild',
+      'has_operator_allowlist',
+      'has_invoker_id',
+    ] as const;
+    for (const k of booleanKeys) expect(typeof d[k]).toBe('boolean');
+    expect(d.command).toBe('recall-wedge-live-demo');
+    expect(d.stage).toBe('pre_dixie_gate');
+    // The whole serialized snapshot leaks no sentinel id / token / url.
+    const serialized = JSON.stringify(d);
+    for (const sentinel of ALL_SENTINELS) {
+      expect(serialized).not.toContain(sentinel);
+    }
+  });
+});
+
+describe('Phase 42B · diagnostics are logged on the pre-Dixie refusal path', () => {
+  test('disabled path logs exactly one safe gate-refusal line with refusal_code=disabled', async () => {
+    const lines = await captureWarn(() =>
+      handleRecallWedgeLiveDemoInteraction(interaction(), {}),
+    );
+    const gateLines = lines.filter((l) => l.includes('pre-dixie gate refusal'));
+    expect(gateLines.length).toBe(1);
+    const line = gateLines[0]!;
+    expect(line).toContain('command=recall-wedge-live-demo');
+    expect(line).toContain('stage=pre_dixie_gate');
+    expect(line).toContain('enabled_gate=false');
+    expect(line).toContain('refusal_code=disabled');
+  });
+
+  test.each([
+    [
+      'wrong-guild',
+      () => secretInteraction({ guild_id: SENTINEL_OTHER_GUILD }),
+      () => secretEnv(),
+      'refusal_code=missing_or_wrong_guild',
+      'guild_gate=false',
+    ],
+    [
+      'non-operator',
+      () =>
+        secretInteraction({
+          member: { user: { id: SENTINEL_OTHER_USER, username: 'x' } },
+        }),
+      () => secretEnv(),
+      'refusal_code=non_operator',
+      'operator_gate=false',
+    ],
+    [
+      'empty-allowlist',
+      () => secretInteraction(),
+      () =>
+        secretEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+      'refusal_code=empty_allowlist',
+      'has_operator_allowlist=false',
+    ],
+  ] as const)(
+    '%s path logs a safe line and the PUBLIC refusal is unchanged',
+    async (_label, buildInt, buildEnv, expectedCode, expectedBoolean) => {
+      let res: Awaited<
+        ReturnType<typeof handleRecallWedgeLiveDemoInteraction>
+      > | null = null;
+      const lines = await captureWarn(async () => {
+        res = await handleRecallWedgeLiveDemoInteraction(buildInt(), buildEnv());
+      });
+      // Public refusal unchanged.
+      expect(res!.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+      expect(res!.data?.flags).toBe(MessageFlags.EPHEMERAL);
+      // The public refusal string itself names no gate / code.
+      expect(res!.data?.content).not.toContain(expectedCode);
+      // Exactly one gate-refusal diagnostic line with the right code + boolean.
+      const gateLines = lines.filter((l) => l.includes('pre-dixie gate refusal'));
+      expect(gateLines.length).toBe(1);
+      expect(gateLines[0]!).toContain(expectedCode);
+      expect(gateLines[0]!).toContain(expectedBoolean);
+    },
+  );
+
+  test('NO IDs / tokens / allowlist / env values appear in ANY refusal log line', async () => {
+    // Exercise each pre-Dixie refusal path with a fully secret-loaded env +
+    // interaction, capturing every warn line across all of them.
+    const cases: Array<{ int: DiscordInteraction; env: Record<string, string | undefined> }> = [
+      // disabled: secret vars still loaded (enable flag away from exact "true")
+      { int: secretInteraction(), env: secretEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_ENABLED: 'false' }) },
+      {
+        int: secretInteraction({ guild_id: SENTINEL_OTHER_GUILD }),
+        env: secretEnv(),
+      }, // wrong guild
+      { int: secretInteraction({ guild_id: undefined }), env: secretEnv() }, // missing guild
+      {
+        int: secretInteraction({
+          member: { user: { id: SENTINEL_OTHER_USER, username: 'x' } },
+        }),
+        env: secretEnv(),
+      }, // non-operator
+      {
+        int: secretInteraction(),
+        env: secretEnv({
+          RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '',
+        }),
+      }, // empty allowlist
+      {
+        int: secretInteraction({ member: undefined, user: undefined }),
+        env: secretEnv(),
+      }, // missing invoker
+    ];
+    const lines = await captureWarn(async () => {
+      for (const c of cases) {
+        await handleRecallWedgeLiveDemoInteraction(c.int, c.env);
+      }
+    });
+    const gateLines = lines.filter((l) => l.includes('pre-dixie gate refusal'));
+    // One safe line per refused case.
+    expect(gateLines.length).toBe(cases.length);
+    for (const line of gateLines) {
+      for (const sentinel of ALL_SENTINELS) {
+        expect(line).not.toContain(sentinel);
+      }
+      // No env NAMES either (booleans describe presence, never the var name).
+      expect(line).not.toContain('RECALL_WEDGE_DIXIE_');
+      expect(line).not.toContain('RECALL_WEDGE_LIVE_DISCORD_DEMO_');
+      expect(line).not.toContain('DISCORD_BOT_TOKEN');
+      // No stack-trace markers.
+      expect(line).not.toContain('    at ');
+      expect(line).not.toMatch(/Error:/);
+    }
+  });
+
+  test('the success path emits NO pre-Dixie gate-refusal line', async () => {
+    const client = countingClient(liveResult('served'));
+    const lines = await captureWarn(() =>
+      handleRecallWedgeLiveDemoInteraction(secretInteraction(), secretEnv(), {
+        loadLiveClient: async () => client.module,
+      }),
+    );
+    expect(lines.filter((l) => l.includes('pre-dixie gate refusal')).length).toBe(0);
+    expect(client.recallCalls()).toBe(1);
+  });
+});
+
+describe('Phase 42B · refused paths still never load or call Dixie (with diagnostics)', () => {
+  for (const [label, build] of [
+    ['disabled', () => ({ int: secretInteraction(), env: {} as Record<string, string | undefined> })],
+    ['wrong-guild', () => ({ int: secretInteraction({ guild_id: SENTINEL_OTHER_GUILD }), env: secretEnv() })],
+    ['missing-guild', () => ({ int: secretInteraction({ guild_id: undefined }), env: secretEnv() })],
+    [
+      'non-operator',
+      () => ({
+        int: secretInteraction({ member: { user: { id: SENTINEL_OTHER_USER, username: 'x' } } }),
+        env: secretEnv(),
+      }),
+    ],
+    [
+      'empty-allowlist',
+      () => ({
+        int: secretInteraction(),
+        env: secretEnv({ RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS: '' }),
+      }),
+    ],
+  ] as const) {
+    test(`${label} path: diagnostic logged, but NO client load and NO recall call`, async () => {
+      const client = countingClient(liveResult('served'));
+      const loader = countingLoader(client.module);
+      const { int, env } = build();
+      let res: Awaited<
+        ReturnType<typeof handleRecallWedgeLiveDemoInteraction>
+      > | null = null;
+      const lines = await captureWarn(async () => {
+        res = await handleRecallWedgeLiveDemoInteraction(int, env, {
+          loadLiveClient: loader.load,
+        });
+      });
+      expect(res!.data?.content).toBe(RECALL_WEDGE_LIVE_DEMO_GENERIC_REFUSAL);
+      // Diagnostic emitted, client untouched (no load, no egress).
+      expect(lines.filter((l) => l.includes('pre-dixie gate refusal')).length).toBe(1);
       expect(loader.loads()).toBe(0);
       expect(client.recallCalls()).toBe(0);
     });

--- a/apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
@@ -172,6 +172,145 @@ export function isRecallWedgeLiveDiscordDemoOperator(
   return operatorIds.includes(invokerId);
 }
 
+// -- pre-Dixie gate diagnostics (Phase 42B · §K safe operator diagnostics) -
+//
+// Phase 41A §K explicitly permits "safe operator diagnostics ... if they
+// contain no IDs / secrets / private fields — stable reason codes are fine."
+// Phase 42B adds exactly that for the pre-Dixie refusal path: a single safe
+// log line of BOOLEANS and a stable refusal CODE so an operator can see WHICH
+// gate tripped without the public/ephemeral refusal ever revealing it.
+//
+// Hard no-leak contract (mirrors §K + the runbook §M "do not record" list):
+// the diagnostics carry NO guild IDs, NO user IDs, NO operator allowlist
+// contents, NO tokens, NO Dixie URL / token, NO raw interaction or Dixie
+// payload, NO channel / message IDs, NO env names or values, and NO stack
+// traces — only booleans and a fixed reason-code enum. The booleans answer
+// "is the value present / does the gate pass" without ever surfacing the
+// value itself.
+
+/**
+ * Stable, no-leak reason codes for a pre-Dixie gate refusal. These name
+ * WHICH gate tripped for the operator log ONLY — they never reach Discord
+ * (the public refusal stays the single generic string). `unknown_gate_refusal`
+ * is a defensive fallback that should never be emitted in practice (it would
+ * mean the refusal path ran with all gate booleans passing).
+ */
+export type RecallWedgeLiveDemoRefusalCode =
+  | 'disabled'
+  | 'missing_or_wrong_guild'
+  | 'empty_allowlist'
+  | 'non_operator'
+  | 'missing_invoker'
+  | 'unknown_gate_refusal';
+
+/**
+ * The safe, booleans-only snapshot of the pre-Dixie gate state. Every field is
+ * a boolean or the fixed reason-code enum — there is intentionally no slot for
+ * an ID, env value, token, or payload. `refusal_code` is null when ALL pre-Dixie
+ * gates pass (the handler then proceeds to the gated live path).
+ */
+export interface RecallWedgeLiveDemoGateDiagnostics {
+  readonly command: typeof RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME;
+  readonly stage: 'pre_dixie_gate';
+  readonly enabled_gate: boolean;
+  readonly guild_gate: boolean;
+  readonly operator_gate: boolean;
+  readonly has_configured_guild: boolean;
+  readonly has_interaction_guild: boolean;
+  readonly has_operator_allowlist: boolean;
+  readonly has_invoker_id: boolean;
+  readonly refusal_code: RecallWedgeLiveDemoRefusalCode | null;
+}
+
+/**
+ * Compute the safe pre-Dixie gate diagnostics. Pure: reads only env + the
+ * presence/equality of interaction fields, evaluates the same three gate
+ * helpers the handler uses, and derives a stable `refusal_code` following the
+ * handler's precedence (enabled → guild → operator). Calls no client, makes no
+ * network request, and copies NO id / value / token / payload into its result.
+ *
+ * `refusal_code` is null exactly when `enabled_gate && guild_gate &&
+ * operator_gate` — i.e. when the handler would NOT refuse before Dixie. The
+ * operator-gate failure is split into `empty_allowlist` (no allowlist
+ * configured), `missing_invoker` (allowlist present but no invoker id), and
+ * `non_operator` (invoker present but not allowlisted) so the operator log
+ * distinguishes a misconfiguration from a genuinely-unauthorized caller —
+ * still without ever logging the allowlist or the id.
+ */
+export function computeRecallWedgeLiveDemoGateDiagnostics(
+  interaction: DiscordInteraction,
+  env: Env,
+): RecallWedgeLiveDemoGateDiagnostics {
+  const enabled_gate = shouldEnableRecallWedgeLiveDiscordDemo(env);
+  const guild_gate = isRecallWedgeLiveDiscordDemoAllowedGuild(interaction, env);
+  const operator_gate = isRecallWedgeLiveDiscordDemoOperator(interaction, env);
+
+  const has_configured_guild =
+    resolveRecallWedgeLiveDiscordDemoGuildId(env) !== null;
+  const has_interaction_guild = Boolean(interaction.guild_id);
+  const has_operator_allowlist =
+    parseRecallWedgeLiveDiscordDemoOperatorIds(env).length > 0;
+  const has_invoker_id = Boolean(
+    interaction.member?.user?.id ?? interaction.user?.id,
+  );
+
+  let refusal_code: RecallWedgeLiveDemoRefusalCode | null;
+  if (!enabled_gate) {
+    refusal_code = 'disabled';
+  } else if (!guild_gate) {
+    refusal_code = 'missing_or_wrong_guild';
+  } else if (!operator_gate) {
+    refusal_code = !has_operator_allowlist
+      ? 'empty_allowlist'
+      : !has_invoker_id
+        ? 'missing_invoker'
+        : 'non_operator';
+  } else {
+    refusal_code = null;
+  }
+
+  return {
+    command: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+    stage: 'pre_dixie_gate',
+    enabled_gate,
+    guild_gate,
+    operator_gate,
+    has_configured_guild,
+    has_interaction_guild,
+    has_operator_allowlist,
+    has_invoker_id,
+    refusal_code,
+  };
+}
+
+/**
+ * Emit the safe pre-Dixie gate diagnostics as ONE operator log line. Called
+ * only on the refusal path (so the line always carries a refusal code; a null
+ * code is coerced to the defensive `unknown_gate_refusal`). The line is
+ * booleans + the reason code only — it matches the repo's `interactions: …`
+ * single-line key=value log convention and the lowercase-log voice rule, and
+ * it contains no id / env value / token / payload by construction (the
+ * `RecallWedgeLiveDemoGateDiagnostics` shape has nowhere to put one).
+ */
+function logRecallWedgeLiveDemoGateRefusal(
+  diagnostics: RecallWedgeLiveDemoGateDiagnostics,
+): void {
+  const refusal_code = diagnostics.refusal_code ?? 'unknown_gate_refusal';
+  console.warn(
+    `interactions: ${diagnostics.command} pre-dixie gate refusal · ` +
+      `command=${diagnostics.command} ` +
+      `stage=${diagnostics.stage} ` +
+      `enabled_gate=${diagnostics.enabled_gate} ` +
+      `guild_gate=${diagnostics.guild_gate} ` +
+      `operator_gate=${diagnostics.operator_gate} ` +
+      `has_configured_guild=${diagnostics.has_configured_guild} ` +
+      `has_interaction_guild=${diagnostics.has_interaction_guild} ` +
+      `has_operator_allowlist=${diagnostics.has_operator_allowlist} ` +
+      `has_invoker_id=${diagnostics.has_invoker_id} ` +
+      `refusal_code=${refusal_code}`,
+  );
+}
+
 // -- fixed deterministic operator/dev request shape (Phase 41A §H) ---------
 
 /**
@@ -414,13 +553,20 @@ export async function handleRecallWedgeLiveDemoInteraction(
   // Gate order is irrelevant to the user: all gates fail to the SAME refusal.
   // No client load — and therefore no network egress — happens before these
   // checks, so a refused interaction never reaches the live path.
-  if (!shouldEnableRecallWedgeLiveDiscordDemo(env)) {
-    return recallWedgeLiveDemoRefusal();
-  }
-  if (!isRecallWedgeLiveDiscordDemoAllowedGuild(interaction, env)) {
-    return recallWedgeLiveDemoRefusal();
-  }
-  if (!isRecallWedgeLiveDiscordDemoOperator(interaction, env)) {
+  //
+  // Phase 42B (§K safe operator diagnostics): compute the booleans-only gate
+  // snapshot up front. The PUBLIC refusal is unchanged — still the single
+  // generic ephemeral string with no hint of which gate tripped — but on a
+  // pre-Dixie refusal we emit ONE safe operator log line (booleans + stable
+  // reason code, no IDs / tokens / env values / payloads) so operators can
+  // diagnose which gate is failing. `refusal_code` is null only when all three
+  // gates pass, so the log fires exactly on the refusal branch below.
+  const gateDiagnostics = computeRecallWedgeLiveDemoGateDiagnostics(
+    interaction,
+    env,
+  );
+  if (gateDiagnostics.refusal_code !== null) {
+    logRecallWedgeLiveDemoGateRefusal(gateDiagnostics);
     return recallWedgeLiveDemoRefusal();
   }
 

--- a/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md
+++ b/docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md
@@ -708,6 +708,26 @@ Concise triage. Keep secrets and raw IDs out of chat and docs throughout.
   the guild, and the operator's ID is in
   `RECALL_WEDGE_LIVE_DISCORD_DEMO_OPERATOR_USER_IDS`. The refusal is
   intentionally generic.
+  - **Phase 42B safe diagnostic (operator logs only).** To see *which*
+    pre-Dixie gate tripped without changing the generic refusal, read the
+    runtime's operator log for the single line
+    `interactions: recall-wedge-live-demo pre-dixie gate refusal · …`. It
+    carries **booleans + a stable reason code only** — `enabled_gate`,
+    `guild_gate`, `operator_gate`, `has_configured_guild`,
+    `has_interaction_guild`, `has_operator_allowlist`, `has_invoker_id`,
+    and `refusal_code` (one of `disabled` / `missing_or_wrong_guild` /
+    `empty_allowlist` / `non_operator` / `missing_invoker` /
+    `unknown_gate_refusal`). It logs **no** guild / user / channel /
+    command IDs, **no** operator allowlist contents, **no** tokens, **no**
+    Dixie URL / token, **no** env names or values, and **no** raw
+    interaction / Dixie payload or stack trace. Map the code:
+    `disabled` → fix the enable flag (exact `"true"`);
+    `missing_or_wrong_guild` → fix the configured / interaction guild
+    (see `has_configured_guild` vs `has_interaction_guild` to tell which
+    side is missing); `empty_allowlist` → set the operator allowlist;
+    `non_operator` → the invoker is not allowlisted; `missing_invoker` →
+    no invoker id was present on the interaction. The Discord-facing
+    refusal stays the single generic string regardless.
 - **Command appears but returns a safe config summary** — the Discord
   gates passed but the Dixie env is missing / invalid. Set / fix the
   `RECALL_WEDGE_DIXIE_*` env (§D.4 / §I) and redeploy. The summary names


### PR DESCRIPTION
## Summary

Phase 42B adds safe dev/operator diagnostics for `/recall-wedge-live-demo` pre-Dixie refusal paths.

Dixie Phase 32K direct seeded smoke has already passed: direct Dixie live recall returned HTTP 200 served with pack + receipt and no raw_reasons. The remaining blocker is that `/recall-wedge-live-demo` is registered and invokes in Discord, but returns the generic refusal string:

`recall-wedge-live-demo is not available here.`

The handler intentionally uses the same public refusal for disabled, wrong guild, missing guild, non-operator, empty allowlist, load failure, and unsafe output. This PR adds safe pre-Dixie diagnostic booleans/reason codes so operators can determine which local Discord gate is failing without exposing IDs, tokens, env values, or payloads.

## Files

Changed:

- apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
- apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
- docs/RECALL-WEDGE-LIVE-DIXIE-DISCORD-DEMO-OPERATIONAL-RUNBOOK.md

## Implementation

This PR adds a single safe diagnostic log line on pre-Dixie refusal paths.

The log includes only booleans and stable enum reason codes:

- command=recall-wedge-live-demo
- stage=pre_dixie_gate
- enabled_gate=true/false
- guild_gate=true/false
- operator_gate=true/false
- has_configured_guild=true/false
- has_interaction_guild=true/false
- has_operator_allowlist=true/false
- has_invoker_id=true/false
- refusal_code=disabled | missing_or_wrong_guild | empty_allowlist | non_operator | missing_invoker | unknown_gate_refusal

The public Discord refusal string is unchanged:

`recall-wedge-live-demo is not available here.`

## Safety

The diagnostic log does not include:

- actual guild IDs
- actual user IDs
- operator allowlist contents
- Discord bot token
- Dixie token
- Dixie URL
- raw interaction payload
- raw Dixie payload
- channel IDs
- message IDs
- stack traces

Refused paths still return before loading or calling the live Dixie client.

## Results

Validation:

- git diff --check: pass
- cd apps/bot && bun test src/discord-interactions/recall-wedge-live-demo.test.ts: 154 pass / 0 fail
- cd apps/bot && bun test src/discord-interactions/: 270 pass / 0 fail
- secret/live-value scan: clean after excluding the deliberate fake SENTINEL example test URL

Codex audit:

- Verdict: ACCEPT
- Scope accepted as exactly the three expected files
- Public behavior accepted
- Diagnostic no-leak safety accepted
- Refused-path no-Dixie-call behavior accepted
- Test coverage accepted
- No required patch

## Non-goals

This PR does not:

- change command registration
- make the command public
- widen operator or guild access
- call Dixie on refused paths
- change Freeside Characters normal character commands
- change Dixie
- change package or lockfiles
- add migrations
- add scripts or CLI commands
- add screenshots/images/binaries
- add memory admission
- add Discord history input
- add public rollout
- add LLM or voice behavior
