### PR TITLE
Phase 42C fix: align live recall demo seeded signature

### DIFF
--- a/apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts
@@ -72,6 +72,12 @@ import {
 // for the test's own assertions + to feed the injected client seam.
 import {
   LIVE_DIXIE_CLIENT_BANNED_PUBLIC_SUBSTRINGS,
+  RECALL_DEV_SEED_KEY_REF,
+  RECALL_DEV_SEED_SIGNER_ID,
+  RECALL_DEV_SEED_SIGNER_TYPE,
+  buildDevSeededRecallSignature,
+  computeDevSeededSignature,
+  computeDevSeededSignedPayloadHash,
   findBannedPublicSubstring,
   type LiveDixieClientConfig,
   type LiveDixieRecallClassification,
@@ -118,12 +124,15 @@ function interaction(
 }
 
 // A dummy live Dixie config — the injected client never uses it for a real
-// call, so its field values are inert placeholders (no secrets).
+// call, so its field values are inert placeholders (no secrets). The tenant /
+// caller wallet is a synthetic 0x+40-hex value (all-lowercase) so the Phase
+// 32C signature the handler computes from it is shaped like a real request.
+const DUMMY_WALLET = '0xabcdef0000000000000000000000000000000032';
 const DUMMY_CONFIG = {
   baseUrl: 'https://dixie.example.test',
   serviceToken: 'inert',
-  tenantId: '0xinert',
-  callerActorId: '0xinert',
+  tenantId: DUMMY_WALLET,
+  callerActorId: DUMMY_WALLET,
   requestKeyPrefix: 'p41b',
   timeoutMs: 10_000,
 } satisfies LiveDixieClientConfig;
@@ -178,6 +187,9 @@ function countingClient(
       if (opts.throwOnRecall) throw new Error('simulated live client failure');
       return result;
     },
+    // Use the REAL signature builder so captured-input assertions exercise the
+    // genuine Phase 32K dev-sign algorithm (canonical → sha256 → hmac).
+    buildDevSeededRecallSignature,
     findBannedPublicSubstring,
   };
   return {
@@ -946,7 +958,10 @@ describe('Phase 41B · input source is the fixed synthetic probe (no freeform qu
     // Fixed probe identity — not derived from any option.
     expect(captured!.recallRequestId).toBe('recall-wedge-live-demo-1');
     expect(captured!.task).toContain('operator/dev probe');
-    expect(captured!.environmentFrame).toBe('private_operator');
+    // Phase 42C: the probe uses the Phase 32K-compatible request shape.
+    expect(captured!.environmentFrame).toBe('private_chat');
+    expect(captured!.detailLevel).toBe('standard');
+    expect(captured!.receiptDetail).toBe('standard');
     // None of the smuggled freeform values reached the request.
     const serialized = JSON.stringify(captured);
     expect(serialized).not.toContain('remember my secret');
@@ -984,6 +999,164 @@ describe('Phase 41B · input source is the fixed synthetic probe (no freeform qu
     expect(moduleSource).not.toMatch(/\.options\?\./);
     expect(moduleSource).not.toMatch(/message[_-]?history/i);
     expect(moduleSource).not.toMatch(/getMessages|fetchMessages|channel\.messages/);
+  });
+});
+
+// =====================================================================
+// D2. Phase 42C · Phase 32K-compatible dev/operator seeded request + signature
+//
+// The old Phase 37C-style fixed probe (environmentFrame=private_operator,
+// detailLevel/receiptDetail=minimal, signed_payload_hash=sha256:0000…,
+// signature=devsig, key_ref=recall-wedge-live-demo-kref) was REFUSED live with
+// seam.signer_not_competent. Phase 42C aligns the probe with Dixie's Phase 32K
+// dev/operator seeded-estate smoke: private_chat + standard + standard, a
+// signed payload hash computed over {actor_id, estate_id, task,
+// environment_frame, risk_profile} bound to the configured tenant wallet, and a
+// dev:<hmac_sha256(key_ref, hash)> signature using the PUBLIC dev-seed labels.
+// =====================================================================
+
+describe('Phase 42C · live request uses the Phase 32K-compatible seeded shape', () => {
+  test('the captured request frame/detail are private_chat / standard / standard', async () => {
+    const client = countingClient(liveResult('served'));
+    await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    const captured = client.capturedInput();
+    expect(captured).toBeDefined();
+    expect(captured!.environmentFrame).toBe('private_chat');
+    expect(captured!.detailLevel).toBe('standard');
+    expect(captured!.receiptDetail).toBe('standard');
+  });
+
+  test('signed_payload_hash is computed over {actor_id, estate_id, task, environment_frame, risk_profile}', async () => {
+    const client = countingClient(liveResult('served'));
+    await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    const captured = client.capturedInput()!;
+    // Recompute the expected hash the same way the client does — over the five
+    // canonical fields bound to the configured tenant wallet (DUMMY_WALLET).
+    const expectedHash = computeDevSeededSignedPayloadHash({
+      actor_id: DUMMY_WALLET,
+      estate_id: DUMMY_WALLET,
+      task: captured.task,
+      environment_frame: captured.environmentFrame,
+      risk_profile: captured.riskProfile,
+    });
+    expect(captured.signature.signed_payload_hash).toBe(expectedHash);
+    expect(captured.signature.signed_payload_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // It is NOT the old zero placeholder.
+    expect(captured.signature.signed_payload_hash).not.toBe(
+      'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+    );
+  });
+
+  test('signature is dev:<hmac_sha256(key_ref, signed_payload_hash)>', async () => {
+    const client = countingClient(liveResult('served'));
+    await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    const captured = client.capturedInput()!;
+    const expectedSig = computeDevSeededSignature(
+      captured.signature.key_ref,
+      captured.signature.signed_payload_hash,
+    );
+    expect(captured.signature.signature).toBe(expectedSig);
+    expect(captured.signature.signature).toMatch(/^dev:[0-9a-f]{64}$/);
+    // It is NOT the old placeholder.
+    expect(captured.signature.signature).not.toBe('devsig');
+  });
+
+  test('signer_id / signer_type / key_ref are the public Phase 32K dev-seed labels', async () => {
+    const client = countingClient(liveResult('served'));
+    await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    const sig = client.capturedInput()!.signature;
+    expect(sig.signer_id).toBe(RECALL_DEV_SEED_SIGNER_ID);
+    expect(sig.signer_type).toBe(RECALL_DEV_SEED_SIGNER_TYPE);
+    expect(sig.key_ref).toBe(RECALL_DEV_SEED_KEY_REF);
+    expect(sig.signature_type).toBe('dev_signature');
+  });
+
+  test('the old Phase 37C placeholders never appear in the live request', async () => {
+    const client = countingClient(liveResult('served'));
+    await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    const serialized = JSON.stringify(client.capturedInput());
+    expect(serialized).not.toContain('devsig');
+    expect(serialized).not.toContain(
+      'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+    );
+    expect(serialized).not.toContain('recall-wedge-live-demo-kref');
+    expect(serialized).not.toContain('recall-wedge-live-demo-signer');
+    expect(serialized).not.toContain('private_operator');
+  });
+
+  test('the signing wallet comes from config (env), not the interaction', async () => {
+    // A distinctive wallet supplied via the config loader (the env path) must
+    // be the one bound into the signed payload — proving the actor/estate
+    // identity is env-driven, never read from Discord input.
+    const ENV_WALLET = '0xabcdef0000000000000000000000000000000aaa';
+    const client = countingClient(liveResult('served'), {
+      loadConfig: () => ({ ...DUMMY_CONFIG, tenantId: ENV_WALLET, callerActorId: ENV_WALLET }),
+    });
+    await handleRecallWedgeLiveDemoInteraction(
+      interaction({
+        // Smuggle a different wallet-shaped option; it must be ignored.
+        data: {
+          id: 'cmd',
+          name: RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
+          options: [{ name: 'wallet', type: 3, value: '0xdeadbeef' }],
+        },
+      }),
+      fullEnv(),
+      { loadLiveClient: async () => client.module },
+    );
+    const captured = client.capturedInput()!;
+    const expectedHash = computeDevSeededSignedPayloadHash({
+      actor_id: ENV_WALLET,
+      estate_id: ENV_WALLET,
+      task: captured.task,
+      environment_frame: captured.environmentFrame,
+      risk_profile: captured.riskProfile,
+    });
+    expect(captured.signature.signed_payload_hash).toBe(expectedHash);
+    expect(JSON.stringify(captured)).not.toContain('0xdeadbeef');
+  });
+
+  test('the rendered output never leaks the wallet, hash, or signature material', async () => {
+    const client = countingClient(liveResult('served'));
+    const res = await handleRecallWedgeLiveDemoInteraction(interaction(), fullEnv(), {
+      loadLiveClient: async () => client.module,
+    });
+    const content = res.data?.content ?? '';
+    expect(content).not.toContain(DUMMY_WALLET);
+    expect(content).not.toContain('dev:');
+    expect(content).not.toContain('sha256:');
+    expect(content).not.toContain(RECALL_DEV_SEED_KEY_REF);
+    expect(findBannedPublicSubstring(content)).toBeNull();
+    expect(content).toContain('classification: served');
+  });
+
+  test('handler module hard-codes none of the Phase 32K dev-seed labels (they live in the client)', () => {
+    const moduleSource = readFileSync(
+      resolve(__dirname, 'recall-wedge-live-demo.ts'),
+      'utf8',
+    );
+    // The public labels are owned by the live client; the handler reaches them
+    // only through buildDevSeededRecallSignature, never as inline string copies.
+    expect(moduleSource).not.toContain('dev-seed-key:dixie-operator-smoke');
+    expect(moduleSource).not.toContain('signer:dixie-dev-seeded-operator');
+    // No leftover Phase 37C placeholder signature material either.
+    expect(moduleSource).not.toContain('devsig');
+    expect(moduleSource).not.toContain('recall-wedge-live-demo-kref');
+    expect(moduleSource).not.toContain(
+      'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+    );
+    // The handler reaches the dev-sign builder on the live client.
+    expect(moduleSource).toContain('buildDevSeededRecallSignature');
   });
 });
 

--- a/apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
+++ b/apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
@@ -63,10 +63,12 @@
 // runtime is pulled in lazily via defaultLoadLiveClient ONLY after every
 // Discord gate passes (see the handler below).
 import type {
+  BuildDevSeededSignatureInput,
   LiveDixieClientConfig,
   LiveDixieRecallClassification,
   LiveDixieRecallResult,
   LiveRecallInput,
+  LiveRecallSignatureEnvelopeInput,
 } from '@freeside-characters/persona-engine/recall-wedge/live-dixie-client';
 import {
   InteractionResponseType,
@@ -311,40 +313,77 @@ function logRecallWedgeLiveDemoGateRefusal(
   );
 }
 
-// -- fixed deterministic operator/dev request shape (Phase 41A §H) ---------
+// -- fixed deterministic operator/dev request shape (Phase 41A §H · Phase 42C) --
 
 /**
- * The ONLY input that reaches the live Dixie request from Discord — a FIXED
- * synthetic operator/dev probe (Phase 41A §H option 1). It is a code-reviewed
- * constant, NOT derived from the interaction: no option is read, no message
- * history is read, no channel content is read, and there is no fallback to
- * interaction text. Its shape mirrors the Phase 37C runner's
- * `DEFAULT_OPERATOR_INPUT` (operator-supplied tenant / caller / request-key
- * inputs the live client already constructs). It carries no real secret value
- * — secrets live only in the Phase 37C client's own `RECALL_WEDGE_DIXIE_*`
- * env (§G), which this module does not read. No fixed idempotencyKey is set,
- * so the live client mints a fresh key per call (no reuse).
+ * The fixed synthetic operator/dev probe SHAPE (Phase 41A §H option 1) — every
+ * field except the signature, which is computed per call (Phase 42C). It is a
+ * code-reviewed constant, NOT derived from the interaction: no option is read,
+ * no message history is read, no channel content is read, and there is no
+ * fallback to interaction text.
+ *
+ * Phase 42C aligns this probe with Dixie's Phase 32K dev/operator seeded-estate
+ * smoke (the only shape that passes against live seeded Dixie):
+ *   - `environmentFrame: 'private_chat'` (was `private_operator`);
+ *   - `detailLevel: 'standard'` / `receiptDetail: 'standard'` (were `minimal`).
+ * The signature itself is NOT a constant here — it binds to
+ * `actor_id === estate_id === wallet`, and the wallet only exists once the
+ * Phase 37C client's `RECALL_WEDGE_DIXIE_*` config is loaded. So the handler
+ * computes a fresh Phase 32K `dev_signature` (via the client's
+ * `buildDevSeededRecallSignature`) AFTER config load, using the configured
+ * tenant wallet — never any Discord input, never a hard-coded placeholder.
+ * This carries no secret value: the signer / key_ref are PUBLIC dev-seed
+ * labels fixed by Dixie's seed contract, and the live Dixie secrets live only
+ * in the Phase 37C client's own env (§G), which this module does not read.
+ * No fixed idempotencyKey is set, so the live client mints a fresh key per
+ * call (no reuse).
  */
-const RECALL_WEDGE_LIVE_DEMO_FIXED_INPUT: LiveRecallInput = {
+const RECALL_WEDGE_LIVE_DEMO_PROBE = {
   recallRequestId: 'recall-wedge-live-demo-1',
   task: 'recall-wedge-live-demo operator/dev probe',
-  environmentFrame: 'private_operator',
+  environmentFrame: 'private_chat',
   riskProfile: 'low',
-  detailLevel: 'minimal',
-  receiptDetail: 'minimal',
-  signature: {
-    signature_id: 'recall-wedge-live-demo-sig',
-    signer_id: 'recall-wedge-live-demo-signer',
-    signer_type: 'operator',
-    signature_type: 'dev_signature',
-    signed_payload_hash:
-      'sha256:0000000000000000000000000000000000000000000000000000000000000000',
-    signature: 'devsig',
-    signed_at: '2026-05-18T00:00:00Z',
-    key_ref: 'recall-wedge-live-demo-kref',
-  },
+  detailLevel: 'standard',
+  receiptDetail: 'standard',
+  signatureId: 'recall-wedge-live-demo-sig',
+  signedAt: '2026-05-18T00:00:00Z',
   createdAt: '2026-05-18T00:00:00Z',
-};
+} as const;
+
+/**
+ * Build the full live recall input for the fixed probe by computing a Phase
+ * 32K-compatible `dev_signature` from the configured tenant wallet
+ * (`config.tenantId`, which the live client already binds to
+ * `actor_id === estate_id === requested_by`). The crypto lives in the Phase
+ * 37C client (`buildDevSeededRecallSignature`); this module only assembles the
+ * already-fixed probe fields around it. The wallet is read from config (env),
+ * never from the interaction, and is used ONLY to sign — it is never logged or
+ * rendered.
+ */
+function buildRecallWedgeLiveDemoInput(
+  client: RecallWedgeLiveDixieClientModule,
+  config: LiveDixieClientConfig,
+): LiveRecallInput {
+  const probe = RECALL_WEDGE_LIVE_DEMO_PROBE;
+  const signature = client.buildDevSeededRecallSignature({
+    wallet: config.tenantId,
+    task: probe.task,
+    environmentFrame: probe.environmentFrame,
+    riskProfile: probe.riskProfile,
+    signatureId: probe.signatureId,
+    signedAt: probe.signedAt,
+  });
+  return {
+    recallRequestId: probe.recallRequestId,
+    task: probe.task,
+    environmentFrame: probe.environmentFrame,
+    riskProfile: probe.riskProfile,
+    detailLevel: probe.detailLevel,
+    receiptDetail: probe.receiptDetail,
+    signature,
+    createdAt: probe.createdAt,
+  };
+}
 
 // -- live Dixie client seam (Phase 41A §J · lazy after gates) --------------
 
@@ -363,6 +402,12 @@ export interface RecallWedgeLiveDixieClientModule {
     input: LiveRecallInput,
     config: LiveDixieClientConfig,
   ) => Promise<LiveDixieRecallResult>;
+  // Phase 42C · computes a self-consistent Phase 32K dev/operator seeded-estate
+  // `dev_signature` envelope from the configured tenant wallet (the crypto and
+  // the public dev-seed labels live in the client, never here).
+  readonly buildDevSeededRecallSignature: (
+    input: BuildDevSeededSignatureInput,
+  ) => LiveRecallSignatureEnvelopeInput;
   readonly findBannedPublicSubstring: (value: unknown) => string | null;
 }
 
@@ -586,12 +631,14 @@ export async function handleRecallWedgeLiveDemoInteraction(
   let summary: RenderableLiveSummary;
   try {
     const config = client.loadLiveDixieClientConfigFromEnv(env);
+    // Phase 42C: assemble the fixed probe with a per-call Phase 32K-compatible
+    // dev signature bound to the configured tenant wallet (from env via
+    // config, never from the interaction). The request shape is otherwise the
+    // code-reviewed constant above — no option is read.
+    const input = buildRecallWedgeLiveDemoInput(client, config);
     let result: LiveDixieRecallResult;
     try {
-      result = await client.liveRecallViaDixie(
-        RECALL_WEDGE_LIVE_DEMO_FIXED_INPUT,
-        config,
-      );
+      result = await client.liveRecallViaDixie(input, config);
     } catch {
       // A thrown live client fails closed (Phase 41A §I / §J).
       return recallWedgeLiveDemoRefusal();

--- a/packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts
+++ b/packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts
@@ -32,8 +32,14 @@ import {
   LIVE_DIXIE_CLIENT_MAX_TIMEOUT_MS,
   LIVE_DIXIE_DISALLOWED_ENVIRONMENT_FRAMES,
   LIVE_DIXIE_RECALL_CLASSIFICATIONS,
+  RECALL_DEV_SEED_KEY_REF,
+  RECALL_DEV_SEED_SIGNER_ID,
+  RECALL_DEV_SEED_SIGNER_TYPE,
   LiveDixieClientConfigError,
+  buildDevSeededRecallSignature,
   buildLiveDixieRecallRequestPlan,
+  computeDevSeededSignature,
+  computeDevSeededSignedPayloadHash,
   computeLiveDixieRequestFingerprint,
   createIdempotencyReuseDetector,
   findBannedPublicSubstring,
@@ -43,6 +49,7 @@ import {
   type LiveDixieFetchLike,
   type LiveRecallInput,
 } from "./live-dixie-client.ts";
+import { createHash, createHmac } from "node:crypto";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -448,6 +455,147 @@ describe("idempotency · key/content fingerprinting", () => {
     );
     // Only the first call hit the fake network; the second short-circuited.
     expect(calls).toBe(1);
+  });
+});
+
+// -- 2b. Phase 32K dev/operator seeded-estate signature -------------------
+
+describe("dev-seeded-estate signature · Phase 32K dev-sign algorithm", () => {
+  // Independent re-implementation of Dixie Phase 32K's canonicalize → sha256 →
+  // hmac, as the source of truth this client must match byte-for-byte
+  // (mirrors ../loa-dixie/.../dev-seeded-live-estate.test.ts).
+  function canonicalize(v: unknown): string {
+    if (v === null) return "null";
+    if (typeof v === "boolean") return v ? "true" : "false";
+    if (typeof v === "number") return JSON.stringify(v);
+    if (typeof v === "string") return JSON.stringify(v);
+    if (Array.isArray(v)) return "[" + v.map(canonicalize).join(",") + "]";
+    if (typeof v === "object") {
+      const obj = v as Record<string, unknown>;
+      const keys = Object.keys(obj).sort();
+      const parts: string[] = [];
+      for (const k of keys) {
+        const child = obj[k];
+        if (child === undefined) continue;
+        parts.push(JSON.stringify(k) + ":" + canonicalize(child));
+      }
+      return "{" + parts.join(",") + "}";
+    }
+    throw new Error(`canonicalize: unsupported type ${typeof v}`);
+  }
+  function refSha256Of(value: unknown): string {
+    const bytes = typeof value === "string" ? value : canonicalize(value);
+    return "sha256:" + createHash("sha256").update(bytes).digest("hex");
+  }
+  function refDevSignatureFor(keyRef: string, payloadHash: string): string {
+    return `dev:${createHmac("sha256", keyRef).update(payloadHash).digest("hex")}`;
+  }
+
+  const PAYLOAD = {
+    actor_id: WALLET,
+    estate_id: WALLET,
+    task: "phase-32k-dev-seed-smoke",
+    environment_frame: "private_chat",
+    risk_profile: "low",
+  };
+
+  test("exports the PUBLIC Phase 32K dev-seed labels verbatim", () => {
+    expect(RECALL_DEV_SEED_SIGNER_ID).toBe("signer:dixie-dev-seeded-operator");
+    expect(RECALL_DEV_SEED_SIGNER_TYPE).toBe("actor_controller");
+    expect(RECALL_DEV_SEED_KEY_REF).toBe("dev-seed-key:dixie-operator-smoke");
+  });
+
+  test("computeDevSeededSignedPayloadHash matches the reference sha256 over canonical sorted-key JSON", () => {
+    expect(computeDevSeededSignedPayloadHash(PAYLOAD)).toBe(refSha256Of(PAYLOAD));
+    expect(computeDevSeededSignedPayloadHash(PAYLOAD)).toMatch(
+      /^sha256:[0-9a-f]{64}$/,
+    );
+  });
+
+  test("hash is independent of input key order (canonicalization sorts keys)", () => {
+    const reordered = {
+      risk_profile: "low",
+      task: "phase-32k-dev-seed-smoke",
+      estate_id: WALLET,
+      actor_id: WALLET,
+      environment_frame: "private_chat",
+    };
+    expect(computeDevSeededSignedPayloadHash(reordered)).toBe(
+      computeDevSeededSignedPayloadHash(PAYLOAD),
+    );
+  });
+
+  test("computeDevSeededSignature matches the reference hmac_sha256(key_ref, hash)", () => {
+    const hash = computeDevSeededSignedPayloadHash(PAYLOAD);
+    expect(computeDevSeededSignature(RECALL_DEV_SEED_KEY_REF, hash)).toBe(
+      refDevSignatureFor(RECALL_DEV_SEED_KEY_REF, hash),
+    );
+    expect(computeDevSeededSignature(RECALL_DEV_SEED_KEY_REF, hash)).toMatch(
+      /^dev:[0-9a-f]{64}$/,
+    );
+  });
+
+  test("buildDevSeededRecallSignature produces a fully self-consistent envelope from the public labels", () => {
+    const env = buildDevSeededRecallSignature({
+      wallet: WALLET,
+      task: "phase-32k-dev-seed-smoke",
+      environmentFrame: "private_chat",
+      riskProfile: "low",
+      signatureId: "sig_phase32k",
+      signedAt: "2026-05-30T00:00:00.000Z",
+    });
+    expect(env.signer_id).toBe(RECALL_DEV_SEED_SIGNER_ID);
+    expect(env.signer_type).toBe(RECALL_DEV_SEED_SIGNER_TYPE);
+    expect(env.key_ref).toBe(RECALL_DEV_SEED_KEY_REF);
+    expect(env.signature_type).toBe("dev_signature");
+    expect(env.signature_id).toBe("sig_phase32k");
+    expect(env.signed_at).toBe("2026-05-30T00:00:00.000Z");
+    // The hash is over the five canonical fields bound to the wallet.
+    expect(env.signed_payload_hash).toBe(refSha256Of(PAYLOAD));
+    // The signature is hmac over that hash keyed by the key_ref label.
+    expect(env.signature).toBe(
+      refDevSignatureFor(RECALL_DEV_SEED_KEY_REF, env.signed_payload_hash),
+    );
+    // It carries none of the old Phase 37C placeholders.
+    expect(env.signature).not.toBe("devsig");
+    expect(env.signed_payload_hash).not.toBe(
+      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    );
+  });
+
+  test("a request plan built around the dev-seeded signature carries it on the wire", () => {
+    const signature = buildDevSeededRecallSignature({
+      wallet: WALLET,
+      task: "phase-32k-dev-seed-smoke",
+      environmentFrame: "private_chat",
+      riskProfile: "low",
+      signatureId: "sig_phase32k",
+      signedAt: "2026-05-30T00:00:00.000Z",
+    });
+    const plan = buildLiveDixieRecallRequestPlan(
+      buildInput({
+        task: "phase-32k-dev-seed-smoke",
+        environmentFrame: "private_chat",
+        riskProfile: "low",
+        detailLevel: "standard",
+        receiptDetail: "standard",
+        signature,
+      }),
+      buildConfig(),
+    );
+    const request = (plan.body as Record<string, unknown>).request as Record<
+      string,
+      unknown
+    >;
+    const sig = request.signature as Record<string, unknown>;
+    expect(sig.signer_id).toBe(RECALL_DEV_SEED_SIGNER_ID);
+    expect(sig.key_ref).toBe(RECALL_DEV_SEED_KEY_REF);
+    expect(sig.signature_type).toBe("dev_signature");
+    expect(sig.signed_payload_hash).toBe(signature.signed_payload_hash);
+    expect(sig.signature).toBe(signature.signature);
+    expect(request.environment_frame).toBe("private_chat");
+    expect(request.include_receipt_detail).toBe("standard");
+    expect((plan.body as Record<string, unknown>).detail_level).toBe("standard");
   });
 });
 

--- a/packages/persona-engine/src/recall-wedge/live-dixie-client.ts
+++ b/packages/persona-engine/src/recall-wedge/live-dixie-client.ts
@@ -34,6 +34,16 @@
 //     (HTTP refusal classes + raw_reasons shape);
 //   - ../loa-dixie/app/tests/integration/recall-intake/route.test.ts (proven
 //     wire shape; Bearer/wallet-bridge auth; required headers).
+//   - ../loa-dixie/app/src/services/straylight-recall-intake/dev-seeded-estate.ts
+//     (Phase 32K dev/operator seeded estate — PUBLIC, non-secret signer /
+//     keyring labels exported so a caller can build a self-consistent
+//     `dev_signature`; the seed stores no secret and the dev signature carries
+//     no cryptographic authority);
+//   - ../loa-dixie/app/tests/integration/recall-intake/dev-seeded-live-estate.test.ts
+//     (Phase 32K dev-sign algorithm: canonical sorted-key JSON → sha256 →
+//     hmac_sha256 keyed by the public key_ref label).
+
+import { createHash, createHmac } from "node:crypto";
 
 // -- classification vocabulary ---------------------------------------------
 
@@ -519,6 +529,108 @@ export function buildLiveDixieRecallRequestPlan(
     body: requestBody,
     idempotencyKey,
     fingerprint: fingerprintForBody(requestBody),
+  };
+}
+
+// -- Phase 32K dev/operator seeded-estate signature ------------------------
+//
+// Dixie Phase 32K (../loa-dixie/.../dev-seeded-estate.ts) seeds a default-off,
+// dev/operator-only estate whose keyring carries a single signer entry. The
+// signer/keyring labels below are PUBLIC, non-secret identifiers that Dixie
+// EXPORTS precisely so a caller can construct a self-consistent
+// `dev_signature` envelope. They are constants here (not env-driven, not
+// secrets): the seed contract fixes the exact strings, the seed stores no
+// secret, and a `dev_signature` carries no cryptographic authority — it is
+// development-only and only accepted when Dixie's own seed gate is on. The
+// HMAC "key" is the public `key_ref` LABEL, not key material.
+//
+// The dev signature is verified by Dixie's Straylight runtime via
+// `signatures.ts#verifyEnvelopeSelfConsistency`, which recomputes the hash
+// from the request's canonical recall payload and the HMAC from the
+// envelope's `key_ref` — so the payload we sign here must mirror exactly the
+// payload Dixie reconstructs (the five fields below), and the request body
+// must carry the same field values.
+export const RECALL_DEV_SEED_SIGNER_ID =
+  "signer:dixie-dev-seeded-operator" as const;
+export const RECALL_DEV_SEED_SIGNER_TYPE = "actor_controller" as const;
+export const RECALL_DEV_SEED_KEY_REF =
+  "dev-seed-key:dixie-operator-smoke" as const;
+
+// The EXACT canonical payload the dev signature is computed over — these five
+// keys and no others, mirroring Dixie Phase 32K's `buildSignedBody`
+// (`actor_id`, `estate_id`, `task`, `environment_frame`, `risk_profile`).
+export interface DevSeededSignaturePayload {
+  readonly actor_id: string;
+  readonly estate_id: string;
+  readonly task: string;
+  readonly environment_frame: string;
+  readonly risk_profile: string;
+}
+
+// `sha256:<hex>` over the canonical sorted-key JSON of the payload. Uses the
+// same `stableStringify` canonicalizer the fingerprint path uses; it is
+// byte-identical to Dixie's `canonicalize` for a flat all-string payload
+// (sorted keys, JSON-encoded string values).
+export function computeDevSeededSignedPayloadHash(
+  payload: DevSeededSignaturePayload,
+): string {
+  const canonical = stableStringify(payload);
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}
+
+// `dev:<hex>` where `<hex>` = hmac_sha256(key_ref, signed_payload_hash),
+// mirroring Dixie Phase 32K's `devSignatureFor`.
+export function computeDevSeededSignature(
+  keyRef: string,
+  signedPayloadHash: string,
+): string {
+  return `dev:${createHmac("sha256", keyRef).update(signedPayloadHash).digest("hex")}`;
+}
+
+export interface BuildDevSeededSignatureInput {
+  readonly wallet: string;
+  readonly task: string;
+  readonly environmentFrame: LiveRecallEnvironmentFrame;
+  readonly riskProfile: LiveRecallRiskLevel;
+  readonly signatureId: string;
+  readonly signedAt: string;
+  // Optional overrides default to the public dev-seed labels above. Present so
+  // a future operator-seeded tenant with different labels can be driven
+  // without forking this helper; the demo path uses the defaults.
+  readonly signerId?: string;
+  readonly signerType?: LiveRecallSignatureEnvelopeInput["signer_type"];
+  readonly keyRef?: string;
+}
+
+// Build a fully self-consistent `dev_signature` envelope for the Phase 32K
+// dev/operator seeded estate. The signed payload binds
+// `actor_id === estate_id === wallet` (the route's authoritative-tenant rule),
+// so the hash Dixie recomputes server-side over the request matches. No secret
+// is read or stored; the signature is computed entirely from the public
+// labels and the (public-shaped) payload.
+export function buildDevSeededRecallSignature(
+  input: BuildDevSeededSignatureInput,
+): LiveRecallSignatureEnvelopeInput {
+  const signerId = input.signerId ?? RECALL_DEV_SEED_SIGNER_ID;
+  const signerType = input.signerType ?? RECALL_DEV_SEED_SIGNER_TYPE;
+  const keyRef = input.keyRef ?? RECALL_DEV_SEED_KEY_REF;
+  const signed_payload_hash = computeDevSeededSignedPayloadHash({
+    actor_id: input.wallet,
+    estate_id: input.wallet,
+    task: input.task,
+    environment_frame: input.environmentFrame,
+    risk_profile: input.riskProfile,
+  });
+  const signature = computeDevSeededSignature(keyRef, signed_payload_hash);
+  return {
+    signature_id: input.signatureId,
+    signer_id: signerId,
+    signer_type: signerType,
+    signature_type: "dev_signature",
+    signed_payload_hash,
+    signature,
+    signed_at: input.signedAt,
+    key_ref: keyRef,
   };
 }
 


### PR DESCRIPTION
## Summary

Phase 42C aligns `/recall-wedge-live-demo` with the Phase 32K-compatible seeded Dixie request and signature shape.

Dixie Phase 32K direct seeded smoke has already passed against live Railway Dixie:

- allowlist_http=201
- verify_http=200
- recall_http=200
- outcome=served
- has_pack=true
- has_receipt=true
- has_raw_reasons=false

Before this patch, Freeside Characters `/recall-wedge-live-demo` was registered, passed local Discord gates, called Dixie, and no longer returned service_unauthorized, but Dixie denied the request with:

- classification: denied_or_forbidden
- outcome: denied
- route: /api/recall/intake
- reason: seam.signer_not_competent

The cause was the older Phase 37C fixed request/signature shape. This PR updates the Freeside Characters live demo request to use the Phase 32K seeded dev/operator signature contract.

## Files

Changed:

- packages/persona-engine/src/recall-wedge/live-dixie-client.ts
- packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts
- apps/bot/src/discord-interactions/recall-wedge-live-demo.ts
- apps/bot/src/discord-interactions/recall-wedge-live-demo.test.ts

## Implementation

This PR updates the live demo request shape to use:

- environment frame: private_chat
- detail level: standard
- receipt detail: standard
- stable task: recall-wedge-live-demo operator/dev probe
- actor / estate / requested_by / caller tenant / caller actor bound to configured Dixie tenant/caller config, not Discord input
- signed_payload_hash computed as sha256 over canonical sorted-key serialization of:
  - actor_id
  - estate_id
  - task
  - environment_frame
  - risk_profile
- signature computed as dev:<hmac_sha256(key_ref, signed_payload_hash)>
- signer_id, signer_type, and key_ref as public Phase 32K dev-seed labels
- fresh idempotency key behavior preserved through the existing live Dixie client path

The old placeholder live-demo signature shape is removed from live request construction:

- no devsig placeholder
- no zero hash
- no recall-wedge-live-demo-kref
- no recall-wedge-live-demo-signer
- no private_operator live request frame

## Safety

This PR does not widen the command.

The command remains:

- disabled by default
- guild-scoped
- operator-gated
- ephemeral-only
- fixed-input only
- no Discord message history
- no command options
- no freeform recall query
- no memory admission
- no candidate writes
- no "remember this"

The public refusal string remains unchanged:

recall-wedge-live-demo is not available here.

No IDs, tokens, raw env, raw interaction, raw Dixie payloads, wallets, hashes, or signatures are logged. The existing Phase 42B diagnostic remains booleans-only.

## Results

Validation:

- git diff --check: clean
- apps/bot: bun test src/discord-interactions/recall-wedge-live-demo.test.ts: 162 pass / 0 fail
- packages/persona-engine: bun test src/recall-wedge/live-dixie-client.test.ts: 74 pass / 0 fail
- packages/persona-engine: bun test src/recall-wedge/: 511 pass / 0 fail
- apps/bot full discord-interactions directory: one pre-existing unrelated missing-package failure in onboarding-dispatch.test.ts, reproduced on clean main with changes stashed

Codex audit:

- Verdict: ACCEPT
- Scope accepted as exactly the four expected Freeside files
- Request/signature correctness accepted
- Public behavior accepted
- No new input/admission surface accepted
- Diagnostic/logging no-leak posture accepted
- Test coverage accepted
- No required patch

## Non-goals

This PR does not:

- change Dixie
- import from loa-dixie
- change package or lockfiles
- change command registration
- change dispatch
- widen guild/operator access
- make the command public
- add freeform recall
- read Discord command options
- read Discord message history
- add memory admission
- add candidate writes
- add "remember this"
- change normal character commands
- add screenshots/images/binaries
