### PR TITLE
feat(network/bot): role-awareness endpoint GET /guild-roles (Track 2 P2)

### DIFF
--- a/apps/bot/src/discord-interactions/guild-roles.test.ts
+++ b/apps/bot/src/discord-interactions/guild-roles.test.ts
@@ -1,0 +1,353 @@
+// guild-roles.test.ts — GET /guild-roles?world=SLUG role-awareness surface.
+//
+// Covers the auth-grade, fail-closed handler exported from server.ts:
+//   - 503 when ROLE_AWARENESS_SERVICE_TOKEN is unset (misconfigured)
+//   - 401 when the caller token is missing or wrong (constant-time compare)
+//   - 400 when ?world= fails the slug grammar
+//   - 404 when no manifest claims the world
+//   - 200 happy path: roles mapped, @everyone excluded, sorted position-desc
+//   - 500 when the discord fetch rejects (clean, no leaked error text)
+//   - 503 when the bot client is unavailable / not ready
+//
+// The discord client + manifests are injected via InteractionServerArgs, so
+// no real DISCORD_BOT_TOKEN or gateway connection is required.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { Config } from '@freeside-characters/persona-engine';
+import { handleGuildRoles, type InteractionServerArgs } from './server.ts';
+import type { WorldManifestQuestSubset } from '../world-resolver.ts';
+
+// The mock client only needs the surface handleGuildRoles touches: isReady()
+// + guilds.fetch() → { id, roles.cache }. Typed via the getClient slot on
+// InteractionServerArgs (no direct discord.js dependency in apps/bot).
+type GetClient = NonNullable<InteractionServerArgs['getClient']>;
+type BotClient = Awaited<ReturnType<GetClient>>;
+
+const TOKEN = 'svc-token-abcdef-0123456789';
+const GUILD_ID = '111111111111111111';
+
+const MANIFESTS: readonly WorldManifestQuestSubset[] = [
+  { slug: 'mongolian', tenant_id: 'mibera', guild_ids: [GUILD_ID] },
+];
+
+// A discord.js Role is iterable out of guild.roles.cache (a Collection). We
+// only read id/name/hexColor/managed/position, so a plain array of these
+// structural objects is a faithful stand-in.
+const ROLE_EVERYONE = {
+  id: GUILD_ID, // @everyone shares the guild id — must be excluded
+  name: '@everyone',
+  hexColor: '#000000',
+  managed: false,
+  position: 0,
+};
+const ROLE_MOD = {
+  id: '222',
+  name: 'Moderator',
+  hexColor: '#ff0000',
+  managed: false,
+  position: 5,
+};
+const ROLE_MEMBER = {
+  id: '333',
+  name: 'Member',
+  hexColor: '#000000', // no-color — surfaced as-is
+  managed: false,
+  position: 2,
+};
+const ROLE_BOT = {
+  id: '444',
+  name: 'BotManaged',
+  hexColor: '#00ff00',
+  managed: true,
+  position: 8,
+};
+
+// A discord.js DiscordAPIError carries a numeric `.code`. We stand it in with
+// a plain Error + a `code` property so the handler's defensive `.code` probe
+// (no direct discord.js dep in apps/bot) matches what production sees.
+class FakeDiscordAPIError extends Error {
+  constructor(public readonly code: number, message: string) {
+    super(message);
+  }
+}
+
+function fakeGuild(id: string) {
+  return {
+    id,
+    roles: {
+      // Unsorted on purpose so the handler's sort is exercised.
+      // An array exposes `.values()`, matching the Collection the
+      // handler iterates in production.
+      cache: [ROLE_MEMBER, ROLE_BOT, ROLE_EVERYONE, ROLE_MOD],
+    },
+  };
+}
+
+function mockClient(
+  over: Partial<{
+    ready: boolean;
+    fetchThrows: boolean;
+    fetchRejectCode: number;
+    cacheHit: boolean;
+  }> = {},
+): BotClient {
+  const ready = over.ready ?? true;
+  // Cache-first lookup: by default the cache MISSES (empty Map) so existing
+  // tests still exercise the `guilds.fetch` REST fallback. `cacheHit: true`
+  // pre-populates the cache so the handler should NOT call fetch.
+  const cache = new Map<string, ReturnType<typeof fakeGuild>>();
+  if (over.cacheHit) cache.set(GUILD_ID, fakeGuild(GUILD_ID));
+  return {
+    isReady: () => ready,
+    guilds: {
+      cache,
+      fetch: async (id: string) => {
+        if (over.fetchRejectCode !== undefined) {
+          throw new FakeDiscordAPIError(over.fetchRejectCode, 'discord REST — internal detail');
+        }
+        if (over.fetchThrows) throw new Error('discord REST 500 — internal detail');
+        return fakeGuild(id);
+      },
+    },
+  } as unknown as BotClient;
+}
+
+function makeArgs(
+  over: Partial<InteractionServerArgs> = {},
+  clientOver: Partial<{
+    ready: boolean;
+    fetchThrows: boolean;
+    fetchRejectCode: number;
+    cacheHit: boolean;
+  }> = {},
+): InteractionServerArgs {
+  return {
+    config: {} as Config,
+    characters: [],
+    manifests: MANIFESTS,
+    getClient: async () => mockClient(clientOver),
+    ...over,
+  };
+}
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/guild-roles', { headers });
+}
+
+function urlFor(world: string | null): URL {
+  const u = new URL('http://localhost/guild-roles');
+  if (world !== null) u.searchParams.set('world', world);
+  return u;
+}
+
+describe('GET /guild-roles — auth (fail-closed)', () => {
+  afterEach(() => {
+    delete process.env.ROLE_AWARENESS_SERVICE_TOKEN;
+  });
+
+  test('503 when ROLE_AWARENESS_SERVICE_TOKEN is unset', async () => {
+    delete process.env.ROLE_AWARENESS_SERVICE_TOKEN;
+    const res = await handleGuildRoles(req({ 'X-Service-Token': TOKEN }), urlFor('mongolian'), makeArgs());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'service_misconfigured' });
+  });
+
+  test('401 when caller token is missing', async () => {
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = TOKEN;
+    const res = await handleGuildRoles(req(), urlFor('mongolian'), makeArgs());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  test('401 when caller token is wrong', async () => {
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = TOKEN;
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': 'wrong-token-same-len-aaaaaa' }),
+      urlFor('mongolian'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('401 (not 500/throw) when caller token has a DIFFERENT length', async () => {
+    // The auth block runs OUTSIDE the try/catch, and timingSafeEqual throws on
+    // unequal-length buffers — so the length pre-check in serviceTokenMatches is
+    // load-bearing. A single-char token against the multi-char configured secret
+    // must return 401 cleanly, never propagate a RangeError as a 500.
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = TOKEN;
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': 'x' }),
+      urlFor('mongolian'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  test('whitespace-only ROLE_AWARENESS_SERVICE_TOKEN trims to misconfig (503), not a valid secret', async () => {
+    // A trailing-whitespace / whitespace-only env must NOT become a usable
+    // secret. `.trim()` collapses it to '' → the 503 misconfig gate fires.
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = '   ';
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': '   ' }),
+      urlFor('mongolian'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'service_misconfigured' });
+  });
+
+  test('Authorization: Bearer is accepted as a fallback', async () => {
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = TOKEN;
+    const res = await handleGuildRoles(
+      req({ Authorization: `Bearer ${TOKEN}` }),
+      urlFor('mongolian'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /guild-roles — input validation', () => {
+  beforeEach(() => {
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = TOKEN;
+  });
+  afterEach(() => {
+    delete process.env.ROLE_AWARENESS_SERVICE_TOKEN;
+  });
+
+  test('400 on a bad slug (uppercase / illegal chars)', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('Mongolian!'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_world_slug' });
+  });
+
+  test('400 when ?world is absent', async () => {
+    const res = await handleGuildRoles(req({ 'X-Service-Token': TOKEN }), urlFor(null), makeArgs());
+    expect(res.status).toBe(400);
+  });
+
+  test('404 when no manifest claims the world', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('unknown-world'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'world_not_found' });
+  });
+});
+
+describe('GET /guild-roles — fetch + mapping', () => {
+  beforeEach(() => {
+    process.env.ROLE_AWARENESS_SERVICE_TOKEN = TOKEN;
+  });
+  afterEach(() => {
+    delete process.env.ROLE_AWARENESS_SERVICE_TOKEN;
+  });
+
+  test('200 happy path — roles mapped, @everyone excluded, sorted position desc', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs(),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      world: string;
+      guild_id: string;
+      roles: Array<{ id: string; name: string; color: string; managed: boolean; position: number }>;
+    };
+    expect(body.world).toBe('mongolian');
+    expect(body.guild_id).toBe(GUILD_ID);
+
+    // @everyone (id === guild.id) excluded.
+    expect(body.roles.find((r) => r.id === GUILD_ID)).toBeUndefined();
+    expect(body.roles).toHaveLength(3);
+
+    // Sorted by position descending: BotManaged(8) > Moderator(5) > Member(2).
+    expect(body.roles.map((r) => r.id)).toEqual(['444', '222', '333']);
+
+    // Field mapping: color comes from hexColor; "#000000" surfaced as-is.
+    expect(body.roles[1]).toEqual({
+      id: '222',
+      name: 'Moderator',
+      color: '#ff0000',
+      managed: false,
+      position: 5,
+    });
+    expect(body.roles.find((r) => r.id === '333')?.color).toBe('#000000');
+    expect(body.roles.find((r) => r.id === '444')?.managed).toBe(true);
+  });
+
+  test('200 cache-first — a cached guild is served without a REST fetch', async () => {
+    // The Guilds intent populates guilds.cache on the gateway. When the guild
+    // is already cached, the handler must read from cache and skip guilds.fetch.
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs({}, { cacheHit: true }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { guild_id: string; roles: Array<{ id: string }> };
+    expect(body.guild_id).toBe(GUILD_ID);
+    // @everyone still excluded; same 3 roles surface from the cached guild.
+    expect(body.roles.map((r) => r.id)).toEqual(['444', '222', '333']);
+  });
+
+  test('404 guild_not_joined when the bot is not in the guild (Unknown Guild 10004)', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs({}, { fetchRejectCode: 10004 }),
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'guild_not_joined' });
+  });
+
+  test('404 guild_not_joined on Missing Access (50001)', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs({}, { fetchRejectCode: 50001 }),
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'guild_not_joined' });
+  });
+
+  test('503 when the bot client is not ready', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs({}, { ready: false }),
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'bot_unavailable' });
+  });
+
+  test('503 when getClient resolves null (no DISCORD_BOT_TOKEN)', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs({ getClient: async () => null }),
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'bot_unavailable' });
+  });
+
+  test('500 when the discord fetch rejects — no internal error text leaked', async () => {
+    const res = await handleGuildRoles(
+      req({ 'X-Service-Token': TOKEN }),
+      urlFor('mongolian'),
+      makeArgs({}, { fetchThrows: true }),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toBe(JSON.stringify({ error: 'internal_error' }));
+    expect(body).not.toContain('internal detail');
+  });
+});

--- a/apps/bot/src/discord-interactions/server.ts
+++ b/apps/bot/src/discord-interactions/server.ts
@@ -17,9 +17,17 @@
  * Routes:
  *   GET  /health              health probe
  *   POST /webhooks/discord    Discord interactions endpoint
+ *   GET  /guild-roles?world=  authenticated role-awareness surface (dashboard
+ *                             role-map editor populates its picker from this)
  */
 
+import { timingSafeEqual } from 'node:crypto';
 import type { CharacterConfig, Config } from '@freeside-characters/persona-engine';
+import { getBotClient } from '@freeside-characters/persona-engine';
+import {
+  resolveGuildForWorld,
+  type WorldManifestQuestSubset,
+} from '../world-resolver.ts';
 import {
   InteractionResponseType,
   InteractionType,
@@ -37,6 +45,13 @@ import { verifyMetricsSnapshot } from '@freeside-characters/persona-engine/onboa
 
 const DEFAULT_PORT = 3001;
 
+/**
+ * The discord.js `Client | null` returned by `getBotClient`. Derived from the
+ * function's return type so `apps/bot` needn't take a direct `discord.js`
+ * dependency (it only depends on `persona-engine`, which owns that import).
+ */
+type BotClient = Awaited<ReturnType<typeof getBotClient>>;
+
 export interface InteractionServerHandle {
   /** Stop the HTTP server (called from shutdown handlers). */
   stop: () => void;
@@ -51,6 +66,19 @@ export interface InteractionServerArgs {
   port?: number;
   /** cycle-009 · sprint-3 — the onboarding verify web surface (C4). Off when absent/disabled. */
   verifyRuntime?: VerifyRuntime;
+  /**
+   * World manifests for the `/guild-roles` role-awareness surface. Same list
+   * the quest runtime consumes (slug + guild_ids). When absent or empty, every
+   * `?world=` resolves to 404 `world_not_found` (the endpoint stays inert
+   * rather than leaking — fail-closed default). Defaults to `[]`.
+   */
+  manifests?: readonly WorldManifestQuestSubset[];
+  /**
+   * Discord client accessor for `/guild-roles`. Defaults to the production
+   * `getBotClient`; tests inject a mock so no real DISCORD_BOT_TOKEN / gateway
+   * connection is required.
+   */
+  getClient?: (config: Config) => Promise<BotClient>;
 }
 
 export function startInteractionServer(args: InteractionServerArgs): InteractionServerHandle {
@@ -81,6 +109,13 @@ export function startInteractionServer(args: InteractionServerArgs): Interaction
           // cycle-009 · T5.4 — verify metrics for the cutover monitor (only when onboarding is on).
           onboarding: args.verifyRuntime?.enabled ? verifyMetricsSnapshot() : 'disabled',
         });
+      }
+
+      // Role-awareness surface — authenticated (X-Service-Token / Bearer),
+      // fail-closed. Sibling of a future role-GRANT endpoint, so auth is
+      // auth-grade here even though this is read-only.
+      if (request.method === 'GET' && url.pathname === '/guild-roles') {
+        return handleGuildRoles(request, url, args);
       }
 
       if (request.method === 'POST' && url.pathname === '/webhooks/discord') {
@@ -217,6 +252,161 @@ async function handleDiscordPost(
     data: { content: `interaction type ${interaction.type} not yet supported`, flags: 64 },
   };
   return jsonResponse(fallback);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// GET /guild-roles?world=SLUG — role-awareness surface
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * World-slug grammar accepted on `?world=`. Lowercase-leading, then
+ * lowercase-alnum / hyphen, 2–21 chars total. Mirrors the slug shape used
+ * across the world-manifest registry. Anything else → 400.
+ */
+const WORLD_SLUG_RE = /^[a-z][a-z0-9-]{1,20}$/;
+
+/**
+ * Structural subset of discord.js `Role` we read from `guild.roles.cache`.
+ * Kept minimal so tests mock freely without constructing a real Role.
+ */
+interface RoleLike {
+  readonly id: string;
+  readonly name: string;
+  readonly hexColor: string;
+  readonly managed: boolean;
+  readonly position: number;
+}
+
+/** Shape returned to the dashboard role picker (one entry per role). */
+interface RoleView {
+  readonly id: string;
+  readonly name: string;
+  /** `role.hexColor` — Discord emits "#000000" for no-color · surfaced as-is. */
+  readonly color: string;
+  readonly managed: boolean;
+  readonly position: number;
+}
+
+/**
+ * Constant-time service-token compare. Length is checked FIRST (and short-
+ * circuits) so `timingSafeEqual` never throws on unequal-length buffers and
+ * never leaks length via the exception path. The pre-check itself is not the
+ * timing-sensitive comparison — the byte compare on equal-length buffers is.
+ */
+function serviceTokenMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Extract the caller's service token. Primary header is `X-Service-Token`
+ * (cluster seam-1 convention); `Authorization: Bearer <token>` is accepted as
+ * a fallback. Returns null when neither is present.
+ */
+function extractServiceToken(request: Request): string | null {
+  const direct = request.headers.get('X-Service-Token');
+  if (direct) return direct;
+  const auth = request.headers.get('Authorization');
+  if (auth && auth.startsWith('Bearer ')) return auth.slice('Bearer '.length);
+  return null;
+}
+
+/**
+ * GET /guild-roles?world=SLUG → the Discord roles of the guild the world maps
+ * to, for the dashboard role-map editor's role picker.
+ *
+ * Auth (fail-closed): requires `ROLE_AWARENESS_SERVICE_TOKEN`. Unset → 503
+ * (misconfigured). Missing / wrong caller token → 401. Constant-time compare.
+ *
+ * Response 200: `{ world, guild_id, roles: [{ id, name, color, managed,
+ * position }] }` where `color` is `role.hexColor` (Discord emits "#000000"
+ * for no-color — surfaced as-is). The `@everyone` role (id === guild.id) is
+ * excluded; roles are sorted by `position` descending (top of the Discord
+ * hierarchy first).
+ */
+export async function handleGuildRoles(
+  request: Request,
+  url: URL,
+  args: InteractionServerArgs,
+): Promise<Response> {
+  // 1. AUTH — fail-closed. Unset env = misconfiguration, not a 401.
+  // `.trim()` matches the repo convention (onboarding-runtime.ts:45) and
+  // removes the trailing-newline silent-401 footgun. A whitespace-only env
+  // trims to '' → still falls into the 503 misconfig gate, never a valid secret.
+  const expectedToken = process.env.ROLE_AWARENESS_SERVICE_TOKEN?.trim();
+  if (!expectedToken || expectedToken.length === 0) {
+    console.error('guild-roles: ROLE_AWARENESS_SERVICE_TOKEN unset — refusing (503)');
+    return jsonResponse({ error: 'service_misconfigured' }, 503);
+  }
+  const provided = extractServiceToken(request);
+  if (!provided || !serviceTokenMatches(provided, expectedToken)) {
+    return jsonResponse({ error: 'unauthorized' }, 401);
+  }
+
+  // 2. INPUT — validate slug grammar before any lookup.
+  const world = url.searchParams.get('world') ?? '';
+  if (!WORLD_SLUG_RE.test(world)) {
+    return jsonResponse({ error: 'invalid_world_slug' }, 400);
+  }
+
+  // 3. RESOLVE — world slug → guild_id via the manifests.
+  const manifests = args.manifests ?? [];
+  const guildId = resolveGuildForWorld(world, manifests);
+  if (!guildId) {
+    return jsonResponse({ error: 'world_not_found' }, 404);
+  }
+
+  // 4. FETCH — wrap so a rejected promise becomes a clean 500 (no crash, no
+  //    internal error text leaked to the body).
+  try {
+    const getClient = args.getClient ?? getBotClient;
+    const client = await getClient(args.config);
+    if (!client || !client.isReady()) {
+      return jsonResponse({ error: 'bot_unavailable' }, 503);
+    }
+
+    // Cache-first: the Guilds intent populates guild.roles.cache on the
+    // gateway, so a cached guild avoids the REST round-trip. Fall back to
+    // a fetch when the gateway hasn't cached it yet.
+    const guild =
+      client.guilds.cache.get(guildId) ?? (await client.guilds.fetch(guildId));
+    // discord.js `guild.roles.cache` is a Collection (extends Map) — iterate
+    // `.values()` to get Roles (a bare `for…of` over a Collection yields
+    // [id, Role] tuples). Arrays expose `.values()` too, so test mocks work.
+    const roleCache = guild.roles.cache as unknown as { values(): Iterable<RoleLike> };
+    const roles: RoleView[] = [];
+    for (const role of roleCache.values()) {
+      // EXCLUDE @everyone — its id is identical to the FETCHED guild's id.
+      if (role.id === guild.id) continue;
+      roles.push({
+        id: role.id,
+        name: role.name,
+        color: role.hexColor, // "#000000" for no-color · surfaced as-is
+        managed: role.managed,
+        position: role.position,
+      });
+    }
+    // Discord role hierarchy: highest position first.
+    roles.sort((x, y) => y.position - x.position);
+
+    return jsonResponse({ world, guild_id: guildId, roles });
+  } catch (err) {
+    // Bot-not-in-guild is an expected, distinct failure — not a transient
+    // backend error. discord.js DiscordAPIError exposes a numeric `.code`:
+    //   10004 Unknown Guild   · the guild doesn't exist or the bot can't see it
+    //   50001 Missing Access  · the bot isn't a member of the guild
+    // Check `.code` defensively (apps/bot takes NO direct discord.js dep, so we
+    // avoid importing DiscordAPIError — a property probe is enough). Genuine
+    // transient failures (REST 500s, timeouts) still fall through to the 500.
+    const code = (err as { code?: unknown }).code;
+    if (code === 10004 || code === 50001) {
+      return jsonResponse({ error: 'guild_not_joined' }, 404);
+    }
+    console.error('guild-roles: failed to fetch roles:', err);
+    return jsonResponse({ error: 'internal_error' }, 500);
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -515,12 +515,27 @@ async function main(): Promise<void> {
           `DISCORD_BOT_TOKEN + ONBOARDING_VERIFIED_ROLE_ID + ONBOARDING_STATE_SECRET to enable)`,
       );
     }
+    // World manifests for the `/guild-roles` role-awareness surface. Derived
+    // from the same guild env the quest runtime uses (QUEST_GUILD_ID falls
+    // back to DISCORD_GUILD_ID). Single-world (mongolian) until the
+    // freeside-worlds registry loader lands (cycle-B B-1.12 swap target);
+    // empty guild_ids → `/guild-roles` resolves 404 world_not_found.
+    const roleAwarenessGuildId =
+      process.env.QUEST_GUILD_ID ?? process.env.DISCORD_GUILD_ID;
+    const roleAwarenessManifests: readonly WorldManifestQuestSubset[] = [
+      {
+        slug: 'mongolian',
+        tenant_id: 'mibera',
+        guild_ids: roleAwarenessGuildId ? [roleAwarenessGuildId] : [],
+      },
+    ];
     try {
       interactionServer = startInteractionServer({
         config,
         characters,
         port: config.INTERACTIONS_PORT,
         verifyRuntime: onboardingWiring?.verify,
+        manifests: roleAwarenessManifests,
       });
       console.log(
         `interactions:   listening on :${interactionServer.port} · ` +

--- a/apps/bot/src/world-resolver.ts
+++ b/apps/bot/src/world-resolver.ts
@@ -118,6 +118,34 @@ export const resolveEngineConfigForGuild = (
 };
 
 /**
+ * Reverse of `resolveWorldForGuild`: given a world slug, find the first
+ * Discord guild_id that world declares.
+ *
+ * Used by the bot's `/guild-roles` endpoint (role-awareness surface) so the
+ * dashboard can resolve `?world=SLUG` → guild → role list. First-declared
+ * guild wins (a world with multiple guilds picks its primary by declaration
+ * order — same operator-controlled ordering convention as
+ * `resolveWorldForGuild`).
+ *
+ * Returns null when:
+ *   - no manifest's slug matches `world_slug`, OR
+ *   - the matched manifest declares no guild_ids (empty / absent array).
+ *
+ * Pure-data function · no IO · no Discord API call.
+ */
+export const resolveGuildForWorld = (
+  world_slug: string,
+  manifests: readonly WorldManifestQuestSubset[],
+): string | null => {
+  for (const m of manifests) {
+    if (m.slug !== world_slug) continue;
+    if (!m.guild_ids || m.guild_ids.length === 0) return null;
+    return m.guild_ids[0]!;
+  }
+  return null;
+};
+
+/**
  * cycle-B sprint-1 (B-1.7): resolve the canonical tenant_id for a Discord
  * guild from the world-manifest registry.
  *


### PR DESCRIPTION
**bot `GET /guild-roles` — role-awareness endpoint** (Track 2 P2, deploy-gate 2 of 2)

A new authed read endpoint returning a guild's Discord roles (`{id, name, color, managed, position}`), so the dashboard role-map editor can offer a live role picker. Net-new on the bot's `Bun.serve` interactions server.

- **Auth: fail-closed** service-token (`X-Service-Token`, env `ROLE_AWARENESS_SERVICE_TOKEN`; `Bearer` fallback). 503 on unset env, 401 on bad token (constant-time, length-guarded). Slug validated before resolve; `@everyone` excluded; sorted by role position. Sibling of a future role-**grant** endpoint — held to that bar.
- Resolves the guild from `?world=<slug>` via the world manifest (reverse lookup).
- Tests: **547 pass / 0 fail**, typecheck clean. BB CONVERGED (0 BLOCKER/HIGH); 5 hardening findings applied (token trim, length-guard test, `guild.id` exclusion, cache-first lookup, bot-not-in-guild → 404 `guild_not_joined`).

⚠️ Deploy note: set `ROLE_AWARENESS_SERVICE_TOKEN` on the bot's Railway; auto-deploys from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
