### PR TITLE
Phase 43C docs: add Admission Wedge fixture contract

### DIFF
--- a/docs/ADMISSION-WEDGE-MVP-DESIGN.md
+++ b/docs/ADMISSION-WEDGE-MVP-DESIGN.md
@@ -738,7 +738,12 @@ re-opens its own decision artifact under the decision-map §7 gates:
   transition that moves between them under synthetic / operator-dev
   authority — fixture / deterministic packet only, no production store,
   no Discord admission command, no live admission route. **The
-  recommended sequel — but it is not authorized here.**
+  recommended sequel — but it is not authorized here.** *Status note: a
+  Phase 43C **fixture / operator-contract** now exists at
+  `docs/admission-wedge/fixtures/` — it proves the §D invariant against a
+  deterministic fixture graph with a dependency-free validator, but it is
+  contract-only and is **not** this Lane A implementation; the runtime
+  Lane A implementation remains separately gated.*
 - **b. Phase 43C-alt — Straylight / Dixie cross-repo contract request
   first.** Before any implementation, a docs-level contract request to
   Straylight (canonical admission / estate / receipt semantics) and Dixie
@@ -765,6 +770,15 @@ commit to one, under its own gate.
 
 ## O. Cross-references
 
+- `docs/admission-wedge/fixtures/` — **Phase 43C** Admission Wedge
+  fixture / operator-contract (added after this design). It makes the §D
+  invariant and the §H / §I / §J proof obligations mechanically checkable
+  against a small deterministic candidate → transition → admitted →
+  recall-proof fixture graph, with a dependency-free validator. It is
+  **fixture / operator-contract only** — **not** the §N(a) Lane A
+  implementation, **no** runtime, **no** Discord command, **no** live
+  admission route, **no** storage. The Lane A implementation remains a
+  later, separately gated phase.
 - `docs/RECALL-WEDGE-POST-ACCEPTANCE-ADMISSION-WEDGE-DECISION-GATE.md` —
   Phase 43A decision gate (PR #151); the authority that selected the
   Admission Wedge and recommended this design (its §M). This design

--- a/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+++ b/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
@@ -1081,6 +1081,17 @@ implementation, only after 43B's design is accepted. A dev-only
 `/remember-this` (Lane B) is a separately gated, riskier, later follow-up
 — not Phase 43B, not the MVP wedge's first step.
 
+> **Status note (Phase 43C fixture / operator-contract).** A Phase 43C
+> **fixture / operator-contract** now exists at
+> `docs/admission-wedge/fixtures/`: deterministic candidate → transition
+> → admitted → recall-proof fixtures plus a dependency-free validator
+> that proves the §43A/§43B invariant (candidate is not admitted memory,
+> not recallable before admission, recallable only after an explicit
+> accept; rejected never recalls; supersession does not leak the wrong
+> prior state). It is **contract-only** — no runtime, no command, no live
+> admission route, no storage. The runtime Lane A implementation and the
+> §7 live-memory-admission gates remain in force and separately gated.
+
 ### 9.1 Historical context — superseded Phase 35B recommendation
 
 > **Superseded.** Kept for ladder continuity only. The recommendation

--- a/docs/admission-wedge/fixtures/README.md
+++ b/docs/admission-wedge/fixtures/README.md
@@ -1,0 +1,238 @@
+# Admission Wedge fixtures — Phase 43C
+
+Deterministic fixtures attached to `docs/ADMISSION-WEDGE-MVP-DESIGN.md`
+(Phase 43B design). They follow Phase 43B and make its core invariant
+**provable** against a small, fixture-bound graph — without implementing
+production admission.
+
+> **Phase 43C is fixture / operator-contract only.** It is the first
+> reviewed artifact after the Phase 43B design, but it is **not** the
+> Lane A implementation. It writes deterministic candidate / transition /
+> admitted / recall-proof **fixtures** and a dependency-free validator
+> that asserts the invariant holds across them. It does **not** implement
+> production admission, **does not** implement a live command, **does
+> not** authorize `/remember-this`, and **does not** ingest Discord
+> history. A future live implementation remains separately gated under
+> the decision-map §7 gates.
+
+## What this proves
+
+The load-bearing invariant, carried verbatim from Phase 43B §D / Phase
+43A §E, made mechanically checkable here:
+
+1. **Candidate memory is not admitted memory.** A candidate
+   (`admission_state = candidate_pending`) and an admitted assertion
+   (`admission_state = admitted`) are distinct states.
+2. **Candidate memory is not recallable before admission.** The
+   before-admission recall proof excludes the candidate
+   (`recall_result = excluded`,
+   `exclusion_reason = candidate_not_admitted`), and the candidate body
+   never appears in recall output.
+3. **A candidate becomes recall-eligible only after an explicit admission
+   transition accepts it.** Only after `trans-001` accepts `cand-001`
+   does `assn-001` exist and recall classify `served`.
+4. **A rejected candidate never becomes recallable.** `trans-002` rejects
+   `cand-002`, mints no admitted assertion, and the rejection recall
+   proof stays excluded permanently.
+5. **A superseded / corrected candidate does not leak the wrong prior
+   state into ordinary recall.** `trans-011` accepts the correction
+   `cand-011` as `assn-011` and supersedes `assn-010`; ordinary recall
+   returns only the corrected active `assn-011`, never the wrong prior
+   `assn-010`. The supersedes link is preserved for audit, not rendered.
+6. **The proof is deterministic, local, and operator / fixture-only.**
+   No wall-clock (logical stamps only), no network, no storage, no
+   secrets, Node built-ins only.
+
+## What lives here
+
+```
+docs/admission-wedge/fixtures/
+  candidates/
+    cand-001-accepted-pending.json     candidate that will be accepted
+    cand-002-rejected-pending.json     candidate that will be rejected
+    cand-010-original-pending.json     candidate admitted then corrected
+    cand-011-correction-pending.json   candidate that corrects assn-010
+  transitions/
+    trans-001-accept.json              accept cand-001 -> assn-001
+    trans-002-reject.json              reject cand-002 (no assertion minted)
+    trans-010-accept-original.json     accept cand-010 -> assn-010
+    trans-011-supersede.json           accept cand-011 -> assn-011, supersede assn-010
+  admitted/
+    assn-001-active.json               active admitted assertion
+    assn-010-superseded.json           superseded prior state (audit only)
+    assn-011-active-correction.json    corrected active assertion
+  recall-proofs/
+    proof-001-before-admission-excluded.json   candidate excluded pre-admission
+    proof-002-after-admission-included.json     admitted assertion included
+    proof-003-rejected-excluded.json             rejected candidate excluded
+    proof-004-supersession-corrected.json        corrected included, prior excluded
+  validate-fixtures.mjs                deterministic, dependency-free validator
+  README.md                            this file
+```
+
+## The fixture graph
+
+```
+cand-001  --trans-001(accept)-->  assn-001 (active)        --> proof-002 (served, included)
+   |                                                            audit links: cand-001, trans-001, rcpt-001
+   `--(pending)---------------------------------------------> proof-001 (not_found, excluded)
+
+cand-002  --trans-002(reject)-->  (no assertion)           --> proof-003 (not_found, excluded)
+
+cand-010  --trans-010(accept)-->  assn-010 (active)
+cand-011  --trans-011(accept,                assn-010 -> superseded
+            supersedes assn-010)-> assn-011 (active)        --> proof-004 (served, includes assn-011 only;
+                                                                excludes superseded assn-010)
+```
+
+Every id is a short deterministic fixture id (`cand-*`, `trans-*`,
+`assn-*`, `rcpt-*`, `proof-*`). Stamps are logical
+(`fixture-logical-stamp-NNNN`), never wall-clock — so the proof is
+byte-stable, consistent with the Recall Wedge's deterministic posture.
+
+## Fixture kinds (and what they are NOT)
+
+These are **design-level doctrine vocabulary** for a future
+implementation — they are **not** implemented schemas, **not** storage
+tables, **not** Dixie / Straylight API contracts, and **not** a data
+model that exists. Straylight owns the canonical admission / estate /
+receipt semantics (Phase 43B §K); these fixtures are design intent a
+future gate would reconcile against that authority. Each fixture carries
+a `schema_note` restating this.
+
+- **Candidate packet** (`candidate_memory_packet`) — a proposed memory,
+  `admission_state = candidate_pending`, `recall_eligibility =
+  ineligible`. From the recall surface's perspective it is absent. Its
+  `candidate_payload.body_private` and `provenance.source_material` carry
+  sentinels that must never reach recall output.
+- **Admission transition** (`admission_transition`) — the single explicit
+  door from candidate to admitted / rejected / superseded. Authored under
+  `admission_authority = operator_dev_synthetic`, never an arbitrary
+  user. Idempotent (a retry resolves to the same `admitted_assertion_id`)
+  and audited (every transition carries a `receipt_ref` / `audit_ref`).
+- **Admitted packet** (`admitted_memory_packet`) — the output of an
+  accept / supersede, `admission_state = admitted`, `assertion_status =
+  active`, `recall_eligibility = eligible`, read-compatible with the
+  accepted Recall Wedge path. A superseded prior packet keeps
+  `assertion_status = superseded` and `recall_eligibility = ineligible`.
+- **Recall proof** (`admission_recall_proof`) — a deterministic record of
+  what ordinary recall does at a given phase (before admission, after
+  admission, rejected, supersession). It carries only short ids and
+  public-safe summaries — never a private body. The source candidate and
+  receipt appear under `audit_links` only, never as ordinary recall
+  material.
+
+## No-leak posture
+
+Ordinary recall output (the four `recall-proofs/*.json`) must never carry
+a private body. Candidate / admitted / superseded private bodies and
+source material are tagged with sentinels
+(`CANDIDATE_PRIVATE_SENTINEL_*`, `SOURCE_SENTINEL_*`,
+`ADMITTED_PRIVATE_SENTINEL_*`, `SUPERSEDED_PRIVATE_SENTINEL_*`). The
+validator greps every recall-proof fixture for those sentinels and fails
+if any appears. This mirrors the Recall Wedge's no-leak boundary; the
+Admission Wedge does not widen it.
+
+## The validator
+
+`validate-fixtures.mjs` is deterministic, dependency-free, and uses Node
+built-ins only (`node:fs`, `node:path`, `node:url`). It adds no package
+and no lockfile entry.
+
+Run it:
+
+```bash
+node docs/admission-wedge/fixtures/validate-fixtures.mjs
+```
+
+It checks:
+
+1. all required directories and fixture files exist;
+2. every fixture JSON parses;
+3. required fields exist per fixture kind (candidate, transition,
+   admitted, recall-proof), plus shared `synthetic === true` and a
+   consistent `actor_id`;
+4. the candidate-pending fixtures are not recallable
+   (`admission_state = candidate_pending`, `recall_eligibility =
+   ineligible`);
+5. the accepted transition references its candidate and mints the
+   expected admitted assertion id;
+6. the admitted packet references the accepted transition and candidate
+   and is admitted / active / eligible;
+7. the before-admission recall proof excludes the candidate
+   (`recall_result = excluded`, classification not `served`, empty
+   `included_assertion_ids`, no candidate payload rendered);
+8. the after-admission recall proof includes **only** the admitted
+   assertion (`[assn-001]`), not the raw candidate; the source candidate
+   and admission receipt are preserved under `audit_links` only;
+9. the rejected candidate mints no admitted assertion (transition
+   `admitted_assertion_id = null`, no admitted packet derives from it)
+   and its recall proof stays excluded
+   (`exclusion_reason = candidate_rejected`);
+10. the supersession recall proof includes the corrected active assertion
+    (`[assn-011]`) and excludes the superseded wrong prior state
+    (`assn-010`); the superseded packet is `superseded` / ineligible; the
+    supersedes link is preserved for audit; the prior state is not
+    rendered;
+11. no fixture contains banned raw material — Discord snowflakes / long
+    id runs, JWTs, secret / bearer / provider tokens, PEM private keys,
+    0x addresses, postgres URLs, http(s) / Railway URLs, or
+    screenshot / image / binary references;
+12. no fixture **claims** production storage, production admission,
+    production auth / consent, public remember-this, Discord history
+    ingestion, or user chat becoming memory (only negated disclaimers —
+    "no production storage", "not from chat" — are allowed);
+13. the no-leak gate: no recall-proof fixture carries a private body
+    sentinel.
+
+It prints a summary (fixtures checked, assertions evaluated, checks
+passed, checks failed) and an `ok` line on success. It exits `0` on
+success and **nonzero** on any failure.
+
+The validator is fixture-only: it imports no Straylight / Dixie types, it
+calls no live client, it renders nothing, and it admits / stores nothing.
+
+## What this is NOT (scope guard)
+
+Carried from Phase 43B §M — none of the following is authorized,
+implemented, or claimed by Phase 43C:
+
+- production memory admission, production storage, or a durable estate
+  store;
+- a live Dixie admission route or a Straylight production store;
+- a Discord command (including any `/remember-this`) or public
+  remember-this surface;
+- Discord message-history ingestion, live message ingestion, ambient
+  listening, or user chat becoming memory;
+- production auth / consent, cross-user sharing, or public rollout;
+- Telegram / private-chat surfaces;
+- LLM rewriting or character-voice admission / rendering;
+- a forget / revoke / correction UI (supersession here is a doctrine
+  partition + audit link, not a UI);
+- any claim that Finn is production-wired.
+
+If a later phase needs any of the above, it must open the gate that owns
+it (decision-map §7) — Phase 43C authorizes none of them.
+
+## Naming note (binding, carried from Phase 43B §B.1)
+
+- **"Freeside Characters"** / **`freeside-characters`** is the current
+  Discord app / this repo. The current bot identity is **"loa."** The
+  bare word "Freeside" is **not** used to name the current app.
+- **"Freeside platform"** is reserved for the future broader platform and
+  is out of scope here.
+- **"Dixie"** is the deployed Recall Wedge service; **"Straylight"** is
+  the memory / continuity substrate that would eventually own canonical
+  admission semantics. **"Finn"** is not production-wired for any wedge.
+
+## Cross-references
+
+- `docs/ADMISSION-WEDGE-MVP-DESIGN.md` — Phase 43B design (the §F packet
+  shapes, §D invariant, and §H / §I / §J proof obligations these fixtures
+  make concrete).
+- `docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md` — Phase 35A option matrix;
+  §7 (live memory admission gates) and §8 (prohibitions) govern any
+  admission work and stay in force.
+- `docs/recall-wedge/fixtures/` — the accepted Recall Wedge fixture
+  pattern this directory mirrors (deterministic fixtures + a
+  dependency-free no-leak validator).

--- a/docs/admission-wedge/fixtures/admitted/assn-001-active.json
+++ b/docs/admission-wedge/fixtures/admitted/assn-001-active.json
@@ -1,0 +1,29 @@
+{
+  "fixture_kind": "admitted_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.3)",
+  "synthetic": true,
+  "assertion_id": "assn-001",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "assertion_class": "observation",
+  "assertion_status": "active",
+  "admission_state": "admitted",
+  "source_candidate_id": "cand-001",
+  "admission_transition_id": "trans-001",
+  "admission_receipt_ref": "rcpt-001",
+  "supersedes_assertion_id": null,
+  "recall_eligibility": "eligible",
+  "visibility_class": "public_safe_summary",
+  "summary_public": "operator participates in the admission-wedge fixture proof",
+  "body_private": "admitted body retained for governed continuity — ADMITTED_PRIVATE_SENTINEL_001 — never rendered on a public surface",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "admission_authority": "operator_dev_synthetic",
+    "note": "admitted from cand-001 via trans-001 under synthetic operator/dev authority; audit only"
+  },
+  "created_at": "fixture-logical-stamp-0001",
+  "admitted_at": "fixture-logical-stamp-0002",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; read-compatible with the accepted Recall Wedge path; no production storage, no production admission"
+}

--- a/docs/admission-wedge/fixtures/admitted/assn-010-superseded.json
+++ b/docs/admission-wedge/fixtures/admitted/assn-010-superseded.json
@@ -1,0 +1,32 @@
+{
+  "fixture_kind": "admitted_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.3, J)",
+  "synthetic": true,
+  "assertion_id": "assn-010",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "assertion_class": "preference",
+  "assertion_status": "superseded",
+  "admission_state": "superseded",
+  "source_candidate_id": "cand-010",
+  "admission_transition_id": "trans-010",
+  "admission_receipt_ref": "rcpt-010",
+  "superseded_by_assertion_id": "assn-011",
+  "superseded_by_transition_id": "trans-011",
+  "supersedes_assertion_id": null,
+  "recall_eligibility": "ineligible",
+  "visibility_class": "superseded_audit_only",
+  "summary_public": "operator prefers the morning festival slot",
+  "body_private": "prior admitted body retained for audit only — SUPERSEDED_PRIVATE_SENTINEL_010 — wrong prior state, never rendered as active governed continuity",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "admission_authority": "operator_dev_synthetic",
+    "note": "originally admitted from cand-010 via trans-010; superseded by assn-011 via trans-011; retained for audit reconstruction, not ordinary recall"
+  },
+  "created_at": "fixture-logical-stamp-0005",
+  "admitted_at": "fixture-logical-stamp-0006",
+  "superseded_at": "fixture-logical-stamp-0008",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; superseded record kept for auditability; not ordinary-recall-eligible; this is the wrong prior state and must not leak as active memory"
+}

--- a/docs/admission-wedge/fixtures/admitted/assn-011-active-correction.json
+++ b/docs/admission-wedge/fixtures/admitted/assn-011-active-correction.json
@@ -1,0 +1,29 @@
+{
+  "fixture_kind": "admitted_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.3, J)",
+  "synthetic": true,
+  "assertion_id": "assn-011",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "assertion_class": "preference",
+  "assertion_status": "active",
+  "admission_state": "admitted",
+  "source_candidate_id": "cand-011",
+  "admission_transition_id": "trans-011",
+  "admission_receipt_ref": "rcpt-011",
+  "supersedes_assertion_id": "assn-010",
+  "recall_eligibility": "eligible",
+  "visibility_class": "public_safe_summary",
+  "summary_public": "operator prefers the evening festival slot",
+  "body_private": "corrected admitted body retained for governed continuity — ADMITTED_PRIVATE_SENTINEL_011 — never rendered on a public surface",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "admission_authority": "operator_dev_synthetic",
+    "note": "admitted from cand-011 via trans-011 under synthetic operator/dev authority; corrects (supersedes) assn-010; audit only"
+  },
+  "created_at": "fixture-logical-stamp-0007",
+  "admitted_at": "fixture-logical-stamp-0008",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; read-compatible with the accepted Recall Wedge path; this is the corrected active state; no production storage, no production admission"
+}

--- a/docs/admission-wedge/fixtures/candidates/cand-001-accepted-pending.json
+++ b/docs/admission-wedge/fixtures/candidates/cand-001-accepted-pending.json
@@ -1,0 +1,29 @@
+{
+  "fixture_kind": "candidate_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.1)",
+  "synthetic": true,
+  "candidate_id": "cand-001",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "source_kind": "reviewed_deterministic_operator_fixture",
+  "source_ref": "fixture:docs/admission-wedge/fixtures/candidates/cand-001-accepted-pending.json",
+  "proposed_assertion_class": "observation",
+  "admission_state": "candidate_pending",
+  "recall_eligibility": "ineligible",
+  "visibility_class": "candidate_never_rendered",
+  "candidate_payload": {
+    "boundary": "public_safe",
+    "summary_public": "operator participates in the admission-wedge fixture proof",
+    "body_private": "candidate body held for review only — CANDIDATE_PRIVATE_SENTINEL_001 — never rendered while pending"
+  },
+  "created_at": "fixture-logical-stamp-0001",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "source_material": "synthetic operator-authored candidate text — SOURCE_SENTINEL_001 — audit only, never rendered",
+    "admission_authority_hint": "operator_dev_synthetic",
+    "note": "reviewed operator fixture; not derived from prior messages, not from chat; authority is synthetic operator/dev only"
+  },
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; not for any live or durable use; a candidate is only a proposal and is not governed continuity"
+}

--- a/docs/admission-wedge/fixtures/candidates/cand-002-rejected-pending.json
+++ b/docs/admission-wedge/fixtures/candidates/cand-002-rejected-pending.json
@@ -1,0 +1,29 @@
+{
+  "fixture_kind": "candidate_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.1)",
+  "synthetic": true,
+  "candidate_id": "cand-002",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "source_kind": "reviewed_deterministic_operator_fixture",
+  "source_ref": "fixture:docs/admission-wedge/fixtures/candidates/cand-002-rejected-pending.json",
+  "proposed_assertion_class": "context",
+  "admission_state": "candidate_pending",
+  "recall_eligibility": "ineligible",
+  "visibility_class": "candidate_never_rendered",
+  "candidate_payload": {
+    "boundary": "public_safe",
+    "summary_public": "a proposed note the operator will decline",
+    "body_private": "candidate body proposed for review — CANDIDATE_PRIVATE_SENTINEL_002 — never rendered while pending"
+  },
+  "created_at": "fixture-logical-stamp-0003",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "source_material": "synthetic operator-authored candidate text — SOURCE_SENTINEL_002 — audit only, never rendered",
+    "admission_authority_hint": "operator_dev_synthetic",
+    "note": "reviewed operator fixture; not derived from prior messages, not from chat; authority is synthetic operator/dev only"
+  },
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; not for any live or durable use; this candidate is declined and never becomes governed continuity"
+}

--- a/docs/admission-wedge/fixtures/candidates/cand-010-original-pending.json
+++ b/docs/admission-wedge/fixtures/candidates/cand-010-original-pending.json
@@ -1,0 +1,29 @@
+{
+  "fixture_kind": "candidate_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.1)",
+  "synthetic": true,
+  "candidate_id": "cand-010",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "source_kind": "reviewed_deterministic_operator_fixture",
+  "source_ref": "fixture:docs/admission-wedge/fixtures/candidates/cand-010-original-pending.json",
+  "proposed_assertion_class": "preference",
+  "admission_state": "candidate_pending",
+  "recall_eligibility": "ineligible",
+  "visibility_class": "candidate_never_rendered",
+  "candidate_payload": {
+    "boundary": "public_safe",
+    "summary_public": "operator prefers the morning festival slot",
+    "body_private": "candidate body for the original preference — CANDIDATE_PRIVATE_SENTINEL_010 — never rendered while pending"
+  },
+  "created_at": "fixture-logical-stamp-0005",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "source_material": "synthetic operator-authored candidate text — SOURCE_SENTINEL_010 — audit only, never rendered",
+    "admission_authority_hint": "operator_dev_synthetic",
+    "note": "reviewed operator fixture; not derived from prior messages, not from chat; authority is synthetic operator/dev only"
+  },
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; not for any live or durable use; this candidate is admitted then later corrected by cand-011"
+}

--- a/docs/admission-wedge/fixtures/candidates/cand-011-correction-pending.json
+++ b/docs/admission-wedge/fixtures/candidates/cand-011-correction-pending.json
@@ -1,0 +1,30 @@
+{
+  "fixture_kind": "candidate_memory_packet",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.1)",
+  "synthetic": true,
+  "candidate_id": "cand-011",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "source_kind": "reviewed_deterministic_operator_fixture",
+  "source_ref": "fixture:docs/admission-wedge/fixtures/candidates/cand-011-correction-pending.json",
+  "proposed_assertion_class": "preference",
+  "proposed_supersedes_assertion_id": "assn-010",
+  "admission_state": "candidate_pending",
+  "recall_eligibility": "ineligible",
+  "visibility_class": "candidate_never_rendered",
+  "candidate_payload": {
+    "boundary": "public_safe",
+    "summary_public": "operator prefers the evening festival slot",
+    "body_private": "candidate body for the corrected preference — CANDIDATE_PRIVATE_SENTINEL_011 — never rendered while pending"
+  },
+  "created_at": "fixture-logical-stamp-0007",
+  "provenance": {
+    "source_kind": "reviewed_deterministic_operator_fixture",
+    "source_material": "synthetic operator-authored candidate text — SOURCE_SENTINEL_011 — audit only, never rendered",
+    "admission_authority_hint": "operator_dev_synthetic",
+    "note": "reviewed operator fixture; corrects an earlier admitted assertion; not derived from prior messages, not from chat; authority is synthetic operator/dev only"
+  },
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; not for any live or durable use; this candidate corrects (supersedes) assn-010"
+}

--- a/docs/admission-wedge/fixtures/recall-proofs/proof-001-before-admission-excluded.json
+++ b/docs/admission-wedge/fixtures/recall-proofs/proof-001-before-admission-excluded.json
@@ -1,0 +1,27 @@
+{
+  "fixture_kind": "admission_recall_proof",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.5, H)",
+  "synthetic": true,
+  "proof_id": "proof-001",
+  "proof_phase": "before_admission",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "recall_route": "/api/recall/intake",
+  "recall_classification": "not_found",
+  "considered_candidate_id": "cand-001",
+  "considered_admission_state": "candidate_pending",
+  "recall_result": "excluded",
+  "exclusion_reason": "candidate_not_admitted",
+  "included_assertion_ids": [],
+  "excluded_candidate_ids": ["cand-001"],
+  "public_recall_output": {
+    "public_summary": "nothing to recall here",
+    "denied_or_refused": true,
+    "rendered_candidate_payload": false
+  },
+  "no_leak_note": "candidate body, source material, candidate_payload, and provenance are not rendered; a not-yet-admitted candidate is absent from governed recall — existence is not recallability",
+  "reuse_note": "reuses the accepted Recall Wedge fail-closed behavior unchanged; this is the safe not-found family, never the served family",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; demonstrates candidate memory is not recallable before admission"
+}

--- a/docs/admission-wedge/fixtures/recall-proofs/proof-002-after-admission-included.json
+++ b/docs/admission-wedge/fixtures/recall-proofs/proof-002-after-admission-included.json
@@ -1,0 +1,31 @@
+{
+  "fixture_kind": "admission_recall_proof",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.5)",
+  "synthetic": true,
+  "proof_id": "proof-002",
+  "proof_phase": "after_admission",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "recall_route": "/api/recall/intake",
+  "recall_classification": "served",
+  "recall_result": "included",
+  "inclusion_reason": "admitted_active_assertion",
+  "included_assertion_ids": ["assn-001"],
+  "excluded_candidate_ids": ["cand-001"],
+  "public_recall_output": {
+    "public_summary": "operator participates in the admission-wedge fixture proof",
+    "denied_or_refused": false,
+    "rendered_candidate_payload": false
+  },
+  "audit_links": {
+    "source_candidate_id": "cand-001",
+    "admission_transition_id": "trans-001",
+    "admission_receipt_ref": "rcpt-001",
+    "audit_link_note": "the source candidate and admission receipt are preserved as audit links only; the raw candidate is NOT treated as ordinary recall material and is not rendered"
+  },
+  "no_leak_note": "only the admitted assertion's public_safe summary is recallable; the raw candidate, candidate_payload, body_private, source material, receipt body, and authority identifier are not rendered",
+  "reuse_note": "reuses the accepted Recall Wedge served behavior unchanged; same classification/outcome/route the recall half already produces",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; demonstrates an admitted assertion becomes recall-eligible only after an explicit admission transition"
+}

--- a/docs/admission-wedge/fixtures/recall-proofs/proof-003-rejected-excluded.json
+++ b/docs/admission-wedge/fixtures/recall-proofs/proof-003-rejected-excluded.json
@@ -1,0 +1,30 @@
+{
+  "fixture_kind": "admission_recall_proof",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.5, I)",
+  "synthetic": true,
+  "proof_id": "proof-003",
+  "proof_phase": "rejected",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "recall_route": "/api/recall/intake",
+  "recall_classification": "not_found",
+  "considered_candidate_id": "cand-002",
+  "considered_admission_state": "rejected",
+  "admission_decision": "rejected",
+  "admission_transition_id": "trans-002",
+  "admitted_assertion_id": null,
+  "recall_result": "excluded",
+  "exclusion_reason": "candidate_rejected",
+  "included_assertion_ids": [],
+  "excluded_candidate_ids": ["cand-002"],
+  "public_recall_output": {
+    "public_summary": "nothing to recall here",
+    "denied_or_refused": true,
+    "rendered_candidate_payload": false
+  },
+  "no_leak_note": "a rejected candidate never mints an admitted assertion and never becomes recallable; its body, payload, source material, and the rejection receipt body are not rendered; rejection is terminal for recallability",
+  "reuse_note": "reuses the accepted Recall Wedge fail-closed behavior unchanged; never the served family, before during or after rejection",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; demonstrates a rejected candidate never becomes recallable"
+}

--- a/docs/admission-wedge/fixtures/recall-proofs/proof-004-supersession-corrected.json
+++ b/docs/admission-wedge/fixtures/recall-proofs/proof-004-supersession-corrected.json
@@ -1,0 +1,37 @@
+{
+  "fixture_kind": "admission_recall_proof",
+  "fixture_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.5, J)",
+  "synthetic": true,
+  "proof_id": "proof-004",
+  "proof_phase": "supersession",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "recall_route": "/api/recall/intake",
+  "recall_classification": "served",
+  "recall_result": "included",
+  "inclusion_reason": "admitted_active_assertion",
+  "included_assertion_ids": ["assn-011"],
+  "excluded_assertion_ids": ["assn-010"],
+  "corrected_active_assertion_id": "assn-011",
+  "superseded_assertion_id": "assn-010",
+  "superseded_excluded_reason": "assertion_superseded",
+  "public_recall_output": {
+    "public_summary": "operator prefers the evening festival slot",
+    "denied_or_refused": false,
+    "rendered_candidate_payload": false,
+    "rendered_prior_state": false
+  },
+  "audit_links": {
+    "source_candidate_id": "cand-011",
+    "admission_transition_id": "trans-011",
+    "admission_receipt_ref": "rcpt-011",
+    "supersedes_assertion_id": "assn-010",
+    "supersede_transition_id": "trans-011",
+    "audit_link_note": "the supersedes link assn-011 -> assn-010 and the supersede transition are preserved for audit reconstruction only; the prior state is NOT rendered as active governed continuity"
+  },
+  "no_leak_note": "ordinary recall returns only the corrected active assertion assn-011; the wrong prior state assn-010 does not surface as active governed continuity; no candidate payload, body_private, or prior-state body is rendered",
+  "reuse_note": "reuses the accepted Recall Wedge served behavior unchanged; supersession is a doctrine partition, not a forget/revoke/correction UI",
+  "authorization_note": "synthetic, reviewed, fixture/operator-only; demonstrates correction preserves auditability without leaking the wrong prior state into ordinary recall"
+}

--- a/docs/admission-wedge/fixtures/transitions/trans-001-accept.json
+++ b/docs/admission-wedge/fixtures/transitions/trans-001-accept.json
@@ -1,0 +1,22 @@
+{
+  "fixture_kind": "admission_transition",
+  "transition_kind": "admission_transition",
+  "transition_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.2)",
+  "synthetic": true,
+  "transition_id": "trans-001",
+  "candidate_id": "cand-001",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "admission_authority": "operator_dev_synthetic",
+  "admission_authority_note": "synthetic operator/dev authority only; never an arbitrary user; audit material, never rendered to any public surface",
+  "admission_decision": "accepted",
+  "admitted_assertion_id": "assn-001",
+  "supersedes_assertion_id": null,
+  "reason_code": "operator_reviewed_accept",
+  "decided_at": "fixture-logical-stamp-0002",
+  "receipt_ref": "rcpt-001",
+  "audit_ref": "rcpt-001",
+  "idempotency_note": "admitting cand-001 twice must not mint a second assertion; a retry resolves to the same admitted_assertion_id assn-001"
+}

--- a/docs/admission-wedge/fixtures/transitions/trans-002-reject.json
+++ b/docs/admission-wedge/fixtures/transitions/trans-002-reject.json
@@ -1,0 +1,22 @@
+{
+  "fixture_kind": "admission_transition",
+  "transition_kind": "admission_transition",
+  "transition_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.2)",
+  "synthetic": true,
+  "transition_id": "trans-002",
+  "candidate_id": "cand-002",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "admission_authority": "operator_dev_synthetic",
+  "admission_authority_note": "synthetic operator/dev authority only; never an arbitrary user; audit material, never rendered to any public surface",
+  "admission_decision": "rejected",
+  "admitted_assertion_id": null,
+  "supersedes_assertion_id": null,
+  "reason_code": "operator_reviewed_reject",
+  "decided_at": "fixture-logical-stamp-0004",
+  "receipt_ref": "rcpt-002",
+  "audit_ref": "rcpt-002",
+  "terminality_note": "rejection is terminal for this candidate's recallability; there is no path back to admitted without a new candidate and a new transition"
+}

--- a/docs/admission-wedge/fixtures/transitions/trans-010-accept-original.json
+++ b/docs/admission-wedge/fixtures/transitions/trans-010-accept-original.json
@@ -1,0 +1,22 @@
+{
+  "fixture_kind": "admission_transition",
+  "transition_kind": "admission_transition",
+  "transition_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.2)",
+  "synthetic": true,
+  "transition_id": "trans-010",
+  "candidate_id": "cand-010",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "admission_authority": "operator_dev_synthetic",
+  "admission_authority_note": "synthetic operator/dev authority only; never an arbitrary user; audit material, never rendered to any public surface",
+  "admission_decision": "accepted",
+  "admitted_assertion_id": "assn-010",
+  "supersedes_assertion_id": null,
+  "reason_code": "operator_reviewed_accept",
+  "decided_at": "fixture-logical-stamp-0006",
+  "receipt_ref": "rcpt-010",
+  "audit_ref": "rcpt-010",
+  "idempotency_note": "admitting cand-010 twice must not mint a second assertion; a retry resolves to the same admitted_assertion_id assn-010"
+}

--- a/docs/admission-wedge/fixtures/transitions/trans-011-supersede.json
+++ b/docs/admission-wedge/fixtures/transitions/trans-011-supersede.json
@@ -1,0 +1,23 @@
+{
+  "fixture_kind": "admission_transition",
+  "transition_kind": "admission_transition",
+  "transition_version": "phase-43c.0",
+  "schema_version": "admission-wedge-mvp.0",
+  "schema_note": "design-level doctrine vocabulary, not an implemented schema, not a storage table, not a Dixie/Straylight API contract (see docs/ADMISSION-WEDGE-MVP-DESIGN.md F.2)",
+  "synthetic": true,
+  "transition_id": "trans-011",
+  "candidate_id": "cand-011",
+  "actor_id": "freeside-characters:shared-substrate",
+  "estate_id": "estate-operator-dev-001",
+  "admission_authority": "operator_dev_synthetic",
+  "admission_authority_note": "synthetic operator/dev authority only; never an arbitrary user; audit material, never rendered to any public surface",
+  "admission_decision": "accepted",
+  "admission_subdecision": "supersede",
+  "admitted_assertion_id": "assn-011",
+  "supersedes_assertion_id": "assn-010",
+  "reason_code": "operator_reviewed_correction",
+  "decided_at": "fixture-logical-stamp-0008",
+  "receipt_ref": "rcpt-011",
+  "audit_ref": "rcpt-011",
+  "supersession_note": "this accept corrects assn-010; assn-010 becomes superseded and is no longer ordinary-recall-eligible; the supersedes link is preserved for audit only"
+}

--- a/docs/admission-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/admission-wedge/fixtures/validate-fixtures.mjs
@@ -1,0 +1,798 @@
+#!/usr/bin/env node
+// Phase 43C Admission Wedge fixture/operator-contract validator.
+// Deterministic, dependency-free, Node-built-ins only.
+//
+// Companion to docs/ADMISSION-WEDGE-MVP-DESIGN.md (Phase 43B design) and
+// the accepted Recall Wedge fixture validator
+// (docs/recall-wedge/fixtures/validate-fixtures.mjs).
+//
+// Scope: this is fixture / operator-contract validation ONLY. It proves
+// the Admission Wedge core invariant against a small deterministic
+// fixture graph (candidate -> transition -> admitted -> recall-proof).
+// It is NOT a live admission route, NOT production admission, NOT
+// production storage, NOT a Discord command, NOT a renderer, NOT a live
+// Dixie/Straylight client. It admits nothing and stores nothing; it
+// reads JSON fixtures and asserts the invariant holds.
+//
+// The invariant proved (docs/ADMISSION-WEDGE-MVP-DESIGN.md §D):
+//   1. candidate memory is not admitted memory;
+//   2. candidate memory is not recallable before admission;
+//   3. a candidate becomes recall-eligible only after an explicit
+//      admission transition accepts it;
+//   4. a rejected candidate never becomes recallable;
+//   5. a superseded/corrected candidate does not leak the wrong prior
+//      state into ordinary recall;
+//   6. the proof is deterministic, local, and operator/fixture-only.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = __dirname;
+
+const CANDIDATES_DIR = join(FIXTURES_DIR, "candidates");
+const TRANSITIONS_DIR = join(FIXTURES_DIR, "transitions");
+const ADMITTED_DIR = join(FIXTURES_DIR, "admitted");
+const RECALL_PROOFS_DIR = join(FIXTURES_DIR, "recall-proofs");
+
+// --- required fixture files (by directory) ---------------------------------
+
+const REQUIRED = {
+  candidates: [
+    "cand-001-accepted-pending.json",
+    "cand-002-rejected-pending.json",
+    "cand-010-original-pending.json",
+    "cand-011-correction-pending.json",
+  ],
+  transitions: [
+    "trans-001-accept.json",
+    "trans-002-reject.json",
+    "trans-010-accept-original.json",
+    "trans-011-supersede.json",
+  ],
+  admitted: [
+    "assn-001-active.json",
+    "assn-010-superseded.json",
+    "assn-011-active-correction.json",
+  ],
+  "recall-proofs": [
+    "proof-001-before-admission-excluded.json",
+    "proof-002-after-admission-included.json",
+    "proof-003-rejected-excluded.json",
+    "proof-004-supersession-corrected.json",
+  ],
+};
+
+const DIR_BY_KEY = {
+  candidates: CANDIDATES_DIR,
+  transitions: TRANSITIONS_DIR,
+  admitted: ADMITTED_DIR,
+  "recall-proofs": RECALL_PROOFS_DIR,
+};
+
+// --- banned raw material (check 11) ----------------------------------------
+//
+// No fixture may contain real secrets / raw long IDs / live URLs /
+// binary-evidence references. Each entry is [label, regexp].
+const BANNED_MATERIAL = [
+  ["discord snowflake / raw long id (17+ digit run)", /\d{17,}/],
+  ["jwt", /eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/],
+  ["openai-style secret token", /\bsk-[A-Za-z0-9]{12,}/],
+  ["github token", /\bgh[pousr]_[A-Za-z0-9]{20,}/],
+  ["slack token", /\bxox[baprs]-[A-Za-z0-9-]{8,}/],
+  ["bearer token", /\bBearer\s+[A-Za-z0-9._-]{12,}/],
+  ["pem private key", /-----BEGIN [A-Z ]*PRIVATE KEY-----/],
+  ["hex private key / 0x address (40+ hex)", /0x[a-fA-F0-9]{40,}/],
+  ["postgres url", /postgres(?:ql)?:\/\//i],
+  ["http(s) url", /https?:\/\//i],
+  ["railway url", /railway\.app/i],
+  [
+    "screenshot / image / binary evidence reference",
+    /\.(?:png|jpe?g|gif|webp|bmp|svg|mp4|mov|avi|pdf|zip|bin)\b/i,
+  ],
+  ["inline image data uri", /data:image\//i],
+];
+
+// --- forbidden claims (check 12) -------------------------------------------
+//
+// No fixture may *claim* production admission, production storage,
+// production auth/consent, public remember-this, Discord history
+// ingestion, or user chat becoming memory. Some of these phrases legitly
+// appear in fixtures ONLY as disclaimers (e.g. "no production storage").
+// So each occurrence is allowed only when negated by a nearby negation
+// token; an un-negated occurrence is treated as a forbidden claim.
+const FORBIDDEN_CLAIM_PHRASES = [
+  "production storage",
+  "production admission",
+  "production auth",
+  "production consent",
+  "public remember-this",
+  "remember-this",
+  "discord history",
+  "message history",
+  "history ingestion",
+  "discord chat becomes memory",
+  "chat becomes memory",
+  "chat becoming memory",
+  "user chat",
+  "production-wired",
+  "production wired",
+];
+
+const NEGATION_RE = /\b(?:no|not|never|without|neither|nor|cannot)\b|n['’]t\b/i;
+
+// --- private body sentinels (no-leak gate over recall proofs) --------------
+//
+// Candidate / admitted / superseded private bodies and source material
+// carry these sentinels. Ordinary recall output (the recall-proof
+// fixtures) must contain NONE of them: the no-leak boundary holds.
+const PRIVATE_BODY_SENTINELS = [
+  "CANDIDATE_PRIVATE_SENTINEL",
+  "SOURCE_SENTINEL",
+  "ADMITTED_PRIVATE_SENTINEL",
+  "SUPERSEDED_PRIVATE_SENTINEL",
+];
+
+const EXPECTED_ACTOR_ID = "freeside-characters:shared-substrate";
+
+// --- accumulators ----------------------------------------------------------
+
+const failures = [];
+const successes = [];
+let checksChecked = 0;
+
+function fail(msg) {
+  failures.push(msg);
+}
+function ok(msg) {
+  successes.push(msg);
+}
+function check(cond, okMsg, failMsg) {
+  checksChecked += 1;
+  if (cond) ok(okMsg);
+  else fail(failMsg);
+  return cond;
+}
+
+function loadJson(path) {
+  try {
+    const raw = readFileSync(path, "utf8");
+    return { raw, parsed: JSON.parse(raw) };
+  } catch (err) {
+    fail(`could not parse ${rel(path)}: ${err.message}`);
+    return null;
+  }
+}
+
+function listJsonFiles(dir) {
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => join(dir, name))
+      .filter((p) => statSync(p).isFile());
+  } catch {
+    return [];
+  }
+}
+
+function rel(p) {
+  return p.replace(FIXTURES_DIR + "/", "");
+}
+
+function dirExists(dir) {
+  try {
+    return statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function fieldsPresent(obj, fields, label) {
+  for (const f of fields) {
+    const present = obj != null && Object.prototype.hasOwnProperty.call(obj, f);
+    check(
+      present,
+      `${label}: field "${f}" present`,
+      `${label}: required field "${f}" missing`,
+    );
+  }
+}
+
+function hasNegationBefore(haystack, idx, window = 36) {
+  const start = Math.max(0, idx - window);
+  return NEGATION_RE.test(haystack.slice(start, idx));
+}
+
+// === 1. required directories + files exist =================================
+
+for (const [key, dir] of Object.entries(DIR_BY_KEY)) {
+  check(
+    dirExists(dir),
+    `dir: ${key}/ present`,
+    `dir: required directory ${key}/ is missing`,
+  );
+}
+
+for (const [key, files] of Object.entries(REQUIRED)) {
+  const dir = DIR_BY_KEY[key];
+  for (const fname of files) {
+    const path = join(dir, fname);
+    let present = false;
+    try {
+      present = statSync(path).isFile();
+    } catch {
+      present = false;
+    }
+    check(
+      present,
+      `file: ${key}/${fname} present`,
+      `file: required fixture ${key}/${fname} is missing`,
+    );
+  }
+}
+
+// === 2. every fixture JSON parses ==========================================
+
+const allJsonFiles = [
+  ...listJsonFiles(CANDIDATES_DIR),
+  ...listJsonFiles(TRANSITIONS_DIR),
+  ...listJsonFiles(ADMITTED_DIR),
+  ...listJsonFiles(RECALL_PROOFS_DIR),
+];
+
+const rawByPath = new Map();
+for (const f of allJsonFiles) {
+  const loaded = loadJson(f);
+  if (loaded) {
+    rawByPath.set(f, loaded.raw);
+    ok(`parsed ${rel(f)}`);
+  }
+  checksChecked += 1;
+}
+
+// Load the known fixtures by exact path so relationships can be asserted.
+const cand001 = loadJson(join(CANDIDATES_DIR, "cand-001-accepted-pending.json"))?.parsed;
+const cand002 = loadJson(join(CANDIDATES_DIR, "cand-002-rejected-pending.json"))?.parsed;
+const cand010 = loadJson(join(CANDIDATES_DIR, "cand-010-original-pending.json"))?.parsed;
+const cand011 = loadJson(join(CANDIDATES_DIR, "cand-011-correction-pending.json"))?.parsed;
+
+const trans001 = loadJson(join(TRANSITIONS_DIR, "trans-001-accept.json"))?.parsed;
+const trans002 = loadJson(join(TRANSITIONS_DIR, "trans-002-reject.json"))?.parsed;
+const trans010 = loadJson(join(TRANSITIONS_DIR, "trans-010-accept-original.json"))?.parsed;
+const trans011 = loadJson(join(TRANSITIONS_DIR, "trans-011-supersede.json"))?.parsed;
+
+const assn001 = loadJson(join(ADMITTED_DIR, "assn-001-active.json"))?.parsed;
+const assn010 = loadJson(join(ADMITTED_DIR, "assn-010-superseded.json"))?.parsed;
+const assn011 = loadJson(join(ADMITTED_DIR, "assn-011-active-correction.json"))?.parsed;
+
+const proof001 = loadJson(join(RECALL_PROOFS_DIR, "proof-001-before-admission-excluded.json"))?.parsed;
+const proof002 = loadJson(join(RECALL_PROOFS_DIR, "proof-002-after-admission-included.json"))?.parsed;
+const proof003 = loadJson(join(RECALL_PROOFS_DIR, "proof-003-rejected-excluded.json"))?.parsed;
+const proof004 = loadJson(join(RECALL_PROOFS_DIR, "proof-004-supersession-corrected.json"))?.parsed;
+
+// === 3. required fields per fixture kind ===================================
+
+const CANDIDATE_FIELDS = [
+  "fixture_kind",
+  "fixture_version",
+  "candidate_id",
+  "actor_id",
+  "estate_id",
+  "source_kind",
+  "source_ref",
+  "proposed_assertion_class",
+  "candidate_payload",
+  "admission_state",
+  "visibility_class",
+  "created_at",
+  "provenance",
+];
+const TRANSITION_FIELDS = [
+  "transition_kind",
+  "transition_version",
+  "transition_id",
+  "candidate_id",
+  "actor_id",
+  "estate_id",
+  "admission_authority",
+  "admission_decision",
+  "admitted_assertion_id", // present (may be null on reject)
+  "reason_code",
+  "decided_at",
+];
+const ADMITTED_FIELDS = [
+  "assertion_id",
+  "actor_id",
+  "estate_id",
+  "assertion_class",
+  "assertion_status",
+  "admission_state",
+  "source_candidate_id",
+  "admission_transition_id",
+  "recall_eligibility",
+  "visibility_class",
+  "provenance",
+  "created_at",
+  "admitted_at",
+];
+const PROOF_FIELDS = [
+  "fixture_kind",
+  "proof_id",
+  "proof_phase",
+  "actor_id",
+  "estate_id",
+  "recall_route",
+  "recall_result",
+];
+
+for (const [label, c] of [
+  ["cand-001", cand001],
+  ["cand-002", cand002],
+  ["cand-010", cand010],
+  ["cand-011", cand011],
+]) {
+  if (c) fieldsPresent(c, CANDIDATE_FIELDS, label);
+}
+for (const [label, t] of [
+  ["trans-001", trans001],
+  ["trans-002", trans002],
+  ["trans-010", trans010],
+  ["trans-011", trans011],
+]) {
+  if (t) {
+    fieldsPresent(t, TRANSITION_FIELDS, label);
+    // receipt_ref OR audit_ref must be present.
+    const hasReceipt =
+      Object.prototype.hasOwnProperty.call(t, "receipt_ref") ||
+      Object.prototype.hasOwnProperty.call(t, "audit_ref");
+    check(
+      hasReceipt,
+      `${label}: receipt_ref/audit_ref present`,
+      `${label}: must carry receipt_ref or audit_ref`,
+    );
+  }
+}
+for (const [label, a] of [
+  ["assn-001", assn001],
+  ["assn-010", assn010],
+  ["assn-011", assn011],
+]) {
+  if (a) fieldsPresent(a, ADMITTED_FIELDS, label);
+}
+for (const [label, p] of [
+  ["proof-001", proof001],
+  ["proof-002", proof002],
+  ["proof-003", proof003],
+  ["proof-004", proof004],
+]) {
+  if (p) fieldsPresent(p, PROOF_FIELDS, label);
+}
+
+// Shared invariants: synthetic === true, consistent actor id.
+for (const [label, o] of [
+  ["cand-001", cand001],
+  ["cand-002", cand002],
+  ["cand-010", cand010],
+  ["cand-011", cand011],
+  ["trans-001", trans001],
+  ["trans-002", trans002],
+  ["trans-010", trans010],
+  ["trans-011", trans011],
+  ["assn-001", assn001],
+  ["assn-010", assn010],
+  ["assn-011", assn011],
+  ["proof-001", proof001],
+  ["proof-002", proof002],
+  ["proof-003", proof003],
+  ["proof-004", proof004],
+]) {
+  if (!o) continue;
+  check(
+    o.synthetic === true,
+    `${label}: synthetic === true`,
+    `${label}: synthetic must be true (fixtures are synthetic/operator-only)`,
+  );
+  check(
+    o.actor_id === EXPECTED_ACTOR_ID,
+    `${label}: actor_id === ${EXPECTED_ACTOR_ID}`,
+    `${label}: actor_id must be ${EXPECTED_ACTOR_ID}, got ${o.actor_id}`,
+  );
+}
+
+// === 4. candidate-pending fixture is not recallable ========================
+
+if (cand001) {
+  check(
+    cand001.admission_state === "candidate_pending",
+    "candidate cand-001: admission_state === candidate_pending",
+    `candidate cand-001: admission_state must be candidate_pending, got ${cand001.admission_state}`,
+  );
+  check(
+    cand001.recall_eligibility === "ineligible",
+    "candidate cand-001: recall_eligibility === ineligible (not recallable)",
+    `candidate cand-001: recall_eligibility must be ineligible, got ${cand001.recall_eligibility}`,
+  );
+}
+// All candidate fixtures must be pending + ineligible.
+for (const [label, c] of [
+  ["cand-001", cand001],
+  ["cand-002", cand002],
+  ["cand-010", cand010],
+  ["cand-011", cand011],
+]) {
+  if (!c) continue;
+  check(
+    c.admission_state === "candidate_pending",
+    `candidate ${label}: admission_state === candidate_pending`,
+    `candidate ${label}: admission_state must be candidate_pending, got ${c.admission_state}`,
+  );
+  check(
+    c.recall_eligibility === "ineligible",
+    `candidate ${label}: recall_eligibility === ineligible`,
+    `candidate ${label}: recall_eligibility must be ineligible, got ${c.recall_eligibility}`,
+  );
+}
+
+// === 5. accepted transition references the candidate =======================
+
+if (trans001) {
+  check(
+    trans001.admission_decision === "accepted",
+    "transition trans-001: admission_decision === accepted",
+    `transition trans-001: admission_decision must be accepted, got ${trans001.admission_decision}`,
+  );
+  check(
+    trans001.candidate_id === "cand-001",
+    "transition trans-001: candidate_id references cand-001",
+    `transition trans-001: candidate_id must be cand-001, got ${trans001.candidate_id}`,
+  );
+  check(
+    typeof trans001.admitted_assertion_id === "string" &&
+      trans001.admitted_assertion_id === "assn-001",
+    "transition trans-001: mints admitted_assertion_id assn-001",
+    `transition trans-001: admitted_assertion_id must be assn-001, got ${trans001.admitted_assertion_id}`,
+  );
+}
+
+// === 6. admitted packet references the accepted transition and candidate ===
+
+if (assn001) {
+  check(
+    assn001.assertion_id === "assn-001",
+    "admitted assn-001: assertion_id === assn-001",
+    `admitted assn-001: assertion_id must be assn-001, got ${assn001.assertion_id}`,
+  );
+  check(
+    assn001.admission_transition_id === "trans-001",
+    "admitted assn-001: admission_transition_id references trans-001",
+    `admitted assn-001: admission_transition_id must be trans-001, got ${assn001.admission_transition_id}`,
+  );
+  check(
+    assn001.source_candidate_id === "cand-001",
+    "admitted assn-001: source_candidate_id references cand-001",
+    `admitted assn-001: source_candidate_id must be cand-001, got ${assn001.source_candidate_id}`,
+  );
+  check(
+    assn001.admission_state === "admitted" &&
+      assn001.assertion_status === "active" &&
+      assn001.recall_eligibility === "eligible",
+    "admitted assn-001: admitted + active + recall-eligible",
+    `admitted assn-001: must be admitted/active/eligible, got state=${assn001.admission_state} status=${assn001.assertion_status} elig=${assn001.recall_eligibility}`,
+  );
+}
+
+// === 7. before-admission recall proof excludes the candidate ===============
+
+if (proof001) {
+  check(
+    proof001.recall_result === "excluded",
+    "proof-001 (before admission): recall_result === excluded",
+    `proof-001: recall_result must be excluded, got ${proof001.recall_result}`,
+  );
+  check(
+    proof001.exclusion_reason === "candidate_not_admitted",
+    "proof-001: exclusion_reason === candidate_not_admitted",
+    `proof-001: exclusion_reason must be candidate_not_admitted, got ${proof001.exclusion_reason}`,
+  );
+  check(
+    proof001.considered_admission_state === "candidate_pending",
+    "proof-001: considered_admission_state === candidate_pending",
+    `proof-001: considered_admission_state must be candidate_pending, got ${proof001.considered_admission_state}`,
+  );
+  const included = Array.isArray(proof001.included_assertion_ids)
+    ? proof001.included_assertion_ids
+    : null;
+  check(
+    included !== null && included.length === 0,
+    "proof-001: included_assertion_ids is empty",
+    `proof-001: included_assertion_ids must be empty, got ${JSON.stringify(proof001.included_assertion_ids)}`,
+  );
+  check(
+    included !== null && !included.includes(cand001?.candidate_id ?? "cand-001"),
+    "proof-001: candidate not present in included_assertion_ids",
+    "proof-001: candidate must not appear in included_assertion_ids",
+  );
+  check(
+    proof001.recall_classification !== "served",
+    "proof-001: classification is not 'served' (safe not-found family)",
+    "proof-001: classification must not be 'served' before admission",
+  );
+  check(
+    proof001.public_recall_output?.rendered_candidate_payload === false,
+    "proof-001: no candidate payload rendered in recall output",
+    "proof-001: public_recall_output.rendered_candidate_payload must be false",
+  );
+}
+
+// === 8. after-admission recall proof includes ONLY the admitted assertion ==
+
+if (proof002) {
+  check(
+    proof002.recall_result === "included",
+    "proof-002 (after admission): recall_result === included",
+    `proof-002: recall_result must be included, got ${proof002.recall_result}`,
+  );
+  check(
+    proof002.inclusion_reason === "admitted_active_assertion",
+    "proof-002: inclusion_reason === admitted_active_assertion",
+    `proof-002: inclusion_reason must be admitted_active_assertion, got ${proof002.inclusion_reason}`,
+  );
+  check(
+    proof002.recall_classification === "served",
+    "proof-002: classification === served (reuses accepted recall path)",
+    `proof-002: classification must be served, got ${proof002.recall_classification}`,
+  );
+  const included = Array.isArray(proof002.included_assertion_ids)
+    ? proof002.included_assertion_ids
+    : [];
+  check(
+    included.length === 1 && included[0] === "assn-001",
+    "proof-002: included_assertion_ids === [assn-001] (only the admitted assertion)",
+    `proof-002: included_assertion_ids must be exactly [assn-001], got ${JSON.stringify(proof002.included_assertion_ids)}`,
+  );
+  check(
+    !included.includes("cand-001"),
+    "proof-002: raw candidate NOT in included_assertion_ids",
+    "proof-002: raw candidate must not be treated as ordinary recall material",
+  );
+  check(
+    proof002.audit_links?.source_candidate_id === "cand-001",
+    "proof-002: source candidate linked under audit_links only",
+    "proof-002: audit_links.source_candidate_id must reference cand-001",
+  );
+  check(
+    proof002.audit_links?.admission_transition_id === "trans-001" &&
+      proof002.audit_links?.admission_receipt_ref === "rcpt-001",
+    "proof-002: admission transition + receipt reference preserved",
+    "proof-002: audit_links must preserve admission_transition_id trans-001 and admission_receipt_ref rcpt-001",
+  );
+  check(
+    proof002.public_recall_output?.rendered_candidate_payload === false,
+    "proof-002: no candidate payload rendered in recall output",
+    "proof-002: public_recall_output.rendered_candidate_payload must be false",
+  );
+}
+
+// === 9. rejected candidate: no admitted assertion, excluded from recall ====
+
+if (trans002) {
+  check(
+    trans002.admission_decision === "rejected",
+    "transition trans-002: admission_decision === rejected",
+    `transition trans-002: admission_decision must be rejected, got ${trans002.admission_decision}`,
+  );
+  check(
+    trans002.candidate_id === "cand-002",
+    "transition trans-002: candidate_id references cand-002",
+    `transition trans-002: candidate_id must be cand-002, got ${trans002.candidate_id}`,
+  );
+  check(
+    trans002.admitted_assertion_id === null,
+    "transition trans-002: no admitted_assertion_id minted (null)",
+    `transition trans-002: admitted_assertion_id must be null on reject, got ${JSON.stringify(trans002.admitted_assertion_id)}`,
+  );
+}
+if (proof003) {
+  check(
+    proof003.recall_result === "excluded",
+    "proof-003 (rejected): recall_result === excluded",
+    `proof-003: recall_result must be excluded, got ${proof003.recall_result}`,
+  );
+  check(
+    proof003.exclusion_reason === "candidate_rejected",
+    "proof-003: exclusion_reason === candidate_rejected",
+    `proof-003: exclusion_reason must be candidate_rejected, got ${proof003.exclusion_reason}`,
+  );
+  check(
+    proof003.admitted_assertion_id === null,
+    "proof-003: no admitted_assertion_id (null)",
+    `proof-003: admitted_assertion_id must be null, got ${JSON.stringify(proof003.admitted_assertion_id)}`,
+  );
+  const included = Array.isArray(proof003.included_assertion_ids)
+    ? proof003.included_assertion_ids
+    : [];
+  check(
+    included.length === 0,
+    "proof-003: included_assertion_ids is empty",
+    `proof-003: included_assertion_ids must be empty, got ${JSON.stringify(proof003.included_assertion_ids)}`,
+  );
+  check(
+    proof003.recall_classification !== "served",
+    "proof-003: classification is not 'served' (rejection is terminal)",
+    "proof-003: rejected candidate must never classify as served",
+  );
+  // No admitted assertion fixture may ever cite cand-002 as its source.
+  const rejectedAdmitted = [assn001, assn010, assn011].some(
+    (a) => a && a.source_candidate_id === "cand-002",
+  );
+  check(
+    !rejectedAdmitted,
+    "proof-003: no admitted packet derives from rejected cand-002",
+    "proof-003: a rejected candidate must not back any admitted assertion",
+  );
+}
+
+// === 10. supersession: corrected active included, wrong prior excluded =====
+
+if (trans011) {
+  check(
+    trans011.admission_decision === "accepted" &&
+      trans011.supersedes_assertion_id === "assn-010",
+    "transition trans-011: accepted supersede of assn-010",
+    `transition trans-011: must be accepted with supersedes_assertion_id assn-010, got decision=${trans011.admission_decision} supersedes=${trans011.supersedes_assertion_id}`,
+  );
+}
+if (assn010) {
+  check(
+    assn010.admission_state === "superseded" &&
+      assn010.assertion_status === "superseded",
+    "admitted assn-010: marked superseded",
+    `admitted assn-010: must be superseded, got state=${assn010.admission_state} status=${assn010.assertion_status}`,
+  );
+  check(
+    assn010.recall_eligibility === "ineligible",
+    "admitted assn-010: recall_eligibility === ineligible (wrong prior state)",
+    `admitted assn-010: superseded record must be recall-ineligible, got ${assn010.recall_eligibility}`,
+  );
+  check(
+    assn010.superseded_by_assertion_id === "assn-011",
+    "admitted assn-010: superseded_by references assn-011 (audit link preserved)",
+    `admitted assn-010: superseded_by_assertion_id must be assn-011, got ${assn010.superseded_by_assertion_id}`,
+  );
+}
+if (assn011) {
+  check(
+    assn011.admission_state === "admitted" &&
+      assn011.assertion_status === "active" &&
+      assn011.recall_eligibility === "eligible",
+    "admitted assn-011: corrected state is admitted/active/eligible",
+    `admitted assn-011: corrected state must be admitted/active/eligible, got state=${assn011.admission_state} status=${assn011.assertion_status} elig=${assn011.recall_eligibility}`,
+  );
+  check(
+    assn011.supersedes_assertion_id === "assn-010",
+    "admitted assn-011: supersedes assn-010 (audit link preserved)",
+    `admitted assn-011: supersedes_assertion_id must be assn-010, got ${assn011.supersedes_assertion_id}`,
+  );
+}
+if (proof004) {
+  const included = Array.isArray(proof004.included_assertion_ids)
+    ? proof004.included_assertion_ids
+    : [];
+  const excluded = Array.isArray(proof004.excluded_assertion_ids)
+    ? proof004.excluded_assertion_ids
+    : [];
+  check(
+    included.length === 1 && included[0] === "assn-011",
+    "proof-004 (supersession): includes only corrected active assn-011",
+    `proof-004: included_assertion_ids must be exactly [assn-011], got ${JSON.stringify(proof004.included_assertion_ids)}`,
+  );
+  check(
+    !included.includes("assn-010"),
+    "proof-004: wrong prior state assn-010 NOT included",
+    "proof-004: superseded assn-010 must not appear in ordinary recall",
+  );
+  check(
+    excluded.includes("assn-010"),
+    "proof-004: superseded assn-010 explicitly excluded",
+    "proof-004: excluded_assertion_ids must contain superseded assn-010",
+  );
+  check(
+    proof004.recall_classification === "served" &&
+      proof004.inclusion_reason === "admitted_active_assertion",
+    "proof-004: corrected state served as admitted active assertion",
+    `proof-004: must be served/admitted_active_assertion, got classification=${proof004.recall_classification} reason=${proof004.inclusion_reason}`,
+  );
+  check(
+    proof004.audit_links?.supersedes_assertion_id === "assn-010",
+    "proof-004: supersedes link preserved for audit reconstruction",
+    "proof-004: audit_links.supersedes_assertion_id must be assn-010",
+  );
+  check(
+    proof004.public_recall_output?.rendered_prior_state === false,
+    "proof-004: wrong prior state NOT rendered in recall output",
+    "proof-004: public_recall_output.rendered_prior_state must be false",
+  );
+}
+
+// === 11. no banned raw material in any fixture =============================
+
+for (const [path, raw] of rawByPath) {
+  for (const [label, re] of BANNED_MATERIAL) {
+    checksChecked += 1;
+    if (re.test(raw)) {
+      fail(`banned material: ${rel(path)} matches ${label}`);
+    }
+  }
+  ok(`${rel(path)}: no banned raw material`);
+}
+
+// === 12. no forbidden production / ingestion / remember-this claims ========
+
+for (const [path, raw] of rawByPath) {
+  const hay = raw.toLowerCase();
+  let clean = true;
+  for (const phrase of FORBIDDEN_CLAIM_PHRASES) {
+    let from = 0;
+    while (true) {
+      const idx = hay.indexOf(phrase, from);
+      if (idx === -1) break;
+      checksChecked += 1;
+      if (!hasNegationBefore(hay, idx)) {
+        fail(
+          `forbidden claim: ${rel(path)} asserts "${phrase}" without a negation (only negated disclaimers are allowed)`,
+        );
+        clean = false;
+      }
+      from = idx + phrase.length;
+    }
+  }
+  if (clean) ok(`${rel(path)}: no forbidden production/ingestion claims`);
+}
+
+// === no-leak gate: recall proofs never carry private bodies ================
+
+for (const f of listJsonFiles(RECALL_PROOFS_DIR)) {
+  const raw = rawByPath.get(f);
+  if (raw == null) continue;
+  for (const sentinel of PRIVATE_BODY_SENTINELS) {
+    checksChecked += 1;
+    if (raw.includes(sentinel)) {
+      fail(
+        `no-leak: recall proof ${rel(f)} leaks private body sentinel "${sentinel}"`,
+      );
+    }
+  }
+  ok(`${rel(f)}: no private body sentinels (ordinary recall is no-leak)`);
+}
+
+// === report ================================================================
+
+const fixtureLines = allJsonFiles
+  .map((f) => `  ${rel(f)}`)
+  .sort();
+
+console.log("admission-wedge phase 43c fixture/operator-contract validator");
+console.log("-------------------------------------------------------------");
+console.log("fixtures checked:");
+for (const line of fixtureLines) console.log(line);
+console.log("");
+console.log(`assertions evaluated: ${checksChecked}`);
+console.log(`checks passed: ${successes.length}`);
+console.log(`checks failed: ${failures.length}`);
+
+if (failures.length > 0) {
+  console.log("");
+  console.log("failures:");
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log("");
+console.log(
+  "ok — admission wedge invariant holds: candidate is not admitted memory, " +
+    "is not recallable before admission, becomes recallable only after an " +
+    "explicit accept, rejected never recalls, and supersession does not leak " +
+    "the wrong prior state into ordinary recall. fixture/operator-only.",
+);
+process.exit(0);


### PR DESCRIPTION
## Summary

Phase 43C adds the Admission Wedge fixture/operator-contract proof.

This is a medium-sized fixture + validator slice after Phase 43B / PR #152. It makes the Admission Wedge invariant executable locally without adding a live admission implementation.

Core invariant preserved:

- candidate memory is not admitted memory
- candidate memory is not recallable as governed continuity before admission
- candidate memory becomes recall-eligible only after an explicit admission transition accepts it
- rejected candidates never become recallable
- superseded/corrected prior state does not leak into ordinary recall as active memory

## Files

New fixture/operator-contract tree:

- docs/admission-wedge/fixtures/README.md
- docs/admission-wedge/fixtures/validate-fixtures.mjs
- docs/admission-wedge/fixtures/candidates/*.json
- docs/admission-wedge/fixtures/transitions/*.json
- docs/admission-wedge/fixtures/admitted/*.json
- docs/admission-wedge/fixtures/recall-proofs/*.json

Modified docs with narrow status/cross-reference notes:

- docs/ADMISSION-WEDGE-MVP-DESIGN.md
- docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md

## What this proves

The fixture graph proves:

- pending candidate is structurally present but recall-ineligible
- before-admission recall excludes the candidate
- accepted transition references the candidate and mints the expected admitted assertion
- admitted assertion references the accepted transition and source candidate
- after-admission recall includes the admitted assertion without treating raw candidate payload as ordinary recall material
- rejected candidate mints no admitted assertion and remains excluded
- correction/supersession includes only the corrected active assertion in ordinary recall while preserving audit/provenance links to the prior state

## Validation

Validated locally:

- git diff --check: clean
- node docs/recall-wedge/fixtures/validate-fixtures.mjs: 122 checks passed / 0 failed
- node docs/admission-wedge/fixtures/validate-fixtures.mjs: 318 checks passed / 0 failed
- Codex independent audit: VERDICT ACCEPT, no required patches

Codex specifically confirmed:

- scope is fixture/operator-contract only
- changed files are docs/fixture/validator only
- no runtime Discord behavior, command, route, storage, production auth/consent, public surface, LLM/voice, Finn production wiring, package, lockfile, config, CI, or generated file was added
- pending candidates are not recallable
- accepted transition/admitted packet links are correct
- before-admission recall excludes candidate material
- after-admission recall includes only the admitted assertion and keeps the source candidate under audit links
- rejected candidate has no admitted assertion and remains excluded
- supersession includes only the corrected active assertion in ordinary recall and excludes the superseded prior state
- validator uses dependency-free Node built-ins only
- docs are correctly scoped and naming is correct
- no raw IDs, secrets, tokens, URLs, screenshots, or binary evidence were found

## Non-goals

This PR does not authorize or add:

- runtime Discord behavior
- Discord command changes
- `/remember-this`
- public remember-this
- Discord history ingestion
- user chat becoming memory
- live Dixie admission route
- production admission
- production storage
- production auth/consent
- public rollout
- Telegram/private-chat surfaces
- Finn production wiring
- LLM rewriting
- character voice
- forget/revoke/correction UI
- package or lockfile changes
- CI/config/generated changes
