### PR TITLE
Phase 44A feat: add Admission Wedge fixture reducer

### DIFF
--- a/docs/ADMISSION-WEDGE-MVP-DESIGN.md
+++ b/docs/ADMISSION-WEDGE-MVP-DESIGN.md
@@ -779,6 +779,19 @@ commit to one, under its own gate.
   implementation, **no** runtime, **no** Discord command, **no** live
   admission route, **no** storage. The Lane A implementation remains a
   later, separately gated phase.
+- `packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.ts`
+  (+ `.test.ts`) — **Phase 44A** fixture-bound reducer / adapter (added
+  after the Phase 43C contract). It turns the Phase 43C fixture shapes into
+  a pure, dependency-free local reducer that proves the §D invariant *in
+  code* (candidate classification · admission transition · recall-proof
+  projection · whole-scenario reduction) with stable fail-closed reason
+  codes and a no-leak seal over every safe projection. It is
+  **fixture-bound only**: it admits nothing, stores nothing, reaches no
+  network, and is imported only by its own test — **not** wired into
+  Discord, Dixie, the public renderer, the live client, dispatch, startup,
+  command registration, or any package export. It is **not** the §N(a) Lane
+  A implementation and **does not** authorize a live admission
+  implementation; the blocked work in §M and the Lane A gate stay in force.
 - `docs/RECALL-WEDGE-POST-ACCEPTANCE-ADMISSION-WEDGE-DECISION-GATE.md` —
   Phase 43A decision gate (PR #151); the authority that selected the
   Admission Wedge and recommended this design (its §M). This design

--- a/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+++ b/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
@@ -1092,6 +1092,24 @@ implementation, only after 43B's design is accepted. A dev-only
 > admission route, no storage. The runtime Lane A implementation and the
 > §7 live-memory-admission gates remain in force and separately gated.
 
+> **Status note (Phase 44A fixture-bound reducer / adapter).** Phase 44A
+> adds a pure, dependency-free local reducer / adapter over the Phase 43C
+> fixtures at
+> `packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.ts`
+> (+ test), proving the §43A/§43B invariant *in code* against the
+> already-existing fixture graph (classify candidate · apply transition ·
+> project recall proof · reduce scenario, with stable fail-closed reason
+> codes and a no-leak seal on every safe projection). It is **fixture-bound
+> only**: it admits nothing, stores nothing, reaches no network, and is
+> imported only by its own test — **not** wired into Discord, Dixie, the
+> public renderer, the live client, dispatch, startup, command
+> registration, or any package export. It **does not** authorize a live
+> admission implementation, production admission, production storage,
+> production auth / consent, public remember-this, Discord history
+> ingestion, user chat becoming memory, a live Dixie admission route, or
+> any Finn production wiring. The runtime Lane A implementation and the §7
+> live-memory-admission gates remain in force and separately gated.
+
 ### 9.1 Historical context — superseded Phase 35B recommendation
 
 > **Superseded.** Kept for ladder continuity only. The recommendation

--- a/docs/admission-wedge/fixtures/README.md
+++ b/docs/admission-wedge/fixtures/README.md
@@ -15,6 +15,18 @@ production admission.
 > history. A future live implementation remains separately gated under
 > the decision-map §7 gates.
 
+> **Phase 44A status note (fixture-bound reducer / adapter).** Phase 44A
+> adds a pure, dependency-free local reducer / adapter over these fixtures
+> at
+> `packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.ts`
+> (+ test) that proves the invariant below *in code*. It is **fixture-bound
+> only** — it admits nothing, stores nothing, reaches no network, and is
+> imported only by its own test (not wired into Discord, Dixie, the public
+> renderer, the live client, dispatch, startup, command registration, or
+> any package export). It does **not** mutate these fixtures and does
+> **not** authorize a live admission implementation. The runtime Lane A
+> implementation and the decision-map §7 gates remain separately gated.
+
 ## What this proves
 
 The load-bearing invariant, carried verbatim from Phase 43B §D / Phase

--- a/packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.test.ts
+++ b/packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.test.ts
@@ -1,0 +1,1203 @@
+// Phase 44A · Admission Wedge fixture-bound reducer regression gate.
+//
+// Authority: docs/ADMISSION-WEDGE-MVP-DESIGN.md (Phase 43B design) and the
+// Phase 43C fixture/operator-contract under docs/admission-wedge/fixtures/.
+//
+// These tests drive the pure reducer in ./admission-wedge-fixture-reducer.ts
+// against the Phase 43C fixtures, loaded from disk with node:fs (the same
+// pattern dixie-envelope-adapter.test.ts uses to read
+// docs/recall-wedge/fixtures). They prove the §D invariant in code:
+//
+//   1. a pending candidate is not admitted and not recall-eligible;
+//   2. before-admission recall excludes the candidate and renders no payload;
+//   3. an accepted transition mints exactly the admitted assertion;
+//   4. the admitted assertion references its source candidate and transition;
+//   5. after-admission recall includes the admitted assertion only;
+//   6. a rejected candidate mints no assertion and stays excluded;
+//   7. supersession/correction includes the corrected active assertion only;
+//   8. the superseded prior is preserved as audit/provenance, not ordinary
+//      recall;
+//   9. a mismatched candidate/transition fails closed;
+//  10. an accepted transition without an admitted assertion fails closed;
+//  11. a rejected transition that mints an assertion fails closed;
+//  12. a candidate marked recall-eligible before admission fails closed;
+//  13. a private sentinel in ordinary recall projection fails closed;
+//  14. an unknown/malformed fixture kind/version fails closed;
+//  15. reducer output never contains a raw candidate/private payload in any
+//      safe projection field.
+//
+// Scope reminder (Phase 43B §M / 43C): this is a fixture-bound reducer. It
+// admits nothing, stores nothing, reaches no network, and is wired into no
+// Discord/Dixie/runtime path. It authorizes no live admission.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ADMISSION_PRIVATE_BODY_SENTINELS,
+  ADMISSION_REDUCER_REASON_CODES,
+  applyAdmissionTransition,
+  classifyAdmissionCandidate,
+  projectAdmissionRecallProof,
+  reduceAdmissionFixtureScenario,
+  safeDetail,
+  safeDetailForReason,
+  scanForUnsafeProjection,
+} from "./admission-wedge-fixture-reducer.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/admission-wedge/fixtures",
+);
+
+function loadFixture(relPath: string): unknown {
+  return JSON.parse(readFileSync(resolve(FIXTURE_DIR, relPath), "utf8"));
+}
+
+// -- the Phase 43C fixture graph, loaded from disk ------------------------
+
+const CAND_001 = loadFixture("candidates/cand-001-accepted-pending.json");
+const CAND_002 = loadFixture("candidates/cand-002-rejected-pending.json");
+const CAND_010 = loadFixture("candidates/cand-010-original-pending.json");
+const CAND_011 = loadFixture("candidates/cand-011-correction-pending.json");
+
+const TRANS_001 = loadFixture("transitions/trans-001-accept.json");
+const TRANS_002 = loadFixture("transitions/trans-002-reject.json");
+const TRANS_010 = loadFixture("transitions/trans-010-accept-original.json");
+const TRANS_011 = loadFixture("transitions/trans-011-supersede.json");
+
+const ASSN_001 = loadFixture("admitted/assn-001-active.json");
+const ASSN_010 = loadFixture("admitted/assn-010-superseded.json");
+const ASSN_011 = loadFixture("admitted/assn-011-active-correction.json");
+
+const PROOF_001 = loadFixture(
+  "recall-proofs/proof-001-before-admission-excluded.json",
+);
+const PROOF_002 = loadFixture(
+  "recall-proofs/proof-002-after-admission-included.json",
+);
+const PROOF_003 = loadFixture(
+  "recall-proofs/proof-003-rejected-excluded.json",
+);
+const PROOF_004 = loadFixture(
+  "recall-proofs/proof-004-supersession-corrected.json",
+);
+
+// Deep-clone helper so a mutated fixture in one test cannot bleed into
+// another. Fixtures are plain JSON, so structuredClone is safe.
+function clone<T>(o: T): T {
+  return structuredClone(o);
+}
+
+// Collect every string emitted in a reducer output object (recursively).
+function collectStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const v of value) collectStrings(v, out);
+  } else if (value && typeof value === "object") {
+    for (const v of Object.values(value)) collectStrings(v, out);
+  }
+  return out;
+}
+
+// =========================================================================
+// 0. fixture sanity — non-vacuous: the fixtures carry the sentinels and
+//    payloads we later assert never leak.
+// =========================================================================
+
+describe("Phase 44A · fixture sanity (non-vacuous)", () => {
+  test("candidate fixtures carry a private body + source sentinel", () => {
+    const raw = readFileSync(
+      resolve(FIXTURE_DIR, "candidates/cand-001-accepted-pending.json"),
+      "utf8",
+    );
+    expect(raw).toContain("CANDIDATE_PRIVATE_SENTINEL_001");
+    expect(raw).toContain("SOURCE_SENTINEL_001");
+  });
+
+  test("admitted fixtures carry a private body sentinel", () => {
+    const raw = readFileSync(
+      resolve(FIXTURE_DIR, "admitted/assn-001-active.json"),
+      "utf8",
+    );
+    expect(raw).toContain("ADMITTED_PRIVATE_SENTINEL_001");
+  });
+
+  test("scanForUnsafeProjection detects each private sentinel", () => {
+    for (const sentinel of ADMISSION_PRIVATE_BODY_SENTINELS) {
+      expect(scanForUnsafeProjection(sentinel)).toBe("private_body_sentinel");
+      expect(scanForUnsafeProjection({ a: { b: [sentinel] } })).toBe(
+        "private_body_sentinel",
+      );
+      // also as a key
+      const obj: Record<string, unknown> = {};
+      obj[sentinel] = "clean";
+      expect(scanForUnsafeProjection(obj)).toBe("private_body_sentinel");
+    }
+    expect(scanForUnsafeProjection({ ok: "fine" })).toBeNull();
+    expect(scanForUnsafeProjection(42)).toBeNull();
+    expect(scanForUnsafeProjection(null)).toBeNull();
+  });
+});
+
+// =========================================================================
+// 1. pending candidate is not admitted and not recall-eligible
+// =========================================================================
+
+describe("Phase 44A · 1. candidate classification", () => {
+  test("a pending candidate is classified candidate / not admitted / not recall-eligible", () => {
+    const r = classifyAdmissionCandidate(CAND_001);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.kind).toBe("candidate");
+    expect(r.candidateId).toBe("cand-001");
+    expect(r.admitted).toBe(false);
+    expect(r.recallEligible).toBe(false);
+    expect(r.ordinaryRecallMaterial).toBe(false);
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+    );
+  });
+
+  test("the correction candidate carries its proposed supersedes link", () => {
+    const r = classifyAdmissionCandidate(CAND_011);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.proposedSupersedesAssertionId).toBe("assn-010");
+  });
+
+  test("classification carries no candidate body / source material", () => {
+    const r = classifyAdmissionCandidate(CAND_001);
+    expect(r.ok).toBe(true);
+    const strings = collectStrings(r);
+    for (const s of strings) {
+      expect(s).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+      expect(s).not.toContain("SOURCE_SENTINEL");
+      expect(s).not.toContain("body_private");
+    }
+    expect(scanForUnsafeProjection(r)).toBeNull();
+  });
+});
+
+// =========================================================================
+// 2. before-admission recall excludes candidate; renders no payload
+// =========================================================================
+
+describe("Phase 44A · 2. before-admission recall", () => {
+  test("before-admission recall is excluded with candidate_not_admitted", () => {
+    const r = projectAdmissionRecallProof({
+      recallProof: PROOF_001,
+      candidateId: "cand-001",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.recallResult !== "excluded") return;
+    expect(r.recallResult).toBe("excluded");
+    expect(r.recallEligible).toBe(false);
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+    );
+    expect(r.includedAssertionIds).toEqual([]);
+    expect(r.renderedCandidatePayload).toBe(false);
+    expect(r.excludedCandidateIds).toContain("cand-001");
+  });
+
+  test("the before-admission scenario reducer holds the invariant", () => {
+    const proof = reduceAdmissionFixtureScenario({
+      kind: "before_admission",
+      candidate: CAND_001,
+      recallProof: PROOF_001,
+    });
+    expect(proof.ok).toBe(true);
+    if (!proof.ok) return;
+    expect(proof.scenario).toBe("before_admission");
+    expect(proof.recall.recallResult).toBe("excluded");
+    expect(proof.invariantsHeld).toContain(
+      "candidate_not_recallable_before_admission",
+    );
+  });
+});
+
+// =========================================================================
+// 3 + 4. accepted transition mints exactly the admitted assertion, which
+//        references its source candidate and transition.
+// =========================================================================
+
+describe("Phase 44A · 3+4. accepted transition", () => {
+  test("accept mints exactly the admitted assertion assn-001", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: ASSN_001,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.decision).toBe("accepted");
+    expect(r.admittedAssertion).not.toBeNull();
+    expect(r.admittedAssertion?.assertionId).toBe("assn-001");
+    expect(r.admittedAssertion?.admitted).toBe(true);
+    expect(r.admittedAssertion?.recallEligible).toBe(true);
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion,
+    );
+  });
+
+  test("the admitted assertion references source candidate + transition under audit", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: ASSN_001,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || !r.admittedAssertion) return;
+    expect(r.admittedAssertion.audit.sourceCandidateId).toBe("cand-001");
+    expect(r.admittedAssertion.audit.admissionTransitionId).toBe("trans-001");
+    expect(r.admittedAssertion.audit.admissionReceiptRef).toBe("rcpt-001");
+  });
+
+  test("admitted assertion projection leaks no private body", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: ASSN_001,
+    });
+    expect(r.ok).toBe(true);
+    expect(scanForUnsafeProjection(r)).toBeNull();
+    for (const s of collectStrings(r)) {
+      expect(s).not.toContain("ADMITTED_PRIVATE_SENTINEL");
+      expect(s).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+    }
+  });
+});
+
+// =========================================================================
+// 5. after-admission recall includes the admitted assertion only
+// =========================================================================
+
+describe("Phase 44A · 5. after-admission recall", () => {
+  test("after-admission recall includes only assn-001, served", () => {
+    const r = projectAdmissionRecallProof({
+      recallProof: PROOF_002,
+      candidateId: "cand-001",
+      admittedAssertionId: "assn-001",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.recallResult).toBe("included");
+    expect(r.recallEligible).toBe(true);
+    expect(r.includedAssertionIds).toEqual(["assn-001"]);
+    expect(r.includedAssertionIds).not.toContain("cand-001");
+    expect(r.renderedCandidatePayload).toBe(false);
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion,
+    );
+  });
+
+  test("the source candidate is preserved under audit only, not as recall material", () => {
+    const r = projectAdmissionRecallProof({
+      recallProof: PROOF_002,
+      admittedAssertionId: "assn-001",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.recallResult !== "included") return;
+    expect(r.audit.sourceCandidateId).toBe("cand-001");
+    expect(r.audit.admissionReceiptRef).toBe("rcpt-001");
+    // candidate appears under audit, never in the recall material.
+    expect(r.includedAssertionIds).not.toContain("cand-001");
+  });
+
+  test("the full accepted scenario reducer holds the invariant", () => {
+    const proof = reduceAdmissionFixtureScenario({
+      kind: "accepted",
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: ASSN_001,
+      recallProof: PROOF_002,
+    });
+    expect(proof.ok).toBe(true);
+    if (!proof.ok) return;
+    expect(proof.scenario).toBe("accepted");
+    expect(proof.transition?.admittedAssertion?.assertionId).toBe("assn-001");
+    expect(proof.recall.recallResult).toBe("included");
+    expect(proof.invariantsHeld).toContain(
+      "admitted_assertion_references_candidate_and_transition",
+    );
+  });
+});
+
+// =========================================================================
+// 6. rejected candidate mints no assertion and stays excluded
+// =========================================================================
+
+describe("Phase 44A · 6. rejection path", () => {
+  test("reject mints no admitted assertion", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_002,
+      transition: TRANS_002,
+      admittedAssertion: null,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.decision).toBe("rejected");
+    expect(r.admittedAssertion).toBeNull();
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_rejected,
+    );
+  });
+
+  test("rejected recall stays excluded with candidate_rejected", () => {
+    const r = projectAdmissionRecallProof({
+      recallProof: PROOF_003,
+      candidateId: "cand-002",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.recallResult).toBe("excluded");
+    expect(r.includedAssertionIds).toEqual([]);
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_rejected,
+    );
+  });
+
+  test("the full rejected scenario reducer holds the invariant", () => {
+    const proof = reduceAdmissionFixtureScenario({
+      kind: "rejected",
+      candidate: CAND_002,
+      transition: TRANS_002,
+      recallProof: PROOF_003,
+    });
+    expect(proof.ok).toBe(true);
+    if (!proof.ok) return;
+    expect(proof.scenario).toBe("rejected");
+    expect(proof.transition?.admittedAssertion).toBeNull();
+    expect(proof.invariantsHeld).toContain("rejected_never_recallable");
+  });
+});
+
+// =========================================================================
+// 7 + 8. supersession includes corrected active only; superseded prior is
+//        audit/provenance, not ordinary recall.
+// =========================================================================
+
+describe("Phase 44A · 7+8. supersession / correction", () => {
+  test("supersede transition mints the corrected active assertion assn-011", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_011,
+      transition: TRANS_011,
+      admittedAssertion: ASSN_011,
+      supersededAssertion: ASSN_010,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.decision !== "accepted") return;
+    expect(r.decision).toBe("accepted");
+    expect(r.admittedAssertion?.assertionId).toBe("assn-011");
+    expect(r.supersededAssertionId).toBe("assn-010");
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion,
+    );
+    expect(r.admittedAssertion?.audit.supersedesAssertionId).toBe("assn-010");
+  });
+
+  test("supersession recall includes only corrected active assn-011, excludes prior assn-010", () => {
+    const r = projectAdmissionRecallProof({
+      recallProof: PROOF_004,
+      candidateId: "cand-011",
+      admittedAssertionId: "assn-011",
+      supersededAssertionId: "assn-010",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok || r.recallResult !== "included") return;
+    expect(r.includedAssertionIds).toEqual(["assn-011"]);
+    expect(r.includedAssertionIds).not.toContain("assn-010");
+    expect(r.excludedAssertionIds).toContain("assn-010");
+    expect(r.renderedPriorState).toBe(false);
+    expect(r.supersededReasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.superseded_not_ordinary_recallable,
+    );
+    // the supersedes link is preserved for audit reconstruction.
+    expect(r.audit.supersedesAssertionId).toBe("assn-010");
+  });
+
+  test("the full supersession scenario reducer holds the invariant", () => {
+    const proof = reduceAdmissionFixtureScenario({
+      kind: "supersession",
+      correctionCandidate: CAND_011,
+      supersedeTransition: TRANS_011,
+      correctedAssertion: ASSN_011,
+      supersededAssertion: ASSN_010,
+      recallProof: PROOF_004,
+    });
+    expect(proof.ok).toBe(true);
+    if (!proof.ok) return;
+    expect(proof.scenario).toBe("supersession");
+    expect(proof.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion,
+    );
+    expect(proof.invariantsHeld).toContain(
+      "superseded_prior_excluded_from_ordinary_recall",
+    );
+    expect(proof.invariantsHeld).toContain(
+      "supersedes_link_preserved_for_audit",
+    );
+  });
+
+  test("the superseded prior, on its own, never surfaces as active recall material", () => {
+    // assn-010 is superseded/ineligible; if a recall proof tried to serve it
+    // as active, the reducer must fail closed. Synthesize that violation.
+    const leakyProof = {
+      ...(clone(PROOF_004) as Record<string, unknown>),
+      included_assertion_ids: ["assn-010"],
+    };
+    const r = projectAdmissionRecallProof({
+      recallProof: leakyProof,
+      admittedAssertionId: "assn-011",
+      supersededAssertionId: "assn-010",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+    );
+  });
+});
+
+// =========================================================================
+// 9. mismatched candidate / transition fails closed
+// =========================================================================
+
+describe("Phase 44A · 9. mismatched candidate/transition fails closed", () => {
+  test("a transition pointing at a different candidate is refused", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_001, // cand-001
+      transition: TRANS_010, // references cand-010
+      admittedAssertion: ASSN_010,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_transition,
+    );
+  });
+
+  test("a transition minting a different assertion id than the supplied admitted packet is refused", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001, // mints assn-001
+      admittedAssertion: ASSN_010, // is assn-010
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+    );
+  });
+
+  test("an admitted assertion whose source_candidate_id mismatches the candidate is refused", () => {
+    // craft a transition that mints assn-001 but for the wrong candidate's
+    // assertion provenance: feed cand-001 + trans-001 but an assertion whose
+    // source_candidate_id was tampered.
+    const tampered = clone(ASSN_001) as Record<string, unknown>;
+    tampered.source_candidate_id = "cand-999";
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: tampered,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_assertion,
+    );
+  });
+});
+
+// =========================================================================
+// 10. accepted transition without an admitted assertion fails closed
+// =========================================================================
+
+describe("Phase 44A · 10. accept without admitted assertion fails closed", () => {
+  test("an accept transition with no admitted assertion supplied is refused", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      // admittedAssertion omitted
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.accepted_transition_missing_assertion,
+    );
+  });
+
+  test("an accept transition whose admitted_assertion_id is null is refused", () => {
+    const tampered = clone(TRANS_001) as Record<string, unknown>;
+    tampered.admitted_assertion_id = null;
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: tampered,
+      admittedAssertion: ASSN_001,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.accepted_transition_missing_assertion,
+    );
+  });
+});
+
+// =========================================================================
+// 11. rejected transition that mints an assertion fails closed
+// =========================================================================
+
+describe("Phase 44A · 11. reject that mints an assertion fails closed", () => {
+  test("a reject transition with a non-null admitted_assertion_id is refused", () => {
+    const tampered = clone(TRANS_002) as Record<string, unknown>;
+    tampered.admitted_assertion_id = "assn-002";
+    const r = applyAdmissionTransition({
+      candidate: CAND_002,
+      transition: tampered,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.rejected_transition_minted_assertion,
+    );
+  });
+
+  test("a reject transition with an admitted assertion supplied is refused", () => {
+    const r = applyAdmissionTransition({
+      candidate: CAND_002,
+      transition: TRANS_002,
+      admittedAssertion: ASSN_001,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.rejected_transition_minted_assertion,
+    );
+  });
+});
+
+// =========================================================================
+// 12. candidate marked recall-eligible before admission fails closed
+// =========================================================================
+
+describe("Phase 44A · 12. candidate recall-eligible before admission fails closed", () => {
+  test("a candidate claiming recall_eligibility=eligible is refused", () => {
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.recall_eligibility = "eligible";
+    const r = classifyAdmissionCandidate(tampered);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_recall_eligible_before_admission,
+    );
+  });
+
+  test("a candidate whose admission_state is already admitted is refused", () => {
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.admission_state = "admitted";
+    const r = classifyAdmissionCandidate(tampered);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    // recall_eligibility is still ineligible, so this trips the state check.
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+    );
+  });
+});
+
+// =========================================================================
+// 13. private sentinel in ordinary recall projection fails closed
+// =========================================================================
+
+describe("Phase 44A · 13. private sentinel in ordinary recall fails closed", () => {
+  test("a recall proof leaking a private sentinel in public_recall_output is refused", () => {
+    const leaky = clone(PROOF_002) as Record<string, unknown>;
+    (leaky.public_recall_output as Record<string, unknown>).public_summary =
+      "leaked ADMITTED_PRIVATE_SENTINEL_001 body";
+    const r = projectAdmissionRecallProof({
+      recallProof: leaky,
+      admittedAssertionId: "assn-001",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_private_sentinel_projection,
+    );
+  });
+
+  test("a recall proof that renders the candidate payload is refused", () => {
+    const leaky = clone(PROOF_001) as Record<string, unknown>;
+    (leaky.public_recall_output as Record<string, unknown>).rendered_candidate_payload =
+      true;
+    const r = projectAdmissionRecallProof({
+      recallProof: leaky,
+      candidateId: "cand-001",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_candidate_payload_projection,
+    );
+  });
+
+  test("a recall proof treating the candidate as ordinary recall material is refused", () => {
+    const leaky = clone(PROOF_002) as Record<string, unknown>;
+    leaky.included_assertion_ids = ["cand-001"];
+    const r = projectAdmissionRecallProof({
+      recallProof: leaky,
+      candidateId: "cand-001",
+      admittedAssertionId: "assn-001",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_included_in_ordinary_recall,
+    );
+  });
+});
+
+// =========================================================================
+// 14. unknown / malformed fixture kind/version fails closed
+// =========================================================================
+
+describe("Phase 44A · 14. unknown/malformed fixture fails closed", () => {
+  test("non-object input is refused", () => {
+    for (const bad of [null, undefined, 42, "string", []]) {
+      const r = classifyAdmissionCandidate(bad);
+      expect(r.ok).toBe(false);
+      if (r.ok) continue;
+      expect(r.reasonCode).toBe(
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      );
+    }
+  });
+
+  test("a candidate with the wrong fixture_kind is refused", () => {
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.fixture_kind = "admitted_memory_packet";
+    const r = classifyAdmissionCandidate(tampered);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+    );
+  });
+
+  test("an unknown fixture_version is refused", () => {
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.fixture_version = "phase-99z.0";
+    const r = classifyAdmissionCandidate(tampered);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+    );
+  });
+
+  test("a recall proof with the wrong fixture_kind is refused", () => {
+    const tampered = clone(PROOF_001) as Record<string, unknown>;
+    tampered.fixture_kind = "candidate_memory_packet";
+    const r = projectAdmissionRecallProof({ recallProof: tampered });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+    );
+  });
+
+  test("a transition with an unknown admission_decision is refused", () => {
+    const tampered = clone(TRANS_001) as Record<string, unknown>;
+    tampered.admission_decision = "maybe";
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: tampered,
+      admittedAssertion: ASSN_001,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+    );
+  });
+});
+
+// =========================================================================
+// 15. reducer output never contains raw candidate/private payload in any
+//     safe projection field (full graph sweep).
+// =========================================================================
+
+describe("Phase 44A · 15. no raw candidate/private payload in safe output", () => {
+  const SCENARIOS = [
+    reduceAdmissionFixtureScenario({
+      kind: "before_admission",
+      candidate: CAND_001,
+      recallProof: PROOF_001,
+    }),
+    reduceAdmissionFixtureScenario({
+      kind: "accepted",
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: ASSN_001,
+      recallProof: PROOF_002,
+    }),
+    reduceAdmissionFixtureScenario({
+      kind: "rejected",
+      candidate: CAND_002,
+      transition: TRANS_002,
+      recallProof: PROOF_003,
+    }),
+    reduceAdmissionFixtureScenario({
+      kind: "supersession",
+      correctionCandidate: CAND_011,
+      supersedeTransition: TRANS_011,
+      correctedAssertion: ASSN_011,
+      supersededAssertion: ASSN_010,
+      recallProof: PROOF_004,
+    }),
+  ];
+
+  test("every scenario succeeds", () => {
+    for (const s of SCENARIOS) {
+      expect(s.ok).toBe(true);
+    }
+  });
+
+  test("no scenario output contains a private body sentinel", () => {
+    for (const s of SCENARIOS) {
+      expect(scanForUnsafeProjection(s)).toBeNull();
+      for (const str of collectStrings(s)) {
+        for (const sentinel of ADMISSION_PRIVATE_BODY_SENTINELS) {
+          expect(str).not.toContain(sentinel);
+        }
+      }
+    }
+  });
+
+  test("no scenario output contains body_private / source_material text", () => {
+    for (const s of SCENARIOS) {
+      for (const str of collectStrings(s)) {
+        // the literal candidate/admitted body strings carry the word "body"
+        // plus the sentinel; we already check sentinels. Belt-and-suspenders:
+        // the raw 'body held for review' phrasing must not appear.
+        expect(str).not.toContain("held for review");
+        expect(str).not.toContain("never rendered");
+      }
+    }
+  });
+
+  test("the sealing gate replaces a contaminated success with a fail-closed result", () => {
+    // Feed a recall proof whose ordinary-recall material is clean but whose
+    // public_summary on the included path carries a long-id run (a banned
+    // category). The seal must catch it.
+    const leaky = clone(PROOF_002) as Record<string, unknown>;
+    (leaky.public_recall_output as Record<string, unknown>).public_summary =
+      "12345678901234567890";
+    const r = projectAdmissionRecallProof({
+      recallProof: leaky,
+      admittedAssertionId: "assn-001",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_private_sentinel_projection,
+    );
+  });
+});
+
+// =========================================================================
+// 16. static guards — the reducer is fixture-bound and reaches nothing live.
+// =========================================================================
+
+describe("Phase 44A · static source guards", () => {
+  const reducerSource = readFileSync(
+    resolve(__dirname, "admission-wedge-fixture-reducer.ts"),
+    "utf8",
+  );
+
+  test("reducer imports nothing at all (dependency-free)", () => {
+    expect(reducerSource).not.toMatch(/^\s*import\s/m);
+  });
+
+  test("reducer contains no network / fs / process primitives", () => {
+    expect(reducerSource).not.toMatch(/\bfetch\s*\(/);
+    expect(reducerSource).not.toMatch(/globalThis\.fetch/);
+    expect(reducerSource).not.toMatch(/from\s+["']node:fs["']/);
+    expect(reducerSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(reducerSource).not.toMatch(/readFileSync/);
+    expect(reducerSource).not.toMatch(/process\.env/);
+    expect(reducerSource).not.toMatch(/Date\.now/);
+  });
+
+  test("reducer imports no Discord / Dixie / Straylight / LLM dependency", () => {
+    expect(reducerSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(reducerSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(reducerSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(reducerSource).not.toMatch(/live-dixie-client/);
+    expect(reducerSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+  });
+
+  test("reducer makes no live-admission / production claim", () => {
+    const lc = reducerSource.toLowerCase();
+    // these phrases appear only inside negated disclaimers in the header.
+    for (const phrase of [
+      "production admission",
+      "live admission route",
+      "production storage",
+    ]) {
+      // every occurrence must be preceded on its line by a negation token.
+      const lines = lc.split("\n").filter((l) => l.includes(phrase));
+      for (const line of lines) {
+        expect(/\b(no|not|never|nothing|reaches no)\b/.test(line)).toBe(true);
+      }
+    }
+  });
+});
+
+// =========================================================================
+// 17. fail-closed detail sealing — a fail-closed `detail` NEVER echoes a raw
+//     input value (private sentinel, long id, secret, url, raw payload).
+//     Codex VERDICT: PATCH. Several fail branches historically interpolated
+//     raw input into `detail`; these tests pin the value-free behavior and
+//     are non-vacuous (the malformed inputs DO carry the banned material).
+// =========================================================================
+
+describe("Phase 44A · 17. fail-closed detail never echoes raw input", () => {
+  // a 20-digit operational-style id — matches the reducer's long-id-run gate
+  // (\d{17,}). Used as a "must not leak" probe.
+  const LONG_ID_20 = "12345678901234567890";
+  // a private-body sentinel suffix variant — `classifyUnsafeString` matches
+  // on the prefix, so this trips the private_body_sentinel category.
+  const SENTINEL_X = "CANDIDATE_PRIVATE_SENTINEL_X";
+
+  // Serialize the ENTIRE reducer output (not just top-level fields) so a leak
+  // buried in any nested field/key is caught.
+  function serialize(value: unknown): string {
+    return JSON.stringify(value);
+  }
+
+  // Assert a fail-closed output is well-formed, keeps a stable reason code,
+  // carries a non-empty string detail, and leaks nothing unsafe anywhere in
+  // its full serialized form.
+  function expectSealedFail(
+    r: { ok: boolean; reasonCode?: unknown; detail?: unknown },
+    expectedReason: string,
+  ): void {
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reasonCode).toBe(expectedReason);
+    expect(typeof r.detail).toBe("string");
+    expect((r.detail as string).length).toBeGreaterThan(0);
+    // full-output scan + recursive sentinel/long-id sweep.
+    expect(scanForUnsafeProjection(r)).toBeNull();
+  }
+
+  // -- 1. sentinel in a malformed candidate fails closed, never echoed -----
+
+  test("malformed candidate carrying a private sentinel fails closed without echoing it", () => {
+    // inject the sentinel into candidate_id and trip the eligible-before-
+    // admission gate (old code interpolated candidate_id into detail).
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.candidate_id = SENTINEL_X;
+    tampered.recall_eligibility = "eligible";
+
+    // non-vacuous: the input genuinely carries the banned material.
+    expect(serialize(tampered)).toContain("CANDIDATE_PRIVATE_SENTINEL");
+
+    const r = classifyAdmissionCandidate(tampered);
+    expectSealedFail(
+      r,
+      ADMISSION_REDUCER_REASON_CODES.candidate_recall_eligible_before_admission,
+    );
+    // full serialized output — not just top-level fields — is sentinel-free.
+    expect(serialize(r)).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+    expect(serialize(r)).not.toContain(SENTINEL_X);
+  });
+
+  test("sentinel in candidate fixture_kind / fixture_version is not echoed", () => {
+    for (const field of ["fixture_kind", "fixture_version"]) {
+      const tampered = clone(CAND_001) as Record<string, unknown>;
+      tampered[field] = SENTINEL_X;
+      expect(serialize(tampered)).toContain(SENTINEL_X);
+      const r = classifyAdmissionCandidate(tampered);
+      expectSealedFail(
+        r,
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      );
+      expect(serialize(r)).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+    }
+  });
+
+  // -- 2. long id in malformed input fails closed, never echoed ------------
+
+  test("malformed candidate carrying a 20-digit id fails closed without echoing it", () => {
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.candidate_id = LONG_ID_20;
+    tampered.recall_eligibility = "eligible";
+
+    // non-vacuous: the input genuinely carries the long id.
+    expect(serialize(tampered)).toContain(LONG_ID_20);
+
+    const r = classifyAdmissionCandidate(tampered);
+    expectSealedFail(
+      r,
+      ADMISSION_REDUCER_REASON_CODES.candidate_recall_eligible_before_admission,
+    );
+    // full serialized output is long-id-free.
+    expect(serialize(r)).not.toContain(LONG_ID_20);
+  });
+
+  test("long id in a wrong-shaped candidate (bad admission_state) is not echoed", () => {
+    const tampered = clone(CAND_001) as Record<string, unknown>;
+    tampered.candidate_id = LONG_ID_20;
+    tampered.admission_state = "admitted"; // trips the state gate
+    const r = classifyAdmissionCandidate(tampered);
+    expectSealedFail(r, ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape);
+    expect(serialize(r)).not.toContain(LONG_ID_20);
+  });
+
+  // -- 3. mismatched ids fail closed with stable codes, no raw ids ---------
+
+  // NB: short, seal-clean ids are used here on purpose. A LONG-id candidate
+  // is refused by the projection seal (unsafe_private_sentinel_projection)
+  // before the mismatch branch is ever reached — itself a safe outcome, but
+  // it would not exercise the mismatch detail strings. These distinctive
+  // short ids reach the actual mismatch branches; the old code interpolated
+  // them verbatim into `detail`, the patched code must not.
+  test("mismatched candidate/transition ids fail closed with no raw ids in detail", () => {
+    const cand = clone(CAND_001) as Record<string, unknown>;
+    cand.candidate_id = "cand-src-xyz";
+    const trans = clone(TRANS_001) as Record<string, unknown>;
+    trans.candidate_id = "cand-other-xyz"; // mismatched
+    trans.transition_id = "trans-tid-xyz";
+
+    const r = applyAdmissionTransition({
+      candidate: cand,
+      transition: trans,
+      admittedAssertion: ASSN_001,
+    });
+    expectSealedFail(
+      r,
+      ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_transition,
+    );
+    const out = serialize(r);
+    expect(out).not.toContain("cand-src-xyz");
+    expect(out).not.toContain("cand-other-xyz");
+    expect(out).not.toContain("trans-tid-xyz");
+  });
+
+  test("mismatched transition->assertion id fails closed with no raw ids in detail", () => {
+    // accept transition mints assn-001 but the supplied admitted packet is a
+    // different assertion — old code echoed both ids into detail.
+    const assn = clone(ASSN_001) as Record<string, unknown>;
+    assn.assertion_id = "assn-weird-xyz";
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001, // mints assn-001
+      admittedAssertion: assn,
+    });
+    expectSealedFail(
+      r,
+      ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+    );
+    expect(serialize(r)).not.toContain("assn-weird-xyz");
+  });
+
+  test("mismatched candidate->assertion provenance fails closed with no raw ids in detail", () => {
+    const assn = clone(ASSN_001) as Record<string, unknown>;
+    assn.source_candidate_id = "cand-wrong-xyz"; // mismatched provenance
+    const r = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: assn,
+    });
+    expectSealedFail(
+      r,
+      ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_assertion,
+    );
+    expect(serialize(r)).not.toContain("cand-wrong-xyz");
+  });
+
+  // -- 4. private-sentinel leakage, full serialized output -----------------
+
+  test("no malformed-input fail-closed output leaks a private sentinel (full serialized sweep)", () => {
+    // a battery of malformed inputs across all three reducers, each carrying a
+    // sentinel in a field the OLD code would have interpolated into detail.
+    const fails: Array<{ ok: boolean }> = [];
+
+    {
+      const c = clone(CAND_001) as Record<string, unknown>;
+      c.fixture_kind = "ADMITTED_PRIVATE_SENTINEL_777";
+      fails.push(classifyAdmissionCandidate(c));
+    }
+    {
+      const t = clone(TRANS_001) as Record<string, unknown>;
+      t.fixture_kind = "SOURCE_SENTINEL_777";
+      fails.push(
+        applyAdmissionTransition({
+          candidate: CAND_001,
+          transition: t,
+          admittedAssertion: ASSN_001,
+        }),
+      );
+    }
+    {
+      const t = clone(TRANS_001) as Record<string, unknown>;
+      t.admission_decision = "SUPERSEDED_PRIVATE_SENTINEL_777";
+      fails.push(
+        applyAdmissionTransition({
+          candidate: CAND_001,
+          transition: t,
+          admittedAssertion: ASSN_001,
+        }),
+      );
+    }
+    {
+      const p = clone(PROOF_001) as Record<string, unknown>;
+      p.fixture_kind = "CANDIDATE_PRIVATE_SENTINEL_777";
+      fails.push(projectAdmissionRecallProof({ recallProof: p }));
+    }
+
+    for (const r of fails) {
+      expect(r.ok).toBe(false);
+      // full serialized output carries NONE of the private sentinels.
+      const out = serialize(r);
+      for (const sentinel of ADMISSION_PRIVATE_BODY_SENTINELS) {
+        expect(out).not.toContain(sentinel);
+      }
+      expect(scanForUnsafeProjection(r)).toBeNull();
+    }
+  });
+
+  // -- 5. long-id leakage, full serialized output --------------------------
+
+  test("no malformed-input fail-closed output leaks a long id (full serialized sweep)", () => {
+    const probes: Array<{ id: string; out: string }> = [];
+
+    {
+      const id = "11111111111111111111";
+      const t = clone(TRANS_001) as Record<string, unknown>;
+      t.transition_id = id;
+      t.admission_decision = "maybe"; // unknown decision -> fail
+      const r = applyAdmissionTransition({
+        candidate: CAND_001,
+        transition: t,
+        admittedAssertion: ASSN_001,
+      });
+      expect(r.ok).toBe(false);
+      probes.push({ id, out: serialize(r) });
+    }
+    {
+      const id = "22222222222222222222";
+      const p = clone(PROOF_002) as Record<string, unknown>;
+      p.proof_id = id;
+      p.recall_result = "weird"; // unknown result -> fail
+      const r = projectAdmissionRecallProof({ recallProof: p });
+      expect(r.ok).toBe(false);
+      probes.push({ id, out: serialize(r) });
+    }
+    {
+      const id = "33333333333333333333";
+      const a = clone(ASSN_001) as Record<string, unknown>;
+      a.assertion_id = id; // != the minted assn-001 -> mismatch fail
+      const r = applyAdmissionTransition({
+        candidate: CAND_001,
+        transition: TRANS_001,
+        admittedAssertion: a,
+      });
+      expect(r.ok).toBe(false);
+      probes.push({ id, out: serialize(r) });
+    }
+
+    for (const { id, out } of probes) {
+      expect(out).not.toContain(id);
+    }
+  });
+
+  // -- 6. success-path outputs remain unchanged / equivalent ---------------
+
+  test("success-path outputs are unchanged and carry no detail field", () => {
+    const candidate = classifyAdmissionCandidate(CAND_001);
+    expect(candidate.ok).toBe(true);
+    if (!candidate.ok) return;
+    expect(candidate.candidateId).toBe("cand-001");
+    expect(candidate.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+    );
+    // a success output never carries a fail-closed `detail` field.
+    expect("detail" in candidate).toBe(false);
+
+    const transition = applyAdmissionTransition({
+      candidate: CAND_001,
+      transition: TRANS_001,
+      admittedAssertion: ASSN_001,
+    });
+    expect(transition.ok).toBe(true);
+    if (!transition.ok || transition.decision !== "accepted") return;
+    expect(transition.admittedAssertion.assertionId).toBe("assn-001");
+    expect(transition.admittedAssertion.audit.sourceCandidateId).toBe(
+      "cand-001",
+    );
+    expect(transition.admittedAssertion.audit.admissionTransitionId).toBe(
+      "trans-001",
+    );
+    expect(transition.admittedAssertion.publicSummary).toBe(
+      "operator participates in the admission-wedge fixture proof",
+    );
+    expect("detail" in transition).toBe(false);
+
+    const recall = projectAdmissionRecallProof({
+      recallProof: PROOF_002,
+      candidateId: "cand-001",
+      admittedAssertionId: "assn-001",
+    });
+    expect(recall.ok).toBe(true);
+    if (!recall.ok || recall.recallResult !== "included") return;
+    expect(recall.includedAssertionIds).toEqual(["assn-001"]);
+    expect(recall.publicSummary).toBe(
+      "operator participates in the admission-wedge fixture proof",
+    );
+    expect("detail" in recall).toBe(false);
+  });
+
+  // -- the backstop helper itself (defense-in-depth) -----------------------
+
+  test("safeDetail seals every detail by reason code, including short raw ids", () => {
+    const code = ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape;
+    const sealed = safeDetailForReason(code);
+    // sentinel
+    const a = safeDetail(code, "leak CANDIDATE_PRIVATE_SENTINEL_001 here");
+    expect(a).toBe(sealed);
+    expect(a).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+    expect(a).toContain(code); // stable reason code preserved
+    // long id
+    const b = safeDetail(code, "id 12345678901234567890 leaked");
+    expect(b).toBe(sealed);
+    expect(b).not.toContain("12345678901234567890");
+    // url
+    const c = safeDetail(code, "see https://evil.example/secret");
+    expect(c).toBe(sealed);
+    expect(c).not.toContain("https://");
+    // short ids are raw fixture values even though they are not caught by the
+    // long-id/sentinel/url scan.
+    const shortId = safeDetail(code, "candidate cand-001 leaked");
+    expect(shortId).toBe(sealed);
+    expect(shortId).not.toContain("cand-001");
+    // a clean detail is still sealed to the stable reason-code detail.
+    const clean = "candidate: unknown fixture_kind";
+    expect(safeDetail(code, clean)).toBe(sealed);
+
+    const unsafeReason = safeDetail(
+      "CANDIDATE_PRIVATE_SENTINEL_X" as typeof code,
+      "irrelevant",
+    );
+    expect(unsafeReason).toBe(sealed);
+    expect(unsafeReason).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.ts
+++ b/packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.ts
@@ -1,0 +1,1181 @@
+// Phase 44A · Admission Wedge fixture-bound reducer / adapter.
+//
+// Authority: docs/ADMISSION-WEDGE-MVP-DESIGN.md (Phase 43B design) and the
+// Phase 43C fixture / operator-contract under docs/admission-wedge/fixtures/
+// (PR #155). Phase 44A turns that fixture contract into a pure, local,
+// dependency-free reducer that proves the §D invariant *in code* — over
+// already-loaded fixture-like objects.
+//
+// What this reducer proves (docs/ADMISSION-WEDGE-MVP-DESIGN.md §D):
+//   1. candidate memory is not admitted memory;
+//   2. candidate memory is not recallable as governed continuity before
+//      admission;
+//   3. an accepted admission transition mints an admitted assertion;
+//   4. a rejected candidate never mints an admitted assertion and never
+//      becomes recallable;
+//   5. supersession/correction recalls only the corrected active assertion
+//      while preserving audit/provenance links to the superseded prior state;
+//   6. raw candidate / private payload is never treated as ordinary recall
+//      material;
+//   7. unsupported or malformed fixture inputs fail closed.
+//
+// What this reducer is NOT (carried verbatim from Phase 43B §M / 43C scope):
+//   - it is NOT a live admission implementation. It admits nothing, stores
+//     nothing, and reaches no network. It is pure over already-parsed
+//     fixture-like objects;
+//   - it is NOT wired into Discord, Dixie, the public renderer, the live
+//     client, dispatch, startup, command registration, or any package
+//     export. It is imported only by its own test file;
+//   - it does NOT authorize production admission, production storage,
+//     production auth / consent, public remember-this, Discord history
+//     ingestion, user chat becoming memory, a live Dixie admission route, or
+//     a Finn production wiring. All of those remain blocked.
+//
+// Determinism: this module reads no clock, no env, no filesystem, and no
+// network. It is a pure function of its inputs. Its test loads the Phase 43C
+// fixtures from disk and feeds them in.
+
+// -- stable reason codes ---------------------------------------------------
+//
+// Every reducer outcome carries a stable reason code rather than a raw
+// error. The first five are SUCCESS classifications; the rest are
+// FAIL-CLOSED codes. Tests and future audits pin against these names.
+export const ADMISSION_REDUCER_REASON_CODES = {
+  // success classifications
+  candidate_not_admitted: "candidate_not_admitted",
+  admitted_active_assertion: "admitted_active_assertion",
+  candidate_rejected: "candidate_rejected",
+  corrected_active_assertion: "corrected_active_assertion",
+  superseded_not_ordinary_recallable: "superseded_not_ordinary_recallable",
+  // fail-closed codes
+  unsupported_fixture_shape: "unsupported_fixture_shape",
+  mismatched_candidate_transition: "mismatched_candidate_transition",
+  mismatched_candidate_assertion: "mismatched_candidate_assertion",
+  mismatched_transition_assertion: "mismatched_transition_assertion",
+  accepted_transition_missing_assertion: "accepted_transition_missing_assertion",
+  rejected_transition_minted_assertion: "rejected_transition_minted_assertion",
+  admitted_assertion_missing_provenance: "admitted_assertion_missing_provenance",
+  candidate_recall_eligible_before_admission:
+    "candidate_recall_eligible_before_admission",
+  candidate_included_in_ordinary_recall: "candidate_included_in_ordinary_recall",
+  superseded_included_as_active_recall: "superseded_included_as_active_recall",
+  unsafe_candidate_payload_projection: "unsafe_candidate_payload_projection",
+  unsafe_private_sentinel_projection: "unsafe_private_sentinel_projection",
+} as const;
+
+export type AdmissionReducerReasonCode =
+  (typeof ADMISSION_REDUCER_REASON_CODES)[keyof typeof ADMISSION_REDUCER_REASON_CODES];
+
+const ADMISSION_REDUCER_REASON_CODE_SET = new Set<string>(
+  Object.values(ADMISSION_REDUCER_REASON_CODES),
+);
+
+// -- private-body sentinels (no-leak gate) ---------------------------------
+//
+// The Phase 43C candidate / admitted / superseded private bodies and source
+// material carry these sentinel prefixes. Ordinary recall material — and the
+// reducer's own safe projection output — must contain NONE of them. Mirrors
+// the validator's PRIVATE_BODY_SENTINELS (docs/admission-wedge/fixtures/
+// validate-fixtures.mjs); the reducer does not widen the boundary.
+export const ADMISSION_PRIVATE_BODY_SENTINELS = [
+  "CANDIDATE_PRIVATE_SENTINEL",
+  "SOURCE_SENTINEL",
+  "ADMITTED_PRIVATE_SENTINEL",
+  "SUPERSEDED_PRIVATE_SENTINEL",
+] as const;
+
+// -- supported fixture vocabulary ------------------------------------------
+
+const SUPPORTED_FIXTURE_VERSION_PREFIX = "phase-43c";
+
+const FIXTURE_KIND = {
+  candidate: "candidate_memory_packet",
+  transition: "admission_transition",
+  admitted: "admitted_memory_packet",
+  recallProof: "admission_recall_proof",
+} as const;
+
+// -- output shapes ---------------------------------------------------------
+
+export interface AdmissionFailClosed {
+  readonly ok: false;
+  readonly reasonCode: AdmissionReducerReasonCode;
+  // Generic diagnostic selected only from the stable reason code. It carries
+  // no raw private body, candidate / fixture value, operational id, long id,
+  // secret, url, stack trace, or json fragment. The stable `reasonCode` is the
+  // machine-readable outcome; `detail` is a sealed human breadcrumb.
+  readonly detail: string;
+}
+
+export interface CandidateClassificationOk {
+  readonly ok: true;
+  readonly kind: "candidate";
+  readonly candidateId: string;
+  readonly admitted: false;
+  readonly recallEligible: false;
+  readonly ordinaryRecallMaterial: false;
+  readonly proposedSupersedesAssertionId: string | null;
+  readonly reasonCode: "candidate_not_admitted";
+}
+export type CandidateClassification =
+  | CandidateClassificationOk
+  | AdmissionFailClosed;
+
+export interface AdmittedAssertionProjection {
+  readonly assertionId: string;
+  readonly admitted: true;
+  readonly active: true;
+  readonly recallEligible: true;
+  // the single public-safe summary string (boundary = public_safe). It is
+  // scanned for sentinels before being emitted.
+  readonly publicSummary: string;
+  // source candidate / transition / receipt preserved as audit / provenance
+  // links ONLY — short ids, never raw bodies.
+  readonly audit: {
+    readonly sourceCandidateId: string;
+    readonly admissionTransitionId: string;
+    readonly admissionReceiptRef: string | null;
+    readonly supersedesAssertionId: string | null;
+  };
+}
+
+export interface AdmissionTransitionAcceptedOk {
+  readonly ok: true;
+  readonly decision: "accepted";
+  readonly candidateId: string;
+  readonly transitionId: string;
+  readonly admittedAssertion: AdmittedAssertionProjection;
+  readonly supersededAssertionId: string | null;
+  readonly reasonCode: "admitted_active_assertion" | "corrected_active_assertion";
+}
+export interface AdmissionTransitionRejectedOk {
+  readonly ok: true;
+  readonly decision: "rejected";
+  readonly candidateId: string;
+  readonly transitionId: string;
+  readonly admittedAssertion: null;
+  readonly reasonCode: "candidate_rejected";
+}
+export type AdmissionTransitionResult =
+  | AdmissionTransitionAcceptedOk
+  | AdmissionTransitionRejectedOk
+  | AdmissionFailClosed;
+
+export interface RecallProofExcludedOk {
+  readonly ok: true;
+  readonly phase: string;
+  readonly recallResult: "excluded";
+  readonly recallEligible: false;
+  readonly includedAssertionIds: readonly string[]; // always empty / candidate-free
+  readonly excludedCandidateIds: readonly string[];
+  readonly renderedCandidatePayload: false;
+  readonly publicSummary: string;
+  readonly reasonCode: "candidate_not_admitted" | "candidate_rejected";
+  readonly recallRoute: string;
+}
+export interface RecallProofIncludedOk {
+  readonly ok: true;
+  readonly phase: string;
+  readonly recallResult: "included";
+  readonly recallEligible: true;
+  readonly includedAssertionIds: readonly string[]; // admitted assertion ids only
+  readonly excludedAssertionIds: readonly string[]; // superseded prior state, if any
+  readonly renderedCandidatePayload: false;
+  readonly renderedPriorState: false;
+  readonly publicSummary: string;
+  readonly reasonCode: "admitted_active_assertion" | "corrected_active_assertion";
+  readonly supersededReasonCode: "superseded_not_ordinary_recallable" | null;
+  readonly audit: {
+    readonly sourceCandidateId: string | null;
+    readonly admissionTransitionId: string | null;
+    readonly admissionReceiptRef: string | null;
+    readonly supersedesAssertionId: string | null;
+  };
+  readonly recallRoute: string;
+}
+export type RecallProofProjection =
+  | RecallProofExcludedOk
+  | RecallProofIncludedOk
+  | AdmissionFailClosed;
+
+export type AdmissionScenarioKind =
+  | "before_admission"
+  | "accepted"
+  | "rejected"
+  | "supersession";
+
+export interface AdmissionScenarioProofOk {
+  readonly ok: true;
+  readonly scenario: AdmissionScenarioKind;
+  readonly reasonCode: AdmissionReducerReasonCode;
+  readonly candidate: CandidateClassificationOk;
+  readonly transition:
+    | AdmissionTransitionAcceptedOk
+    | AdmissionTransitionRejectedOk
+    | null;
+  readonly recall: RecallProofExcludedOk | RecallProofIncludedOk;
+  readonly invariantsHeld: readonly string[];
+}
+export type AdmissionScenarioProof =
+  | AdmissionScenarioProofOk
+  | AdmissionFailClosed;
+
+export type AdmissionFixtureScenario =
+  | { readonly kind: "before_admission"; readonly candidate: unknown; readonly recallProof: unknown }
+  | {
+      readonly kind: "accepted";
+      readonly candidate: unknown;
+      readonly transition: unknown;
+      readonly admittedAssertion: unknown;
+      readonly recallProof: unknown;
+    }
+  | {
+      readonly kind: "rejected";
+      readonly candidate: unknown;
+      readonly transition: unknown;
+      readonly recallProof: unknown;
+    }
+  | {
+      readonly kind: "supersession";
+      readonly correctionCandidate: unknown;
+      readonly supersedeTransition: unknown;
+      readonly correctedAssertion: unknown;
+      readonly supersededAssertion: unknown;
+      readonly recallProof: unknown;
+    };
+
+// -- safe field readers ----------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}
+function getString(rec: Record<string, unknown>, key: string): string | null {
+  const v = rec[key];
+  return typeof v === "string" ? v : null;
+}
+function getStringArray(
+  rec: Record<string, unknown>,
+  key: string,
+): readonly string[] | null {
+  const v = rec[key];
+  if (!Array.isArray(v)) return null;
+  if (!v.every((x) => typeof x === "string")) return null;
+  return v as string[];
+}
+
+// Fail-closed details are always sealed by reason code. The local detail passed
+// by each branch is intentionally ignored at the emission boundary so no raw
+// input value, fixture value, id, url, secret, stack trace, or json fragment can
+// leave the reducer through `detail`.
+export function safeDetailForReason(
+  reasonCode: AdmissionReducerReasonCode,
+): string {
+  const safeReasonCode = ADMISSION_REDUCER_REASON_CODE_SET.has(reasonCode)
+    ? reasonCode
+    : ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape;
+  return `fail-closed: ${safeReasonCode}`;
+}
+
+export function safeDetail(
+  reasonCode: AdmissionReducerReasonCode,
+  detail: string,
+): string {
+  void detail;
+  return safeDetailForReason(reasonCode);
+}
+
+function fail(
+  reasonCode: AdmissionReducerReasonCode,
+  detail: string,
+): AdmissionFailClosed {
+  return { ok: false, reasonCode, detail: safeDetail(reasonCode, detail) };
+}
+
+// -- no-leak / unsafe-projection scan --------------------------------------
+//
+// Walks every string value AND every key in `value` and returns a stable
+// category label for the first unsafe substring encountered, or null. It
+// returns a CATEGORY, never the raw matched value, so a fail-closed detail
+// built from it can never itself carry the banned material.
+function classifyUnsafeString(s: string): string | null {
+  for (const sentinel of ADMISSION_PRIVATE_BODY_SENTINELS) {
+    if (s.includes(sentinel)) return "private_body_sentinel";
+  }
+  if (/\d{17,}/.test(s)) return "long_id_run";
+  if (/0x[a-fA-F0-9]{40,}/.test(s)) return "hex_address";
+  if (/https?:\/\//i.test(s)) return "url";
+  if (/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(s)) return "pem_private_key";
+  return null;
+}
+
+export function scanForUnsafeProjection(
+  value: unknown,
+  visited: WeakSet<object> = new WeakSet(),
+): string | null {
+  if (typeof value === "string") return classifyUnsafeString(value);
+  if (Array.isArray(value)) {
+    if (visited.has(value)) return null;
+    visited.add(value);
+    for (const item of value) {
+      const hit = scanForUnsafeProjection(item, visited);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (isPlainObject(value)) {
+    if (visited.has(value)) return null;
+    visited.add(value);
+    for (const [key, sub] of Object.entries(value)) {
+      const keyHit = classifyUnsafeString(key);
+      if (keyHit) return keyHit;
+      const hit = scanForUnsafeProjection(sub, visited);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  return null;
+}
+
+// Final output gate. Every successful projection is sealed: its entire
+// output object is scanned, and if any unsafe material slipped through it is
+// replaced with a fail-closed result. This guarantees the reducer never
+// emits a raw candidate / private body, long id, secret, or url in a
+// safe-projection field — even if a future fixture or refactor regresses.
+function sealAdmissionProjection<T extends object>(
+  result: T,
+): T | AdmissionFailClosed {
+  const hit = scanForUnsafeProjection(result);
+  if (hit) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_private_sentinel_projection,
+      `blocked: unsafe material (${hit}) in safe projection output`,
+    );
+  }
+  return result;
+}
+
+function isSupportedVersion(version: string | null): boolean {
+  if (version === null) return false;
+  return version.startsWith(SUPPORTED_FIXTURE_VERSION_PREFIX + ".");
+}
+
+// =========================================================================
+// 1. classifyAdmissionCandidate
+// =========================================================================
+//
+// A candidate is a proposal, not governed continuity. Classify it and prove
+// it is not admitted, not recall-eligible, and not ordinary recall material.
+// Fails closed on a malformed candidate, an unknown kind/version, a missing
+// id, or a candidate that claims recall-eligibility before admission.
+export function classifyAdmissionCandidate(
+  candidate: unknown,
+): CandidateClassification {
+  const rec = asRecord(candidate);
+  if (!rec) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "candidate: not an object",
+    );
+  }
+  const fixtureKind = getString(rec, "fixture_kind");
+  if (fixtureKind !== FIXTURE_KIND.candidate) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "candidate: unknown fixture_kind",
+    );
+  }
+  if (!isSupportedVersion(getString(rec, "fixture_version"))) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "candidate: unsupported fixture_version",
+    );
+  }
+  const candidateId = getString(rec, "candidate_id");
+  if (!candidateId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      'candidate: required field "candidate_id" missing',
+    );
+  }
+  // a candidate that already claims recall-eligibility before admission is a
+  // direct violation of the invariant — fail closed (not merely malformed).
+  const recallEligibility = getString(rec, "recall_eligibility");
+  if (recallEligibility === "eligible") {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.candidate_recall_eligible_before_admission,
+      'candidate: recall_eligibility is "eligible" before admission',
+    );
+  }
+  if (recallEligibility !== "ineligible") {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      'candidate: recall_eligibility must be "ineligible"',
+    );
+  }
+  const admissionState = getString(rec, "admission_state");
+  if (admissionState !== "candidate_pending") {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      'candidate: admission_state must be "candidate_pending"',
+    );
+  }
+
+  const result: CandidateClassificationOk = {
+    ok: true,
+    kind: "candidate",
+    candidateId,
+    admitted: false,
+    recallEligible: false,
+    ordinaryRecallMaterial: false,
+    proposedSupersedesAssertionId:
+      getString(rec, "proposed_supersedes_assertion_id"),
+    reasonCode: ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+  };
+  // candidate payload (summary_public / body_private / source_material) is
+  // deliberately NOT carried into the classification — a candidate is
+  // never_rendered. Seal anyway to keep the contract uniform.
+  return sealAdmissionProjection(result);
+}
+
+// =========================================================================
+// 2. applyAdmissionTransition
+// =========================================================================
+//
+// The single explicit door: candidate -> admitted (accept / supersede) or
+// candidate -> rejected. Verifies the candidate<->transition<->assertion
+// linkage and mints (or refuses) the admitted assertion projection. Fails
+// closed on every linkage break, on an accept with no minted assertion, and
+// on a reject that mints one.
+export function applyAdmissionTransition(args: {
+  readonly candidate: unknown;
+  readonly transition: unknown;
+  readonly admittedAssertion?: unknown;
+  readonly supersededAssertion?: unknown;
+}): AdmissionTransitionResult {
+  const candidate = classifyAdmissionCandidate(args.candidate);
+  if (!candidate.ok) return candidate;
+
+  const tRec = asRecord(args.transition);
+  if (!tRec) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "transition: not an object",
+    );
+  }
+  if (getString(tRec, "fixture_kind") !== FIXTURE_KIND.transition) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "transition: unknown fixture_kind",
+    );
+  }
+  if (!isSupportedVersion(getString(tRec, "transition_version"))) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "transition: unsupported transition_version",
+    );
+  }
+  const transitionId = getString(tRec, "transition_id");
+  if (!transitionId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      'transition: required field "transition_id" missing',
+    );
+  }
+  const transitionCandidateId = getString(tRec, "candidate_id");
+  if (!transitionCandidateId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      'transition: required field "candidate_id" missing',
+    );
+  }
+  if (transitionCandidateId !== candidate.candidateId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_transition,
+      "transition: candidate_id does not match the candidate",
+    );
+  }
+
+  const decision = getString(tRec, "admission_decision");
+  const mintedId = "admitted_assertion_id" in tRec ? tRec.admitted_assertion_id : undefined;
+
+  if (decision === "rejected") {
+    // a rejected transition must mint nothing.
+    if (mintedId !== null) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.rejected_transition_minted_assertion,
+        "transition: rejected but admitted_assertion_id is not null",
+      );
+    }
+    if (args.admittedAssertion != null) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.rejected_transition_minted_assertion,
+        "transition: rejected but an admitted assertion was supplied",
+      );
+    }
+    const rejected: AdmissionTransitionRejectedOk = {
+      ok: true,
+      decision: "rejected",
+      candidateId: candidate.candidateId,
+      transitionId,
+      admittedAssertion: null,
+      reasonCode: ADMISSION_REDUCER_REASON_CODES.candidate_rejected,
+    };
+    return sealAdmissionProjection(rejected);
+  }
+
+  if (decision !== "accepted") {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "transition: unknown admission_decision",
+    );
+  }
+
+  // -- accepted (and possibly supersede) --
+  if (typeof mintedId !== "string" || mintedId.length === 0) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.accepted_transition_missing_assertion,
+      "transition: accepted but admitted_assertion_id is missing/null",
+    );
+  }
+  const aRec = asRecord(args.admittedAssertion);
+  if (!aRec) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.accepted_transition_missing_assertion,
+      "transition: accepted but no admitted assertion supplied",
+    );
+  }
+  if (getString(aRec, "fixture_kind") !== FIXTURE_KIND.admitted) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "admitted assertion: unknown fixture_kind",
+    );
+  }
+  if (!isSupportedVersion(getString(aRec, "fixture_version"))) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "admitted assertion: unsupported fixture_version",
+    );
+  }
+  const assertionId = getString(aRec, "assertion_id");
+  if (!assertionId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      'admitted assertion: required field "assertion_id" missing',
+    );
+  }
+  if (assertionId !== mintedId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+      "transition: minted assertion id does not match the supplied admitted assertion",
+    );
+  }
+  // provenance: the admitted assertion must reference its source candidate
+  // and its admitting transition.
+  const sourceCandidateId = getString(aRec, "source_candidate_id");
+  if (!sourceCandidateId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.admitted_assertion_missing_provenance,
+      "admitted assertion: source_candidate_id missing",
+    );
+  }
+  const admissionTransitionId = getString(aRec, "admission_transition_id");
+  if (!admissionTransitionId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.admitted_assertion_missing_provenance,
+      "admitted assertion: admission_transition_id missing",
+    );
+  }
+  if (sourceCandidateId !== candidate.candidateId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_assertion,
+      "admitted assertion: source_candidate_id does not match the candidate",
+    );
+  }
+  if (admissionTransitionId !== transitionId) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+      "admitted assertion: admission_transition_id does not match the transition",
+    );
+  }
+  // the freshly admitted assertion must be admitted / active / eligible.
+  if (
+    getString(aRec, "admission_state") !== "admitted" ||
+    getString(aRec, "assertion_status") !== "active" ||
+    getString(aRec, "recall_eligibility") !== "eligible"
+  ) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "admitted assertion: must be admitted/active/eligible",
+    );
+  }
+  const publicSummary = getString(aRec, "summary_public");
+  if (publicSummary === null) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "admitted assertion: summary_public missing",
+    );
+  }
+
+  // -- supersession sub-decision --
+  const supersedesId =
+    "supersedes_assertion_id" in tRec ? tRec.supersedes_assertion_id : null;
+  let reasonCode: "admitted_active_assertion" | "corrected_active_assertion" =
+    ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion;
+  let supersededAssertionId: string | null = null;
+
+  if (typeof supersedesId === "string" && supersedesId.length > 0) {
+    reasonCode = ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion;
+    supersededAssertionId = supersedesId;
+    // the corrected assertion must record the supersedes link.
+    if (getString(aRec, "supersedes_assertion_id") !== supersedesId) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+        "admitted assertion: supersedes_assertion_id does not match the transition's",
+      );
+    }
+    // if the prior state was supplied, prove it was correctly retired.
+    if (args.supersededAssertion != null) {
+      const pRec = asRecord(args.supersededAssertion);
+      if (!pRec) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "superseded assertion: not an object",
+        );
+      }
+      const priorId = getString(pRec, "assertion_id");
+      if (priorId !== supersedesId) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+          "superseded assertion: id does not match supersedes_assertion_id",
+        );
+      }
+      if (
+        getString(pRec, "admission_state") !== "superseded" ||
+        getString(pRec, "assertion_status") !== "superseded" ||
+        getString(pRec, "recall_eligibility") !== "ineligible"
+      ) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "superseded assertion: must be superseded/ineligible",
+        );
+      }
+      if (getString(pRec, "superseded_by_assertion_id") !== assertionId) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+          "superseded assertion: superseded_by_assertion_id does not reference the corrected assertion",
+        );
+      }
+    }
+  } else if (supersedesId !== null && supersedesId !== undefined) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "transition: supersedes_assertion_id has unexpected shape",
+    );
+  }
+
+  const admittedAssertion: AdmittedAssertionProjection = {
+    assertionId,
+    admitted: true,
+    active: true,
+    recallEligible: true,
+    publicSummary,
+    audit: {
+      sourceCandidateId,
+      admissionTransitionId,
+      admissionReceiptRef: getString(aRec, "admission_receipt_ref"),
+      supersedesAssertionId: supersededAssertionId,
+    },
+  };
+  const accepted: AdmissionTransitionAcceptedOk = {
+    ok: true,
+    decision: "accepted",
+    candidateId: candidate.candidateId,
+    transitionId,
+    admittedAssertion,
+    supersededAssertionId,
+    reasonCode,
+  };
+  return sealAdmissionProjection(accepted);
+}
+
+// =========================================================================
+// 3. projectAdmissionRecallProof
+// =========================================================================
+//
+// Project the recall-proof fixture into a small, safe recall result. The
+// ordinary-recall portion of the proof (public_recall_output +
+// included_assertion_ids) is scanned for private sentinels and candidate
+// material; the candidate / receipt / supersedes links live only under
+// audit. Fails closed if a candidate is treated as ordinary recall material,
+// if the superseded prior state surfaces as active, if a candidate payload
+// is rendered, or if a private sentinel reaches ordinary recall output.
+export function projectAdmissionRecallProof(args: {
+  readonly recallProof: unknown;
+  readonly candidateId?: string;
+  readonly admittedAssertionId?: string;
+  readonly supersededAssertionId?: string;
+}): RecallProofProjection {
+  const rec = asRecord(args.recallProof);
+  if (!rec) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "recall proof: not an object",
+    );
+  }
+  if (getString(rec, "fixture_kind") !== FIXTURE_KIND.recallProof) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "recall proof: unknown fixture_kind",
+    );
+  }
+  if (!isSupportedVersion(getString(rec, "fixture_version"))) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "recall proof: unsupported fixture_version",
+    );
+  }
+  const proofId = getString(rec, "proof_id");
+  const phase = getString(rec, "proof_phase");
+  const recallRoute = getString(rec, "recall_route");
+  if (!proofId || !phase || !recallRoute) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      "recall proof: required field (proof_id / proof_phase / recall_route) missing",
+    );
+  }
+
+  // -- no-leak gate over the ORDINARY-RECALL portion of the proof only --
+  // audit_links (which legitimately carry the source candidate / receipt /
+  // supersedes ids) are excluded from this scan.
+  const publicOutput = asRecord(rec.public_recall_output);
+  const ordinaryRecallMaterial = {
+    public_recall_output: rec.public_recall_output,
+    included_assertion_ids: rec.included_assertion_ids,
+  };
+  const leak = scanForUnsafeProjection(ordinaryRecallMaterial);
+  if (leak === "private_body_sentinel") {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_private_sentinel_projection,
+      "recall proof: private sentinel in ordinary recall output",
+    );
+  }
+  if (leak) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_private_sentinel_projection,
+      `recall proof: unsafe material (${leak}) in ordinary recall output`,
+    );
+  }
+
+  // a rendered candidate payload is never permitted on the recall surface.
+  if (publicOutput && publicOutput.rendered_candidate_payload !== false) {
+    return fail(
+      ADMISSION_REDUCER_REASON_CODES.unsafe_candidate_payload_projection,
+      "recall proof: rendered_candidate_payload must be false",
+    );
+  }
+
+  const recallResult = getString(rec, "recall_result");
+  const classification = getString(rec, "recall_classification");
+  const included = getStringArray(rec, "included_assertion_ids") ?? [];
+  const publicSummary = publicOutput
+    ? getString(publicOutput, "public_summary") ?? ""
+    : "";
+
+  if (recallResult === "excluded") {
+    // before-admission and rejected both fail closed to the not-found family.
+    if (classification === "served") {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+        'recall proof: excluded result must not classify "served"',
+      );
+    }
+    // the candidate must not appear as ordinary recall material.
+    const consideredCandidate =
+      args.candidateId ?? getString(rec, "considered_candidate_id");
+    if (consideredCandidate && included.includes(consideredCandidate)) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.candidate_included_in_ordinary_recall,
+        "recall proof: candidate present in included_assertion_ids",
+      );
+    }
+    if (included.length !== 0) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.candidate_included_in_ordinary_recall,
+        "recall proof: excluded result must have empty included_assertion_ids",
+      );
+    }
+    const exclusionReason = getString(rec, "exclusion_reason");
+    let reasonCode: "candidate_not_admitted" | "candidate_rejected";
+    if (exclusionReason === "candidate_not_admitted") {
+      reasonCode = ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted;
+    } else if (exclusionReason === "candidate_rejected") {
+      reasonCode = ADMISSION_REDUCER_REASON_CODES.candidate_rejected;
+    } else {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+        "recall proof: unknown exclusion_reason",
+      );
+    }
+    const excludedCandidateIds =
+      getStringArray(rec, "excluded_candidate_ids") ?? [];
+    const result: RecallProofExcludedOk = {
+      ok: true,
+      phase,
+      recallResult: "excluded",
+      recallEligible: false,
+      includedAssertionIds: [],
+      excludedCandidateIds,
+      renderedCandidatePayload: false,
+      publicSummary,
+      reasonCode,
+      recallRoute,
+    };
+    return sealAdmissionProjection(result);
+  }
+
+  if (recallResult === "included") {
+    if (classification !== "served") {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+        'recall proof: included result must classify "served"',
+      );
+    }
+    if (included.length === 0) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+        "recall proof: included result must have a non-empty included_assertion_ids",
+      );
+    }
+    // a candidate id must never be treated as ordinary recall material.
+    const candidateId =
+      args.candidateId ?? getString(rec, "considered_candidate_id");
+    if (candidateId && included.includes(candidateId)) {
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.candidate_included_in_ordinary_recall,
+        "recall proof: raw candidate present in included_assertion_ids",
+      );
+    }
+    if (args.admittedAssertionId) {
+      if (
+        included.length !== 1 ||
+        included[0] !== args.admittedAssertionId
+      ) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+          "recall proof: included_assertion_ids must be exactly the admitted assertion id",
+        );
+      }
+    }
+
+    // supersession: detect from the proof or the supplied context.
+    const proofSupersededId = getString(rec, "superseded_assertion_id");
+    const supersededId = args.supersededAssertionId ?? proofSupersededId;
+    const excludedAssertionIds =
+      getStringArray(rec, "excluded_assertion_ids") ?? [];
+    let reasonCode: "admitted_active_assertion" | "corrected_active_assertion" =
+      ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion;
+    let supersededReasonCode:
+      | "superseded_not_ordinary_recallable"
+      | null = null;
+
+    if (supersededId) {
+      reasonCode = ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion;
+      supersededReasonCode =
+        ADMISSION_REDUCER_REASON_CODES.superseded_not_ordinary_recallable;
+      // the wrong prior state must NOT surface as active ordinary recall.
+      if (included.includes(supersededId)) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.superseded_included_as_active_recall,
+          "recall proof: superseded prior present in included_assertion_ids",
+        );
+      }
+      if (!excludedAssertionIds.includes(supersededId)) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.superseded_included_as_active_recall,
+          "recall proof: superseded prior not recorded in excluded_assertion_ids",
+        );
+      }
+      if (publicOutput && publicOutput.rendered_prior_state !== false) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.superseded_included_as_active_recall,
+          "recall proof: rendered_prior_state must be false",
+        );
+      }
+    }
+
+    const auditRec = asRecord(rec.audit_links);
+    const result: RecallProofIncludedOk = {
+      ok: true,
+      phase,
+      recallResult: "included",
+      recallEligible: true,
+      includedAssertionIds: included,
+      excludedAssertionIds,
+      renderedCandidatePayload: false,
+      renderedPriorState: false,
+      publicSummary,
+      reasonCode,
+      supersededReasonCode,
+      audit: {
+        sourceCandidateId: auditRec
+          ? getString(auditRec, "source_candidate_id")
+          : null,
+        admissionTransitionId: auditRec
+          ? getString(auditRec, "admission_transition_id")
+          : null,
+        admissionReceiptRef: auditRec
+          ? getString(auditRec, "admission_receipt_ref")
+          : null,
+        supersedesAssertionId: auditRec
+          ? getString(auditRec, "supersedes_assertion_id")
+          : null,
+      },
+      recallRoute,
+    };
+    return sealAdmissionProjection(result);
+  }
+
+  return fail(
+    ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+    "recall proof: unknown recall_result",
+  );
+}
+
+// =========================================================================
+// 4. reduceAdmissionFixtureScenario
+// =========================================================================
+//
+// Compose the three reducers over one of the four Phase 43C scenarios and
+// cross-check the pieces against each other. Returns a single small proof
+// object, or fails closed at the first violation.
+export function reduceAdmissionFixtureScenario(
+  scenario: AdmissionFixtureScenario,
+): AdmissionScenarioProof {
+  switch (scenario.kind) {
+    case "before_admission": {
+      const candidate = classifyAdmissionCandidate(scenario.candidate);
+      if (!candidate.ok) return candidate;
+      const recall = projectAdmissionRecallProof({
+        recallProof: scenario.recallProof,
+        candidateId: candidate.candidateId,
+      });
+      if (!recall.ok) return recall;
+      if (recall.recallResult !== "excluded") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "before_admission: recall proof must be excluded",
+        );
+      }
+      if (recall.reasonCode !== ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          `before_admission: expected candidate_not_admitted, got ${recall.reasonCode}`,
+        );
+      }
+      const proof: AdmissionScenarioProofOk = {
+        ok: true,
+        scenario: "before_admission",
+        reasonCode: ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+        candidate,
+        transition: null,
+        recall,
+        invariantsHeld: [
+          "candidate_is_not_admitted",
+          "candidate_not_recallable_before_admission",
+          "candidate_payload_not_rendered",
+        ],
+      };
+      return sealAdmissionProjection(proof);
+    }
+
+    case "accepted": {
+      const candidate = classifyAdmissionCandidate(scenario.candidate);
+      if (!candidate.ok) return candidate;
+      const transition = applyAdmissionTransition({
+        candidate: scenario.candidate,
+        transition: scenario.transition,
+        admittedAssertion: scenario.admittedAssertion,
+      });
+      if (!transition.ok) return transition;
+      if (transition.decision !== "accepted") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "accepted: transition must be an accept",
+        );
+      }
+      const recall = projectAdmissionRecallProof({
+        recallProof: scenario.recallProof,
+        candidateId: candidate.candidateId,
+        admittedAssertionId: transition.admittedAssertion.assertionId,
+      });
+      if (!recall.ok) return recall;
+      if (recall.recallResult !== "included") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "accepted: recall proof must be included",
+        );
+      }
+      // cross-check: the served assertion is exactly the one the transition
+      // minted; its source candidate matches under audit.
+      if (recall.includedAssertionIds[0] !== transition.admittedAssertion.assertionId) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+          "accepted: recall included id does not match the minted assertion",
+        );
+      }
+      if (
+        recall.audit.sourceCandidateId !== null &&
+        recall.audit.sourceCandidateId !== candidate.candidateId
+      ) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.mismatched_candidate_assertion,
+          "accepted: recall audit source candidate does not match",
+        );
+      }
+      const proof: AdmissionScenarioProofOk = {
+        ok: true,
+        scenario: "accepted",
+        reasonCode: ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion,
+        candidate,
+        transition,
+        recall,
+        invariantsHeld: [
+          "accept_mints_admitted_assertion",
+          "admitted_assertion_references_candidate_and_transition",
+          "admitted_assertion_recall_eligible",
+          "raw_candidate_not_ordinary_recall_material",
+        ],
+      };
+      return sealAdmissionProjection(proof);
+    }
+
+    case "rejected": {
+      const candidate = classifyAdmissionCandidate(scenario.candidate);
+      if (!candidate.ok) return candidate;
+      const transition = applyAdmissionTransition({
+        candidate: scenario.candidate,
+        transition: scenario.transition,
+        admittedAssertion: null,
+      });
+      if (!transition.ok) return transition;
+      if (transition.decision !== "rejected") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "rejected: transition must be a reject",
+        );
+      }
+      const recall = projectAdmissionRecallProof({
+        recallProof: scenario.recallProof,
+        candidateId: candidate.candidateId,
+      });
+      if (!recall.ok) return recall;
+      if (recall.recallResult !== "excluded") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "rejected: recall proof must be excluded",
+        );
+      }
+      if (recall.reasonCode !== ADMISSION_REDUCER_REASON_CODES.candidate_rejected) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          `rejected: expected candidate_rejected, got ${recall.reasonCode}`,
+        );
+      }
+      const proof: AdmissionScenarioProofOk = {
+        ok: true,
+        scenario: "rejected",
+        reasonCode: ADMISSION_REDUCER_REASON_CODES.candidate_rejected,
+        candidate,
+        transition,
+        recall,
+        invariantsHeld: [
+          "rejected_mints_no_assertion",
+          "rejected_never_recallable",
+          "rejection_is_terminal",
+        ],
+      };
+      return sealAdmissionProjection(proof);
+    }
+
+    case "supersession": {
+      const candidate = classifyAdmissionCandidate(scenario.correctionCandidate);
+      if (!candidate.ok) return candidate;
+      const transition = applyAdmissionTransition({
+        candidate: scenario.correctionCandidate,
+        transition: scenario.supersedeTransition,
+        admittedAssertion: scenario.correctedAssertion,
+        supersededAssertion: scenario.supersededAssertion,
+      });
+      if (!transition.ok) return transition;
+      if (transition.decision !== "accepted") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "supersession: transition must be an accept",
+        );
+      }
+      if (transition.reasonCode !== ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "supersession: transition must be a supersede (corrected_active_assertion)",
+        );
+      }
+      const recall = projectAdmissionRecallProof({
+        recallProof: scenario.recallProof,
+        candidateId: candidate.candidateId,
+        admittedAssertionId: transition.admittedAssertion.assertionId,
+        supersededAssertionId: transition.supersededAssertionId ?? undefined,
+      });
+      if (!recall.ok) return recall;
+      if (recall.recallResult !== "included") {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+          "supersession: recall proof must be included",
+        );
+      }
+      // cross-check: corrected active included; superseded prior excluded.
+      if (recall.includedAssertionIds[0] !== transition.admittedAssertion.assertionId) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.mismatched_transition_assertion,
+          "supersession: recall included id does not match the corrected assertion",
+        );
+      }
+      if (
+        transition.supersededAssertionId &&
+        !recall.excludedAssertionIds.includes(transition.supersededAssertionId)
+      ) {
+        return fail(
+          ADMISSION_REDUCER_REASON_CODES.superseded_included_as_active_recall,
+          "supersession: superseded prior not recorded as excluded in recall",
+        );
+      }
+      const proof: AdmissionScenarioProofOk = {
+        ok: true,
+        scenario: "supersession",
+        reasonCode: ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion,
+        candidate,
+        transition,
+        recall,
+        invariantsHeld: [
+          "supersede_mints_corrected_active_assertion",
+          "corrected_state_recalled_not_prior",
+          "superseded_prior_excluded_from_ordinary_recall",
+          "supersedes_link_preserved_for_audit",
+        ],
+      };
+      return sealAdmissionProjection(proof);
+    }
+
+    default: {
+      // exhaustiveness guard — any unknown scenario kind fails closed.
+      const exhaustive: never = scenario;
+      void exhaustive;
+      return fail(
+        ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+        "scenario: unknown kind",
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 44A adds a fixture-bound Admission Wedge reducer/adapter over the Phase 43C fixture contract.

This is the first Admission Wedge code slice, but it remains pure, local, and test-only. It does not add a live admission implementation.

The reducer proves in code:

- candidate memory is not admitted memory
- candidate memory is not recallable before explicit admission
- accepted transition mints an admitted assertion
- rejected candidate mints no admitted assertion and remains excluded
- supersession/correction recalls only the corrected active assertion while preserving audit/provenance
- raw candidate/private payload is never ordinary recall material
- malformed or unsupported fixture inputs fail closed

## Files

Added:

- packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.ts
- packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.test.ts

Modified with minimal Phase 44A status notes:

- docs/ADMISSION-WEDGE-MVP-DESIGN.md
- docs/admission-wedge/fixtures/README.md
- docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md

## Implementation notes

The reducer is fixture-bound and local:

- no runtime Discord behavior
- no Discord command changes
- no Dixie route or live network calls
- no storage
- no production auth/consent
- no public surface
- no package exports
- no package or lockfile changes
- no config, CI, or generated changes

The reducer is imported only by its own test file.

## Safety patch from Codex audit

Codex initially returned PATCH because fail-closed detail strings could echo raw malformed input, including private sentinels and long IDs.

That blocker was patched by sealing fail-closed detail output through stable reason-code rendering. The final patch-resolution verdict was:

- VERDICT: ACCEPT
- previous fail-closed detail leakage blocker: fully resolved
- remaining required patches: none
- exact file:line concerns: none

## Validation

Validated locally:

- git diff --check: pass
- node docs/recall-wedge/fixtures/validate-fixtures.mjs: 122 checks passed / 0 failed
- node docs/admission-wedge/fixtures/validate-fixtures.mjs: 318 checks passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.test.ts: 57 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts: 52 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts: 110 tests passed / 0 failed

Global persona-engine typecheck remains at a known dirty baseline unrelated to this slice. Codex confirmed no new recall-wedge / admission-wedge-fixture-reducer diagnostics.

## Non-goals

This PR does not authorize or add:

- runtime Discord behavior
- Discord command changes
- `/remember-this`
- public remember-this
- Discord history ingestion
- user chat becoming memory
- live Dixie admission route
- live network calls
- production admission
- production storage
- production auth/consent
- public rollout
- Telegram/private-chat surfaces
- Finn production wiring
- LLM rewriting
- character voice
- forget/revoke/correction UI
- package or lockfile changes
- CI/config/generated changes
