### PR TITLE
Phase 44C feat: add Admission Wedge fixture runner

### DIFF
--- a/docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md
+++ b/docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md
@@ -392,3 +392,47 @@ Other related artifacts (read only; **unchanged by Phase 44B**):
   accepted controlled dev/operator seeded live recall (PR #150); the
   read-side primitive a future recall-after-admission proof would reuse
   unchanged, well beyond this gate.
+
+---
+
+## 12. Phase 44C status note — fixture-bound dev/operator reducer runner added
+
+> Added by Phase 44C, 2026-06-02. Status note only; the decision in §5–§9
+> is unchanged and the §8.2 boundaries stay in force.
+
+Phase 44C implements the Option A lane this gate selected (§7), inside the
+§8.1 scope and under the §8.2 boundaries:
+
+- `packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts`
+  (+ `.test.ts`) — a local dev/operator runner that *reads* the existing
+  Phase 43C fixtures, *calls* the existing Phase 44A reducer
+  (`reduceAdmissionFixtureScenario`), and prints operator-safe scenario
+  summaries for the five §8.1 scenarios:
+  - `before_admission_excluded` — candidate excluded before admission;
+  - `accepted_admitted_included` — admitted assertion included;
+  - `rejected_excluded` — rejected candidate excluded, nothing minted;
+  - `supersession_corrected_only` — corrected active included, prior excluded;
+  - `malformed_fail_closed` — a synthetic, in-memory malformed candidate
+    (carrying a private sentinel + a long-id run, never written to fixture
+    JSON) routed through the same reducer entry point, proving fail-closed
+    behavior without leaking its unsafe input.
+- Each summary carries only safe fields: scenario name, outcome
+  (`excluded` / `included` / `fail_closed`), a stable reducer reason code,
+  short fixture ids (included / excluded), an audit-link **presence**
+  boolean (never the raw audit body), and a canned one-line summary. Every
+  summary is sealed through the Phase 44A reducer's `scanForUnsafeProjection`
+  no-leak scan.
+- It runs the existing acceptance set: `git diff --check` clean, both
+  fixture validators pass, the Phase 44A reducer test passes, the new runner
+  test passes, and the multi-surface + live-Dixie regressions pass
+  (proving no live-egress regression).
+
+Phase 44C does **not** authorize live admission, a Discord command,
+`/remember-this`, public remember-this, Discord history ingestion, user
+chat becoming memory, storage writes, production auth / consent, a live
+Dixie admission route, network calls, package exports, public renderer
+changes, dispatch / startup / command-registration changes, LLM / voice
+behavior, or Finn production wiring. The runner is imported only by its own
+test and the local `import.meta.main` CLI guard; it is not exported from the
+package surface and is wired into no runtime path. The §8.2 boundaries and
+the decision-map §7 / §8 gates remain in force.

--- a/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+++ b/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
@@ -978,6 +978,47 @@ admission implementation."
 
 ---
 
+### 5q. Phase 44C addendum — fixture-bound dev/operator reducer runner added; runner only, no live admission
+
+> Added by Phase 44C, 2026-06-02. Targeted addendum, not a rewrite of this
+> section.
+
+Status as of Phase 44C:
+
+- **Phase 44C implements the Option A lane Phase 44B selected (§5p).** It
+  adds a local dev/operator runner
+  (`packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts`
+  + `.test.ts`) that *reads* the existing Phase 43C fixtures and *calls* the
+  existing Phase 44A reducer to print operator-safe scenario summaries
+  (before-admission excluded; accepted included; rejected excluded;
+  supersession corrected-only; a synthetic malformed fail-closed case
+  constructed in memory, never written to fixture JSON). Each summary carries
+  only safe fields — scenario name, outcome, stable reducer reason code,
+  short fixture ids, an audit-link presence boolean, a canned one-liner — and
+  is sealed through the reducer's own no-leak scan.
+- **It mutates no fixture and reimplements no reducer semantics.** The runner
+  reads the Phase 43C fixtures read-only and composes the Phase 44A reducer;
+  it is the analogue of the accepted Recall Wedge Phase 35B dev/operator
+  runner.
+- **It is wired into no runtime path.** The runner is imported only by its
+  own test and a local `import.meta.main` CLI guard; it is not exported from
+  the package surface and is not reachable from Discord, Dixie, the renderer,
+  dispatch, startup, or command registration.
+- **Live Dixie-backed admission, production storage / admission, public
+  remember-this, Discord history ingestion, user chat becoming memory,
+  production auth / consent, public rollout, Telegram / private chat, LLM /
+  voice, a forget / revoke / correction UI, package exports, and Finn
+  production wiring all remain blocked** behind separate later gates. Phase
+  44C expands the Phase 43A / 43B / 44B authorization in no way, and §7 (live
+  memory admission gates) and §8 (prohibitions) stay in force.
+
+This addendum does not duplicate the Phase 44C status note in
+`docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md` §12; it only records that
+the Phase 44B-selected runner lane is now implemented as a fixture-bound
+dev/operator runner, not a live admission implementation.
+
+---
+
 ## 6. Decision gates before live Dixie client (Option C)
 
 Before a live Dixie client is allowed, all of the following must hold:
@@ -1185,6 +1226,22 @@ implementation, only after 43B's design is accepted. A dev-only
 > user-facing write path, live Dixie admission route, or Finn production
 > wiring. See §5p. The runtime Lane A implementation and the §7
 > live-memory-admission gates remain in force and separately gated.
+
+> **Status note (Phase 44C fixture-bound dev/operator reducer runner).**
+> Phase 44C implements the Phase 44B-selected Option A lane: a local
+> dev/operator runner
+> (`packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts`
+> + test) that reads the Phase 43C fixtures, calls the Phase 44A reducer,
+> and prints operator-safe scenario summaries (before-admission excluded;
+> accepted included; rejected excluded; supersession corrected-only; a
+> synthetic malformed fail-closed case). It mutates no fixture, reimplements
+> no reducer semantics, is imported only by its own test + a local CLI guard
+> (not exported, wired into no runtime path), and authorizes no live
+> admission, storage, command, Dixie route, network call, package export,
+> LLM / voice, or Finn production wiring. See §5q and
+> `docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md` §12. The runtime Lane A
+> implementation and the §7 live-memory-admission gates remain in force and
+> separately gated.
 
 ### 9.1 Historical context — superseded Phase 35B recommendation
 

--- a/docs/admission-wedge/fixtures/README.md
+++ b/docs/admission-wedge/fixtures/README.md
@@ -256,3 +256,14 @@ it (decision-map §7) — Phase 43C authorizes none of them.
   would *read* these fixtures and *call* that reducer; it would **not**
   add, mutate, or regenerate any fixture here, and it authorizes no live
   admission, storage, command, or Dixie route.
+- `packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts`
+  (+ `.test.ts`) — **Phase 44C** fixture-bound dev/operator reducer runner.
+  It *reads* these fixtures (read-only; it adds, mutates, and regenerates
+  nothing here) and *calls* the Phase 44A reducer to print operator-safe
+  scenario summaries (before-admission excluded; accepted included; rejected
+  excluded; supersession corrected-only; a synthetic malformed fail-closed
+  case constructed in memory, never written here). It is imported only by
+  its own test and a local CLI guard — not exported from the package and
+  wired into no runtime path — and it authorizes no live admission, storage,
+  command, Dixie route, network call, package export, LLM / voice, or Finn
+  production wiring.

--- a/packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.test.ts
+++ b/packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.test.ts
@@ -1,0 +1,527 @@
+// Phase 44C · Admission Wedge fixture-bound dev/operator reducer runner —
+// regression gate.
+//
+// Authority: docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md (Phase 44B gate
+// §7 selects this lane, §8 bounds it, §9 sets these acceptance criteria),
+// over the Phase 43C fixtures and the Phase 44A reducer.
+//
+// These tests prove the runner:
+//   1. loads the EXISTING Phase 43C fixtures successfully;
+//   2. before-admission summary excludes the candidate;
+//   3. accepted/admitted summary includes the admitted assertion only;
+//   4. rejected summary excludes the rejected candidate and mints/includes no
+//      admitted assertion;
+//   5. supersession summary includes the corrected active assertion only and
+//      excludes the superseded prior state from ordinary recall;
+//   6. the synthetic malformed scenario fails closed;
+//   7. output carries no private sentinel, raw candidate payload, long ids,
+//      raw fixture bodies, urls, secrets, stack traces, or binary/screenshot
+//      references;
+//   8. the runner imports + calls the Phase 44A reducer rather than
+//      reimplementing its main logic;
+//   9. the runner file is not imported from any runtime path
+//      (Discord/Dixie/renderer/dispatch/startup/command registration/package
+//      exports).
+//
+// Scope reminder (Phase 44B gate §8.2): this is a fixture-bound dev/operator
+// runner. It admits nothing, stores nothing, reaches no network, and is wired
+// into no runtime path. It authorizes no live admission.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ADMISSION_REDUCER_REASON_CODES,
+  scanForUnsafeProjection,
+} from "./admission-wedge-fixture-reducer.ts";
+import {
+  ADMISSION_DEMO_SCENARIO_PLANS,
+  ADMISSION_FIXTURE_DEMO_REPORT_TITLE,
+  MALFORMED_DEMO_LONG_ID,
+  MALFORMED_DEMO_SENTINEL,
+  NON_GOALS_HEADER,
+  SCENARIO_SECTION_HEADER_PREFIX,
+  buildAdmissionFixtureDemoReport,
+  buildMalformedDemoCandidate,
+  extractFormattedScenarioSection,
+  formatAdmissionFixtureDemoReport,
+  loadAdmissionWedgeFixtures,
+  runAdmissionFixtureDemo,
+  type AdmissionScenarioSafeSummary,
+} from "./run-admission-wedge-fixture-demo.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Collect every string emitted anywhere in a value (recursively).
+function collectStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") out.push(value);
+  else if (Array.isArray(value)) for (const v of value) collectStrings(v, out);
+  else if (value && typeof value === "object")
+    for (const v of Object.values(value)) collectStrings(v, out);
+  return out;
+}
+
+function summaryByName(
+  report: ReturnType<typeof buildAdmissionFixtureDemoReport>,
+  name: string,
+): AdmissionScenarioSafeSummary {
+  const s = report.summaries.find((x) => x.scenario === name);
+  if (!s) throw new Error(`missing scenario summary: ${name}`);
+  return s;
+}
+
+// =========================================================================
+// 1. runner loads existing fixtures successfully
+// =========================================================================
+
+describe("Phase 44C · 1. loads existing Phase 43C fixtures", () => {
+  test("loadAdmissionWedgeFixtures reads every fixture from disk", () => {
+    const f = loadAdmissionWedgeFixtures();
+    // every fixture parsed to an object (not null / not a parse miss).
+    for (const v of Object.values(f)) {
+      expect(typeof v).toBe("object");
+      expect(v).not.toBeNull();
+    }
+    // spot-check the candidate id is the real Phase 43C id.
+    expect((f.cand001 as Record<string, unknown>).candidate_id).toBe(
+      "cand-001",
+    );
+  });
+
+  test("buildAdmissionFixtureDemoReport produces all five gate scenarios", () => {
+    const report = buildAdmissionFixtureDemoReport();
+    expect(report.title).toBe(ADMISSION_FIXTURE_DEMO_REPORT_TITLE);
+    expect(report.summaries.map((s) => s.scenario)).toEqual([
+      "before_admission_excluded",
+      "accepted_admitted_included",
+      "rejected_excluded",
+      "supersession_corrected_only",
+      "malformed_fail_closed",
+    ]);
+    expect(report.counts.total).toBe(5);
+    expect(report.counts.all_outcomes_matched_expected).toBe(true);
+  });
+
+  test("report is deterministic across invocations", () => {
+    const a = formatAdmissionFixtureDemoReport(buildAdmissionFixtureDemoReport());
+    const b = formatAdmissionFixtureDemoReport(buildAdmissionFixtureDemoReport());
+    expect(a).toBe(b);
+  });
+});
+
+// =========================================================================
+// 2. before-admission summary excludes the candidate
+// =========================================================================
+
+describe("Phase 44C · 2. before-admission excludes candidate", () => {
+  const report = buildAdmissionFixtureDemoReport();
+  const s = summaryByName(report, "before_admission_excluded");
+
+  test("outcome is excluded with candidate_not_admitted", () => {
+    expect(s.outcome).toBe("excluded");
+    expect(s.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+    );
+  });
+
+  test("the candidate is in excludedIds and never in includedAssertionIds", () => {
+    expect(s.excludedIds).toContain("cand-001");
+    expect(s.includedAssertionIds).toEqual([]);
+  });
+});
+
+// =========================================================================
+// 3. accepted/admitted summary includes the admitted assertion only
+// =========================================================================
+
+describe("Phase 44C · 3. accepted includes admitted assertion only", () => {
+  const report = buildAdmissionFixtureDemoReport();
+  const s = summaryByName(report, "accepted_admitted_included");
+
+  test("outcome is included with admitted_active_assertion", () => {
+    expect(s.outcome).toBe("included");
+    expect(s.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion,
+    );
+  });
+
+  test("includes exactly the admitted assertion assn-001 and no candidate id", () => {
+    expect(s.includedAssertionIds).toEqual(["assn-001"]);
+    expect(s.includedAssertionIds).not.toContain("cand-001");
+  });
+
+  test("audit-link presence is reported without the raw audit body", () => {
+    expect(s.auditLinkPresent).toBe(true);
+    // no raw audit fields are exposed on the summary object.
+    expect("audit" in s).toBe(false);
+  });
+});
+
+// =========================================================================
+// 4. rejected summary excludes the rejected candidate; mints no assertion
+// =========================================================================
+
+describe("Phase 44C · 4. rejected excludes candidate, mints nothing", () => {
+  const report = buildAdmissionFixtureDemoReport();
+  const s = summaryByName(report, "rejected_excluded");
+
+  test("outcome is excluded with candidate_rejected", () => {
+    expect(s.outcome).toBe("excluded");
+    expect(s.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.candidate_rejected,
+    );
+  });
+
+  test("excludes cand-002 and includes / mints no admitted assertion", () => {
+    expect(s.excludedIds).toContain("cand-002");
+    expect(s.includedAssertionIds).toEqual([]);
+  });
+});
+
+// =========================================================================
+// 5. supersession includes corrected active only; excludes superseded prior
+// =========================================================================
+
+describe("Phase 44C · 5. supersession corrected-only", () => {
+  const report = buildAdmissionFixtureDemoReport();
+  const s = summaryByName(report, "supersession_corrected_only");
+
+  test("outcome is included with corrected_active_assertion", () => {
+    expect(s.outcome).toBe("included");
+    expect(s.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion,
+    );
+  });
+
+  test("includes only the corrected active assn-011, excludes the prior assn-010", () => {
+    expect(s.includedAssertionIds).toEqual(["assn-011"]);
+    expect(s.includedAssertionIds).not.toContain("assn-010");
+    expect(s.excludedIds).toContain("assn-010");
+  });
+});
+
+// =========================================================================
+// 6. synthetic malformed scenario fails closed
+// =========================================================================
+
+describe("Phase 44C · 6. malformed scenario fails closed", () => {
+  const report = buildAdmissionFixtureDemoReport();
+  const s = summaryByName(report, "malformed_fail_closed");
+
+  test("outcome is fail_closed with a stable reason code", () => {
+    expect(s.outcome).toBe("fail_closed");
+    expect(s.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES
+        .candidate_recall_eligible_before_admission,
+    );
+    expect(s.includedAssertionIds).toEqual([]);
+    expect(s.excludedIds).toEqual([]);
+  });
+
+  test("the synthetic malformed candidate is non-vacuous (genuinely carries unsafe input)", () => {
+    const raw = JSON.stringify(buildMalformedDemoCandidate());
+    expect(raw).toContain(MALFORMED_DEMO_SENTINEL);
+    expect(raw).toContain(MALFORMED_DEMO_LONG_ID);
+    // and the reducer's own scan flags it — proving the fail-closed path is real.
+    expect(scanForUnsafeProjection(buildMalformedDemoCandidate())).not.toBeNull();
+  });
+
+  test("the malformed summary leaks neither the sentinel nor the long id", () => {
+    const out = JSON.stringify(s);
+    expect(out).not.toContain(MALFORMED_DEMO_SENTINEL);
+    expect(out).not.toContain(MALFORMED_DEMO_LONG_ID);
+    expect(out).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+    expect(scanForUnsafeProjection(s)).toBeNull();
+  });
+});
+
+// =========================================================================
+// 7. no-leak posture — output carries no unsafe material
+// =========================================================================
+
+describe("Phase 44C · 7. safe-output / no-leak posture", () => {
+  const report = buildAdmissionFixtureDemoReport();
+  const formatted = formatAdmissionFixtureDemoReport(report);
+
+  test("the structured report scans clean (reducer no-leak seal)", () => {
+    expect(scanForUnsafeProjection(report)).toBeNull();
+  });
+
+  test("no string anywhere in the report contains a private body sentinel", () => {
+    for (const s of collectStrings(report)) {
+      expect(s).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+      expect(s).not.toContain("SOURCE_SENTINEL");
+      expect(s).not.toContain("ADMITTED_PRIVATE_SENTINEL");
+      expect(s).not.toContain("SUPERSEDED_PRIVATE_SENTINEL");
+    }
+  });
+
+  test("no raw candidate / admitted body text reaches the output", () => {
+    // these phrases live only inside the never-rendered fixture bodies.
+    expect(formatted).not.toContain("held for review");
+    expect(formatted).not.toContain("never rendered");
+    expect(formatted).not.toContain("body_private");
+    expect(formatted).not.toContain("source_material");
+    expect(formatted).not.toContain("candidate_payload");
+  });
+
+  test("no long ids, hex addresses, urls, jwts, or pem keys appear", () => {
+    expect(formatted).not.toMatch(/\d{17,}/);
+    expect(formatted).not.toMatch(/0x[a-fA-F0-9]{40,}/);
+    expect(formatted).not.toMatch(/https?:\/\//i);
+    expect(formatted).not.toMatch(/\beyJ[A-Za-z0-9_-]{10,}/); // JWT-ish
+    expect(formatted).not.toMatch(/-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+  });
+
+  test("no stack-trace or operational-id markers appear", () => {
+    expect(formatted).not.toContain("at Object.");
+    expect(formatted).not.toMatch(/\n\s+at\s+\S+\s+\(/); // node stack frame
+    expect(formatted).not.toContain("Error:");
+  });
+
+  test("no screenshot / binary / image evidence references appear", () => {
+    expect(formatted).not.toMatch(/\.(png|jpg|jpeg|gif|webp|pdf|mp4|bin)\b/i);
+    expect(formatted).not.toContain("data:image");
+    expect(formatted).not.toContain("base64");
+  });
+
+  test("each scenario section body scans clean and stays short-id-only", () => {
+    for (const plan of ADMISSION_DEMO_SCENARIO_PLANS) {
+      const section = extractFormattedScenarioSection(formatted, plan.name);
+      expect(scanForUnsafeProjection(section.body)).toBeNull();
+      expect(section.body).not.toMatch(/\d{17,}/);
+    }
+  });
+});
+
+// =========================================================================
+// 8. runner imports + calls the Phase 44A reducer (does not reimplement it)
+// =========================================================================
+
+describe("Phase 44C · 8. composes the Phase 44A reducer", () => {
+  const moduleSource = readFileSync(
+    resolve(__dirname, "run-admission-wedge-fixture-demo.ts"),
+    "utf8",
+  );
+
+  test("imports the Phase 44A reducer entry point", () => {
+    expect(moduleSource).toMatch(
+      /from\s+["']\.\/admission-wedge-fixture-reducer\.ts["']/,
+    );
+    expect(moduleSource).toContain("reduceAdmissionFixtureScenario");
+  });
+
+  test("calls reduceAdmissionFixtureScenario for every scenario plan", () => {
+    // one call per the five scenarios, all routed through the reducer.
+    const calls = (
+      moduleSource.match(/reduceAdmissionFixtureScenario\s*\(/g) ?? []
+    ).length;
+    expect(calls).toBe(ADMISSION_DEMO_SCENARIO_PLANS.length);
+  });
+
+  test("does not reimplement the reducer's core decision logic locally", () => {
+    // the runner must not redefine the reducer's primitive functions — those
+    // belong to the Phase 44A module. (It legitimately imports the reason
+    // codes + scan; it must not declare its own copies.)
+    expect(moduleSource).not.toMatch(
+      /function\s+classifyAdmissionCandidate\b/,
+    );
+    expect(moduleSource).not.toMatch(/function\s+applyAdmissionTransition\b/);
+    expect(moduleSource).not.toMatch(
+      /function\s+projectAdmissionRecallProof\b/,
+    );
+    expect(moduleSource).not.toMatch(
+      /function\s+reduceAdmissionFixtureScenario\b/,
+    );
+    // and it does not re-declare the reason-code table.
+    expect(moduleSource).not.toMatch(
+      /const\s+ADMISSION_REDUCER_REASON_CODES\s*=/,
+    );
+  });
+
+  test("the runner's outcomes match the reducer's results directly", () => {
+    // call the reducer the same way the plans do and confirm parity — proves
+    // the runner is a projection of the reducer, not an independent oracle.
+    const report = buildAdmissionFixtureDemoReport();
+    for (const plan of ADMISSION_DEMO_SCENARIO_PLANS) {
+      const proof = plan.reduce(loadAdmissionWedgeFixtures());
+      const summary = report.summaries.find((s) => s.scenario === plan.name)!;
+      if (proof.ok) {
+        const expectedOutcome =
+          proof.recall.recallResult === "excluded" ? "excluded" : "included";
+        expect(summary.outcome).toBe(expectedOutcome);
+        expect(summary.reasonCode).toBe(proof.recall.reasonCode);
+      } else {
+        expect(summary.outcome).toBe("fail_closed");
+        expect(summary.reasonCode).toBe(proof.reasonCode);
+      }
+    }
+  });
+});
+
+// =========================================================================
+// 9. runner is not imported from any runtime path
+// =========================================================================
+
+describe("Phase 44C · 9. not wired into any runtime path", () => {
+  const moduleSource = readFileSync(
+    resolve(__dirname, "run-admission-wedge-fixture-demo.ts"),
+    "utf8",
+  );
+
+  test("runner imports no Discord client / dispatch / interactions", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*discord-interactions[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*dispatch[^"']*["']/);
+  });
+
+  test("runner imports no Dixie / Straylight / Finn / live client", () => {
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+    expect(moduleSource).not.toMatch(/from\s+["'][^"']*\/finn[^"']*["']/);
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*live-dixie-client[^"']*["']/,
+    );
+  });
+
+  test("runner imports no public renderer / adapter", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*render-public-recall[^"']*["']/,
+    );
+    expect(moduleSource).not.toMatch(
+      /from\s+["'][^"']*dixie-envelope-adapter[^"']*["']/,
+    );
+  });
+
+  test("runner imports no LLM SDK / production storage", () => {
+    expect(moduleSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+    expect(moduleSource).not.toMatch(/from\s+["']openai["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']pg["']/);
+    expect(moduleSource).not.toMatch(/from\s+["']postgres["']/);
+  });
+
+  test("runner does not register or dispatch Discord commands", () => {
+    expect(moduleSource).not.toMatch(/registerCommand\s*\(/);
+    expect(moduleSource).not.toMatch(/applicationCommands/);
+    expect(moduleSource).not.toMatch(/createWebhook\s*\(/);
+  });
+
+  test("runner reaches no network / clock / env", () => {
+    expect(moduleSource).not.toMatch(/\bfetch\s*\(/);
+    expect(moduleSource).not.toMatch(/process\.env/);
+    expect(moduleSource).not.toMatch(/Date\.now/);
+    expect(moduleSource).not.toMatch(/Math\.random/);
+  });
+
+  test("no other source file imports this runner (not wired into runtime)", () => {
+    // sweep the whole repo (excluding node_modules / .git) for any importer
+    // of this module other than its own test. The runner must be reachable
+    // only by its test and the local CLI guard.
+    const repoRoot = resolve(__dirname, "../../../..");
+    const { execSync } = require("node:child_process") as typeof import("node:child_process");
+    const raw = execSync(
+      "grep -rl --include='*.ts' --include='*.tsx' " +
+        "'run-admission-wedge-fixture-demo' . " +
+        "|| true",
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    const importers = raw
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      // normalize to basenames for comparison.
+      .map((l) => l.replace(/^\.\//, ""));
+    // only the runner itself and its test may reference the module name.
+    const allowed = new Set([
+      "packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts",
+      "packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.test.ts",
+    ]);
+    for (const f of importers) {
+      expect(allowed.has(f)).toBe(true);
+    }
+  });
+
+  test("the runner is not listed in the package.json exports map", () => {
+    const repoRoot = resolve(__dirname, "../../../..");
+    const pkg = readFileSync(
+      resolve(repoRoot, "packages/persona-engine/package.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(pkg) as { exports?: Record<string, unknown> };
+    const exportTargets = Object.values(parsed.exports ?? {}).map(String);
+    for (const target of exportTargets) {
+      expect(target).not.toContain("run-admission-wedge-fixture-demo");
+    }
+  });
+});
+
+// =========================================================================
+// 10. invocation surface
+// =========================================================================
+
+describe("Phase 44C · 10. runner invocation surface", () => {
+  test("runAdmissionFixtureDemo returns report + formatted, prints when asked", () => {
+    const printed: string[] = [];
+    const result = runAdmissionFixtureDemo({ print: (l) => printed.push(l) });
+    expect(result.report.title).toBe(ADMISSION_FIXTURE_DEMO_REPORT_TITLE);
+    expect(result.formatted.length).toBeGreaterThan(0);
+    expect(printed.length).toBe(1);
+    expect(printed[0]).toBe(result.formatted);
+  });
+
+  test("does not print when no print sink is provided", () => {
+    const result = runAdmissionFixtureDemo();
+    expect(result.formatted).toContain(
+      `# ${ADMISSION_FIXTURE_DEMO_REPORT_TITLE}`,
+    );
+  });
+
+  test("formatted report enumerates the non-goals (no live surface claims)", () => {
+    const { formatted } = runAdmissionFixtureDemo();
+    expect(formatted).toContain(`## ${NON_GOALS_HEADER}`);
+    expect(formatted).toContain("no live Dixie admission route");
+    expect(formatted).toContain("no production admission");
+    expect(formatted).toContain("no package export");
+    expect(formatted).toContain("no /remember-this");
+  });
+
+  test("accepts injected fixtures for deterministic test composition", () => {
+    const injected = buildAdmissionFixtureDemoReport({
+      fixtures: loadAdmissionWedgeFixtures(),
+    });
+    expect(injected.counts.all_outcomes_matched_expected).toBe(true);
+  });
+});
+
+// =========================================================================
+// 11. scenario section headers + structure
+// =========================================================================
+
+describe("Phase 44C · 11. report structure", () => {
+  const formatted = formatAdmissionFixtureDemoReport(
+    buildAdmissionFixtureDemoReport(),
+  );
+
+  for (const plan of ADMISSION_DEMO_SCENARIO_PLANS) {
+    test(`includes a scenario section header for ${plan.name}`, () => {
+      expect(formatted).toContain(
+        `## ${SCENARIO_SECTION_HEADER_PREFIX}${plan.name}`,
+      );
+    });
+  }
+
+  test("scope banner precedes the first scenario section", () => {
+    const bannerIdx = formatted.indexOf("> scope (read me first):");
+    const firstScenarioIdx = formatted.indexOf(
+      `## ${SCENARIO_SECTION_HEADER_PREFIX}before_admission_excluded`,
+    );
+    expect(bannerIdx).toBeGreaterThan(-1);
+    expect(firstScenarioIdx).toBeGreaterThan(bannerIdx);
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts
+++ b/packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts
@@ -1,0 +1,538 @@
+// Phase 44C · Admission Wedge fixture-bound dev/operator reducer runner.
+//
+// Authority: docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md (Phase 44B gate,
+// §7 selects this lane, §8 bounds it), over the Phase 43C fixtures
+// (docs/admission-wedge/fixtures/) and the Phase 44A reducer
+// (./admission-wedge-fixture-reducer.ts). It is the analogue of the accepted
+// Recall Wedge Phase 35B dev/operator runner (./run-demo.ts): operator
+// ergonomics over an already-accepted, fixture-bound, pure proof.
+//
+// What this runner does:
+//   1. reads the EXISTING Phase 43C admission-wedge fixture JSON from disk
+//      (Node built-ins only — it adds, mutates, and regenerates nothing);
+//   2. calls the EXISTING Phase 44A reducer (`reduceAdmissionFixtureScenario`)
+//      — it does NOT reimplement reducer semantics;
+//   3. projects each reducer result into a small, safe, operator-readable
+//      scenario summary (stable reason codes + short fixture ids only);
+//   4. covers the five gate §8.1 scenarios:
+//        - before_admission_excluded   — candidate excluded before admission;
+//        - accepted_admitted_included  — admitted assertion included;
+//        - rejected_excluded           — rejected candidate excluded;
+//        - supersession_corrected_only — corrected included, prior excluded;
+//        - malformed_fail_closed       — synthetic malformed input fails closed;
+//   5. seals every summary against private sentinels / long ids / urls / pem
+//      keys via the reducer's own `scanForUnsafeProjection` no-leak scan.
+//
+// What this runner is NOT (carried verbatim from the Phase 44B gate §8.2):
+//   - it is NOT a live admission implementation. It admits nothing, stores
+//     nothing, reaches no network, and reads no clock / env;
+//   - it is NOT wired into Discord, Dixie, the public renderer, the live
+//     client, dispatch, startup, command registration, or any package
+//     export. It is imported only by its own test (and, behind an
+//     `import.meta.main` guard, runnable as a local dev/operator CLI);
+//   - it authorizes NO production admission, production storage, production
+//     auth / consent, public remember-this, Discord history ingestion, user
+//     chat becoming memory, a live Dixie admission route, a dev/operator
+//     candidate command, or any Finn production wiring. All remain blocked.
+//
+// Determinism: this module's only side input is the static Phase 43C fixture
+// JSON on disk; given those bytes it is a pure function. No clock, no env,
+// no network, no random.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ADMISSION_REDUCER_REASON_CODES,
+  reduceAdmissionFixtureScenario,
+  scanForUnsafeProjection,
+  type AdmissionReducerReasonCode,
+  type AdmissionScenarioProof,
+} from "./admission-wedge-fixture-reducer.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/admission-wedge/fixtures",
+);
+
+// -- report constants -------------------------------------------------------
+
+export const ADMISSION_FIXTURE_DEMO_REPORT_TITLE =
+  "Admission Wedge fixture-bound dev/operator reducer demo" as const;
+
+export const SCENARIO_SECTION_HEADER_PREFIX = "Scenario summary: " as const;
+
+export const SCOPE_BANNER_HEADER = "scope (read me first)" as const;
+
+export const INTERNAL_PROOF_HEADER =
+  "Run proof summary [INTERNAL / operator-only]" as const;
+
+export const NON_GOALS_HEADER =
+  "Non-goals / not authorized by this runner" as const;
+
+// Read-me-first scope banner. Mirrors the Recall Wedge runners' banner so an
+// operator can see, before reading any summary, exactly how bounded this is.
+export const SCOPE_BANNER_LINES = [
+  "fixture-bound: reads the existing Phase 43C admission-wedge fixtures only; mutates none of them",
+  "reducer-bound: calls the Phase 44A reducer; does not reimplement reducer semantics",
+  "dev/operator only: a callable runner plus an optional local CLI; not wired into any runtime path",
+  "not live admission: admits nothing, stores nothing, reaches no network, reads no clock / env",
+  "safe output: stable reason codes and short fixture ids only — no raw bodies, payloads, or private text",
+] as const;
+
+// What this runner is explicitly NOT, per the Phase 44B gate §8.2.
+const NON_GOALS = [
+  "no Discord command / dispatch / startup / command registration",
+  "no /remember-this (public or dev-only) and no public remember-this",
+  "no Discord history ingestion / no user chat becoming memory",
+  "no live Dixie admission route / no live network call",
+  "no production admission / production storage / production auth / consent",
+  "no package export — this runner is not exported from the package surface",
+  "no public renderer change / no live Dixie client",
+  "no LLM rewriting / no character voice",
+  "no forget / revoke / correction UI",
+  "no Finn production wiring",
+  "no mutation of the Phase 43C fixture JSON",
+] as const;
+
+// -- safe summary shape -----------------------------------------------------
+//
+// The single per-scenario object an operator (and the tests) read. Every
+// field is intentionally safe: a canned scenario name, an enum outcome, a
+// STABLE reducer reason code, short fixture ids only, an audit-link PRESENCE
+// boolean (never the raw audit body), and a canned one-line summary.
+export type AdmissionScenarioOutcome = "excluded" | "included" | "fail_closed";
+
+export interface AdmissionScenarioSafeSummary {
+  readonly scenario: string;
+  readonly outcome: AdmissionScenarioOutcome;
+  readonly reasonCode: AdmissionReducerReasonCode;
+  // short fixture ids only (e.g. "assn-001"); empty unless this scenario
+  // includes an admitted assertion in ordinary recall.
+  readonly includedAssertionIds: readonly string[];
+  // short fixture ids only — excluded candidate ids (before / rejected) or
+  // the superseded prior assertion id (supersession).
+  readonly excludedIds: readonly string[];
+  // provenance / audit-link PRESENCE only; never the raw audit body.
+  readonly auditLinkPresent: boolean;
+  // canned, operator-safe one-liner describing the scenario.
+  readonly safeSummary: string;
+}
+
+export interface AdmissionFixtureDemoCounts {
+  readonly total: number;
+  readonly excluded: number;
+  readonly included: number;
+  readonly fail_closed: number;
+  // every scenario resolved to the outcome the gate §8.1 expects.
+  readonly all_outcomes_matched_expected: boolean;
+}
+
+export interface AdmissionFixtureDemoReport {
+  readonly title: string;
+  readonly scope_banner: readonly string[];
+  readonly summaries: readonly AdmissionScenarioSafeSummary[];
+  readonly counts: AdmissionFixtureDemoCounts;
+  readonly non_goals: readonly string[];
+}
+
+// -- fixture loading --------------------------------------------------------
+
+export interface AdmissionWedgeFixtureBundle {
+  readonly cand001: unknown;
+  readonly cand002: unknown;
+  readonly cand010: unknown;
+  readonly cand011: unknown;
+  readonly trans001: unknown;
+  readonly trans002: unknown;
+  readonly trans010: unknown;
+  readonly trans011: unknown;
+  readonly assn001: unknown;
+  readonly assn010: unknown;
+  readonly assn011: unknown;
+  readonly proof001: unknown;
+  readonly proof002: unknown;
+  readonly proof003: unknown;
+  readonly proof004: unknown;
+}
+
+function loadFixture(relPath: string): unknown {
+  return JSON.parse(readFileSync(resolve(FIXTURE_DIR, relPath), "utf8"));
+}
+
+// Read the EXISTING Phase 43C fixture graph from disk. Read-only: this never
+// writes, mutates, or regenerates a fixture.
+export function loadAdmissionWedgeFixtures(): AdmissionWedgeFixtureBundle {
+  return {
+    cand001: loadFixture("candidates/cand-001-accepted-pending.json"),
+    cand002: loadFixture("candidates/cand-002-rejected-pending.json"),
+    cand010: loadFixture("candidates/cand-010-original-pending.json"),
+    cand011: loadFixture("candidates/cand-011-correction-pending.json"),
+    trans001: loadFixture("transitions/trans-001-accept.json"),
+    trans002: loadFixture("transitions/trans-002-reject.json"),
+    trans010: loadFixture("transitions/trans-010-accept-original.json"),
+    trans011: loadFixture("transitions/trans-011-supersede.json"),
+    assn001: loadFixture("admitted/assn-001-active.json"),
+    assn010: loadFixture("admitted/assn-010-superseded.json"),
+    assn011: loadFixture("admitted/assn-011-active-correction.json"),
+    proof001: loadFixture(
+      "recall-proofs/proof-001-before-admission-excluded.json",
+    ),
+    proof002: loadFixture(
+      "recall-proofs/proof-002-after-admission-included.json",
+    ),
+    proof003: loadFixture("recall-proofs/proof-003-rejected-excluded.json"),
+    proof004: loadFixture(
+      "recall-proofs/proof-004-supersession-corrected.json",
+    ),
+  };
+}
+
+// -- the synthetic malformed scenario (proves fail-closed) ------------------
+//
+// An IN-MEMORY malformed candidate that deliberately carries a private-body
+// sentinel AND a long-id run, and claims recall-eligibility before admission
+// — a direct invariant violation. It is constructed here at runtime and is
+// NEVER written to fixture JSON. Routed through the SAME reducer entry point
+// as the real scenarios, it must resolve to a stable fail-closed reason code
+// and leak none of its unsafe input into the printed output.
+//
+// The unsafe tokens below exist only so the reducer's no-leak seal and this
+// runner's output seal are exercised non-vacuously; they are synthetic and
+// match the reducer's banned categories (sentinel prefix + 17+ digit run).
+export const MALFORMED_DEMO_SENTINEL = "CANDIDATE_PRIVATE_SENTINEL_DEMO" as const;
+export const MALFORMED_DEMO_LONG_ID = "99999999999999999999" as const;
+
+export function buildMalformedDemoCandidate(): Record<string, unknown> {
+  return {
+    fixture_kind: "candidate_memory_packet",
+    fixture_version: "phase-43c.0",
+    // a long-id run + private sentinel buried in the id — must never surface.
+    candidate_id: `cand-malformed-${MALFORMED_DEMO_LONG_ID}-${MALFORMED_DEMO_SENTINEL}`,
+    actor_id: "freeside-characters:shared-substrate",
+    // the invariant violation that trips the fail-closed gate:
+    recall_eligibility: "eligible",
+    admission_state: "candidate_pending",
+    candidate_payload: {
+      boundary: "public_safe",
+      body_private: `synthetic malformed body — ${MALFORMED_DEMO_SENTINEL} — never rendered`,
+    },
+  };
+}
+
+// -- scenario plans ---------------------------------------------------------
+//
+// Each plan names a scenario, its expected outcome (per gate §8.1), a canned
+// safe one-liner, and a `reduce` that calls the EXISTING Phase 44A reducer.
+// The runner reimplements no reducer logic; it only routes fixtures in and
+// projects safe summaries out.
+interface ScenarioPlan {
+  readonly name: string;
+  readonly expectedOutcome: AdmissionScenarioOutcome;
+  readonly safeSummary: string;
+  readonly reduce: (f: AdmissionWedgeFixtureBundle) => AdmissionScenarioProof;
+}
+
+export const ADMISSION_DEMO_SCENARIO_PLANS: readonly ScenarioPlan[] = [
+  {
+    name: "before_admission_excluded",
+    expectedOutcome: "excluded",
+    safeSummary: "pending candidate excluded before admission",
+    reduce: (f) =>
+      reduceAdmissionFixtureScenario({
+        kind: "before_admission",
+        candidate: f.cand001,
+        recallProof: f.proof001,
+      }),
+  },
+  {
+    name: "accepted_admitted_included",
+    expectedOutcome: "included",
+    safeSummary: "admitted assertion included after an explicit accept",
+    reduce: (f) =>
+      reduceAdmissionFixtureScenario({
+        kind: "accepted",
+        candidate: f.cand001,
+        transition: f.trans001,
+        admittedAssertion: f.assn001,
+        recallProof: f.proof002,
+      }),
+  },
+  {
+    name: "rejected_excluded",
+    expectedOutcome: "excluded",
+    safeSummary: "rejected candidate excluded; no admitted assertion minted",
+    reduce: (f) =>
+      reduceAdmissionFixtureScenario({
+        kind: "rejected",
+        candidate: f.cand002,
+        transition: f.trans002,
+        recallProof: f.proof003,
+      }),
+  },
+  {
+    name: "supersession_corrected_only",
+    expectedOutcome: "included",
+    safeSummary:
+      "corrected active assertion included; superseded prior excluded from ordinary recall",
+    reduce: (f) =>
+      reduceAdmissionFixtureScenario({
+        kind: "supersession",
+        correctionCandidate: f.cand011,
+        supersedeTransition: f.trans011,
+        correctedAssertion: f.assn011,
+        supersededAssertion: f.assn010,
+        recallProof: f.proof004,
+      }),
+  },
+  {
+    name: "malformed_fail_closed",
+    expectedOutcome: "fail_closed",
+    safeSummary: "malformed fixture input rejected fail-closed",
+    reduce: (f) =>
+      // synthetic malformed candidate routed through the SAME reducer entry
+      // point; the recall proof is never reached (classify fails first).
+      reduceAdmissionFixtureScenario({
+        kind: "before_admission",
+        candidate: buildMalformedDemoCandidate(),
+        recallProof: f.proof001,
+      }),
+  },
+] as const;
+
+// -- safe projection --------------------------------------------------------
+
+// Final output seal: scan a built summary for any unsafe material. If the
+// scan ever trips (it must not for the real fixtures), replace the summary
+// with a sealed fail-closed shell so nothing unsafe can reach the operator.
+function sealSummary(
+  summary: AdmissionScenarioSafeSummary,
+): AdmissionScenarioSafeSummary {
+  const hit = scanForUnsafeProjection(summary);
+  if (!hit) return summary;
+  return {
+    scenario: summary.scenario,
+    outcome: "fail_closed",
+    reasonCode:
+      ADMISSION_REDUCER_REASON_CODES.unsafe_private_sentinel_projection,
+    includedAssertionIds: [],
+    excludedIds: [],
+    auditLinkPresent: false,
+    safeSummary: "summary sealed: unsafe material blocked from operator output",
+  };
+}
+
+function toSafeSummary(
+  plan: ScenarioPlan,
+  proof: AdmissionScenarioProof,
+): AdmissionScenarioSafeSummary {
+  if (!proof.ok) {
+    // fail-closed: surface only the stable reason code (the reducer already
+    // seals `detail` by reason code; the runner does not even forward it).
+    return sealSummary({
+      scenario: plan.name,
+      outcome: "fail_closed",
+      reasonCode: proof.reasonCode,
+      includedAssertionIds: [],
+      excludedIds: [],
+      auditLinkPresent: false,
+      safeSummary: plan.safeSummary,
+    });
+  }
+
+  const recall = proof.recall;
+  if (recall.recallResult === "excluded") {
+    return sealSummary({
+      scenario: plan.name,
+      outcome: "excluded",
+      reasonCode: recall.reasonCode,
+      includedAssertionIds: [],
+      excludedIds: recall.excludedCandidateIds,
+      auditLinkPresent: false,
+      safeSummary: plan.safeSummary,
+    });
+  }
+
+  // included
+  const audit = recall.audit;
+  const auditLinkPresent = Boolean(
+    audit.sourceCandidateId ||
+      audit.admissionTransitionId ||
+      audit.admissionReceiptRef ||
+      audit.supersedesAssertionId,
+  );
+  return sealSummary({
+    scenario: plan.name,
+    outcome: "included",
+    reasonCode: recall.reasonCode,
+    includedAssertionIds: recall.includedAssertionIds,
+    excludedIds: recall.excludedAssertionIds,
+    auditLinkPresent,
+    safeSummary: plan.safeSummary,
+  });
+}
+
+// -- report builder ---------------------------------------------------------
+
+export interface BuildAdmissionFixtureDemoReportOptions {
+  readonly fixtures?: AdmissionWedgeFixtureBundle;
+}
+
+export function buildAdmissionFixtureDemoReport(
+  options: BuildAdmissionFixtureDemoReportOptions = {},
+): AdmissionFixtureDemoReport {
+  const fixtures = options.fixtures ?? loadAdmissionWedgeFixtures();
+
+  const summaries: AdmissionScenarioSafeSummary[] = [];
+  let excluded = 0;
+  let included = 0;
+  let failClosed = 0;
+  let allMatched = true;
+
+  for (const plan of ADMISSION_DEMO_SCENARIO_PLANS) {
+    const proof = plan.reduce(fixtures);
+    const summary = toSafeSummary(plan, proof);
+    summaries.push(summary);
+    if (summary.outcome === "excluded") excluded += 1;
+    else if (summary.outcome === "included") included += 1;
+    else failClosed += 1;
+    if (summary.outcome !== plan.expectedOutcome) allMatched = false;
+  }
+
+  return {
+    title: ADMISSION_FIXTURE_DEMO_REPORT_TITLE,
+    scope_banner: SCOPE_BANNER_LINES,
+    summaries,
+    counts: {
+      total: ADMISSION_DEMO_SCENARIO_PLANS.length,
+      excluded,
+      included,
+      fail_closed: failClosed,
+      all_outcomes_matched_expected: allMatched,
+    },
+    non_goals: NON_GOALS,
+  };
+}
+
+// -- formatter --------------------------------------------------------------
+
+function formatScopeBanner(banner: readonly string[]): string {
+  const lines: string[] = [`> ${SCOPE_BANNER_HEADER}:`];
+  for (const item of banner) lines.push(`> - ${item}`);
+  return lines.join("\n");
+}
+
+function formatScenarioSection(summary: AdmissionScenarioSafeSummary): string {
+  return [
+    `## ${SCENARIO_SECTION_HEADER_PREFIX}${summary.scenario}`,
+    `outcome:                ${summary.outcome}`,
+    `reason code:            ${summary.reasonCode}`,
+    `included assertion ids: [${summary.includedAssertionIds.join(", ")}]`,
+    `excluded ids:           [${summary.excludedIds.join(", ")}]`,
+    `audit link present:     ${String(summary.auditLinkPresent)}`,
+    `safe summary:           ${summary.safeSummary}`,
+  ].join("\n");
+}
+
+function formatInternalProof(counts: AdmissionFixtureDemoCounts): string {
+  return [
+    `## ${INTERNAL_PROOF_HEADER}`,
+    "the counts below are operator-only orientation, derived entirely from",
+    "stable reason codes and outcome enums — no raw fixture material",
+    "",
+    "scenario counts:",
+    `  total scenarios:    ${counts.total}`,
+    `  excluded:           ${counts.excluded}`,
+    `  included:           ${counts.included}`,
+    `  fail_closed:        ${counts.fail_closed}`,
+    "",
+    "proof booleans:",
+    `  all_outcomes_matched_expected: ${String(
+      counts.all_outcomes_matched_expected,
+    )}`,
+  ].join("\n");
+}
+
+function formatNonGoals(nonGoals: readonly string[]): string {
+  const lines: string[] = [`## ${NON_GOALS_HEADER}`];
+  for (const item of nonGoals) lines.push(`- ${item}`);
+  return lines.join("\n");
+}
+
+export function formatAdmissionFixtureDemoReport(
+  report: AdmissionFixtureDemoReport,
+): string {
+  const parts: string[] = [
+    `# ${report.title}`,
+    formatScopeBanner(report.scope_banner),
+  ];
+  for (const summary of report.summaries) {
+    parts.push(formatScenarioSection(summary));
+  }
+  parts.push(formatInternalProof(report.counts));
+  parts.push(formatNonGoals(report.non_goals));
+  return parts.join("\n\n");
+}
+
+// -- scenario-section extractor (test helper) -------------------------------
+
+export interface ExtractedScenarioSection {
+  readonly header: string;
+  readonly body: string;
+}
+
+export function extractFormattedScenarioSection(
+  formatted: string,
+  scenario: string,
+): ExtractedScenarioSection {
+  const header = `## ${SCENARIO_SECTION_HEADER_PREFIX}${scenario}`;
+  const headerIdx = formatted.indexOf(header);
+  if (headerIdx < 0) {
+    throw new Error(
+      `run-admission-wedge-fixture-demo: scenario section not found for ${scenario}`,
+    );
+  }
+  const afterHeader = formatted.slice(headerIdx + header.length);
+  const nextHeaderRel = afterHeader.search(/\n## /);
+  const body =
+    nextHeaderRel < 0
+      ? afterHeader.trimStart()
+      : afterHeader.slice(0, nextHeaderRel).trimStart();
+  return { header, body };
+}
+
+// -- runner -----------------------------------------------------------------
+
+export interface RunAdmissionFixtureDemoOptions {
+  readonly fixtures?: AdmissionWedgeFixtureBundle;
+  readonly print?: (line: string) => void;
+}
+
+export function runAdmissionFixtureDemo(
+  options: RunAdmissionFixtureDemoOptions = {},
+): {
+  readonly report: AdmissionFixtureDemoReport;
+  readonly formatted: string;
+} {
+  const report = buildAdmissionFixtureDemoReport({
+    fixtures: options.fixtures,
+  });
+  const formatted = formatAdmissionFixtureDemoReport(report);
+  if (options.print) options.print(formatted);
+  return { report, formatted };
+}
+
+// -- CLI guard --------------------------------------------------------------
+//
+// Local dev/operator convenience only. The runner is reachable as a CLI ONLY
+// when this file is executed directly (`bun run …/run-admission-wedge-fixture-demo.ts`).
+// It is never invoked on import — runtime code does not import this module.
+const isCli =
+  typeof import.meta !== "undefined" &&
+  (import.meta as { main?: boolean }).main === true;
+
+if (isCli) {
+  runAdmissionFixtureDemo({ print: (line) => console.log(line) });
+}


### PR DESCRIPTION
## Summary

Phase 44C adds a fixture-bound dev/operator runner over the existing Admission Wedge fixtures and reducer.

This is a local/dev/operator runner only. It reads the existing Phase 43C fixture JSON, calls the existing Phase 44A reducer, and emits deterministic safe summaries for operator inspection.

It does not add a live admission implementation.

## Files

Added:

- packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.ts
- packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.test.ts

Modified with minimal Phase 44C status notes:

- docs/ADMISSION-WEDGE-REDUCER-ACCEPTANCE-GATE.md
- docs/admission-wedge/fixtures/README.md
- docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md

## Runner scenarios

The runner emits safe summaries for five scenarios:

- before_admission_excluded
- accepted_admitted_included
- rejected_excluded
- supersession_corrected_only
- malformed_fail_closed

The summaries include only safe stable fields:

- scenario name
- outcome
- reason code
- short fixture IDs
- audit-link presence
- canned one-line summary

The malformed scenario is synthetic and in-memory only. It is not written to fixture JSON.

## Safety posture

Runner output does not include:

- raw candidate payload
- private sentinels
- raw fixture bodies
- source material
- long IDs
- secrets
- URLs
- stack traces
- operational IDs
- screenshots or binary evidence
- private candidate text

The runner calls the Phase 44A reducer instead of reimplementing reducer semantics. It is not wired into Discord, Dixie, public renderer, live client, dispatch, startup, command registration, or package exports.

## Codex audit

Codex returned:

- VERDICT: ACCEPT
- no blockers found
- no required patches

Codex confirmed:

- scope is fixture-bound dev/operator reducer runner only
- changed files are exactly the two runner/test files and three docs notes
- no fixture JSON, package/lockfile, config, CI, generated, Discord command, Dixie route/client, renderer, dispatch/startup/registration, or package export changed
- runner reads existing Phase 43C fixtures using Node built-ins only
- runner imports and calls the Phase 44A reducer
- reducer semantics are not reimplemented
- malformed/fail-closed case is synthetic and in-memory only
- output is sealed and safe
- docs preserve blocked lanes and naming rules

## Validation

Validated locally:

- git diff --check: clean
- node docs/recall-wedge/fixtures/validate-fixtures.mjs: 122 checks passed / 0 failed
- node docs/admission-wedge/fixtures/validate-fixtures.mjs: 318 checks passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.test.ts: 57 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.test.ts: 44 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts: 52 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts: 110 tests passed / 0 failed

Global typecheck remains at the known dirty baseline unrelated to this slice.

## Non-goals

This PR does not authorize or add:

- runtime Discord behavior
- Discord command changes
- `/remember-this`
- public remember-this
- Discord history ingestion
- user chat becoming memory
- live Dixie admission route
- live network calls
- storage writes
- production admission
- production storage
- production auth/consent
- public rollout
- Telegram/private-chat surfaces
- Finn production wiring
- LLM rewriting
- character voice
- forget/revoke/correction UI
- package or lockfile changes
- CI/config/generated changes
- package exports
- public renderer changes
- dispatch/startup/command registration changes
