### PR TITLE
feat(shadow): LIVE ScoreSource adapter — Purupuru community tiers → Discord roles (bd-tfl)

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -22,6 +22,7 @@
     "@0xhoneyjar/quests-protocol": "^0.1.2",
     "@freeside-characters/persona-engine": "workspace:*",
     "@freeside-worlds/shadow-substrate": "github:0xHoneyJar/freeside-worlds#26d11b78e6f0c2ce81cbd1fc24088157cea74e53",
+    "@noble/hashes": "^1.6.0",
     "discord.js": "^14.16.3",
     "effect": "^3.10.0",
     "yaml": "^2.6.0"

--- a/apps/bot/src/shadow/composition-root.ts
+++ b/apps/bot/src/shadow/composition-root.ts
@@ -29,6 +29,7 @@ import {
   makeModeControl,
   RosterSource,
   RoleWriter,
+  ScoreSource,
   AcvpEmitter,
   WorldLock,
   AdminAllowlistSource,
@@ -40,16 +41,34 @@ import { makeRosterSourceLive, type LiveRosterConfig } from "./roster-source.liv
 import { RosterSourceMock } from "./roster-source.mock.ts";
 import { makeRoleWriterLive, makeGatedRoleGc, type LiveWriterConfig } from "./role-writer.live.ts";
 import { RoleWriterMock } from "./role-writer.mock.ts";
+import { makeScoreSourceLive, type LiveScoreConfig } from "./score-source.live.ts";
+import { ScoreSourceMock } from "./score-source.mock.ts";
 import { makeAcvpEmitterLive } from "./acvp-emitter.live.ts";
 import { makeAdminAllowlistLive, type LiveAllowlistConfig } from "./admin-allowlist.live.ts";
 import { makeInMemoryWorldLock } from "./world-lock.ts";
 import { computeRollbackPlan, type RolesCreatedEntry, type RoleAssignmentCount } from "./coexistence.ts";
+import { CommunityScoreClient } from "@freeside-characters/persona-engine/score/community-client";
 
 // ── Per-world wiring resolved from the world manifest (purupuru.yaml) ────────
 
 export interface WorldWiring {
   readonly guild_id: string;
   readonly namespace_prefix: string;
+}
+
+/**
+ * Per-world LIVE score wiring (bd-tfl). Resolves a world slug → the score-api
+ * base URL + the community slug + the community-scoped API key. The presence of
+ * the API KEY is the LIVE/MOCK flag (see `resolveScoreClient`): present ⇒ LIVE
+ * ScoreSource (real Purupuru tiers); absent/undefined ⇒ MOCK ScoreSource.
+ */
+export interface WorldScoreWiring {
+  /** score-api base URL, e.g. https://score-api-production.up.railway.app. */
+  readonly scoreApiUrl: string;
+  /** the community slug, e.g. "purupuru". */
+  readonly community: string;
+  /** the community-scoped score-api key (x-api-key). undefined ⇒ MOCK. */
+  readonly apiKey: string | undefined;
 }
 
 export interface ShadowDeps {
@@ -63,6 +82,14 @@ export interface ShadowDeps {
   readonly world: string;
   /** initial apply_mode (seeded from the apply-mode config surface). */
   readonly initialMode: ApplyMode;
+  /**
+   * map a world slug → its LIVE score wiring (bd-tfl). OPTIONAL: when omitted (or
+   * when the resolved wiring has no `apiKey`), the composition uses the MOCK
+   * ScoreSource — so the substrate's `loadLatentCounts` still resolves and the
+   * shadow preview works with NO score-api provisioning. Supply it (with a real
+   * `apiKey`) to read live Purupuru tiers.
+   */
+  readonly resolveScoreWiring?: (world: string) => WorldScoreWiring | undefined;
 }
 
 /** Deploy-provided NATS + signer for the LIVE AcvpEmitter (operator boundary). */
@@ -113,6 +140,40 @@ function liveAllowlistCfg(deps: ShadowDeps): LiveAllowlistConfig {
 }
 
 /**
+ * Resolve the ScoreSource Layer for this composition (bd-tfl). The API-KEY's
+ * presence IS the LIVE/MOCK flag (mirrors the env gate the brief specifies:
+ * `SCORE_PURUPURU_API_KEY` present ⇒ LIVE, absent ⇒ MOCK):
+ *   • a world with score wiring AND a non-empty `apiKey` → LIVE ScoreSource
+ *     (reads the real Purupuru leaderboard via CommunityScoreClient).
+ *   • otherwise → MOCK ScoreSource (the default; the shadow preview works with
+ *     NO score-api provisioning).
+ * The MOCK is also the safe fallback for any world that lacks LIVE wiring, so a
+ * misconfigured world degrades to mock-zeros rather than failing the whole
+ * discrepancy build.
+ */
+function resolveScoreLayer(deps: ShadowDeps): Layer.Layer<ScoreSource> {
+  const resolve = deps.resolveScoreWiring;
+  if (!resolve) return ScoreSourceMock;
+  // Eagerly build a per-world client factory; LIVE only when an apiKey is present.
+  const cfg: LiveScoreConfig = {
+    clientFor: (world: string): CommunityScoreClient | undefined => {
+      const w = resolve(world);
+      if (!w || !w.apiKey || w.apiKey.length === 0) return undefined;
+      return new CommunityScoreClient({
+        baseUrl: w.scoreApiUrl,
+        apiKey: w.apiKey,
+        community: w.community,
+      });
+    },
+  };
+  // If the TARGET world has no live key, prefer the MOCK Layer so we don't
+  // surface fail-closed ScoreErrors for an unprovisioned shadow preview.
+  const target = resolve(deps.world);
+  const targetIsLive = !!target && !!target.apiKey && target.apiKey.length > 0;
+  return targetIsLive ? makeScoreSourceLive(cfg) : ScoreSourceMock;
+}
+
+/**
  * Build the MODE-CONTROL (the apply_mode `Ref` + the shared batch-duration lock,
  * B5/R-10). The gate reads this `Ref` AT INVOCATION; a `rollback` flips it under
  * the same lock so it serializes to a batch boundary.
@@ -137,7 +198,7 @@ export function shadowPreviewLayer(
   mode: ModeControl,
   currentMapHash: () => string,
   emitterLayer: Layer.Layer<AcvpEmitter>,
-): Layer.Layer<GateCheckedRoleWriter | RosterSource> {
+): Layer.Layer<GateCheckedRoleWriter | RosterSource | ScoreSource> {
   const innerWriter = RoleWriterMock;
   const allowlist = makeAdminAllowlistLive(liveAllowlistCfg(deps));
   const worldLock = makeInMemoryWorldLock();
@@ -149,8 +210,14 @@ export function shadowPreviewLayer(
     Layer.provide(Layer.mergeAll(innerWriter, emitterLayer, worldLock)),
   );
 
-  return Layer.mergeAll(gate, RosterSourceMock, allowlist) as Layer.Layer<
-    GateCheckedRoleWriter | RosterSource
+  // ScoreSource (bd-tfl): MOCK by default; LIVE only when the target world has a
+  // community-scoped key wired (resolveScoreWiring). The score READ is read-only
+  // (no Discord writes), so a production shadow preview MAY read real Purupuru
+  // tiers while the writer stays mocked — that IS the point of the preview.
+  const score = resolveScoreLayer(deps);
+
+  return Layer.mergeAll(gate, RosterSourceMock, allowlist, score) as Layer.Layer<
+    GateCheckedRoleWriter | RosterSource | ScoreSource
   >;
 }
 
@@ -168,7 +235,7 @@ export function liveApplyLayer(
   audit: LiveAuditDeps,
   mode: ModeControl,
   currentMapHash: () => string,
-): Layer.Layer<GateCheckedRoleWriter | RosterSource> {
+): Layer.Layer<GateCheckedRoleWriter | RosterSource | ScoreSource> {
   const innerWriter = makeRoleWriterLive(deps.getBotClient, liveWriterCfg(deps));
   const emitter = makeAcvpEmitterLive({
     nats: audit.nats,
@@ -182,11 +249,16 @@ export function liveApplyLayer(
     Layer.provide(Layer.mergeAll(innerWriter, emitter, worldLock)),
   );
 
+  // ScoreSource (bd-tfl): LIVE when the target world has a community-scoped key,
+  // else MOCK. resolveScoreLayer is the env-gated picker.
+  const score = resolveScoreLayer(deps);
+
   return Layer.mergeAll(
     gate,
     makeRosterSourceLive(deps.getBotClient, liveRosterCfg(deps)),
     allowlist,
-  ) as Layer.Layer<GateCheckedRoleWriter | RosterSource>;
+    score,
+  ) as Layer.Layer<GateCheckedRoleWriter | RosterSource | ScoreSource>;
 }
 
 /**
@@ -255,6 +327,8 @@ export {
   makeRoleWriterLive,
   makeGatedRoleGc,
   RoleWriterMock,
+  makeScoreSourceLive,
+  ScoreSourceMock,
   makeAcvpEmitterLive,
   makeAdminAllowlistLive,
   makeInMemoryWorldLock,

--- a/apps/bot/src/shadow/purupuru-tiers.ts
+++ b/apps/bot/src/shadow/purupuru-tiers.ts
@@ -1,0 +1,62 @@
+/**
+ * shadow/purupuru-tiers.ts — the Purupuru community tier LADDER (ordering).
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────────────
+ * The substrate's `RoleRule.qualifies` is `{ source: 'tier', min_tier: <string> }`
+ * where `min_tier` is an OPAQUE tier id the substrate does not interpret
+ * (score-api owns the values — #221). To evaluate "wallet qualifies for this rule"
+ * we need a >= comparison, which needs an ORDERING over tier names. score-api's
+ * `community_tier_config` HAS that ordering (`sort_order`), but the leaderboard
+ * read returns only the `tier` STRING — not `sort_order`. So the ordering must
+ * live on the consumer side.
+ *
+ * ── GROUNDING (score-api origin/main, read 2026-06-03) ───────────────────────
+ * supabase/migrations/20260602_001_cycle032_purupuru_config.sql seeds the
+ * Purupuru `community_tier_config` ladder (by `sort_order`):
+ *   newcomer(1) < member(2) < devoted(3) < core(4) < sovereign(5) < elder(6)
+ * (crowd: newcomer..core score-banded; elite: sovereign/elder rank-based —
+ * elite overrides crowd, so a wallet's single `tier` is already the resolved
+ * winner. The ladder here mirrors `sort_order` exactly so higher = stronger.)
+ *
+ * ⚠ The lore NAMES are PLACEHOLDERS (Jani/zerker calibrate, OQ-4). When the real
+ * lore lands, update this map (and the matching score-api config) together. The
+ * ranks are what's load-bearing; the names are display.
+ */
+
+/**
+ * Purupuru tier → ordinal rank (higher = stronger). Mirrors score-api
+ * `community_tier_config.sort_order` for community_id='purupuru'.
+ */
+export const PURUPURU_TIER_RANK: Readonly<Record<string, number>> = {
+  newcomer: 1,
+  member: 2,
+  devoted: 3,
+  core: 4,
+  sovereign: 5,
+  elder: 6,
+};
+
+/** A tier-rank resolver: a tier name → its ordinal, or undefined if unknown. */
+export type TierRankResolver = (tier: string) => number | undefined;
+
+/** The default resolver, grounded in the seeded Purupuru ladder. */
+export const purupuruTierRank: TierRankResolver = (tier) =>
+  PURUPURU_TIER_RANK[tier.toLowerCase()];
+
+/**
+ * Does `walletTier` satisfy `minTier` (>=) under `rank`? FAIL-CLOSED: an unknown
+ * `walletTier` (not on the ladder) NEVER qualifies; an unknown `minTier` is a
+ * misconfigured rule → NEVER qualifies (so a typo can't accidentally grant
+ * everyone). A null/absent wallet tier (untiered wallet) never qualifies.
+ */
+export function tierQualifies(
+  walletTier: string | null | undefined,
+  minTier: string,
+  rank: TierRankResolver = purupuruTierRank,
+): boolean {
+  if (walletTier == null) return false;
+  const w = rank(walletTier);
+  const m = rank(minTier);
+  if (w === undefined || m === undefined) return false;
+  return w >= m;
+}

--- a/apps/bot/src/shadow/purupuru-tiers.ts
+++ b/apps/bot/src/shadow/purupuru-tiers.ts
@@ -12,11 +12,23 @@
  *
  * ── GROUNDING (score-api origin/main, read 2026-06-03) ───────────────────────
  * supabase/migrations/20260602_001_cycle032_purupuru_config.sql seeds the
- * Purupuru `community_tier_config` ladder (by `sort_order`):
- *   newcomer(1) < member(2) < devoted(3) < core(4) < sovereign(5) < elder(6)
- * (crowd: newcomer..core score-banded; elite: sovereign/elder rank-based —
- * elite overrides crowd, so a wallet's single `tier` is already the resolved
- * winner. The ladder here mirrors `sort_order` exactly so higher = stronger.)
+ * Purupuru `community_tier_config`. ⚠ `sort_order` is PRESENTATION order, NOT
+ * strength order — it does NOT match status for the elite tiers. Ground truth:
+ *   • crowd (score-banded, ascending strength):
+ *       newcomer(score 0-39) < member(40-69) < devoted(70-89) < core(90-99)
+ *   • elite (rank-banded, OVERRIDES crowd — lower rank number = higher status):
+ *       sovereign(rank 1-7, live=7 wallets) is the TOP; elder(rank 8-50,
+ *       live=43 wallets) is next-strongest.
+ * So although `sort_order` lists sovereign(5) before elder(6), sovereign is the
+ * STRONGER tier. The STRENGTH ladder below corrects this:
+ *   newcomer(1) < member(2) < devoted(3) < core(4) < elder(5) < sovereign(6)
+ *
+ * SEMANTIC ASSUMPTION (a CM should confirm): elite OVERRIDES crowd, so EVERY
+ * elite tier ranks above EVERY crowd tier (core(4) < elder(5)). This follows
+ * score-api's "elite overrides crowd" resolveTier model — a wallet's single
+ * resolved `tier` is the elite one whenever it earns one. If a community ever
+ * wants a high-score crowd wallet to outrank a low-rank elite wallet, this
+ * cross-class ordering is the one knob to revisit.
  *
  * ⚠ The lore NAMES are PLACEHOLDERS (Jani/zerker calibrate, OQ-4). When the real
  * lore lands, update this map (and the matching score-api config) together. The
@@ -24,16 +36,20 @@
  */
 
 /**
- * Purupuru tier → ordinal rank (higher = stronger). Mirrors score-api
- * `community_tier_config.sort_order` for community_id='purupuru'.
+ * Purupuru tier → ordinal STRENGTH rank (higher = stronger). This is NOT
+ * score-api's `sort_order` (which inverts the elite pair) — it is the corrected
+ * status ladder: crowd ascending, then elite above all crowd, with sovereign
+ * (rank 1-7) above elder (rank 8-50). See the file header for the grounding.
  */
 export const PURUPURU_TIER_RANK: Readonly<Record<string, number>> = {
+  // crowd (score-banded, ascending)
   newcomer: 1,
   member: 2,
   devoted: 3,
   core: 4,
-  sovereign: 5,
-  elder: 6,
+  // elite (rank-banded, OVERRIDES crowd — sovereign rank 1-7 > elder rank 8-50)
+  elder: 5,
+  sovereign: 6,
 };
 
 /** A tier-rank resolver: a tier name → its ordinal, or undefined if unknown. */

--- a/apps/bot/src/shadow/score-source.live.ts
+++ b/apps/bot/src/shadow/score-source.live.ts
@@ -1,0 +1,109 @@
+/**
+ * shadow/score-source.live.ts — the LIVE `ScoreSource` Layer (bd-tfl).
+ *
+ * Closes the structural hole the brief named: `composition-root.ts` wired
+ * `makeRosterSourceLive / RoleWriterLive / AcvpEmitterLive / AdminAllowlistLive`
+ * but supplied NO `ScoreSource` Layer — so the substrate's
+ * `ScoreSource.latentQualified` port was unimplemented and `loadLatentCounts`
+ * had nothing to call. This is that Layer.
+ *
+ * ── WHAT IT DOES ─────────────────────────────────────────────────────────────
+ * `latentQualified(world, rule)` reads the Purupuru community leaderboard
+ * (score-api REST, via `CommunityScoreClient`) and counts wallets whose `tier`
+ * satisfies the rule's tier qualification (`rule.qualifies.min_tier`, evaluated
+ * with the grounded Purupuru tier ladder in `purupuru-tiers.ts`). That count is
+ * the per-rule "qualified members" number the substrate's `loadLatentCounts`
+ * folds into the `Discrepancy.latent_qualified` projection.
+ *
+ * ── "latent" (qualified-but-not-joined) vs "qualified" — HONEST NUANCE ────────
+ * The port name is `latentQualified` (SDD: "qualified-but-not-joined wallets").
+ * This LIVE adapter returns the QUALIFIED count (wallets at/above the rule's
+ * min_tier), NOT qualified-MINUS-joined. Computing the true latent (excluding
+ * already-joined members) requires joining score-api tiers ⋈ identity-api
+ * wallet↔discord ⋈ the live guild roster — which is exactly the per-member
+ * assign-batch path (part 2 of bd-tfl, score-tier-assignment.ts). The substrate
+ * MOCK has the same simple-count semantics; we match it here rather than
+ * silently changing the projection's meaning. The fuller "minus joined" number
+ * is a follow-up once the part-2 join is wired into a count surface.
+ *
+ * ── PROVENANCE GAP (substrate, NOT fakeable here) ────────────────────────────
+ * Even when this LIVE adapter produces the count, the substrate's
+ * `effectful/loaders.ts` HARDCODES `source: 'MOCK'` on every `LatentQualified`
+ * (read at SHA 26d11b7). So a LIVE count surfaces as `source:'MOCK'` in the
+ * Discrepancy until a freeside-worlds substrate change threads honest LIVE
+ * provenance through `loadLatentCounts`. We DO NOT fake `source:'LIVE'` (the
+ * substrate is SACRED / SHA-pinned). Tracked as a new bead — see the build
+ * report. This adapter is honest about the count; the provenance label is the
+ * substrate's to fix.
+ *
+ * ── FAIL-CLOSED ──────────────────────────────────────────────────────────────
+ * Any REST failure (403 out-of-scope key, 4xx unresolved, 5xx upstream, decode,
+ * transport) maps to a typed `ScoreError`. We NEVER return a silent 0 on error
+ * (a 0 would understate the discrepancy and could be mistaken for "nobody
+ * qualifies"). Mirrors the score-api community-resolver's own fail-closed posture.
+ */
+import { Effect, Layer } from "effect";
+import { ScoreSource, ScoreError } from "./substrate.ts";
+import type { RoleRule } from "@freeside-worlds/shadow-substrate";
+import {
+  CommunityScoreClient,
+  CommunityScoreError,
+} from "@freeside-characters/persona-engine/score/community-client";
+import { tierQualifies, type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
+
+/**
+ * Per-world wiring the LIVE ScoreSource needs: a factory that returns a
+ * `CommunityScoreClient` for the world (or undefined if this world has no LIVE
+ * score wiring — then we fail-closed with a ScoreError rather than guess).
+ */
+export interface LiveScoreConfig {
+  /** map a world slug → its community-scoped score client (undefined ⇒ no wiring). */
+  readonly clientFor: (world: string) => CommunityScoreClient | undefined;
+  /** tier ordering (defaults to the grounded Purupuru ladder). */
+  readonly tierRank?: TierRankResolver;
+}
+
+/** Map a CommunityScoreError (or any throw) to the substrate's typed ScoreError. */
+function toScoreError(e: unknown, ctx: string): ScoreError {
+  if (e instanceof CommunityScoreError) {
+    return new ScoreError({ message: `${ctx}: [${e.kind}] ${e.message}` });
+  }
+  return new ScoreError({
+    message: `${ctx}: ${e instanceof Error ? e.message : String(e)}`,
+  });
+}
+
+/**
+ * Build the LIVE `ScoreSource` Layer. The composition root supplies `clientFor`
+ * (resolved from the world manifest + the SCORE_PURUPURU_API_KEY env).
+ */
+export function makeScoreSourceLive(cfg: LiveScoreConfig): Layer.Layer<ScoreSource> {
+  const rank = cfg.tierRank ?? purupuruTierRank;
+  return Layer.succeed(
+    ScoreSource,
+    ScoreSource.of({
+      latentQualified: (world, rule: RoleRule) =>
+        Effect.tryPromise({
+          try: async (): Promise<number> => {
+            const w = world as unknown as string;
+            const client = cfg.clientFor(w);
+            if (!client) {
+              // fail-closed: no LIVE score wiring for this world. Never silently 0.
+              throw new CommunityScoreError(
+                "bad_request",
+                `no community score client wired for world '${w}' (SCORE_PURUPURU_API_KEY unset or world unmapped)`,
+              );
+            }
+            const page = await client.leaderboard();
+            const minTier = rule.qualifies.min_tier;
+            let count = 0;
+            for (const entry of page.wallets) {
+              if (tierQualifies(entry.tier, minTier, rank)) count += 1;
+            }
+            return count;
+          },
+          catch: (e) => toScoreError(e, `latentQualified(${rule.role_key})`),
+        }),
+    }),
+  );
+}

--- a/apps/bot/src/shadow/score-source.mock.ts
+++ b/apps/bot/src/shadow/score-source.mock.ts
@@ -1,0 +1,54 @@
+/**
+ * shadow/score-source.mock.ts — the MOCK `ScoreSource` Layer (bd-tfl).
+ *
+ * Mirrors the `roster-source.mock.ts` idiom (`Layer.succeed` + `seed*`/`reset*`
+ * fixtures). This is the DEFAULT ScoreSource (the SHADOW/preview path AND the
+ * fallback when `SCORE_PURUPURU_API_KEY` is unset — see composition-root.ts).
+ *
+ * Returns latent-qualified COUNTS per rule with ZERO network calls. The
+ * substrate's `loadLatentCounts` tags every count `source: 'MOCK'` (it hardcodes
+ * that — see the substrate-gap NOTE in score-source.live.ts), so a mock count
+ * and a live count are indistinguishable in provenance until the substrate
+ * carries the LIVE flag. Until then this mock is the honest default.
+ */
+import { Effect, Layer } from "effect";
+import { ScoreSource, ScoreError } from "./substrate.ts";
+import type { RoleRule } from "@freeside-worlds/shadow-substrate";
+
+/** Fixture: keyed by `${world}::${role_key}` → latent count. */
+const _fixtures = new Map<string, number>();
+let _forceFailure = false;
+
+function key(world: string, roleKey: string): string {
+  return `${world}::${roleKey}`;
+}
+
+/** Seed a latent count for a (world, role_key). */
+export function seedLatentCount(world: string, roleKey: string, count: number): void {
+  _fixtures.set(key(world, roleKey), count);
+}
+
+/** Force the next reads to fail with ScoreError (failure-path tests). */
+export function setMockScoreFailure(fail: boolean): void {
+  _forceFailure = fail;
+}
+
+/** Clear all fixtures + reset the failure flag. */
+export function resetMockScoreSource(): void {
+  _fixtures.clear();
+  _forceFailure = false;
+}
+
+export const ScoreSourceMock: Layer.Layer<ScoreSource> = Layer.succeed(
+  ScoreSource,
+  ScoreSource.of({
+    latentQualified: (world, rule: RoleRule) =>
+      Effect.suspend(() => {
+        if (_forceFailure) {
+          return Effect.fail(new ScoreError({ message: "mock score failure (forced)" }));
+        }
+        const w = world as unknown as string;
+        return Effect.succeed(_fixtures.get(key(w, rule.role_key)) ?? 0);
+      }),
+  }),
+);

--- a/apps/bot/src/shadow/score-source.test.ts
+++ b/apps/bot/src/shadow/score-source.test.ts
@@ -70,16 +70,40 @@ function failingClient() {
 }
 
 describe("purupuru-tiers — tierQualifies", () => {
-  test("ladder order: newcomer < member < devoted < core < sovereign < elder", () => {
+  test("STRENGTH ladder: newcomer < member < devoted < core < elder < sovereign", () => {
+    // crowd ascending
     expect(purupuruTierRank("newcomer")).toBeLessThan(purupuruTierRank("member")!);
-    expect(purupuruTierRank("core")).toBeLessThan(purupuruTierRank("sovereign")!);
-    expect(purupuruTierRank("sovereign")).toBeLessThan(purupuruTierRank("elder")!);
+    expect(purupuruTierRank("member")).toBeLessThan(purupuruTierRank("devoted")!);
+    expect(purupuruTierRank("devoted")).toBeLessThan(purupuruTierRank("core")!);
+    // elite OVERRIDES crowd: every elite tier > every crowd tier
+    expect(purupuruTierRank("core")).toBeLessThan(purupuruTierRank("elder")!);
+    // within elite: sovereign (rank 1-7) is STRONGER than elder (rank 8-50).
+    // NOTE: this is the OPPOSITE of score-api sort_order (which lists sovereign
+    // before elder) — sort_order is presentation, not strength.
+    expect(purupuruTierRank("elder")).toBeLessThan(purupuruTierRank("sovereign")!);
   });
 
   test(">= semantics: a wallet at-or-above min_tier qualifies", () => {
-    expect(tierQualifies("sovereign", "core")).toBe(true); // 5 >= 4
+    expect(tierQualifies("sovereign", "core")).toBe(true); // 6 >= 4
     expect(tierQualifies("core", "core")).toBe(true); // 4 >= 4 (boundary)
     expect(tierQualifies("member", "core")).toBe(false); // 2 < 4
+  });
+
+  test("elite > all crowd: a core wallet does NOT qualify an elite min_tier", () => {
+    expect(tierQualifies("core", "elder")).toBe(false); // 4 < 5
+    expect(tierQualifies("core", "sovereign")).toBe(false); // 4 < 6
+  });
+
+  test("min_tier='sovereign' qualifies ONLY sovereign (NOT elder)", () => {
+    expect(tierQualifies("sovereign", "sovereign")).toBe(true); // 6 >= 6
+    expect(tierQualifies("elder", "sovereign")).toBe(false); // 5 < 6 — elder is NOT sovereign-strong
+    expect(tierQualifies("core", "sovereign")).toBe(false);
+  });
+
+  test("min_tier='elder' qualifies elder AND sovereign (the two elite tiers)", () => {
+    expect(tierQualifies("elder", "elder")).toBe(true); // 5 >= 5
+    expect(tierQualifies("sovereign", "elder")).toBe(true); // 6 >= 5 — sovereign outranks elder
+    expect(tierQualifies("core", "elder")).toBe(false); // 4 < 5
   });
 
   test("fail-closed: null/unknown wallet tier never qualifies", () => {
@@ -104,9 +128,9 @@ describe("makeScoreSourceLive.latentQualified (no network)", () => {
 
   test("counts wallets at/above the rule min_tier", async () => {
     const client = clientReturning([
-      { wallet: "0x1", tier: "elder" },     // 6 >= 4 ✓
-      { wallet: "0x2", tier: "sovereign" }, // 5 >= 4 ✓
-      { wallet: "0x3", tier: "core" },      // 4 >= 4 ✓
+      { wallet: "0x1", tier: "elder" },     // 5 >= 4 ✓ (elite > core)
+      { wallet: "0x2", tier: "sovereign" }, // 6 >= 4 ✓ (top tier)
+      { wallet: "0x3", tier: "core" },      // 4 >= 4 ✓ (boundary)
       { wallet: "0x4", tier: "member" },    // 2 < 4 ✗
       { wallet: "0x5", tier: null },        // untiered ✗
       { wallet: "0x6", tier: "newcomer" },  // 1 < 4 ✗

--- a/apps/bot/src/shadow/score-source.test.ts
+++ b/apps/bot/src/shadow/score-source.test.ts
@@ -1,0 +1,220 @@
+/**
+ * score-source.test.ts — the LIVE + MOCK `ScoreSource` Layers (bd-tfl).
+ *
+ * Pins:
+ *   • tier qualification (>=) against the grounded Purupuru ladder, fail-closed
+ *     on unknown/null tiers.
+ *   • makeScoreSourceLive.latentQualified counts wallets at/above min_tier from a
+ *     mocked CommunityScoreClient (NO network — the client's transport is an
+ *     injected fetch).
+ *   • a REST failure surfaces a typed ScoreError (never a silent 0).
+ *   • the MOCK Layer returns seeded counts / 0 default, with a forced-failure path.
+ */
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Effect } from "effect";
+import { ScoreSource } from "./substrate.ts";
+import type { RoleRule } from "@freeside-worlds/shadow-substrate";
+import { makeScoreSourceLive, type LiveScoreConfig } from "./score-source.live.ts";
+import {
+  ScoreSourceMock,
+  seedLatentCount,
+  setMockScoreFailure,
+  resetMockScoreSource,
+} from "./score-source.mock.ts";
+import {
+  CommunityScoreClient,
+  type CommunityScoreClientConfig,
+} from "@freeside-characters/persona-engine/score/community-client";
+import { tierQualifies, purupuruTierRank } from "./purupuru-tiers.ts";
+
+// ── a rule helper (the substrate's RoleRule shape) ──────────────────────────
+function rule(role_key: string, min_tier: string): RoleRule {
+  return {
+    role_key,
+    display_name: role_key,
+    qualifies: { source: "tier", min_tier },
+    create_if_absent: true,
+  } as RoleRule;
+}
+
+// ── a CommunityScoreClient backed by an injected fetch (no network) ─────────
+function clientReturning(wallets: Array<{ wallet: string; tier: string | null }>) {
+  const body = {
+    community: "purupuru",
+    total: wallets.length,
+    wallets: wallets.map((w, i) => ({
+      wallet: w.wallet,
+      rank: i + 1,
+      combined_score: 50,
+      tier: w.tier,
+    })),
+  };
+  const fakeFetch = (async () => Response.json(body)) as unknown as typeof fetch;
+  const cfg: CommunityScoreClientConfig = {
+    baseUrl: "https://score-api.test",
+    apiKey: "sk-test",
+    community: "purupuru",
+    retry: { fetchImpl: fakeFetch, maxAttempts: 1, sleep: async () => {} },
+  };
+  return new CommunityScoreClient(cfg);
+}
+
+function failingClient() {
+  const fakeFetch = (async () => new Response("nope", { status: 403 })) as unknown as typeof fetch;
+  return new CommunityScoreClient({
+    baseUrl: "https://score-api.test",
+    apiKey: "sk-test",
+    community: "purupuru",
+    retry: { fetchImpl: fakeFetch, maxAttempts: 1, sleep: async () => {} },
+  });
+}
+
+describe("purupuru-tiers — tierQualifies", () => {
+  test("ladder order: newcomer < member < devoted < core < sovereign < elder", () => {
+    expect(purupuruTierRank("newcomer")).toBeLessThan(purupuruTierRank("member")!);
+    expect(purupuruTierRank("core")).toBeLessThan(purupuruTierRank("sovereign")!);
+    expect(purupuruTierRank("sovereign")).toBeLessThan(purupuruTierRank("elder")!);
+  });
+
+  test(">= semantics: a wallet at-or-above min_tier qualifies", () => {
+    expect(tierQualifies("sovereign", "core")).toBe(true); // 5 >= 4
+    expect(tierQualifies("core", "core")).toBe(true); // 4 >= 4 (boundary)
+    expect(tierQualifies("member", "core")).toBe(false); // 2 < 4
+  });
+
+  test("fail-closed: null/unknown wallet tier never qualifies", () => {
+    expect(tierQualifies(null, "newcomer")).toBe(false);
+    expect(tierQualifies(undefined, "newcomer")).toBe(false);
+    expect(tierQualifies("ghost-tier", "newcomer")).toBe(false);
+  });
+
+  test("fail-closed: unknown min_tier (misconfigured rule) never qualifies", () => {
+    expect(tierQualifies("sovereign", "typo-tier")).toBe(false);
+  });
+
+  test("case-insensitive on the wallet tier", () => {
+    expect(tierQualifies("SOVEREIGN", "core")).toBe(true);
+  });
+});
+
+describe("makeScoreSourceLive.latentQualified (no network)", () => {
+  const cfgFor = (client: CommunityScoreClient | undefined): LiveScoreConfig => ({
+    clientFor: () => client,
+  });
+
+  test("counts wallets at/above the rule min_tier", async () => {
+    const client = clientReturning([
+      { wallet: "0x1", tier: "elder" },     // 6 >= 4 ✓
+      { wallet: "0x2", tier: "sovereign" }, // 5 >= 4 ✓
+      { wallet: "0x3", tier: "core" },      // 4 >= 4 ✓
+      { wallet: "0x4", tier: "member" },    // 2 < 4 ✗
+      { wallet: "0x5", tier: null },        // untiered ✗
+      { wallet: "0x6", tier: "newcomer" },  // 1 < 4 ✗
+    ]);
+    const layer = makeScoreSourceLive(cfgFor(client));
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) => s.latentQualified("purupuru" as never, rule("purupuru:core", "core"))),
+        Effect.provide(layer),
+      ),
+    );
+    expect(count).toBe(3);
+  });
+
+  test("min_tier=newcomer counts every tiered wallet (lowest rung)", async () => {
+    const client = clientReturning([
+      { wallet: "0x1", tier: "newcomer" },
+      { wallet: "0x2", tier: "elder" },
+      { wallet: "0x3", tier: null }, // untiered still excluded
+    ]);
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          s.latentQualified("purupuru" as never, rule("purupuru:member", "newcomer")),
+        ),
+        Effect.provide(makeScoreSourceLive(cfgFor(client))),
+      ),
+    );
+    expect(count).toBe(2);
+  });
+
+  test("a REST 403 surfaces a typed ScoreError (never a silent 0)", async () => {
+    const layer = makeScoreSourceLive(cfgFor(failingClient()));
+    const res = await Effect.runPromise(
+      Effect.either(
+        ScoreSource.pipe(
+          Effect.flatMap((s) =>
+            s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+          ),
+          Effect.provide(layer),
+        ),
+      ),
+    );
+    expect(res._tag).toBe("Left");
+    if (res._tag === "Left") {
+      expect(res.left._tag).toBe("ScoreError");
+      expect(res.left.message).toContain("forbidden");
+    }
+  });
+
+  test("no client wired for the world → fail-closed ScoreError (not a 0)", async () => {
+    const layer = makeScoreSourceLive(cfgFor(undefined));
+    const res = await Effect.runPromise(
+      Effect.either(
+        ScoreSource.pipe(
+          Effect.flatMap((s) =>
+            s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+          ),
+          Effect.provide(layer),
+        ),
+      ),
+    );
+    expect(res._tag).toBe("Left");
+    if (res._tag === "Left") expect(res.left._tag).toBe("ScoreError");
+  });
+});
+
+describe("MOCK ScoreSource", () => {
+  beforeEach(() => resetMockScoreSource());
+
+  test("returns a seeded count", async () => {
+    seedLatentCount("purupuru", "purupuru:core", 7);
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+        ),
+        Effect.provide(ScoreSourceMock),
+      ),
+    );
+    expect(count).toBe(7);
+  });
+
+  test("unseeded rule → 0 (no network, no throw)", async () => {
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          s.latentQualified("purupuru" as never, rule("purupuru:unknown", "core")),
+        ),
+        Effect.provide(ScoreSourceMock),
+      ),
+    );
+    expect(count).toBe(0);
+  });
+
+  test("forced failure → typed ScoreError", async () => {
+    setMockScoreFailure(true);
+    const res = await Effect.runPromise(
+      Effect.either(
+        ScoreSource.pipe(
+          Effect.flatMap((s) =>
+            s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+          ),
+          Effect.provide(ScoreSourceMock),
+        ),
+      ),
+    );
+    expect(res._tag).toBe("Left");
+    if (res._tag === "Left") expect(res.left._tag).toBe("ScoreError");
+  });
+});

--- a/apps/bot/src/shadow/score-tier-assignment.test.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.test.ts
@@ -1,0 +1,288 @@
+/**
+ * score-tier-assignment.test.ts — the per-member tier→role assign-batch builder
+ * (bd-tfl part 2).
+ *
+ * Two layers of proof:
+ *   1. PURE join + assembly: leaderboard ⋈ identity-link ⋈ role-map → assignments
+ *      → WriteOp[] → WriteIntentBatch (no network, injected WalletDiscordLink).
+ *      Covers: strongest-rule selection, unlinked/unqualified skips, disabled
+ *      map, deterministic op_id/idempotency_key.
+ *   2. END-TO-END through the REAL substrate gate (mirrors shadow-loop.test):
+ *      goLive mints a cap → assembleAssignBatch builds the batch bound to the
+ *      go_live decision → gate.applyBatch writes the assign ops through the MOCK
+ *      writer (zero real Discord I/O). This proves the builder's output is a
+ *      VALID, gate-acceptable batch (the hash-binding invariants hold).
+ */
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  GateCheckedRoleWriter,
+  makeGateCheckedRoleWriter,
+  makeModeControl,
+  goLive,
+  AcvpEmitter,
+  roleMapVersionHash,
+} from "./substrate.ts";
+import { rosterFingerprint } from "@freeside-worlds/shadow-substrate";
+import type {
+  RoleMapConfig,
+  RoleMapVersionInput,
+  WorldSlug,
+  Hex64,
+  ModeControl,
+  RosterVersion,
+} from "@freeside-worlds/shadow-substrate";
+import type { CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
+import { RoleWriterMock, resetMockRoleWriter, capturedWrites } from "./role-writer.mock.ts";
+import { makeRecordingEmitter } from "./acvp-emitter.mock.ts";
+import { makeInMemoryWorldLock } from "./world-lock.ts";
+import { makeAdminAllowlistInMemory } from "./admin-allowlist.live.ts";
+import {
+  buildTierAssignments,
+  assignmentsToOps,
+  assignOpId,
+  assignIdempotencyKey,
+  assembleAssignBatch,
+  type WalletDiscordLink,
+  type AuthorizedTransition,
+} from "./score-tier-assignment.ts";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+function lbEntry(wallet: string, tier: string | null, rank = 1): CommunityLeaderboardEntry {
+  return { wallet, rank, combined_score: 50, tier } as CommunityLeaderboardEntry;
+}
+
+/** A role-map with a low + high tier rule (both Freeside-namespaced). */
+const ROLE_MAP: RoleMapConfig = {
+  enabled: true,
+  namespace_prefix: "purupuru:",
+  rules: [
+    { role_key: "purupuru:member", display_name: "Member", qualifies: { source: "tier", min_tier: "member" }, create_if_absent: true },
+    { role_key: "purupuru:core", display_name: "Core", qualifies: { source: "tier", min_tier: "core" }, create_if_absent: true },
+  ],
+} as RoleMapConfig;
+
+/** Injected link map (wallet → discord snowflake | null). */
+function linkFrom(map: Record<string, string | null>): WalletDiscordLink {
+  return {
+    resolve: async (wallet: string) => map[wallet.toLowerCase()] ?? null,
+  };
+}
+
+// ── 1. pure join ──────────────────────────────────────────────────────────────
+
+describe("buildTierAssignments — the join", () => {
+  test("assigns each linked wallet its STRONGEST qualifying tier role", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [
+        lbEntry("0xcore", "core"),       // qualifies member AND core → core (strongest)
+        lbEntry("0xmember", "member"),   // qualifies member only
+        lbEntry("0xelder", "elder"),     // qualifies both → core (strongest configured)
+      ],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xcore": "100", "0xmember": "200", "0xelder": "300" }),
+    });
+    expect(res.assignments.length).toBe(3);
+    const byMember = Object.fromEntries(res.assignments.map((a) => [a.member_id, a.role_key]));
+    expect(byMember["100"]).toBe("purupuru:core");
+    expect(byMember["200"]).toBe("purupuru:member");
+    expect(byMember["300"]).toBe("purupuru:core"); // elder > core, top configured rule
+  });
+
+  test("a qualified-but-unlinked wallet is skipped (counted), never assigned", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xa", "core"), lbEntry("0xb", "core")],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xa": "100" /* 0xb has no link */ }),
+    });
+    expect(res.assignments.length).toBe(1);
+    expect(res.assignments[0]!.member_id).toBe("100");
+    expect(res.skipped_unlinked).toBe(1);
+  });
+
+  test("a wallet below every rule (or untiered) is skipped as unqualified", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xlow", "newcomer"), lbEntry("0xnull", null)],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xlow": "100", "0xnull": "200" }),
+    });
+    expect(res.assignments.length).toBe(0);
+    expect(res.skipped_unqualified).toBe(2);
+  });
+
+  test("a disabled role-map produces zero assignments", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xa", "core")],
+      roleMap: { ...ROLE_MAP, enabled: false },
+      link: linkFrom({ "0xa": "100" }),
+    });
+    expect(res.assignments.length).toBe(0);
+  });
+});
+
+// ── 2. ops + determinism ──────────────────────────────────────────────────────
+
+describe("assignmentsToOps — op_id / idempotency_key", () => {
+  test("emits assign_role ops only (never create/remove)", () => {
+    const ops = assignmentsToOps("purupuru", "h".repeat(64), [
+      { wallet: "0xa", member_id: "100", tier: "core", role_key: "purupuru:core" },
+    ]);
+    expect(ops.length).toBe(1);
+    expect(ops[0]!.kind).toBe("assign_role");
+    expect((ops[0]!.intent as { role_key: string }).role_key).toBe("purupuru:core");
+    expect((ops[0]!.intent as { member_id: string }).member_id).toBe("100");
+  });
+
+  test("op_id + idempotency_key are deterministic (retry-safe)", () => {
+    const id1 = assignOpId("purupuru", "purupuru:core", "100");
+    const id2 = assignOpId("purupuru", "purupuru:core", "100");
+    expect(id1).toBe(id2);
+    const k1 = assignIdempotencyKey("purupuru", id1, "h".repeat(64));
+    const k2 = assignIdempotencyKey("purupuru", id2, "h".repeat(64));
+    expect(k1).toBe(k2);
+    // a different member → different key
+    const k3 = assignIdempotencyKey("purupuru", assignOpId("purupuru", "purupuru:core", "999"), "h".repeat(64));
+    expect(k3).not.toBe(k1);
+    // 64-hex (sha256)
+    expect(k1).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── 3. END-TO-END through the real gate (mirrors shadow-loop.test) ────────────
+
+const WORLD = "purupuru" as unknown as WorldSlug;
+const ADMIN = "identity:admin-1";
+const h64 = (s: string) => s as unknown as Hex64;
+
+const MAP_INPUT: RoleMapVersionInput = {
+  role_rules: [
+    { role_key: "purupuru:core", display_name: "Core", qualifies: { source: "tier", min_tier: "core" }, create_if_absent: true },
+  ],
+  scaffolding_config: { channels: [] },
+  world_config: { world_slug: "purupuru", guild_id: "111122223333444455", namespace_prefix: "purupuru:", nft_contracts: ["0xabc"] },
+};
+const MAP_HASH = roleMapVersionHash(MAP_INPUT);
+
+const EMPTY_SNAPSHOT = { member_ids: [] as string[], role_ids: [] as string[] };
+const NO_DRIFT = {
+  baseFingerprint: rosterFingerprint(EMPTY_SNAPSHOT),
+  baseSnapshot: EMPTY_SNAPSHOT,
+  freshSnapshot: EMPTY_SNAPSHOT,
+};
+
+const ROSTER_VERSION: RosterVersion = {
+  fingerprint: h64("a".repeat(64)),
+  fetched_at: "2026-06-02T00:00:00Z",
+  member_count: 0,
+};
+
+function fullStack(mode: ModeControl, emitterLayer: Layer.Layer<AcvpEmitter>, allow: readonly string[]) {
+  const allowlist = makeAdminAllowlistInMemory(new Map([[WORLD as unknown as string, allow]]));
+  const lock = makeInMemoryWorldLock();
+  const gate = makeGateCheckedRoleWriter(mode, () => MAP_HASH).pipe(
+    Layer.provide(Layer.mergeAll(RoleWriterMock, emitterLayer, lock)),
+  );
+  return Layer.mergeAll(gate, RoleWriterMock, emitterLayer, lock, allowlist);
+}
+
+beforeEach(() => resetMockRoleWriter());
+
+describe("score-tier-assignment — END-TO-END through the real gate", () => {
+  test("assembled assign-batch writes through the gate (LIVE, MOCK writer)", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+
+    // The PRE-CREATED tier role the gate's writer adopts on assign (a real flow
+    // would create it via the FR-4 create pass first; the MOCK writer's assign
+    // path resolves by name, so seed it through a create captured-write would be
+    // needed — instead we rely on the MOCK writer's create-then-assign path by
+    // including the create op is NOT this builder's job; here we prove the ASSIGN
+    // op the builder emits is gate-VALID and flows). The MOCK writer captures the
+    // assign intent regardless of pre-existing roleset.
+    const assignmentsRes = await buildTierAssignments({
+      leaderboard: [lbEntry("0xcore", "core"), lbEntry("0xelder", "elder")],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xcore": "member-1", "0xelder": "member-2" }),
+    });
+    expect(assignmentsRes.assignments.length).toBe(2);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const mode = yield* makeModeControl("SHADOW");
+        const out = yield* goLive(mode, {
+          actor: ADMIN, world: WORLD, reportHash: h64(MAP_HASH), currentMapHash: h64(MAP_HASH),
+          transitionVersion: 5, evaluatedAt: "2026-06-02T00:00:00Z", rosterFreshness: NO_DRIFT,
+        }).pipe(Effect.provide(Layer.mergeAll(
+          makeAdminAllowlistInMemory(new Map([[WORLD as unknown as string, [ADMIN]]])),
+          emitterLayer,
+        )));
+
+        const transition: AuthorizedTransition = {
+          actor: ADMIN,
+          reportHash: MAP_HASH,
+          authzDecisionId: out.authzDecisionId,
+          transitionVersion: 5,
+          tokenMetadata: { kid: "kid-1", verified_at: "2026-06-02T00:00:00Z", exp: "2026-06-02T01:00:00Z" },
+        };
+        const batch = assembleAssignBatch({
+          world: "purupuru",
+          transition,
+          rosterVersion: ROSTER_VERSION,
+          assignments: assignmentsRes.assignments,
+        });
+
+        return yield* GateCheckedRoleWriter.pipe(
+          Effect.flatMap((g) => g.applyBatch(batch, out.capability)),
+          Effect.provide(fullStack(mode, emitterLayer, [ADMIN])),
+        );
+      }),
+    );
+
+    expect(result.status).toBe("done");
+    expect(result.progress.completed).toBe(2);
+    // exactly the two assign ops, captured by the MOCK writer (zero REAL writes).
+    const assigns = capturedWrites().filter((w) => w.kind === "assign_role");
+    expect(assigns.length).toBe(2);
+    expect(assigns.map((w) => w.member_id).sort()).toEqual(["member-1", "member-2"]);
+    expect(capturedWrites().filter((w) => w.kind === "create_role").length).toBe(0); // assign-only
+    expect(recorder.countOf("shadow.role.applied.v1")).toBe(2);
+    expect(recorder.countOf("shadow.role.rejected.v1")).toBe(0);
+  });
+
+  test("a batch with a MISBOUND report_hash is refused by the gate (hash binding)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const res = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const mode = yield* makeModeControl("SHADOW");
+          const out = yield* goLive(mode, {
+            actor: ADMIN, world: WORLD, reportHash: h64(MAP_HASH), currentMapHash: h64(MAP_HASH),
+            transitionVersion: 9, evaluatedAt: "2026-06-02T00:00:00Z", rosterFreshness: NO_DRIFT,
+          }).pipe(Effect.provide(Layer.mergeAll(
+            makeAdminAllowlistInMemory(new Map([[WORLD as unknown as string, [ADMIN]]])),
+            emitterLayer,
+          )));
+          // build a batch bound to the WRONG report hash (not the go_live one).
+          const transition: AuthorizedTransition = {
+            actor: ADMIN,
+            reportHash: "f".repeat(64), // ≠ MAP_HASH → gate refuses
+            authzDecisionId: out.authzDecisionId,
+            transitionVersion: 9,
+            tokenMetadata: { kid: "kid-1", verified_at: "2026-06-02T00:00:00Z", exp: "2026-06-02T01:00:00Z" },
+          };
+          const batch = assembleAssignBatch({
+            world: "purupuru",
+            transition,
+            rosterVersion: ROSTER_VERSION,
+            assignments: [{ wallet: "0xa", member_id: "m-1", tier: "core", role_key: "purupuru:core" }],
+          });
+          return yield* GateCheckedRoleWriter.pipe(
+            Effect.flatMap((g) => g.applyBatch(batch, out.capability)),
+            Effect.provide(fullStack(mode, emitterLayer, [ADMIN])),
+          );
+        }),
+      ),
+    );
+    expect(res._tag).toBe("Left"); // WriteError: authz binding mismatch
+  });
+});

--- a/apps/bot/src/shadow/score-tier-assignment.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.ts
@@ -1,0 +1,272 @@
+/**
+ * shadow/score-tier-assignment.ts — the per-member tier→role ASSIGN-BATCH
+ * builder (bd-tfl part 2): "manage Discord roles by score-api tier".
+ *
+ * ── THE PATH (grounded against the substrate's write model) ──────────────────
+ *   score-api Purupuru leaderboard (wallet → tier)
+ *     ⋈ identity (wallet ↔ discord SNOWFLAKE)
+ *     ⋈ CM role-map rules (tier → role_key, via RoleRule.qualifies.min_tier)
+ *   → for each linked wallet that qualifies a rule:
+ *         AssignRoleIntent{ role_key, member_id: <discord snowflake> }
+ *   → WriteOp[] (assign_role) → WriteIntentBatch → gate.applyBatch (the SINGLE
+ *     gated write path; this module NEVER touches discord.js directly — the
+ *     cross-repo import-boundary lint forbids it).
+ *
+ * ── WHAT THIS MODULE OWNS vs THE SUBSTRATE GAPS ──────────────────────────────
+ * This module owns the PURE JOIN + the batch ASSEMBLY. It does NOT mint a
+ * `WriteCapability` and does NOT manufacture an `AuthzContext` out of thin air —
+ * BOTH come from the substrate's authorized `goLive` (the SHADOW→LIVE
+ * transition; `goLive` is SACRED / SHA-pinned and returns
+ * `{ capability, authzDecisionId }`). `assembleAssignBatch` therefore TAKES the
+ * go_live outputs + a roster-freshness `RosterVersion` and threads them into a
+ * well-formed `WriteIntentBatch` whose hash-binding invariants the gate enforces.
+ *
+ * TWO genuine seams are NOT closed here (flagged in the build report + a new
+ * bead; do NOT fake them):
+ *   1. The LIVE wallet↔discord-SNOWFLAKE adapter. The join needs a Discord
+ *      snowflake `member_id` (the gate's `assignRole` does
+ *      `guild.members.fetch(member_id)`). The repo's `WalletResolver` port
+ *      surfaces a `discord_handle` (display string), NOT a snowflake — unusable
+ *      for assignment. The freeside_auth MCP resolver DOES carry
+ *      `ResolvedWallet.discord_id` (the snowflake, from `midi_profiles`), but no
+ *      port exposes it to the shadow seam yet. So this builder takes an
+ *      INJECTABLE `WalletDiscordLink` resolver; the live adapter that reads
+ *      `discord_id` is the follow-up.
+ *   2. The orchestration that calls `goLive` (mints the cap) then this builder
+ *      then `applyBatch` is not wired into a bot entrypoint yet — `goLive`
+ *      requires an authorized admin + roster-freshness inputs (the lens/CM
+ *      flow). This module provides the reusable pieces; the entrypoint that
+ *      sequences them is the next layer.
+ *
+ * ── SAFETY ───────────────────────────────────────────────────────────────────
+ *   • assign-ONLY (FR-6 of the brief). This builder NEVER emits a create_role op
+ *     and NEVER a role REMOVAL — shadow-onboarding never strips users (R-6). It
+ *     assigns the highest-qualifying tier role per member.
+ *   • namespace: every `role_key` comes from the CM role-map rules (already
+ *     Freeside-namespaced); the gate's writer re-enforces the namespace guard.
+ *   • idempotent: deterministic `op_id`/`idempotency_key` per (world, report,
+ *     role_key, member_id) so a retried batch is safe (the gate dedups assigns;
+ *     a held role is a Discord no-op).
+ */
+import { sha256 } from "@noble/hashes/sha256";
+import { utf8ToBytes, bytesToHex } from "@noble/hashes/utils";
+import type {
+  RoleRule,
+  RoleMapConfig,
+  WriteOp,
+  WriteIntentBatch,
+  AuthzContext,
+  RosterVersion,
+  Hex64,
+  WorldSlug,
+} from "@freeside-worlds/shadow-substrate";
+import type { CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
+import { tierQualifies, type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
+
+// ─── identity link port (the wallet ↔ discord-snowflake seam) ────────────────
+
+/**
+ * Resolve a wallet → its Discord snowflake `member_id`, or null when the wallet
+ * is not linked. INJECTABLE: tests provide a map; the LIVE adapter (follow-up,
+ * see header gap #1) reads `ResolvedWallet.discord_id` from the freeside_auth /
+ * identity-api source. A null link means the wallet is QUALIFIED-but-not-linked
+ * (counted in `skipped_unlinked`), never assigned.
+ */
+export interface WalletDiscordLink {
+  /** wallet (any case) → discord snowflake, or null if not linked. */
+  resolve(wallet: string): Promise<string | null>;
+}
+
+// ─── the pure join → assign ops ──────────────────────────────────────────────
+
+/** One resolved assignment (pre-WriteOp), for legibility + testing. */
+export interface TierAssignment {
+  readonly wallet: string;
+  readonly member_id: string;
+  readonly tier: string;
+  readonly role_key: string;
+}
+
+export interface BuildAssignmentsInput {
+  readonly leaderboard: ReadonlyArray<CommunityLeaderboardEntry>;
+  readonly roleMap: RoleMapConfig;
+  readonly link: WalletDiscordLink;
+  readonly tierRank?: TierRankResolver;
+}
+
+export interface BuildAssignmentsResult {
+  readonly assignments: ReadonlyArray<TierAssignment>;
+  /** qualified wallets with NO discord link (counted, never assigned). */
+  readonly skipped_unlinked: number;
+  /** wallets that qualified no rule (below every rule's min_tier / untiered). */
+  readonly skipped_unqualified: number;
+}
+
+/**
+ * Pick the STRONGEST rule a wallet's tier qualifies (highest min_tier rank). A
+ * wallet gets at most ONE managed tier role — the top one it earns. Returns the
+ * winning rule or undefined when the wallet qualifies none.
+ */
+function strongestQualifyingRule(
+  tier: string | null,
+  rules: ReadonlyArray<RoleRule>,
+  rank: TierRankResolver,
+): RoleRule | undefined {
+  let best: RoleRule | undefined;
+  let bestRank = -Infinity;
+  for (const rule of rules) {
+    if (!tierQualifies(tier, rule.qualifies.min_tier, rank)) continue;
+    const r = rank(rule.qualifies.min_tier) ?? -Infinity;
+    if (r > bestRank) {
+      best = rule;
+      bestRank = r;
+    }
+  }
+  return best;
+}
+
+/**
+ * Build the per-member assignments by joining the leaderboard ⋈ identity links ⋈
+ * role-map rules. Pure except for the injected `link.resolve` (async). Emits at
+ * most one assignment per linked, qualified wallet (its strongest tier role).
+ * Disabled role-maps (`enabled:false`) produce zero assignments.
+ */
+export async function buildTierAssignments(
+  input: BuildAssignmentsInput,
+): Promise<BuildAssignmentsResult> {
+  const rank = input.tierRank ?? purupuruTierRank;
+  if (!input.roleMap.enabled) {
+    return { assignments: [], skipped_unlinked: 0, skipped_unqualified: 0 };
+  }
+  const rules = input.roleMap.rules;
+  const assignments: TierAssignment[] = [];
+  let skipped_unlinked = 0;
+  let skipped_unqualified = 0;
+
+  for (const entry of input.leaderboard) {
+    const rule = strongestQualifyingRule(entry.tier, rules, rank);
+    if (!rule) {
+      skipped_unqualified += 1;
+      continue;
+    }
+    const memberId = await input.link.resolve(entry.wallet);
+    if (memberId === null || memberId.length === 0) {
+      skipped_unlinked += 1;
+      continue;
+    }
+    assignments.push({
+      wallet: entry.wallet,
+      member_id: memberId,
+      // entry.tier is non-null here (strongestQualifyingRule returned a rule).
+      tier: entry.tier as string,
+      role_key: rule.role_key,
+    });
+  }
+
+  return { assignments, skipped_unlinked, skipped_unqualified };
+}
+
+// ─── op_id / idempotency_key (deterministic, retry-safe) ─────────────────────
+
+/**
+ * Stable JSON (sorted keys) for the hash inputs. The inputs are flat objects of
+ * strings, so a sorted-key serialize is a sufficient canonical form (a full RFC
+ * 8785 JCS is overkill for primitive-only maps and would add a dep apps/bot
+ * doesn't carry). Determinism is the requirement; this delivers it.
+ */
+function stableStringify(obj: Record<string, string>): string {
+  const keys = Object.keys(obj).sort();
+  return JSON.stringify(Object.fromEntries(keys.map((k) => [k, obj[k]])));
+}
+
+function sha256Hex(input: string): string {
+  return bytesToHex(sha256(utf8ToBytes(input)));
+}
+
+/** Deterministic op_id for an assign op (stable across retries). */
+export function assignOpId(world: string, roleKey: string, memberId: string): string {
+  return `assign:${world}:${roleKey}:${memberId}`;
+}
+
+/** = sha256(stableJSON({world, op_id, report_hash})) — the gate's retry key. */
+export function assignIdempotencyKey(
+  world: string,
+  opId: string,
+  reportHash: string,
+): Hex64 {
+  return sha256Hex(stableStringify({ world, op_id: opId, report_hash: reportHash })) as unknown as Hex64;
+}
+
+/** Map resolved assignments → substrate `WriteOp[]` (assign_role only). */
+export function assignmentsToOps(
+  world: string,
+  reportHash: string,
+  assignments: ReadonlyArray<TierAssignment>,
+): WriteOp[] {
+  return assignments.map((a) => {
+    const op_id = assignOpId(world, a.role_key, a.member_id);
+    return {
+      op_id,
+      idempotency_key: assignIdempotencyKey(world, op_id, reportHash),
+      kind: "assign_role" as const,
+      intent: { role_key: a.role_key, member_id: a.member_id as never },
+    };
+  });
+}
+
+// ─── full batch assembly (threads the goLive outputs) ────────────────────────
+
+/**
+ * The pieces the substrate's authorized `goLive` hands back (its `GoLiveOutput`
+ * carries `authzDecisionId`; the caller already knows `reportHash` /
+ * `transitionVersion` it passed in). We take them as inputs rather than
+ * recomputing — the gate binds all four of {current map hash, cap report_hash,
+ * batch report_hash, authz report_hash} + decision_id + transition_version.
+ */
+export interface AuthorizedTransition {
+  readonly actor: string;
+  readonly reportHash: string;
+  readonly authzDecisionId: string;
+  readonly transitionVersion: number;
+  readonly tokenMetadata: { readonly kid: string; readonly verified_at: string; readonly exp: string };
+}
+
+export interface AssembleBatchInput {
+  readonly world: string;
+  readonly transition: AuthorizedTransition;
+  readonly rosterVersion: RosterVersion;
+  readonly assignments: ReadonlyArray<TierAssignment>;
+  /** intra-batch in-flight cap (gate default 4). */
+  readonly maxConcurrent?: number;
+}
+
+/**
+ * Assemble a gate-ready `WriteIntentBatch` of assign ops from resolved
+ * assignments + an authorized transition. The returned batch is what
+ * `GateCheckedRoleWriter.applyBatch(batch, cap)` consumes — the cap being the one
+ * `goLive` minted for the SAME `{reportHash, authzDecisionId, transitionVersion}`.
+ *
+ * NOTE: this builds the assign-only batch. If the namespaced tier roles don't yet
+ * exist on the guild, a SEPARATE create-role pass (the substrate's go_live /
+ * computeProposed flow, FR-4) must precede it — this builder is the ASSIGN half
+ * (per the brief: "per-member tier→role assign-batch").
+ */
+export function assembleAssignBatch(input: AssembleBatchInput): WriteIntentBatch {
+  const { world, transition: t } = input;
+  const authz: AuthzContext = {
+    actor: t.actor,
+    world: world as unknown as WorldSlug,
+    report_hash: t.reportHash as unknown as Hex64,
+    token_metadata: t.tokenMetadata,
+    transition_version: t.transitionVersion,
+    authz_decision_id: t.authzDecisionId,
+    roster_version: input.rosterVersion,
+  };
+  return {
+    world: world as unknown as WorldSlug,
+    report_hash: t.reportHash as unknown as Hex64,
+    authz,
+    ops: assignmentsToOps(world, t.reportHash, input.assignments),
+    max_concurrent: input.maxConcurrent ?? 4,
+  };
+}

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -14,6 +14,7 @@
     "./score/index": "./src/score/index.ts",
     "./score/types": "./src/score/types.ts",
     "./score/client": "./src/score/client.ts",
+    "./score/community-client": "./src/score/community-client.ts",
     "./compose/digest": "./src/compose/digest.ts",
     "./compose/voice-brief": "./src/compose/voice-brief.ts",
     "./compose/voice-memory": "./src/compose/voice-memory.ts",

--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -56,6 +56,19 @@ const ConfigSchema = z.object({
    *  `TENANT_SCORE_API_KEY` env. Unset = direct route (no gateway gate). */
   SCORE_BEARER: z.string().optional(),
 
+  // ─── shadow-onboarding LIVE ScoreSource (bd-tfl) ──────────────────────
+  /**
+   * Community-scoped score-api key for the Purupuru tier read (x-api-key). Its
+   * `api_key_community_scope.allowedCommunities` must include `purupuru`. This
+   * is the LIVE/MOCK FLAG for the shadow ScoreSource adapter:
+   *   set   → LIVE ScoreSource (reads real Purupuru tiers from score-api REST)
+   *   unset → MOCK ScoreSource (default; shadow preview works with no
+   *           score-api provisioning).
+   * See apps/bot/src/shadow/score-source.live.ts + composition-root.ts. */
+  SCORE_PURUPURU_API_KEY: z.string().optional(),
+  /** Community slug for the LIVE ScoreSource read. Defaults to `purupuru`. */
+  SCORE_PURUPURU_COMMUNITY: z.string().default('purupuru'),
+
   // ─── codex-mcp (gumi — mibera-codex lookup, public, no auth) ──────────
   /**
    * HTTP base URL of the codex MCP server. When set, the orchestrator

--- a/packages/persona-engine/src/score/community-client.test.ts
+++ b/packages/persona-engine/src/score/community-client.test.ts
@@ -1,0 +1,146 @@
+/**
+ * community-client.test.ts — the LIVE REST community score client (bd-tfl).
+ *
+ * Pure: injected fetch (response factories), injected sleep (records delays,
+ * never waits). No network. Pins the grounded score-api community contract:
+ *   - leaderboard parse (wallet + tier)
+ *   - x-api-key auth header
+ *   - fail-closed classification (403 forbidden / 404 not_found / 4xx bad / 5xx
+ *     upstream / decode / transport) — NEVER a silent empty result.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CommunityScoreClient,
+  CommunityScoreError,
+} from "./community-client.ts";
+import type { FetchRetryOptions } from "./retry.ts";
+
+const noWait: Pick<FetchRetryOptions, "sleep" | "random"> = {
+  sleep: async () => {},
+  random: () => 0.5,
+};
+
+/** Build a client whose transport is the supplied fake fetch. */
+function client(
+  fakeFetch: typeof fetch,
+  over: Partial<{ community: string; apiKey: string; baseUrl: string }> = {},
+) {
+  return new CommunityScoreClient({
+    baseUrl: over.baseUrl ?? "https://score-api.test",
+    apiKey: over.apiKey ?? "sk-test-key",
+    community: over.community ?? "purupuru",
+    retry: { ...noWait, fetchImpl: fakeFetch, maxAttempts: 1 },
+  });
+}
+
+/** A fake fetch returning a single Response and capturing the request. */
+function once(resp: Response, sink?: { url?: string; init?: RequestInit }) {
+  return (async (url: string, init: RequestInit) => {
+    if (sink) {
+      sink.url = url;
+      sink.init = init;
+    }
+    return resp;
+  }) as unknown as typeof fetch;
+}
+
+const COMMUNITY_BODY = {
+  community: "purupuru",
+  total: 3,
+  cohort_total: 3,
+  truncated: false,
+  meta: { foo: "bar" }, // extra/tolerated
+  wallets: [
+    { wallet: "0xaaa", rank: 1, combined_score: 98, tier: "sovereign", og_score: 50, nft_score: 30, onchain_score: 18 },
+    { wallet: "0xbbb", rank: 12, combined_score: 70, tier: "devoted" },
+    { wallet: "0xccc", rank: null, combined_score: null, tier: null },
+  ],
+};
+
+describe("CommunityScoreClient.leaderboard", () => {
+  test("parses the community leaderboard + sends x-api-key", async () => {
+    const sink: { url?: string; init?: RequestInit } = {};
+    const c = client(once(Response.json(COMMUNITY_BODY), sink));
+    const page = await c.leaderboard();
+
+    expect(page.community).toBe("purupuru");
+    expect(page.wallets.length).toBe(3);
+    expect(page.wallets[0]!.wallet).toBe("0xaaa");
+    expect(page.wallets[0]!.tier).toBe("sovereign");
+    expect(page.wallets[2]!.tier).toBeNull(); // untiered wallet preserved
+
+    // grounded auth + URL shape
+    expect(sink.url).toBe("https://score-api.test/v1/leaderboard?community=purupuru");
+    const headers = sink.init!.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("sk-test-key");
+  });
+
+  test("tolerates additive upstream fields (open struct)", async () => {
+    const body = {
+      community: "purupuru",
+      total: 1,
+      wallets: [{ wallet: "0xddd", rank: 2, combined_score: 80, tier: "core", new_future_field: "x" }],
+    };
+    const c = client(once(Response.json(body)));
+    const page = await c.leaderboard();
+    expect(page.wallets[0]!.tier).toBe("core");
+  });
+
+  test("403 → forbidden (out-of-scope key, fail-closed)", async () => {
+    const c = client(once(new Response("nope", { status: 403 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect(res).toBeInstanceOf(CommunityScoreError);
+    expect((res as CommunityScoreError).kind).toBe("forbidden");
+    expect((res as CommunityScoreError).status).toBe(403);
+  });
+
+  test("404 → not_found", async () => {
+    const c = client(once(new Response("gone", { status: 404 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("not_found");
+  });
+
+  test("400 → bad_request (unresolved community)", async () => {
+    const c = client(once(new Response("bad", { status: 400 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("bad_request");
+  });
+
+  test("500 → upstream", async () => {
+    const c = client(once(new Response("boom", { status: 500 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("upstream");
+  });
+
+  test("malformed body → decode (never a silent empty result)", async () => {
+    const c = client(once(Response.json({ not: "a leaderboard" })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("decode");
+  });
+
+  test("network throw → transport", async () => {
+    const throwing = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const c = client(throwing);
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("transport");
+  });
+});
+
+describe("CommunityScoreClient.walletProfile", () => {
+  test("parses a single wallet profile + correct URL", async () => {
+    const sink: { url?: string; init?: RequestInit } = {};
+    const c = client(once(Response.json({ wallet: "0xaaa", tier: "elder" }), sink));
+    const p = await c.walletProfile("0xAAA");
+    expect(p.wallet).toBe("0xaaa");
+    expect(p.tier).toBe("elder");
+    expect(sink.url).toBe("https://score-api.test/v1/wallets/0xAAA?community=purupuru");
+  });
+
+  test("403 fail-closed on single profile too", async () => {
+    const c = client(once(new Response("nope", { status: 403 })));
+    const res = await c.walletProfile("0xaaa").catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("forbidden");
+  });
+});

--- a/packages/persona-engine/src/score/community-client.ts
+++ b/packages/persona-engine/src/score/community-client.ts
@@ -1,0 +1,242 @@
+/**
+ * score/community-client.ts — the LIVE REST client for score-api's
+ * per-community leaderboard surface (cycle-032 #229/#231/#232, MERGED to
+ * score-api main).
+ *
+ * ── WHY A NEW SURFACE (not the existing client.ts) ───────────────────────────
+ * `client.ts` is the score-MCP transport (`get_zone_digest` / `get_recent_*`
+ * over StreamableHTTP + SSE). This is a DIFFERENT surface: a plain JSON REST
+ * read of the community leaderboard / single-wallet community profile, with
+ * `x-api-key` auth. It shares the transport-hardening (`fetchWithRetry` from
+ * `retry.ts`: honors Retry-After, backs off on 429/5xx) but speaks the REST
+ * contract, not JSON-RPC. The shadow ScoreSource adapter
+ * (apps/bot/src/shadow/score-source.live.ts) is the consumer.
+ *
+ * ── CONTRACT GROUNDING (score-api origin/main, read 2026-06-03) ──────────────
+ *   - GET {SCORE_API_URL}/v1/leaderboard?community={slug}
+ *       → 200 { community, wallets: CommunityLeaderboardEntry[], total, meta,
+ *               cohort_total, truncated }
+ *       (score-api packages/score-api-types entities/leaderboard-entry.ts:
+ *        `communityLeaderboardResponseSchema` + `communityLeaderboardEntrySchema`,
+ *        which extends `leaderboardEntrySchema` with combined_score:number|null
+ *        + tier:string|null.)
+ *   - GET {SCORE_API_URL}/v1/wallets/{address}?community={slug}
+ *       → 200 a single community wallet profile (tier + per-dim tiers).
+ *   - Auth: `x-api-key: <key>` whose `api_key_community_scope.allowedCommunities`
+ *     includes the community (or its `defaultCommunityId` is the community).
+ *     FAIL-CLOSED (score-api src/middleware/community-resolver.ts):
+ *       out-of-scope → 403, unresolved → 4xx, non-active → 404, NEVER a silent
+ *       Mibera read. A community-bound key never falls back to Mibera.
+ *
+ * ── WHY A HAND-MIRRORED SCHEMA, NOT `@0xhoneyjar/score-api-types` ─────────────
+ * `@0xhoneyjar/score-api-types` is published to the GitHub npm registry
+ * (`npm.pkg.github.com`, restricted/authed) as a BUILT `dist/` and lives in a
+ * SUBDIRECTORY of the score-api repo (`packages/score-api-types`) — a bun
+ * git-tarball source (the cluster's sovereign-distribution channel) cannot
+ * target a repo subpath, and the package ships compiled dist rather than source.
+ * Adding it as a dep would require a GH-authed registry + a postinstall build in
+ * a headless dispatch. So we MIRROR the exact community shapes here (via
+ * `@effect/schema`, matching the shadow seam's validation idiom), grounded
+ * against score-api origin/main. This is the SAME precedent already established
+ * in this repo's `apps/bot/src/auth-bridge.ts` (Lock-9: local `JWTClaim` mirrors
+ * the canonical schema "until the bot workspace links the published package").
+ * If/when the typed package becomes consumable, swap these schemas for its
+ * re-exports — the response field names are byte-identical to the upstream.
+ */
+
+import { Schema as S } from '@effect/schema';
+import { fetchWithRetry, type FetchRetryOptions } from './retry.ts';
+
+// ─── Hand-mirrored community contract (grounded: score-api origin/main) ──────
+
+/**
+ * One community leaderboard row. Mirrors score-api
+ * `communityLeaderboardEntrySchema` = base `leaderboardEntrySchema` extended
+ * with `combined_score`/`tier`. We model only the fields this client consumes +
+ * the load-bearing identity/score fields; `@effect/schema` Struct is OPEN here
+ * (we do NOT `.strict()`) so additive upstream fields (display_name, ens_name,
+ * …) never break the read — the consumer reads `wallet`/`tier` and ignores the
+ * rest. Reading is the read-amplification-safe posture: tolerate-extra on a
+ * contract we mirror rather than own.
+ */
+export const CommunityLeaderboardEntry = S.Struct({
+  /** 0x-prefixed EVM address (lowercase per score-api wallet_scores). */
+  wallet: S.String,
+  /** rank-1 is best; null when score-but-no-rank (live-mode rows). */
+  rank: S.NullOr(S.Number),
+  og_score: S.optional(S.NullOr(S.Number)),
+  nft_score: S.optional(S.NullOr(S.Number)),
+  onchain_score: S.optional(S.NullOr(S.Number)),
+  combined_score: S.NullOr(S.Number),
+  /** the community's OWN lore tier name (e.g. "sovereign"); null = untiered. */
+  tier: S.NullOr(S.String),
+});
+export type CommunityLeaderboardEntry = S.Schema.Type<typeof CommunityLeaderboardEntry>;
+
+/**
+ * The `GET /v1/leaderboard?community=` response envelope. Mirrors score-api
+ * `communityLeaderboardResponseSchema`. We validate the load-bearing fields
+ * (`community`, `wallets`) and tolerate the rest (`total`, `meta`,
+ * `cohort_total`, `truncated`).
+ */
+export const CommunityLeaderboardResponse = S.Struct({
+  community: S.String,
+  wallets: S.Array(CommunityLeaderboardEntry),
+});
+export type CommunityLeaderboardResponse = S.Schema.Type<typeof CommunityLeaderboardResponse>;
+
+/**
+ * The `GET /v1/wallets/{address}?community=` single-profile response. score-api
+ * returns the community wallet profile with a `tier` (+ per-dim tiers we don't
+ * consume here). Modeled tolerant-of-extra; we read `wallet` + `tier`.
+ */
+export const CommunityWalletProfile = S.Struct({
+  wallet: S.String,
+  tier: S.optional(S.NullOr(S.String)),
+});
+export type CommunityWalletProfile = S.Schema.Type<typeof CommunityWalletProfile>;
+
+const decodeLeaderboard = S.decodeUnknownEither(CommunityLeaderboardResponse);
+const decodeProfile = S.decodeUnknownEither(CommunityWalletProfile);
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+/** A typed failure from the REST community surface. Mirrors the fail-closed
+ *  posture: 403 = out-of-scope key, 4xx = unresolved/bad request, 5xx = upstream.
+ *  The shadow adapter maps this to the substrate's `ScoreError`. */
+export class CommunityScoreError extends Error {
+  constructor(
+    public readonly kind:
+      | 'forbidden'        // 403 — key not scoped for this community (fail-closed)
+      | 'not_found'        // 404 — community paused/disabled or wallet absent
+      | 'bad_request'      // other 4xx — unresolved community / bad params
+      | 'upstream'         // 5xx after bounded retry
+      | 'decode'           // response did not match the mirrored contract
+      | 'transport',       // network throw
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'CommunityScoreError';
+  }
+}
+
+export interface CommunityScoreClientConfig {
+  /** base URL, e.g. https://score-api-production.up.railway.app (no trailing slash needed). */
+  readonly baseUrl: string;
+  /** the community-scoped score-api key (x-api-key). REQUIRED for the LIVE path. */
+  readonly apiKey: string;
+  /** the community slug, e.g. "purupuru". */
+  readonly community: string;
+  /** retry tuning (tests inject fetchImpl/sleep/random). */
+  readonly retry?: FetchRetryOptions;
+}
+
+/**
+ * The community-scoped REST client. Two reads:
+ *   - `leaderboard()`  → the full community roster (wallet → tier).
+ *   - `walletProfile(address)` → a single wallet's community tier.
+ *
+ * Fail-closed: any non-2xx maps to a typed `CommunityScoreError` (never a silent
+ * empty/Mibera result). A 403 specifically signals the key is out-of-scope.
+ */
+export class CommunityScoreClient {
+  constructor(private readonly cfg: CommunityScoreClientConfig) {}
+
+  private headers(): Record<string, string> {
+    return {
+      Accept: 'application/json',
+      // score-api community-resolver reads `x-api-key` (Vary: X-API-Key).
+      'x-api-key': this.cfg.apiKey,
+    };
+  }
+
+  private base(): string {
+    return this.cfg.baseUrl.replace(/\/+$/, '');
+  }
+
+  /** classify a non-OK Response into a typed error (after the body is consumed). */
+  private async fail(res: Response): Promise<never> {
+    const body = await res.text().catch(() => '');
+    const snippet = body.slice(0, 200);
+    const s = res.status;
+    if (s === 403) {
+      throw new CommunityScoreError(
+        'forbidden',
+        `score-api 403 — key not scoped for community '${this.cfg.community}' (fail-closed): ${snippet}`,
+        s,
+      );
+    }
+    if (s === 404) {
+      throw new CommunityScoreError(
+        'not_found',
+        `score-api 404 — community '${this.cfg.community}' unavailable or wallet absent: ${snippet}`,
+        s,
+      );
+    }
+    if (s >= 400 && s < 500) {
+      throw new CommunityScoreError(
+        'bad_request',
+        `score-api ${s} — unresolved community / bad request: ${snippet}`,
+        s,
+      );
+    }
+    throw new CommunityScoreError(
+      'upstream',
+      `score-api ${s} — upstream error after bounded retry: ${snippet}`,
+      s,
+    );
+  }
+
+  /** GET /v1/leaderboard?community=<slug> — the full community roster. */
+  async leaderboard(): Promise<CommunityLeaderboardResponse> {
+    const url = `${this.base()}/v1/leaderboard?community=${encodeURIComponent(this.cfg.community)}`;
+    let res: Response;
+    try {
+      res = await fetchWithRetry(url, { method: 'GET', headers: this.headers() }, this.cfg.retry);
+    } catch (e) {
+      throw new CommunityScoreError(
+        'transport',
+        `score-api leaderboard transport error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (!res.ok) return this.fail(res);
+    const json = await res.json().catch((e) => {
+      throw new CommunityScoreError('decode', `score-api leaderboard: invalid JSON: ${String(e)}`);
+    });
+    const decoded = decodeLeaderboard(json);
+    if (decoded._tag === 'Left') {
+      throw new CommunityScoreError(
+        'decode',
+        `score-api leaderboard response did not match the community contract: ${String(decoded.left)}`,
+      );
+    }
+    return decoded.right;
+  }
+
+  /** GET /v1/wallets/<address>?community=<slug> — a single wallet's tier. */
+  async walletProfile(address: string): Promise<CommunityWalletProfile> {
+    const url = `${this.base()}/v1/wallets/${encodeURIComponent(address)}?community=${encodeURIComponent(this.cfg.community)}`;
+    let res: Response;
+    try {
+      res = await fetchWithRetry(url, { method: 'GET', headers: this.headers() }, this.cfg.retry);
+    } catch (e) {
+      throw new CommunityScoreError(
+        'transport',
+        `score-api wallet-profile transport error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (!res.ok) return this.fail(res);
+    const json = await res.json().catch((e) => {
+      throw new CommunityScoreError('decode', `score-api wallet-profile: invalid JSON: ${String(e)}`);
+    });
+    const decoded = decodeProfile(json);
+    if (decoded._tag === 'Left') {
+      throw new CommunityScoreError(
+        'decode',
+        `score-api wallet-profile did not match the community contract: ${String(decoded.left)}`,
+      );
+    }
+    return decoded.right;
+  }
+}


### PR DESCRIPTION
## What

LIVE `ScoreSource` adapter that consumes score-api's per-community Purupuru tiers and wires them into the shadow-onboarding substrate, so the characters bot can manage Discord roles by tier (shadow-first, gate-enforced).

Closes the structural hole: `composition-root` supplied every live Layer except `ScoreSource`, so the substrate's `ScoreSource.latentQualified` port was unimplemented and the proposed roster fell back to mock. Bead: `bd-tfl`.

## Contract (verified against the live API, score-api `origin/main` cycle-032 #229/#231/#232)

- `GET /v1/leaderboard?community=purupuru` returns `{community, wallets:[{wallet, rank, combined_score, tier, ...}]}`.
- Auth: `x-api-key`, fail-closed (out-of-scope 403, never a silent Mibera read).
- Purupuru tier bands are the community's own: crowd `newcomer/member/devoted/core` (score-banded) and elite `sovereign`(rank 1-7) / `elder`(rank 8-50), elite overrides crowd.

## What this lands

- **Part 1 (fully wired):** REST `CommunityScoreClient` (`packages/persona-engine/src/score/community-client.ts`) plus `makeScoreSourceLive` (`apps/bot/src/shadow/score-source.live.ts`), wired into both the preview and live-apply Layers. `latentQualified` reads the Purupuru leaderboard and counts wallets at or above a rule's `min_tier` using the grounded strength ladder.
- **Part 2 (pure half):** `buildTierAssignments` and `assembleAssignBatch` (`apps/bot/src/shadow/score-tier-assignment.ts`) build the per-member tier to role assign batch and prove it end to end through the real substrate gate (`goLive` to `applyBatch`) with a mock writer. Two runtime seams (a live wallet to discord snowflake adapter, and the orchestration entrypoint) are scoped into follow-up bead `bd-m2v`.

## Flag

`SCORE_PURUPURU_API_KEY` present routes the LIVE ScoreSource; absent falls back to MOCK (the default). `SCORE_PURUPURU_COMMUNITY` defaults to `purupuru`.

## Tests

shadow suite 81 pass, persona-engine score 29 pass / 1 pre-existing skip, both typechecks 0, import-boundary lint 0. All network-free (injected fetch and injected identity link).

## Review focus

1. The hand-mirrored community response schema in `community-client.ts` (the `@0xhoneyjar/score-api-types` package is a built-dist not bun-git-consumable in headless dispatch; structs are open to tolerate additive upstream fields). Field names verified against the live endpoint.
2. The tier strength ladder in `purupuru-tiers.ts`: `sort_order` is presentation order and inverts the elite pair, so the ladder is grounded in band semantics (`sovereign` rank 1-7 tops `elder` rank 8-50), with the elite-overrides-crowd assumption flagged in a code NOTE.
3. The Part 2 scope boundary: `assembleAssignBatch` is assign-only by design and requires a `goLive`-minted cap, before the orchestration entrypoint (`bd-m2v`) is built.

Does NOT modify the SHA-pinned `@freeside-worlds/shadow-substrate`. Base is `cycle/shadow-onboarding-substrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
