### PR TITLE
feat(shadow): Purupuru tier→Discord-role assignment, hardened (bd-tfl + bd-m2v)

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -22,6 +22,7 @@
     "@0xhoneyjar/quests-protocol": "^0.1.2",
     "@freeside-characters/persona-engine": "workspace:*",
     "@freeside-worlds/shadow-substrate": "github:0xHoneyJar/freeside-worlds#26d11b78e6f0c2ce81cbd1fc24088157cea74e53",
+    "@noble/hashes": "^1.6.0",
     "discord.js": "^14.16.3",
     "effect": "^3.10.0",
     "yaml": "^2.6.0"

--- a/apps/bot/src/shadow/composition-root.test.ts
+++ b/apps/bot/src/shadow/composition-root.test.ts
@@ -1,0 +1,79 @@
+/**
+ * composition-root.test.ts — the SHADOW-vs-LIVE ScoreSource selection
+ * (Bridgebuilder #3). The pre-fix `resolveScoreLayer` returned the MOCK
+ * ScoreSource (zeros) for an unwired world REGARDLESS of mode — a fail-OPEN in
+ * the gated LIVE path (a LIVE go_live would read mock-zeros and create roles
+ * assigning nobody). The fix makes it MODE-AWARE: LIVE fails closed
+ * (LiveScoreWiringMissingError) when wiring is absent; MOCK fallback is allowed
+ * ONLY for SHADOW preview.
+ *
+ * These tests exercise the PUBLIC layer builders (liveApplyLayer /
+ * shadowPreviewLayer). They build Layers only — no Discord, NATS, or pg I/O
+ * (everything is lazy; the score-wiring check fires synchronously at build).
+ */
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import type { Signer } from "@0xhoneyjar/events";
+import {
+  liveApplyLayer,
+  shadowPreviewLayer,
+  buildModeControl,
+  LiveScoreWiringMissingError,
+  type ShadowDeps,
+  type LiveAuditDeps,
+  type WorldScoreWiring,
+} from "./composition-root.ts";
+import { makeRecordingEmitter } from "./acvp-emitter.mock.ts";
+
+const WORLD = "purupuru";
+
+function baseDeps(over: Partial<ShadowDeps> = {}): ShadowDeps {
+  return {
+    getBotClient: async () => null,
+    resolveWorld: () => ({ guild_id: "111122223333444455", namespace_prefix: "purupuru:" }),
+    manifestPath: () => "/tmp/does-not-exist-purupuru.yaml",
+    world: WORLD,
+    initialMode: "SHADOW",
+    ...over,
+  };
+}
+
+// a stub audit boundary (lazy — signer/nats only touched at emit time).
+const auditStub: LiveAuditDeps = {
+  nats: { publish: () => undefined },
+  signer: {} as unknown as Signer,
+};
+
+const liveWiring = (apiKey: string | undefined): ((w: string) => WorldScoreWiring | undefined) =>
+  () => ({ scoreApiUrl: "https://score-api.test", community: "purupuru", apiKey });
+
+describe("resolveScoreLayer (via the layer builders) — mode-aware fail-closed (#3)", () => {
+  test("LIVE with NO score wiring (no resolveScoreWiring) FAILS CLOSED", async () => {
+    const mode = await Effect.runPromise(buildModeControl("LIVE"));
+    expect(() => liveApplyLayer(baseDeps(), auditStub, mode, () => "h".repeat(64))).toThrow(
+      LiveScoreWiringMissingError,
+    );
+  });
+
+  test("LIVE with wiring but NO apiKey FAILS CLOSED (mock-zeros never feeds the gated path)", async () => {
+    const mode = await Effect.runPromise(buildModeControl("LIVE"));
+    const deps = baseDeps({ resolveScoreWiring: liveWiring(undefined) });
+    expect(() => liveApplyLayer(deps, auditStub, mode, () => "h".repeat(64))).toThrow(
+      LiveScoreWiringMissingError,
+    );
+  });
+
+  test("LIVE WITH a real apiKey builds the live stack (no throw)", async () => {
+    const mode = await Effect.runPromise(buildModeControl("LIVE"));
+    const deps = baseDeps({ resolveScoreWiring: liveWiring("sk-live-key") });
+    // builds without throwing — the live ScoreSource is wired.
+    expect(() => liveApplyLayer(deps, auditStub, mode, () => "h".repeat(64))).not.toThrow();
+  });
+
+  test("SHADOW with NO score wiring is ALLOWED (MOCK fallback) — preview works unprovisioned", async () => {
+    const mode = await Effect.runPromise(buildModeControl("SHADOW"));
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    // MOCK fallback is the whole point of an unprovisioned shadow preview.
+    expect(() => shadowPreviewLayer(baseDeps(), mode, () => "h".repeat(64), emitterLayer)).not.toThrow();
+  });
+});

--- a/apps/bot/src/shadow/composition-root.ts
+++ b/apps/bot/src/shadow/composition-root.ts
@@ -29,6 +29,7 @@ import {
   makeModeControl,
   RosterSource,
   RoleWriter,
+  ScoreSource,
   AcvpEmitter,
   WorldLock,
   AdminAllowlistSource,
@@ -40,16 +41,34 @@ import { makeRosterSourceLive, type LiveRosterConfig } from "./roster-source.liv
 import { RosterSourceMock } from "./roster-source.mock.ts";
 import { makeRoleWriterLive, makeGatedRoleGc, type LiveWriterConfig } from "./role-writer.live.ts";
 import { RoleWriterMock } from "./role-writer.mock.ts";
+import { makeScoreSourceLive, type LiveScoreConfig } from "./score-source.live.ts";
+import { ScoreSourceMock } from "./score-source.mock.ts";
 import { makeAcvpEmitterLive } from "./acvp-emitter.live.ts";
 import { makeAdminAllowlistLive, type LiveAllowlistConfig } from "./admin-allowlist.live.ts";
 import { makeInMemoryWorldLock } from "./world-lock.ts";
 import { computeRollbackPlan, type RolesCreatedEntry, type RoleAssignmentCount } from "./coexistence.ts";
+import { CommunityScoreClient } from "@freeside-characters/persona-engine/score/community-client";
 
 // ── Per-world wiring resolved from the world manifest (purupuru.yaml) ────────
 
 export interface WorldWiring {
   readonly guild_id: string;
   readonly namespace_prefix: string;
+}
+
+/**
+ * Per-world LIVE score wiring (bd-tfl). Resolves a world slug → the score-api
+ * base URL + the community slug + the community-scoped API key. The presence of
+ * the API KEY is the LIVE/MOCK flag (see `resolveScoreClient`): present ⇒ LIVE
+ * ScoreSource (real Purupuru tiers); absent/undefined ⇒ MOCK ScoreSource.
+ */
+export interface WorldScoreWiring {
+  /** score-api base URL, e.g. https://score-api-production.up.railway.app. */
+  readonly scoreApiUrl: string;
+  /** the community slug, e.g. "purupuru". */
+  readonly community: string;
+  /** the community-scoped score-api key (x-api-key). undefined ⇒ MOCK. */
+  readonly apiKey: string | undefined;
 }
 
 export interface ShadowDeps {
@@ -63,6 +82,14 @@ export interface ShadowDeps {
   readonly world: string;
   /** initial apply_mode (seeded from the apply-mode config surface). */
   readonly initialMode: ApplyMode;
+  /**
+   * map a world slug → its LIVE score wiring (bd-tfl). OPTIONAL: when omitted (or
+   * when the resolved wiring has no `apiKey`), the composition uses the MOCK
+   * ScoreSource — so the substrate's `loadLatentCounts` still resolves and the
+   * shadow preview works with NO score-api provisioning. Supply it (with a real
+   * `apiKey`) to read live Purupuru tiers.
+   */
+  readonly resolveScoreWiring?: (world: string) => WorldScoreWiring | undefined;
 }
 
 /** Deploy-provided NATS + signer for the LIVE AcvpEmitter (operator boundary). */
@@ -113,6 +140,40 @@ function liveAllowlistCfg(deps: ShadowDeps): LiveAllowlistConfig {
 }
 
 /**
+ * Resolve the ScoreSource Layer for this composition (bd-tfl). The API-KEY's
+ * presence IS the LIVE/MOCK flag (mirrors the env gate the brief specifies:
+ * `SCORE_PURUPURU_API_KEY` present ⇒ LIVE, absent ⇒ MOCK):
+ *   • a world with score wiring AND a non-empty `apiKey` → LIVE ScoreSource
+ *     (reads the real Purupuru leaderboard via CommunityScoreClient).
+ *   • otherwise → MOCK ScoreSource (the default; the shadow preview works with
+ *     NO score-api provisioning).
+ * The MOCK is also the safe fallback for any world that lacks LIVE wiring, so a
+ * misconfigured world degrades to mock-zeros rather than failing the whole
+ * discrepancy build.
+ */
+function resolveScoreLayer(deps: ShadowDeps): Layer.Layer<ScoreSource> {
+  const resolve = deps.resolveScoreWiring;
+  if (!resolve) return ScoreSourceMock;
+  // Eagerly build a per-world client factory; LIVE only when an apiKey is present.
+  const cfg: LiveScoreConfig = {
+    clientFor: (world: string): CommunityScoreClient | undefined => {
+      const w = resolve(world);
+      if (!w || !w.apiKey || w.apiKey.length === 0) return undefined;
+      return new CommunityScoreClient({
+        baseUrl: w.scoreApiUrl,
+        apiKey: w.apiKey,
+        community: w.community,
+      });
+    },
+  };
+  // If the TARGET world has no live key, prefer the MOCK Layer so we don't
+  // surface fail-closed ScoreErrors for an unprovisioned shadow preview.
+  const target = resolve(deps.world);
+  const targetIsLive = !!target && !!target.apiKey && target.apiKey.length > 0;
+  return targetIsLive ? makeScoreSourceLive(cfg) : ScoreSourceMock;
+}
+
+/**
  * Build the MODE-CONTROL (the apply_mode `Ref` + the shared batch-duration lock,
  * B5/R-10). The gate reads this `Ref` AT INVOCATION; a `rollback` flips it under
  * the same lock so it serializes to a batch boundary.
@@ -137,7 +198,7 @@ export function shadowPreviewLayer(
   mode: ModeControl,
   currentMapHash: () => string,
   emitterLayer: Layer.Layer<AcvpEmitter>,
-): Layer.Layer<GateCheckedRoleWriter | RosterSource> {
+): Layer.Layer<GateCheckedRoleWriter | RosterSource | ScoreSource> {
   const innerWriter = RoleWriterMock;
   const allowlist = makeAdminAllowlistLive(liveAllowlistCfg(deps));
   const worldLock = makeInMemoryWorldLock();
@@ -149,8 +210,14 @@ export function shadowPreviewLayer(
     Layer.provide(Layer.mergeAll(innerWriter, emitterLayer, worldLock)),
   );
 
-  return Layer.mergeAll(gate, RosterSourceMock, allowlist) as Layer.Layer<
-    GateCheckedRoleWriter | RosterSource
+  // ScoreSource (bd-tfl): MOCK by default; LIVE only when the target world has a
+  // community-scoped key wired (resolveScoreWiring). The score READ is read-only
+  // (no Discord writes), so a production shadow preview MAY read real Purupuru
+  // tiers while the writer stays mocked — that IS the point of the preview.
+  const score = resolveScoreLayer(deps);
+
+  return Layer.mergeAll(gate, RosterSourceMock, allowlist, score) as Layer.Layer<
+    GateCheckedRoleWriter | RosterSource | ScoreSource
   >;
 }
 
@@ -168,7 +235,7 @@ export function liveApplyLayer(
   audit: LiveAuditDeps,
   mode: ModeControl,
   currentMapHash: () => string,
-): Layer.Layer<GateCheckedRoleWriter | RosterSource> {
+): Layer.Layer<GateCheckedRoleWriter | RosterSource | ScoreSource> {
   const innerWriter = makeRoleWriterLive(deps.getBotClient, liveWriterCfg(deps));
   const emitter = makeAcvpEmitterLive({
     nats: audit.nats,
@@ -182,11 +249,16 @@ export function liveApplyLayer(
     Layer.provide(Layer.mergeAll(innerWriter, emitter, worldLock)),
   );
 
+  // ScoreSource (bd-tfl): LIVE when the target world has a community-scoped key,
+  // else MOCK. resolveScoreLayer is the env-gated picker.
+  const score = resolveScoreLayer(deps);
+
   return Layer.mergeAll(
     gate,
     makeRosterSourceLive(deps.getBotClient, liveRosterCfg(deps)),
     allowlist,
-  ) as Layer.Layer<GateCheckedRoleWriter | RosterSource>;
+    score,
+  ) as Layer.Layer<GateCheckedRoleWriter | RosterSource | ScoreSource>;
 }
 
 /**
@@ -255,6 +327,8 @@ export {
   makeRoleWriterLive,
   makeGatedRoleGc,
   RoleWriterMock,
+  makeScoreSourceLive,
+  ScoreSourceMock,
   makeAcvpEmitterLive,
   makeAdminAllowlistLive,
   makeInMemoryWorldLock,

--- a/apps/bot/src/shadow/composition-root.ts
+++ b/apps/bot/src/shadow/composition-root.ts
@@ -140,20 +140,51 @@ function liveAllowlistCfg(deps: ShadowDeps): LiveAllowlistConfig {
 }
 
 /**
- * Resolve the ScoreSource Layer for this composition (bd-tfl). The API-KEY's
- * presence IS the LIVE/MOCK flag (mirrors the env gate the brief specifies:
- * `SCORE_PURUPURU_API_KEY` present ⇒ LIVE, absent ⇒ MOCK):
- *   • a world with score wiring AND a non-empty `apiKey` → LIVE ScoreSource
- *     (reads the real Purupuru leaderboard via CommunityScoreClient).
- *   • otherwise → MOCK ScoreSource (the default; the shadow preview works with
- *     NO score-api provisioning).
- * The MOCK is also the safe fallback for any world that lacks LIVE wiring, so a
- * misconfigured world degrades to mock-zeros rather than failing the whole
- * discrepancy build.
+ * Raised when a LIVE-apply composition is requested for a world that has no LIVE
+ * score wiring (Bridgebuilder #3). The pre-fix `resolveScoreLayer` returned the
+ * MOCK (zeros) for an unwired world REGARDLESS of mode — a fail-OPEN in the gated
+ * LIVE path (a LIVE go_live would read mock-zeros and create roles assigning
+ * nobody). The composition root refuses to build a LIVE stack on mock score.
  */
-function resolveScoreLayer(deps: ShadowDeps): Layer.Layer<ScoreSource> {
+export class LiveScoreWiringMissingError extends Error {
+  constructor(public readonly world: string) {
+    super(
+      `LIVE apply requested for world '${world}' but no LIVE score wiring is configured ` +
+        `(resolveScoreWiring absent, or the world has no non-empty apiKey). Refusing to fall back ` +
+        `to the MOCK ScoreSource in a LIVE path (it would read mock-zeros and assign nobody). ` +
+        `MOCK score is allowed ONLY for SHADOW preview.`,
+    );
+    this.name = "LiveScoreWiringMissingError";
+  }
+}
+
+/**
+ * Resolve the ScoreSource Layer for this composition (bd-tfl). MODE-AWARE
+ * (Bridgebuilder #3) — the SHADOW-vs-LIVE distinction is load-bearing:
+ *   • LIVE  → REQUIRE live score wiring; FAIL CLOSED (throw
+ *     `LiveScoreWiringMissingError`) when the target world lacks a non-empty
+ *     `apiKey`. NEVER silently fall back to mock-zeros in the gated write path.
+ *   • SHADOW→ MOCK is an allowed fallback (a shadow preview must work with NO
+ *     score-api provisioning); LIVE wiring is still used when present (the read
+ *     is read-only, so a production preview MAY read real Purupuru tiers).
+ *
+ * The API-KEY's presence is the LIVE/MOCK selector (mirrors the brief's env gate:
+ * `SCORE_PURUPURU_API_KEY` present ⇒ LIVE, absent ⇒ MOCK).
+ */
+function resolveScoreLayer(deps: ShadowDeps, mode: "SHADOW" | "LIVE"): Layer.Layer<ScoreSource> {
   const resolve = deps.resolveScoreWiring;
-  if (!resolve) return ScoreSourceMock;
+  const target = resolve?.(deps.world);
+  const targetIsLive = !!target && !!target.apiKey && target.apiKey.length > 0;
+
+  if (mode === "LIVE" && !targetIsLive) {
+    // FAIL CLOSED: a LIVE composition on mock score is the fail-open the review
+    // flagged. Refuse at build time.
+    throw new LiveScoreWiringMissingError(deps.world);
+  }
+  if (!resolve || !targetIsLive) {
+    // SHADOW (or LIVE with — unreachable here — wiring): MOCK is the safe default.
+    return ScoreSourceMock;
+  }
   // Eagerly build a per-world client factory; LIVE only when an apiKey is present.
   const cfg: LiveScoreConfig = {
     clientFor: (world: string): CommunityScoreClient | undefined => {
@@ -166,11 +197,7 @@ function resolveScoreLayer(deps: ShadowDeps): Layer.Layer<ScoreSource> {
       });
     },
   };
-  // If the TARGET world has no live key, prefer the MOCK Layer so we don't
-  // surface fail-closed ScoreErrors for an unprovisioned shadow preview.
-  const target = resolve(deps.world);
-  const targetIsLive = !!target && !!target.apiKey && target.apiKey.length > 0;
-  return targetIsLive ? makeScoreSourceLive(cfg) : ScoreSourceMock;
+  return makeScoreSourceLive(cfg);
 }
 
 /**
@@ -213,8 +240,9 @@ export function shadowPreviewLayer(
   // ScoreSource (bd-tfl): MOCK by default; LIVE only when the target world has a
   // community-scoped key wired (resolveScoreWiring). The score READ is read-only
   // (no Discord writes), so a production shadow preview MAY read real Purupuru
-  // tiers while the writer stays mocked — that IS the point of the preview.
-  const score = resolveScoreLayer(deps);
+  // tiers while the writer stays mocked — that IS the point of the preview. MOCK
+  // fallback is allowed here because this is the SHADOW stack (#3).
+  const score = resolveScoreLayer(deps, "SHADOW");
 
   return Layer.mergeAll(gate, RosterSourceMock, allowlist, score) as Layer.Layer<
     GateCheckedRoleWriter | RosterSource | ScoreSource
@@ -249,9 +277,10 @@ export function liveApplyLayer(
     Layer.provide(Layer.mergeAll(innerWriter, emitter, worldLock)),
   );
 
-  // ScoreSource (bd-tfl): LIVE when the target world has a community-scoped key,
-  // else MOCK. resolveScoreLayer is the env-gated picker.
-  const score = resolveScoreLayer(deps);
+  // ScoreSource (bd-tfl): LIVE requires a community-scoped key — resolveScoreLayer
+  // FAILS CLOSED (throws LiveScoreWiringMissingError) in LIVE mode if absent (#3).
+  // No mock-zeros fallback in the gated write path.
+  const score = resolveScoreLayer(deps, "LIVE");
 
   return Layer.mergeAll(
     gate,

--- a/apps/bot/src/shadow/go-live-orchestrator.test.ts
+++ b/apps/bot/src/shadow/go-live-orchestrator.test.ts
@@ -24,6 +24,7 @@ import {
   makeModeControl,
   RosterSource,
   roleMapVersionHash,
+  rosterFingerprint as rosterFingerprintLocal,
 } from "./substrate.ts";
 import type {
   RoleMapConfig,
@@ -37,7 +38,7 @@ import { makeRecordingEmitter } from "./acvp-emitter.mock.ts";
 import { makeInMemoryWorldLock } from "./world-lock.ts";
 import { makeAdminAllowlistInMemory } from "./admin-allowlist.live.ts";
 import { ScoreSourceMock } from "./score-source.mock.ts";
-import { makeWalletDiscordLinkMock } from "./wallet-discord-link.live.ts";
+import { makeWalletDiscordLinkMock, LinkResolutionError } from "./wallet-discord-link.live.ts";
 import {
   runTierRoleGoLive,
   type GoLiveOrchestrationInput,
@@ -49,6 +50,15 @@ import {
 const WORLD = "purupuru";
 const ADMIN = "identity:admin-1";
 const h64 = (s: string) => s as unknown as Hex64;
+
+/** A valid 17-20-digit Discord snowflake from a short tag (#12 — non-snowflake
+ *  member_ids are counted invalid, never assigned). */
+function sf(tag: string | number): string {
+  const digits = String(tag).replace(/\D/g, "") || "0";
+  return ("7" + digits.padStart(17, "0")).slice(0, 18);
+}
+const M1 = sf(1);
+const M2 = sf(2);
 
 function lbEntry(wallet: string, tier: string | null, rank = 1): CommunityLeaderboardEntry {
   return { wallet, rank, combined_score: 50, tier } as CommunityLeaderboardEntry;
@@ -154,7 +164,7 @@ describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the
       runTierRoleGoLive(
         {
           mode,
-          link: makeWalletDiscordLinkMock({ "0xcore": "member-1", "0xmember": "member-2" }),
+          link: makeWalletDiscordLinkMock({ "0xcore": M1, "0xmember": M2 }),
           rosterIdentity: SNAPSHOT_READER,
         },
         baseInput(),
@@ -185,7 +195,7 @@ describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the
     const creates = capturedWrites().filter((w) => w.kind === "create_role");
     const assigns = capturedWrites().filter((w) => w.kind === "assign_role");
     expect(creates.map((c) => c.role_key).sort()).toEqual(["purupuru:core", "purupuru:member"]);
-    expect(assigns.map((a) => a.member_id).sort()).toEqual(["member-1", "member-2"]);
+    expect(assigns.map((a) => a.member_id).sort()).toEqual([M1, M2].sort());
 
     // audit trail: applied per op, zero rejections.
     expect(recorder.countOf("shadow.role.applied.v1")).toBe(4); // 2 create + 2 assign
@@ -208,7 +218,7 @@ describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the
       runTierRoleGoLive(
         {
           mode,
-          link: makeWalletDiscordLinkMock({ "0xcore": "member-1" }),
+          link: makeWalletDiscordLinkMock({ "0xcore": M1 }),
           rosterIdentity: SNAPSHOT_READER,
         },
         baseInput({ leaderboardReader: async () => [lbEntry("0xcore", "core")] }),
@@ -231,7 +241,7 @@ describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the
       runTierRoleGoLive(
         {
           mode,
-          link: makeWalletDiscordLinkMock({ "0xcore": "member-1" }),
+          link: makeWalletDiscordLinkMock({ "0xcore": M1 }),
           rosterIdentity: SNAPSHOT_READER,
         },
         baseInput({ actor: "identity:not-admin" }),
@@ -256,7 +266,7 @@ describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the
         {
           mode,
           // 0xcore linked, 0xunlinked NOT linked.
-          link: makeWalletDiscordLinkMock({ "0xcore": "member-1" }),
+          link: makeWalletDiscordLinkMock({ "0xcore": M1 }),
           rosterIdentity: SNAPSHOT_READER,
         },
         baseInput({
@@ -273,7 +283,7 @@ describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the
     expect(res.skippedUnlinked).toBe(1);
     expect(res.skippedUnqualified).toBe(1);
     expect(capturedWrites().filter((w) => w.kind === "assign_role").map((w) => w.member_id)).toEqual([
-      "member-1",
+      M1,
     ]);
   });
 });
@@ -289,7 +299,7 @@ describe("runTierRoleGoLive — SHADOW path (preview, zero writes)", () => {
       runTierRoleGoLive(
         {
           mode,
-          link: makeWalletDiscordLinkMock({ "0xcore": "member-1", "0xmember": "member-2" }),
+          link: makeWalletDiscordLinkMock({ "0xcore": M1, "0xmember": M2 }),
           rosterIdentity: SNAPSHOT_READER,
         },
         baseInput({ applyMode: "SHADOW" }),
@@ -307,5 +317,202 @@ describe("runTierRoleGoLive — SHADOW path (preview, zero writes)", () => {
     expect(recorder.countOf("shadow.role.rejected.v1")).toBe(4); // 2 create + 2 assign rejected
     expect(recorder.countOf("shadow.role.applied.v1")).toBe(0);
     expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(0);
+  });
+});
+
+// ── fail-closed orchestration guards (Bridgebuilder #1, #2, #8) ───────────────
+
+describe("runTierRoleGoLive — fail-closed guards", () => {
+  // a RosterSource that records whether currentRoster was read.
+  function recordingRoster(roster: CurrentRoster, sink: { read: boolean }): Layer.Layer<RosterSource> {
+    return Layer.succeed(
+      RosterSource,
+      RosterSource.of({
+        currentRoster: () =>
+          Effect.sync(() => {
+            sink.read = true;
+            return roster;
+          }),
+      }),
+    );
+  }
+
+  function recordingStack(
+    mode: Awaited<ReturnType<typeof runMode>>,
+    emitterLayer: ReturnType<typeof makeRecordingEmitter>["layer"],
+    allow: readonly string[],
+    rosterLayer: Layer.Layer<RosterSource>,
+  ) {
+    const allowlist = makeAdminAllowlistInMemory(new Map([[WORLD, allow]]));
+    const lock = makeInMemoryWorldLock();
+    const gate = makeGateCheckedRoleWriter(mode, () => MAP_HASH).pipe(
+      Layer.provide(Layer.mergeAll(RoleWriterMock, emitterLayer, lock)),
+    );
+    return Layer.mergeAll(gate, RoleWriterMock, emitterLayer, lock, allowlist, rosterLayer, ScoreSourceMock);
+  }
+
+  // #1 — SHADOW preview must AUTHORIZE before any read / batch assembly.
+  test("#1: a DENIED actor in SHADOW fails BEFORE reading roster / leaderboard / links (no batch)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+    const rosterSink = { read: false };
+    const lbSink = { read: false };
+    const linkSink = { read: false };
+
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        {
+          mode,
+          link: {
+            resolve: async (w: string) => {
+              linkSink.read = true;
+              return makeWalletDiscordLinkMock({ "0xcore": M1 }).resolve(w);
+            },
+          },
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput({
+          applyMode: "SHADOW",
+          actor: "identity:not-admin", // NOT allowlisted
+          leaderboardReader: async () => {
+            lbSink.read = true;
+            return [lbEntry("0xcore", "core")];
+          },
+        }),
+      ).pipe(
+        Effect.provide(recordingStack(mode, emitterLayer, [ADMIN], recordingRoster(EMPTY_MANAGED_ROSTER, rosterSink))),
+      ),
+    );
+
+    expect(exit._tag).toBe("Failure"); // authz denied
+    // the load-bearing invariant: NO reads happened (authz gates BEFORE reads).
+    expect(rosterSink.read).toBe(false);
+    expect(lbSink.read).toBe(false);
+    expect(linkSink.read).toBe(false);
+    expect(capturedWrites().length).toBe(0);
+  });
+
+  // #7 — a link-DB outage must FAIL the LIVE run, not silently skip.
+  test("#7: a LinkResolutionError (identity DB down) FAILS the LIVE run (no flip, no writes)", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        {
+          mode,
+          link: {
+            resolve: async () => {
+              throw new LinkResolutionError("identity DB unavailable", ["0xcore"]);
+            },
+          },
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput({ applyMode: "LIVE", leaderboardReader: async () => [lbEntry("0xcore", "core")] }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+
+    expect(exit._tag).toBe("Failure"); // refused, NOT a "success with everyone skipped"
+    expect(capturedWrites().length).toBe(0);
+    expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(0); // never flipped
+  });
+
+  // #8 — leaderboard read is MANDATORY for LIVE.
+  test("#8: LIVE with NO leaderboardReader fails closed (no flip, no roles)", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        { mode, link: makeWalletDiscordLinkMock({ "0xcore": M1 }), rosterIdentity: SNAPSHOT_READER },
+        baseInput({ applyMode: "LIVE", leaderboardReader: undefined }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    expect(capturedWrites().length).toBe(0);
+    expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(0); // never flipped
+  });
+
+  test("#8: SHADOW with NO leaderboardReader is allowed ([] leaderboard)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const res = await Effect.runPromise(
+      runTierRoleGoLive(
+        { mode, link: makeWalletDiscordLinkMock({}), rosterIdentity: SNAPSHOT_READER },
+        baseInput({ applyMode: "SHADOW", leaderboardReader: undefined }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+    expect(res.applyMode).toBe("SHADOW");
+    expect(res.assignCount).toBe(0); // empty leaderboard → no assigns
+  });
+
+  // #2 — roster-freshness pairing/bypass.
+  test("#2: a baseRosterFingerprint WITHOUT baseRosterSnapshot is REFUSED (drift-bypass closed)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        { mode, link: makeWalletDiscordLinkMock({ "0xcore": M1 }), rosterIdentity: SNAPSHOT_READER },
+        baseInput({
+          applyMode: "LIVE",
+          baseRosterFingerprint: h64("a".repeat(64)), // fp WITHOUT snapshot
+          rosterDriftThreshold: 1,
+        }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+    expect(exit._tag).toBe("Failure");
+    expect(capturedWrites().length).toBe(0);
+  });
+
+  test("#2: a positive drift threshold with NO base pair is REFUSED (fresh-vs-fresh = bypass)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        { mode, link: makeWalletDiscordLinkMock({ "0xcore": M1 }), rosterIdentity: SNAPSHOT_READER },
+        baseInput({ applyMode: "LIVE", rosterDriftThreshold: 3 }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+    expect(exit._tag).toBe("Failure");
+  });
+
+  test("#2: a mismatched base pair (fp ≠ fingerprint(snapshot)) is REFUSED", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        { mode, link: makeWalletDiscordLinkMock({ "0xcore": M1 }), rosterIdentity: SNAPSHOT_READER },
+        baseInput({
+          applyMode: "LIVE",
+          baseRosterSnapshot: { member_ids: ["m-1"], role_ids: ["r-1"] },
+          baseRosterFingerprint: h64("f".repeat(64)), // WRONG fp for that snapshot
+          rosterDriftThreshold: 1,
+        }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+    expect(exit._tag).toBe("Failure");
+  });
+
+  test("#2: a CONSISTENT base pair is accepted (LIVE proceeds)", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+    const baseSnapshot = { member_ids: ["member-1", "member-2"], role_ids: ["role-a"] };
+    const res = await Effect.runPromise(
+      runTierRoleGoLive(
+        { mode, link: makeWalletDiscordLinkMock({ "0xcore": M1 }), rosterIdentity: SNAPSHOT_READER },
+        baseInput({
+          applyMode: "LIVE",
+          baseRosterSnapshot: baseSnapshot,
+          baseRosterFingerprint: rosterFingerprintLocal(baseSnapshot),
+          rosterDriftThreshold: 5, // generous — fresh snapshot == base (zero drift)
+          leaderboardReader: async () => [lbEntry("0xcore", "core")],
+        }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+    expect(res.applyMode).toBe("LIVE");
+    expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(1);
   });
 });

--- a/apps/bot/src/shadow/go-live-orchestrator.test.ts
+++ b/apps/bot/src/shadow/go-live-orchestrator.test.ts
@@ -1,0 +1,311 @@
+/**
+ * go-live-orchestrator.test.ts — the go_live → build → applyBatch RUNTIME
+ * entrypoint (bd-m2v SEAM 2). End-to-end through the REAL substrate gate with
+ * the MOCK writer (zero real Discord I/O) + injected link + injected snapshot +
+ * injected leaderboard. NEVER touches the network or discord.js.
+ *
+ * Proves:
+ *   • LIVE path: resolveAuthz grant → goLive mints cap → CREATE pass (FR-4,
+ *     not-yet-created managed roles) + ASSIGN pass → applyBatch writes through
+ *     the gate (MOCK writer captures the intents).
+ *   • CREATE ordering: create_role ops precede assign_role ops in the batch.
+ *   • SHADOW path: NO goLive (no mint, no flip) — applyBatch under SHADOW rejects
+ *     every op, ZERO inner writes; result reflects the preview.
+ *   • the shadow-vs-live branch is the apply_mode Ref (the gate reads it).
+ *   • authz DENY: a non-allowlisted actor fails the LIVE orchestration BEFORE any
+ *     mint or write.
+ *   • SEAM 1 join: an unlinked qualified wallet is skipped (skippedUnlinked), an
+ *     untiered wallet is skipped (skippedUnqualified).
+ */
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  makeGateCheckedRoleWriter,
+  makeModeControl,
+  RosterSource,
+  roleMapVersionHash,
+} from "./substrate.ts";
+import type {
+  RoleMapConfig,
+  RoleMapVersionInput,
+  Hex64,
+  CurrentRoster,
+} from "@freeside-worlds/shadow-substrate";
+import type { CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
+import { RoleWriterMock, resetMockRoleWriter, capturedWrites } from "./role-writer.mock.ts";
+import { makeRecordingEmitter } from "./acvp-emitter.mock.ts";
+import { makeInMemoryWorldLock } from "./world-lock.ts";
+import { makeAdminAllowlistInMemory } from "./admin-allowlist.live.ts";
+import { ScoreSourceMock } from "./score-source.mock.ts";
+import { makeWalletDiscordLinkMock } from "./wallet-discord-link.live.ts";
+import {
+  runTierRoleGoLive,
+  type GoLiveOrchestrationInput,
+  type RosterIdentityReader,
+} from "./go-live-orchestrator.ts";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+const WORLD = "purupuru";
+const ADMIN = "identity:admin-1";
+const h64 = (s: string) => s as unknown as Hex64;
+
+function lbEntry(wallet: string, tier: string | null, rank = 1): CommunityLeaderboardEntry {
+  return { wallet, rank, combined_score: 50, tier } as CommunityLeaderboardEntry;
+}
+
+const ROLE_MAP: RoleMapConfig = {
+  enabled: true,
+  namespace_prefix: "purupuru:",
+  rules: [
+    { role_key: "purupuru:member", display_name: "Member", qualifies: { source: "tier", min_tier: "member" }, create_if_absent: true },
+    { role_key: "purupuru:core", display_name: "Core", qualifies: { source: "tier", min_tier: "core" }, create_if_absent: true },
+  ],
+} as RoleMapConfig;
+
+// The current-map hash the gate's binding guard checks against. Must match the
+// reportHash/currentMapHash the orchestration passes (an unchanged map).
+const MAP_INPUT: RoleMapVersionInput = {
+  role_rules: ROLE_MAP.rules,
+  scaffolding_config: { channels: [] },
+  world_config: {
+    world_slug: WORLD,
+    guild_id: "111122223333444455",
+    namespace_prefix: "purupuru:",
+    nft_contracts: ["0xabc"],
+  },
+};
+const MAP_HASH = roleMapVersionHash(MAP_INPUT);
+
+// A roster with NO managed roles yet → the create pass proposes both tier roles.
+const EMPTY_MANAGED_ROSTER: CurrentRoster = {
+  world: WORLD,
+  roles: [
+    // a pre-existing Collab.Land role (non-managed) — never created/assigned.
+    { role_key: "Holder", members: 10, managed: false },
+  ],
+} as CurrentRoster;
+
+function rosterSourceFixed(roster: CurrentRoster): Layer.Layer<RosterSource> {
+  return Layer.succeed(
+    RosterSource,
+    RosterSource.of({ currentRoster: () => Effect.succeed(roster) }),
+  );
+}
+
+const SNAPSHOT_READER: RosterIdentityReader = async () => ({
+  member_ids: ["member-1", "member-2"],
+  role_ids: ["role-a"],
+});
+
+function fullStack(
+  mode: Awaited<ReturnType<typeof runMode>>,
+  emitterLayer: ReturnType<typeof makeRecordingEmitter>["layer"],
+  allow: readonly string[],
+  roster: CurrentRoster,
+) {
+  const allowlist = makeAdminAllowlistInMemory(new Map([[WORLD, allow]]));
+  const lock = makeInMemoryWorldLock();
+  const gate = makeGateCheckedRoleWriter(mode, () => MAP_HASH).pipe(
+    Layer.provide(Layer.mergeAll(RoleWriterMock, emitterLayer, lock)),
+  );
+  return Layer.mergeAll(
+    gate,
+    RoleWriterMock,
+    emitterLayer,
+    lock,
+    allowlist,
+    rosterSourceFixed(roster),
+    ScoreSourceMock,
+  );
+}
+
+// helper to construct a ModeControl outside Effect.gen for typing fullStack
+async function runMode(initial: "SHADOW" | "LIVE") {
+  return Effect.runPromise(makeModeControl(initial));
+}
+
+function baseInput(overrides: Partial<GoLiveOrchestrationInput> = {}): GoLiveOrchestrationInput {
+  return {
+    world: WORLD,
+    applyMode: "LIVE",
+    actor: ADMIN,
+    reportHash: h64(MAP_HASH),
+    currentMapHash: h64(MAP_HASH),
+    transitionVersion: 7,
+    evaluatedAt: "2026-06-04T00:00:00Z",
+    roleMap: ROLE_MAP,
+    tokenMetadata: { kid: "kid-1", verified_at: "2026-06-04T00:00:00Z", exp: "2026-06-04T01:00:00Z" },
+    leaderboardReader: async () => [lbEntry("0xcore", "core"), lbEntry("0xmember", "member")],
+    ...overrides,
+  };
+}
+
+beforeEach(() => resetMockRoleWriter());
+
+// ── LIVE path ──────────────────────────────────────────────────────────────
+
+describe("runTierRoleGoLive — LIVE path (create pass + assign pass through the gate)", () => {
+  test("goLive → CREATE pass + ASSIGN pass → applyBatch writes through the gate", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const res = await Effect.runPromise(
+      runTierRoleGoLive(
+        {
+          mode,
+          link: makeWalletDiscordLinkMock({ "0xcore": "member-1", "0xmember": "member-2" }),
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER),
+          ),
+        ),
+      ),
+    );
+
+    expect(res.applyMode).toBe("LIVE");
+    expect(res.job.status).toBe("done");
+
+    // CREATE pass (FR-4): both managed tier roles are not-yet-created → 2 creates.
+    expect(res.createCount).toBe(2);
+    // ASSIGN pass: 0xcore→core, 0xmember→member → 2 assigns.
+    expect(res.assignCount).toBe(2);
+
+    // ordering: all create_role ops precede all assign_role ops.
+    const kinds = res.batch.ops.map((o) => o.kind);
+    const firstAssign = kinds.indexOf("assign_role");
+    const lastCreate = kinds.lastIndexOf("create_role");
+    expect(lastCreate).toBeLessThan(firstAssign);
+
+    // MOCK writer captured both passes (zero REAL discord writes).
+    const creates = capturedWrites().filter((w) => w.kind === "create_role");
+    const assigns = capturedWrites().filter((w) => w.kind === "assign_role");
+    expect(creates.map((c) => c.role_key).sort()).toEqual(["purupuru:core", "purupuru:member"]);
+    expect(assigns.map((a) => a.member_id).sort()).toEqual(["member-1", "member-2"]);
+
+    // audit trail: applied per op, zero rejections.
+    expect(recorder.countOf("shadow.role.applied.v1")).toBe(4); // 2 create + 2 assign
+    expect(recorder.countOf("shadow.role.rejected.v1")).toBe(0);
+    // The Ref started SHADOW; applyMode:"LIVE" drove goLive to perform the real
+    // SHADOW→LIVE flip + mint, emitting EXACTLY ONE `mode.transitioned` (the
+    // substrate's go_live transition audit). The gate then read LIVE at apply.
+    expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(1);
+  });
+
+  test("create pass is SKIPPED for already-existing managed roles", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+    const rosterWithCore: CurrentRoster = {
+      world: WORLD,
+      roles: [{ role_key: "purupuru:core", members: 1, managed: true }],
+    } as CurrentRoster;
+
+    const res = await Effect.runPromise(
+      runTierRoleGoLive(
+        {
+          mode,
+          link: makeWalletDiscordLinkMock({ "0xcore": "member-1" }),
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput({ leaderboardReader: async () => [lbEntry("0xcore", "core")] }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], rosterWithCore))),
+    );
+
+    // only purupuru:member needs creating (purupuru:core exists).
+    expect(res.createCount).toBe(1);
+    expect(res.batch.ops.filter((o) => o.kind === "create_role").map((o) => o.intent.role_key)).toEqual([
+      "purupuru:member",
+    ]);
+    expect(res.assignCount).toBe(1);
+  });
+
+  test("authz DENY fails the LIVE orchestration BEFORE any mint/write", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const exit = await Effect.runPromiseExit(
+      runTierRoleGoLive(
+        {
+          mode,
+          link: makeWalletDiscordLinkMock({ "0xcore": "member-1" }),
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput({ actor: "identity:not-admin" }),
+      ).pipe(
+        // allowlist contains ONLY ADMIN, not the actor.
+        Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER)),
+      ),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    // no writes, no go_live transition.
+    expect(capturedWrites().length).toBe(0);
+    expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(0);
+  });
+
+  test("SEAM 1 join: unlinked wallet skipped (skippedUnlinked); untiered skipped (skippedUnqualified)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const res = await Effect.runPromise(
+      runTierRoleGoLive(
+        {
+          mode,
+          // 0xcore linked, 0xunlinked NOT linked.
+          link: makeWalletDiscordLinkMock({ "0xcore": "member-1" }),
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput({
+          leaderboardReader: async () => [
+            lbEntry("0xcore", "core"), // qualifies + linked → assigned
+            lbEntry("0xunlinked", "core"), // qualifies but NOT linked → skipped_unlinked
+            lbEntry("0xlow", "newcomer"), // below every rule → skipped_unqualified
+          ],
+        }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+
+    expect(res.assignCount).toBe(1);
+    expect(res.skippedUnlinked).toBe(1);
+    expect(res.skippedUnqualified).toBe(1);
+    expect(capturedWrites().filter((w) => w.kind === "assign_role").map((w) => w.member_id)).toEqual([
+      "member-1",
+    ]);
+  });
+});
+
+// ── SHADOW path ──────────────────────────────────────────────────────────────
+
+describe("runTierRoleGoLive — SHADOW path (preview, zero writes)", () => {
+  test("SHADOW: NO goLive, gate rejects every op, ZERO inner writes", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+    const mode = await runMode("SHADOW");
+
+    const res = await Effect.runPromise(
+      runTierRoleGoLive(
+        {
+          mode,
+          link: makeWalletDiscordLinkMock({ "0xcore": "member-1", "0xmember": "member-2" }),
+          rosterIdentity: SNAPSHOT_READER,
+        },
+        baseInput({ applyMode: "SHADOW" }),
+      ).pipe(Effect.provide(fullStack(mode, emitterLayer, [ADMIN], EMPTY_MANAGED_ROSTER))),
+    );
+
+    expect(res.applyMode).toBe("SHADOW");
+    // the would-be batch is still built (the preview shape): 2 creates + 2 assigns.
+    expect(res.createCount).toBe(2);
+    expect(res.assignCount).toBe(2);
+    expect(res.job.status).toBe("failed"); // every op rejected = preview, no writes
+
+    // ZERO real writes; per-op rejections confirmed; NO mode transition (no goLive).
+    expect(capturedWrites().length).toBe(0);
+    expect(recorder.countOf("shadow.role.rejected.v1")).toBe(4); // 2 create + 2 assign rejected
+    expect(recorder.countOf("shadow.role.applied.v1")).toBe(0);
+    expect(recorder.countOf("shadow.mode.transitioned.v1")).toBe(0);
+  });
+});

--- a/apps/bot/src/shadow/go-live-orchestrator.ts
+++ b/apps/bot/src/shadow/go-live-orchestrator.ts
@@ -1,0 +1,500 @@
+/**
+ * shadow/go-live-orchestrator.ts — the go_live → build → applyBatch RUNTIME
+ * ENTRYPOINT for per-member tier→role assignment (bd-m2v SEAM 2).
+ *
+ * ── WHAT THIS CLOSES ─────────────────────────────────────────────────────────
+ * The pure half (`score-tier-assignment.ts`) builds a gate-valid WriteIntentBatch
+ * and the E2E test drives goLive→applyBatch by hand. But nothing in the RUNTIME
+ * sequences the real flow. This module is that sequence — the bot entrypoint a
+ * CM action (or a scheduled sweep) calls to manage Discord roles from score-api
+ * tiers:
+ *
+ *   (a) AUTHORIZE the admin    — resolveAuthz({actor, world}) against the
+ *                                manifest `admin_principals` (FR-10).
+ *   (b) GO_LIVE (LIVE only)    — mint the WriteCapability (the substrate's
+ *                                authorized SHADOW→LIVE transition; B1 roster-
+ *                                freshness re-eval + the pure transition guard).
+ *   (c) READ the world         — the LIVE Purupuru leaderboard (via the injected
+ *                                `leaderboardReader`, backed by CommunityScoreClient,
+ *                                bd-tfl) + the current guild roster (RosterSource)
+ *                                + the roster identity snapshot (B1 fingerprint).
+ *   (d) CREATE pass (FR-4)     — `assembleGoLiveBatch` runs the substrate's PURE
+ *                                `computeProposed` to derive the not-yet-created
+ *                                managed tier roles → `create_role` ops, ordered
+ *                                BEFORE the assigns. We INTEGRATE with the
+ *                                substrate's create flow, never reimplement it.
+ *   (e) ASSIGN pass + apply    — the per-member assign ops + `applyBatch` through
+ *                                the gate (the single gated write path).
+ *
+ * ── SHADOW vs LIVE (the DESIRED action is the switch — enforced at the gate) ──
+ * The caller declares the DESIRED action via `input.applyMode` (a CM clicks
+ * "preview" vs "go live"). The substrate's `goLive` IS the SHADOW→LIVE
+ * transition (it flips the shared `apply_mode` Ref + mints the cap), and the gate
+ * reads that Ref AT INVOCATION (R-10):
+ *   • "SHADOW" (preview) → this entrypoint does NOT call goLive (no mint, no mode
+ *               flip; the Ref stays SHADOW). It builds the would-be batch + a
+ *               synthetic cap and runs `applyBatch` — the gate, seeing SHADOW,
+ *               confirms a `shadow.role.rejected.v1` per op and performs ZERO
+ *               inner writes (the substrate-proven invariant). The caller gets
+ *               the batch shape + the gate's rejection, which IS the preview.
+ *   • "LIVE" (apply)    → goLive performs the SHADOW→LIVE flip + mints the cap
+ *               (after the fresh authz + roster-freshness guards), the batch is
+ *               bound to that authorized transition, and `applyBatch` writes
+ *               through the gated adapter (the gate now reads LIVE).
+ * The mode value is NEVER captured here for the gate — the gate reads the shared
+ * `ModeControl` Ref `goLive` just flipped. The DESIRED action picks the PATH; the
+ * gate is the ENFORCED boundary either way.
+ *
+ * ── THE SUBSTRATE GAP THIS HITS (documented, NOT faked) ──────────────────────
+ * The substrate's go_live roster-freshness (B1) needs a `RosterIdentitySnapshot`
+ * (the member-id ⊕ role-id SETS), but the SHA-pinned `RosterSource` port surfaces
+ * only the `CurrentRoster` render-model (per-role member COUNTS). The substrate's
+ * own roster-freshness.ts header acknowledges this: the fingerprint operates on a
+ * RosterIdentitySnapshot the LIVE RosterSource "produces ALONGSIDE the render-
+ * model" — but the pinned `RosterSource` Context.Tag has NO method for the
+ * snapshot, and the repo's LIVE roster adapter does not yet produce one. So this
+ * entrypoint takes the snapshot via an INJECTED `RosterIdentityReader` (the thin
+ * live wiring reads guild member/role ids; tests inject fixtures). When no base
+ * fingerprint is supplied (first go_live, no prior preview), the fresh snapshot
+ * is its own base (zero drift) — the conservative, non-blocking default. The
+ * honest fix (a snapshot method on the substrate RosterSource port) is a
+ * freeside-worlds change — see the seam-3 bead note + bd-m2v.
+ */
+import { Effect } from "effect";
+import {
+  GateCheckedRoleWriter,
+  ScoreSource,
+  RosterSource,
+  RoleWriter,
+  WorldLock,
+  resolveAuthz,
+  goLive,
+  rosterFingerprint,
+  AdminAllowlistSource,
+  AcvpEmitter,
+  ScoreError,
+  AuthzError,
+  RosterError,
+} from "./substrate.ts";
+import type {
+  RoleMapConfig,
+  WorldSlug,
+  Hex64,
+  CurrentRoster,
+  ApplyBatchResult,
+  WriteIntentBatch,
+  RosterVersion,
+  WriteCapability,
+  ModeControl,
+  GuardFailed,
+  ShadowGateRejected,
+  WriteError,
+} from "@freeside-worlds/shadow-substrate";
+import { type CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
+import {
+  buildTierAssignments,
+  assembleGoLiveBatch,
+  type WalletDiscordLink,
+  type AuthorizedTransition,
+  type TierAssignment,
+} from "./score-tier-assignment.ts";
+import { type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
+
+/**
+ * The coarse identity snapshot the B1 roster-freshness fingerprint covers (the
+ * member-id ⊕ role-id sets). Structurally mirrors the substrate's
+ * `RosterIdentitySnapshot` (the substrate exports it only on roster-freshness,
+ * and the RosterSource port that should carry it does not).
+ */
+export interface RosterIdentitySnapshot {
+  readonly member_ids: ReadonlyArray<string>;
+  readonly role_ids: ReadonlyArray<string>;
+}
+
+/**
+ * Reads the live guild's member-id ⊕ role-id snapshot for the B1 fingerprint.
+ * INJECTED (the thin live wiring reads the discord.js guild; tests inject a
+ * fixture). This is the seam the substrate's RosterSource port SHOULD carry but
+ * does not (documented above + in the bead).
+ */
+export type RosterIdentityReader = (world: string) => Promise<RosterIdentitySnapshot>;
+
+/**
+ * Reads the full leaderboard (wallet → tier) for the assign pass. The ScoreSource
+ * port surfaces only a COUNT (`latentQualified`) — not the full roster — so the
+ * per-member assign pass needs the leaderboard directly. The composition root
+ * supplies this (it already builds the `CommunityScoreClient`). When omitted
+ * (MOCK / preview with no live key), the assign pass sees an empty leaderboard →
+ * zero assignments (the create pass still runs from the role-map) — never a
+ * silent guess.
+ */
+export type LeaderboardReader = () => Promise<ReadonlyArray<CommunityLeaderboardEntry>>;
+
+/** Token metadata the upstream (config-service / go_live) already verified. */
+export interface VerifiedTokenMetadata {
+  readonly kid: string;
+  readonly verified_at: string;
+  readonly exp: string;
+}
+
+export interface GoLiveOrchestrationInput {
+  /** the world slug (e.g. "purupuru"). */
+  readonly world: string;
+  /**
+   * the DESIRED action: "SHADOW" (preview — no mint, no flip, gate rejects → zero
+   * writes) or "LIVE" (apply — goLive flips SHADOW→LIVE + mints, gate writes via
+   * the gated adapter). This is the shadow/apply switch, surfaced explicitly so
+   * the caller declares intent rather than the entrypoint inferring it from the
+   * (possibly already-flipped) Ref.
+   */
+  readonly applyMode: "SHADOW" | "LIVE";
+  /** the verified admin actor (identity-api claims.sub). */
+  readonly actor: string;
+  /** the FR-7 report hash (roleMapVersionHash of the current map). */
+  readonly reportHash: Hex64;
+  /** roleMapVersionHash(current map), re-derived fresh at go_live (== reportHash for an unchanged map). */
+  readonly currentMapHash: Hex64;
+  /** ties the minted cap + batch to ONE authorized transition. */
+  readonly transitionVersion: number;
+  /** ISO timestamp the decision is evaluated at (caller-supplied; no clock read). */
+  readonly evaluatedAt: string;
+  /** the CM role-map (tier→role_key rules). */
+  readonly roleMap: RoleMapConfig;
+  /** verified token metadata for the batch AuthzContext. */
+  readonly tokenMetadata: VerifiedTokenMetadata;
+  /** reads the live leaderboard (wallet → tier) for the assign pass. */
+  readonly leaderboardReader?: LeaderboardReader;
+  /**
+   * the frozen base roster fingerprint from the preview the CM approved (B1). If
+   * omitted (a direct go_live with no prior preview), the fresh snapshot is used
+   * as its own base — zero drift, the conservative non-blocking default.
+   */
+  readonly baseRosterFingerprint?: Hex64;
+  /** the base identity snapshot the preview captured (paired with baseRosterFingerprint). */
+  readonly baseRosterSnapshot?: RosterIdentitySnapshot;
+  /** B1 drift threshold override (default: substrate default = 0). */
+  readonly rosterDriftThreshold?: number;
+  /** tier ordering (defaults to the grounded Purupuru ladder). */
+  readonly tierRank?: TierRankResolver;
+  /** intra-batch in-flight cap (gate default 4). */
+  readonly maxConcurrent?: number;
+  /** SOFT 2-week-soak advisory (FR-7) — surfaced, NEVER blocks. */
+  readonly soakSatisfied?: boolean;
+}
+
+/** The orchestration result the caller (lens / CLI / scheduled sweep) consumes. */
+export interface GoLiveOrchestrationResult {
+  /** the apply_mode this run executed under (read from the gate's Ref). */
+  readonly applyMode: "SHADOW" | "LIVE";
+  /** the assembled batch (create pass + assign pass). */
+  readonly batch: WriteIntentBatch;
+  /** the gate's terminal job state (op_status + roles_created ledger). */
+  readonly job: ApplyBatchResult;
+  /** how many tier roles the create pass proposed. */
+  readonly createCount: number;
+  /** how many member assignments the assign pass resolved. */
+  readonly assignCount: number;
+  /** qualified-but-unlinked wallets (counted, never assigned). */
+  readonly skippedUnlinked: number;
+  /** wallets below every rule (untiered / too low). */
+  readonly skippedUnqualified: number;
+}
+
+/**
+ * The Effect requirements this orchestration needs in context. Beyond the gate +
+ * sources, the gate's `applyBatch` re-resolves authz server-side at the write
+ * boundary, so it pulls `RoleWriter | AcvpEmitter | WorldLock |
+ * AdminAllowlistSource` into the SERVICE method's requirement channel (per the
+ * substrate gate's `applyBatch` signature). The composition root provides all of
+ * them (the shadow-preview / live-apply Layer stacks already merge them).
+ */
+export type OrchestrationContext =
+  | GateCheckedRoleWriter
+  | ScoreSource
+  | RosterSource
+  | RoleWriter
+  | WorldLock
+  | AdminAllowlistSource
+  | AcvpEmitter;
+
+/** Typed error union the orchestration can fail with. */
+export type OrchestrationError =
+  | GuardFailed
+  | AuthzError
+  | ScoreError
+  | RosterError
+  | WriteError
+  | ShadowGateRejected;
+
+export interface OrchestrationDeps {
+  /** the apply_mode control the gate reads (SHADOW/LIVE switch). */
+  readonly mode: ModeControl;
+  /** wallet → discord snowflake | null (SEAM 1; live adapter or mock). */
+  readonly link: WalletDiscordLink;
+  /** reads the live guild member-id ⊕ role-id snapshot (B1 fingerprint). */
+  readonly rosterIdentity: RosterIdentityReader;
+}
+
+interface BuiltAssignments {
+  readonly assignments: ReadonlyArray<TierAssignment>;
+  readonly skipped_unlinked: number;
+  readonly skipped_unqualified: number;
+}
+
+/**
+ * Drive the full go_live → build → applyBatch sequence. EFFECTFUL — requires the
+ * gate + ScoreSource + RosterSource + AdminAllowlistSource + AcvpEmitter in
+ * context (the composition root supplies them; SHADOW preview uses MOCK writer,
+ * LIVE apply uses the gated adapter).
+ *
+ * The DESIRED action (`input.applyMode`) chooses the PATH:
+ *   • LIVE  → resolveAuthz (deny ⇒ fail), goLive (SHADOW→LIVE flip + mint cap),
+ *             build batch bound to the authorized transition, applyBatch (real
+ *             writes via the gate, which now reads LIVE).
+ *   • SHADOW→ no goLive (no mint / no flip); build a PREVIEW batch + applyBatch,
+ *             which the gate rejects per op with ZERO inner writes (the preview).
+ */
+export function runTierRoleGoLive(
+  deps: OrchestrationDeps,
+  input: GoLiveOrchestrationInput,
+): Effect.Effect<GoLiveOrchestrationResult, OrchestrationError, OrchestrationContext> {
+  return Effect.gen(function* () {
+    const worldSlug = input.world as unknown as WorldSlug;
+    const rank = input.tierRank ?? purupuruTierRank;
+
+    // The DESIRED action picks the path; goLive (LIVE) flips the shared Ref the
+    // gate reads at apply, SHADOW leaves it untouched (gate rejects → preview).
+    const applyMode = input.applyMode;
+
+    // ── (c) READ the world: roster (counts) + leaderboard + identity snapshot ─
+    const rosterSource = yield* RosterSource;
+    const currentRoster: CurrentRoster = yield* rosterSource.currentRoster(worldSlug);
+
+    const leaderboard = yield* readLeaderboard(input);
+
+    const freshSnapshot = yield* Effect.tryPromise({
+      try: () => deps.rosterIdentity(input.world),
+      catch: (e) =>
+        new RosterError({
+          message: `roster identity snapshot read failed: ${e instanceof Error ? e.message : String(e)}`,
+        }),
+    });
+
+    // ── build the per-member ASSIGN set (SEAM 1 link join) ────────────────────
+    const built: BuiltAssignments = yield* Effect.tryPromise({
+      try: () =>
+        buildTierAssignments({
+          leaderboard,
+          roleMap: input.roleMap,
+          link: deps.link,
+          tierRank: rank,
+        }),
+      catch: (e) =>
+        new ScoreError({
+          message: `assignment build failed: ${e instanceof Error ? e.message : String(e)}`,
+        }),
+    });
+
+    // ── ROSTER VERSION for the batch authz (B1) ───────────────────────────────
+    const rosterVersion: RosterVersion = {
+      fingerprint: rosterFingerprint(freshSnapshot),
+      fetched_at: input.evaluatedAt,
+      member_count: freshSnapshot.member_ids.length,
+    };
+
+    if (applyMode === "LIVE") {
+      return yield* applyLive(deps, input, currentRoster, built, freshSnapshot, rosterVersion);
+    }
+    return yield* applyShadowPreview(deps, input, currentRoster, built, rosterVersion);
+  });
+}
+
+// ─── LIVE path ────────────────────────────────────────────────────────────────
+
+function applyLive(
+  deps: OrchestrationDeps,
+  input: GoLiveOrchestrationInput,
+  currentRoster: CurrentRoster,
+  built: BuiltAssignments,
+  freshSnapshot: RosterIdentitySnapshot,
+  rosterVersion: RosterVersion,
+): Effect.Effect<GoLiveOrchestrationResult, OrchestrationError, OrchestrationContext> {
+  return Effect.gen(function* () {
+    const worldSlug = input.world as unknown as WorldSlug;
+
+    // (a) AUTHORIZE — resolveAuthz (the SAME decision flow goLive uses). A `deny`
+    //     fails the orchestration loud BEFORE goLive (no mint). goLive ALSO
+    //     re-resolves fresh (bypassCache) at the mint, and the gate re-resolves
+    //     AGAIN at the write boundary — three checks, one decision flow.
+    const decision = yield* resolveAuthz({
+      actor: input.actor,
+      world: worldSlug,
+      evaluatedAt: input.evaluatedAt,
+      bypassCache: true,
+    });
+    if (decision.decision !== "grant") {
+      return yield* Effect.fail(
+        new AuthzError({
+          message: `actor '${input.actor}' is not allowlisted for world '${input.world}' (${decision.reason}) — go_live refused`,
+        }),
+      );
+    }
+
+    // (b) GO_LIVE — mint the cap. B1 roster-freshness uses the fresh snapshot as
+    //     its own base when no prior preview fingerprint was supplied (zero
+    //     drift, non-blocking default).
+    const baseSnapshot = input.baseRosterSnapshot ?? freshSnapshot;
+    const baseFingerprint = input.baseRosterFingerprint ?? rosterFingerprint(baseSnapshot);
+    const out = yield* goLive(deps.mode, {
+      actor: input.actor,
+      world: worldSlug,
+      reportHash: input.reportHash,
+      currentMapHash: input.currentMapHash,
+      transitionVersion: input.transitionVersion,
+      evaluatedAt: input.evaluatedAt,
+      soakSatisfied: input.soakSatisfied,
+      rosterFreshness: {
+        baseFingerprint,
+        baseSnapshot,
+        freshSnapshot,
+        threshold: input.rosterDriftThreshold,
+      },
+    });
+
+    // (d)+(e) build the FULL batch (CREATE pass + ASSIGN pass) bound to the
+    // authorized transition, then applyBatch through the gate.
+    const transition: AuthorizedTransition = {
+      actor: input.actor,
+      reportHash: input.reportHash as unknown as string,
+      authzDecisionId: out.authzDecisionId,
+      transitionVersion: input.transitionVersion,
+      tokenMetadata: input.tokenMetadata,
+    };
+    const batch = assembleGoLiveBatch({
+      world: input.world,
+      transition,
+      rosterVersion,
+      assignments: built.assignments,
+      roleMap: input.roleMap,
+      currentRoster,
+      maxConcurrent: input.maxConcurrent,
+    });
+
+    const gate = yield* GateCheckedRoleWriter;
+    const job = yield* gate.applyBatch(batch, out.capability);
+
+    return result("LIVE", batch, job, built);
+  });
+}
+
+// ─── SHADOW preview path ────────────────────────────────────────────────────
+
+function applyShadowPreview(
+  deps: OrchestrationDeps,
+  input: GoLiveOrchestrationInput,
+  currentRoster: CurrentRoster,
+  built: BuiltAssignments,
+  rosterVersion: RosterVersion,
+): Effect.Effect<GoLiveOrchestrationResult, OrchestrationError, OrchestrationContext> {
+  return Effect.gen(function* () {
+    // SHADOW: NO goLive (no mint, no flip). We still build the would-be batch so
+    // the caller sees the preview shape, and we run it through the gate — which,
+    // reading SHADOW at invocation, confirms a per-op rejection and performs ZERO
+    // inner writes (the substrate-proven SHADOW⇒no-writes invariant). The gate
+    // rejects under SHADOW BEFORE it validates the cap binding, so the preview
+    // never needs a real mint.
+    const transition: AuthorizedTransition = {
+      actor: input.actor,
+      reportHash: input.reportHash as unknown as string,
+      authzDecisionId: `preview:${input.actor}:${input.world}`,
+      transitionVersion: input.transitionVersion,
+      tokenMetadata: input.tokenMetadata,
+    };
+    const batch = assembleGoLiveBatch({
+      world: input.world,
+      transition,
+      rosterVersion,
+      assignments: built.assignments,
+      roleMap: input.roleMap,
+      currentRoster,
+      maxConcurrent: input.maxConcurrent,
+    });
+
+    const gate = yield* GateCheckedRoleWriter;
+    // A SHADOW applyBatch fails ShadowGateRejected AFTER confirming a rejection
+    // per op (zero inner writes). We RECOVER it into a preview job result rather
+    // than failing the orchestration — a SHADOW preview "succeeding" means the
+    // gate correctly rejected every op.
+    const job = yield* gate.applyBatch(batch, makePreviewCap()).pipe(
+      Effect.catchTag("ShadowGateRejected", () => Effect.succeed(shadowRejectedJob(batch))),
+    );
+
+    return result("SHADOW", batch, job, built);
+  });
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function readLeaderboard(
+  input: GoLiveOrchestrationInput,
+): Effect.Effect<ReadonlyArray<CommunityLeaderboardEntry>, ScoreError> {
+  const reader = input.leaderboardReader;
+  if (!reader) return Effect.succeed([]);
+  return Effect.tryPromise({
+    try: () => reader(),
+    catch: (e) =>
+      new ScoreError({
+        message: `leaderboard read failed: ${e instanceof Error ? e.message : String(e)}`,
+      }),
+  });
+}
+
+function result(
+  applyMode: "SHADOW" | "LIVE",
+  batch: WriteIntentBatch,
+  job: ApplyBatchResult,
+  built: BuiltAssignments,
+): GoLiveOrchestrationResult {
+  const createCount = batch.ops.filter((o) => o.kind === "create_role").length;
+  const assignCount = batch.ops.filter((o) => o.kind === "assign_role").length;
+  return {
+    applyMode,
+    batch,
+    job,
+    createCount,
+    assignCount,
+    skippedUnlinked: built.skipped_unlinked,
+    skippedUnqualified: built.skipped_unqualified,
+  };
+}
+
+/**
+ * A synthetic preview `WriteCapability` for the SHADOW path. The gate
+ * short-circuits to per-op rejection under SHADOW BEFORE it validates the cap
+ * binding, so this value is never inspected — it exists only to satisfy the
+ * `applyBatch(batch, cap)` signature. We cannot mint a real cap (the constructor
+ * is internal to the substrate's authorized go_live), and SHADOW must NOT mint
+ * one anyway (no transition occurs). The cast is sound: the cap is unreachable
+ * under SHADOW.
+ */
+function makePreviewCap(): WriteCapability {
+  return {
+    report_hash: "0".repeat(64),
+    transition_version: -1,
+    authz_decision_id: "preview",
+  } as unknown as WriteCapability;
+}
+
+/** The job shape a SHADOW applyBatch implies: every op rejected, zero writes. */
+function shadowRejectedJob(batch: WriteIntentBatch): ApplyBatchResult {
+  return {
+    status: "failed",
+    progress: { total: batch.ops.length, completed: 0, failed: batch.ops.length },
+    roles_created: [],
+    op_status: batch.ops.map((o) => ({
+      op_id: o.op_id,
+      status: "failed" as const,
+      error: "shadow_rejected: apply_mode is SHADOW — preview only, zero writes",
+    })),
+  };
+}

--- a/apps/bot/src/shadow/go-live-orchestrator.ts
+++ b/apps/bot/src/shadow/go-live-orchestrator.ts
@@ -98,6 +98,7 @@ import {
   type AuthorizedTransition,
   type TierAssignment,
 } from "./score-tier-assignment.ts";
+import { LinkResolutionError } from "./wallet-discord-link.live.ts";
 import { type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
 
 /**
@@ -198,6 +199,10 @@ export interface GoLiveOrchestrationResult {
   readonly skippedUnlinked: number;
   /** wallets below every rule (untiered / too low). */
   readonly skippedUnqualified: number;
+  /** qualified+linked wallets whose member_id was not a valid snowflake (#12). */
+  readonly skippedInvalid: number;
+  /** extra wallet→member assignments collapsed by per-member dedup (#6). */
+  readonly collapsedDuplicateMembers: number;
 }
 
 /**
@@ -239,6 +244,8 @@ interface BuiltAssignments {
   readonly assignments: ReadonlyArray<TierAssignment>;
   readonly skipped_unlinked: number;
   readonly skipped_unqualified: number;
+  readonly skipped_invalid: number;
+  readonly collapsed_duplicate_members: number;
 }
 
 /**
@@ -266,11 +273,69 @@ export function runTierRoleGoLive(
     // gate reads at apply, SHADOW leaves it untouched (gate rejects → preview).
     const applyMode = input.applyMode;
 
+    // ── (0) AUTHORIZE FIRST — for BOTH shadow and live, BEFORE any read or batch
+    //        assembly (Bridgebuilder #1). The SHADOW preview reads roster /
+    //        leaderboard / wallet-links and assembles a batch carrying Discord
+    //        snowflakes — that is sensitive even though it never WRITES, so a
+    //        denied actor must fail BEFORE we read anything. `bypassCache:true`
+    //        matches the freshness goLive uses. (LIVE re-resolves again inside
+    //        goLive + the gate re-resolves at the write boundary — defense in
+    //        depth; this is the FRONT gate that protects the reads.)
+    const decision = yield* resolveAuthz({
+      actor: input.actor,
+      world: worldSlug,
+      evaluatedAt: input.evaluatedAt,
+      bypassCache: true,
+    });
+    if (decision.decision !== "grant") {
+      return yield* Effect.fail(
+        new AuthzError({
+          message: `actor '${input.actor}' is not allowlisted for world '${input.world}' (${decision.reason}) — ${applyMode === "LIVE" ? "go_live" : "preview"} refused before any read`,
+        }),
+      );
+    }
+
+    // ── (b-pre) ROSTER-FRESHNESS INPUT VALIDATION (Bridgebuilder #2) ──────────
+    // A `baseRosterFingerprint` WITHOUT a `baseRosterSnapshot` (or vice-versa)
+    // when a drift threshold is active would make goLive compare freshSnapshot vs
+    // freshSnapshot (zero drift = a silent BYPASS of the freshness guard). Require
+    // them as a PAIR, and assert the supplied fingerprint actually matches the
+    // supplied snapshot (a mismatched pair is a corrupt/forged base).
+    const driftThreshold = input.rosterDriftThreshold ?? 0;
+    const hasFp = input.baseRosterFingerprint !== undefined;
+    const hasSnap = input.baseRosterSnapshot !== undefined;
+    if (hasFp !== hasSnap) {
+      return yield* Effect.fail(
+        new RosterError({
+          message: `roster-freshness base is half-specified: baseRosterFingerprint ${hasFp ? "set" : "unset"} but baseRosterSnapshot ${hasSnap ? "set" : "unset"} — they MUST be supplied as a pair (an fp without its snapshot silently bypasses the drift guard)`,
+        }),
+      );
+    }
+    if (hasFp && hasSnap) {
+      const computed = rosterFingerprint(input.baseRosterSnapshot!);
+      if ((computed as unknown as string) !== (input.baseRosterFingerprint as unknown as string)) {
+        return yield* Effect.fail(
+          new RosterError({
+            message: `roster-freshness base mismatch: rosterFingerprint(baseRosterSnapshot) ≠ baseRosterFingerprint — the supplied base pair is inconsistent (rejecting; a forged/corrupt base would bypass drift detection)`,
+          }),
+        );
+      }
+    }
+    // A positive drift threshold with NO base pair would compare fresh-vs-fresh
+    // (zero drift) — refuse rather than silently no-op the guard.
+    if (driftThreshold > 0 && !(hasFp && hasSnap)) {
+      return yield* Effect.fail(
+        new RosterError({
+          message: `rosterDriftThreshold=${driftThreshold} requires a base roster snapshot+fingerprint pair (from the approved preview) — without one, drift compares fresh-vs-fresh = 0 (a bypass). Supply the base pair or set threshold 0.`,
+        }),
+      );
+    }
+
     // ── (c) READ the world: roster (counts) + leaderboard + identity snapshot ─
     const rosterSource = yield* RosterSource;
     const currentRoster: CurrentRoster = yield* rosterSource.currentRoster(worldSlug);
 
-    const leaderboard = yield* readLeaderboard(input);
+    const leaderboard = yield* readLeaderboard(input, applyMode);
 
     const freshSnapshot = yield* Effect.tryPromise({
       try: () => deps.rosterIdentity(input.world),
@@ -281,6 +346,10 @@ export function runTierRoleGoLive(
     });
 
     // ── build the per-member ASSIGN set (SEAM 1 link join) ────────────────────
+    // A `LinkResolutionError` (identity DB unavailable, Bridgebuilder #7) is
+    // FAIL-CLOSED: it propagates as a RosterError so the run FAILS (LIVE must not
+    // proceed creating roles + assigning nobody when the link source was down).
+    // Other build errors map to ScoreError.
     const built: BuiltAssignments = yield* Effect.tryPromise({
       try: () =>
         buildTierAssignments({
@@ -290,9 +359,13 @@ export function runTierRoleGoLive(
           tierRank: rank,
         }),
       catch: (e) =>
-        new ScoreError({
-          message: `assignment build failed: ${e instanceof Error ? e.message : String(e)}`,
-        }),
+        e instanceof LinkResolutionError
+          ? new RosterError({
+              message: `identity link resolution failed (DB unavailable) — go_live refused, NOT skipped: ${e.message}`,
+            })
+          : new ScoreError({
+              message: `assignment build failed: ${e instanceof Error ? e.message : String(e)}`,
+            }),
     });
 
     // ── ROSTER VERSION for the batch authz (B1) ───────────────────────────────
@@ -322,27 +395,17 @@ function applyLive(
   return Effect.gen(function* () {
     const worldSlug = input.world as unknown as WorldSlug;
 
-    // (a) AUTHORIZE — resolveAuthz (the SAME decision flow goLive uses). A `deny`
-    //     fails the orchestration loud BEFORE goLive (no mint). goLive ALSO
-    //     re-resolves fresh (bypassCache) at the mint, and the gate re-resolves
-    //     AGAIN at the write boundary — three checks, one decision flow.
-    const decision = yield* resolveAuthz({
-      actor: input.actor,
-      world: worldSlug,
-      evaluatedAt: input.evaluatedAt,
-      bypassCache: true,
-    });
-    if (decision.decision !== "grant") {
-      return yield* Effect.fail(
-        new AuthzError({
-          message: `actor '${input.actor}' is not allowlisted for world '${input.world}' (${decision.reason}) — go_live refused`,
-        }),
-      );
-    }
+    // NOTE: the FRONT authz gate (resolveAuthz, bypassCache) already ran in
+    // `runTierRoleGoLive` BEFORE any read (Bridgebuilder #1). goLive re-resolves
+    // fresh at the mint, and the gate re-resolves AGAIN at the write boundary —
+    // defense in depth. We do not re-check here (it would be a 4th identical
+    // resolve); the reads upstream of this point were already authz-gated.
 
     // (b) GO_LIVE — mint the cap. B1 roster-freshness uses the fresh snapshot as
     //     its own base when no prior preview fingerprint was supplied (zero
-    //     drift, non-blocking default).
+    //     drift, non-blocking default). The fp/snapshot PAIRING + match was
+    //     validated up-front (#2), so a half-specified/forged base never reaches
+    //     here.
     const baseSnapshot = input.baseRosterSnapshot ?? freshSnapshot;
     const baseFingerprint = input.baseRosterFingerprint ?? rosterFingerprint(baseSnapshot);
     const out = yield* goLive(deps.mode, {
@@ -437,9 +500,23 @@ function applyShadowPreview(
 
 function readLeaderboard(
   input: GoLiveOrchestrationInput,
+  applyMode: "SHADOW" | "LIVE",
 ): Effect.Effect<ReadonlyArray<CommunityLeaderboardEntry>, ScoreError> {
   const reader = input.leaderboardReader;
-  if (!reader) return Effect.succeed([]);
+  if (!reader) {
+    // Bridgebuilder #8: the leaderboard read is MANDATORY for LIVE. A missing
+    // reader silently returning [] would flip SHADOW→LIVE + create roles with
+    // ZERO assignments (a destructive no-op that still mutates Discord). FAIL
+    // CLOSED. `[]`-on-missing is allowed ONLY for SHADOW preview.
+    if (applyMode === "LIVE") {
+      return Effect.fail(
+        new ScoreError({
+          message: `LIVE go_live requires a leaderboardReader — none supplied. Refusing (a LIVE run with no leaderboard would create roles and assign nobody).`,
+        }),
+      );
+    }
+    return Effect.succeed([]);
+  }
   return Effect.tryPromise({
     try: () => reader(),
     catch: (e) =>
@@ -465,6 +542,8 @@ function result(
     assignCount,
     skippedUnlinked: built.skipped_unlinked,
     skippedUnqualified: built.skipped_unqualified,
+    skippedInvalid: built.skipped_invalid,
+    collapsedDuplicateMembers: built.collapsed_duplicate_members,
   };
 }
 

--- a/apps/bot/src/shadow/purupuru-tiers.ts
+++ b/apps/bot/src/shadow/purupuru-tiers.ts
@@ -1,0 +1,62 @@
+/**
+ * shadow/purupuru-tiers.ts — the Purupuru community tier LADDER (ordering).
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────────────
+ * The substrate's `RoleRule.qualifies` is `{ source: 'tier', min_tier: <string> }`
+ * where `min_tier` is an OPAQUE tier id the substrate does not interpret
+ * (score-api owns the values — #221). To evaluate "wallet qualifies for this rule"
+ * we need a >= comparison, which needs an ORDERING over tier names. score-api's
+ * `community_tier_config` HAS that ordering (`sort_order`), but the leaderboard
+ * read returns only the `tier` STRING — not `sort_order`. So the ordering must
+ * live on the consumer side.
+ *
+ * ── GROUNDING (score-api origin/main, read 2026-06-03) ───────────────────────
+ * supabase/migrations/20260602_001_cycle032_purupuru_config.sql seeds the
+ * Purupuru `community_tier_config` ladder (by `sort_order`):
+ *   newcomer(1) < member(2) < devoted(3) < core(4) < sovereign(5) < elder(6)
+ * (crowd: newcomer..core score-banded; elite: sovereign/elder rank-based —
+ * elite overrides crowd, so a wallet's single `tier` is already the resolved
+ * winner. The ladder here mirrors `sort_order` exactly so higher = stronger.)
+ *
+ * ⚠ The lore NAMES are PLACEHOLDERS (Jani/zerker calibrate, OQ-4). When the real
+ * lore lands, update this map (and the matching score-api config) together. The
+ * ranks are what's load-bearing; the names are display.
+ */
+
+/**
+ * Purupuru tier → ordinal rank (higher = stronger). Mirrors score-api
+ * `community_tier_config.sort_order` for community_id='purupuru'.
+ */
+export const PURUPURU_TIER_RANK: Readonly<Record<string, number>> = {
+  newcomer: 1,
+  member: 2,
+  devoted: 3,
+  core: 4,
+  sovereign: 5,
+  elder: 6,
+};
+
+/** A tier-rank resolver: a tier name → its ordinal, or undefined if unknown. */
+export type TierRankResolver = (tier: string) => number | undefined;
+
+/** The default resolver, grounded in the seeded Purupuru ladder. */
+export const purupuruTierRank: TierRankResolver = (tier) =>
+  PURUPURU_TIER_RANK[tier.toLowerCase()];
+
+/**
+ * Does `walletTier` satisfy `minTier` (>=) under `rank`? FAIL-CLOSED: an unknown
+ * `walletTier` (not on the ladder) NEVER qualifies; an unknown `minTier` is a
+ * misconfigured rule → NEVER qualifies (so a typo can't accidentally grant
+ * everyone). A null/absent wallet tier (untiered wallet) never qualifies.
+ */
+export function tierQualifies(
+  walletTier: string | null | undefined,
+  minTier: string,
+  rank: TierRankResolver = purupuruTierRank,
+): boolean {
+  if (walletTier == null) return false;
+  const w = rank(walletTier);
+  const m = rank(minTier);
+  if (w === undefined || m === undefined) return false;
+  return w >= m;
+}

--- a/apps/bot/src/shadow/purupuru-tiers.ts
+++ b/apps/bot/src/shadow/purupuru-tiers.ts
@@ -12,11 +12,23 @@
  *
  * ── GROUNDING (score-api origin/main, read 2026-06-03) ───────────────────────
  * supabase/migrations/20260602_001_cycle032_purupuru_config.sql seeds the
- * Purupuru `community_tier_config` ladder (by `sort_order`):
- *   newcomer(1) < member(2) < devoted(3) < core(4) < sovereign(5) < elder(6)
- * (crowd: newcomer..core score-banded; elite: sovereign/elder rank-based —
- * elite overrides crowd, so a wallet's single `tier` is already the resolved
- * winner. The ladder here mirrors `sort_order` exactly so higher = stronger.)
+ * Purupuru `community_tier_config`. ⚠ `sort_order` is PRESENTATION order, NOT
+ * strength order — it does NOT match status for the elite tiers. Ground truth:
+ *   • crowd (score-banded, ascending strength):
+ *       newcomer(score 0-39) < member(40-69) < devoted(70-89) < core(90-99)
+ *   • elite (rank-banded, OVERRIDES crowd — lower rank number = higher status):
+ *       sovereign(rank 1-7, live=7 wallets) is the TOP; elder(rank 8-50,
+ *       live=43 wallets) is next-strongest.
+ * So although `sort_order` lists sovereign(5) before elder(6), sovereign is the
+ * STRONGER tier. The STRENGTH ladder below corrects this:
+ *   newcomer(1) < member(2) < devoted(3) < core(4) < elder(5) < sovereign(6)
+ *
+ * SEMANTIC ASSUMPTION (a CM should confirm): elite OVERRIDES crowd, so EVERY
+ * elite tier ranks above EVERY crowd tier (core(4) < elder(5)). This follows
+ * score-api's "elite overrides crowd" resolveTier model — a wallet's single
+ * resolved `tier` is the elite one whenever it earns one. If a community ever
+ * wants a high-score crowd wallet to outrank a low-rank elite wallet, this
+ * cross-class ordering is the one knob to revisit.
  *
  * ⚠ The lore NAMES are PLACEHOLDERS (Jani/zerker calibrate, OQ-4). When the real
  * lore lands, update this map (and the matching score-api config) together. The
@@ -24,16 +36,20 @@
  */
 
 /**
- * Purupuru tier → ordinal rank (higher = stronger). Mirrors score-api
- * `community_tier_config.sort_order` for community_id='purupuru'.
+ * Purupuru tier → ordinal STRENGTH rank (higher = stronger). This is NOT
+ * score-api's `sort_order` (which inverts the elite pair) — it is the corrected
+ * status ladder: crowd ascending, then elite above all crowd, with sovereign
+ * (rank 1-7) above elder (rank 8-50). See the file header for the grounding.
  */
 export const PURUPURU_TIER_RANK: Readonly<Record<string, number>> = {
+  // crowd (score-banded, ascending)
   newcomer: 1,
   member: 2,
   devoted: 3,
   core: 4,
-  sovereign: 5,
-  elder: 6,
+  // elite (rank-banded, OVERRIDES crowd — sovereign rank 1-7 > elder rank 8-50)
+  elder: 5,
+  sovereign: 6,
 };
 
 /** A tier-rank resolver: a tier name → its ordinal, or undefined if unknown. */

--- a/apps/bot/src/shadow/score-source.live.ts
+++ b/apps/bot/src/shadow/score-source.live.ts
@@ -61,7 +61,22 @@ export interface LiveScoreConfig {
   readonly clientFor: (world: string) => CommunityScoreClient | undefined;
   /** tier ordering (defaults to the grounded Purupuru ladder). */
   readonly tierRank?: TierRankResolver;
+  /**
+   * leaderboard memo TTL in ms (Bridgebuilder #9). The substrate's
+   * `loadLatentCounts` calls `latentQualified(world, rule)` ONCE PER RULE — a
+   * naive adapter fetches the full leaderboard N times for N rules. We memoize
+   * the per-world leaderboard for this short window so N rules = 1 fetch (mirrors
+   * the prior cycle's read-roster-once-per-batch fix). Default 5s — long enough
+   * to span the per-rule loop, short enough that a fresh discrepancy build re-reads.
+   * Set 0/negative to disable the memo (always fetch fresh).
+   */
+  readonly leaderboardMemoTtlMs?: number;
+  /** injectable clock (tests). */
+  readonly now?: () => number;
 }
+
+/** Default leaderboard memo window (ms) — spans the per-rule `loadLatentCounts` loop. */
+const DEFAULT_LEADERBOARD_MEMO_TTL_MS = 5_000;
 
 /** Map a CommunityScoreError (or any throw) to the substrate's typed ScoreError. */
 function toScoreError(e: unknown, ctx: string): ScoreError {
@@ -79,6 +94,37 @@ function toScoreError(e: unknown, ctx: string): ScoreError {
  */
 export function makeScoreSourceLive(cfg: LiveScoreConfig): Layer.Layer<ScoreSource> {
   const rank = cfg.tierRank ?? purupuruTierRank;
+  const memoTtl = cfg.leaderboardMemoTtlMs ?? DEFAULT_LEADERBOARD_MEMO_TTL_MS;
+  const now = cfg.now ?? (() => Date.now());
+
+  // Per-world leaderboard memo (Bridgebuilder #9): MEMOIZE the in-flight fetch +
+  // its result for a short TTL so N tier rules = 1 fetch, not N. We memo the
+  // PROMISE (not just the resolved value) so concurrent per-rule calls within one
+  // tick coalesce onto a single round-trip. An error rejects the shared promise
+  // and is NOT memoized (the entry is cleared so a later call retries).
+  interface MemoEntry {
+    readonly promise: Promise<Awaited<ReturnType<CommunityScoreClient["leaderboard"]>>>;
+    readonly expires_at: number;
+  }
+  const memo = new Map<string, MemoEntry>();
+
+  const leaderboardFor = (
+    world: string,
+    client: CommunityScoreClient,
+  ): Promise<Awaited<ReturnType<CommunityScoreClient["leaderboard"]>>> => {
+    if (memoTtl > 0) {
+      const hit = memo.get(world);
+      if (hit && hit.expires_at > now()) return hit.promise;
+    }
+    const promise = client.leaderboard().catch((e) => {
+      // do not memoize a failure — clear so the next call retries.
+      memo.delete(world);
+      throw e;
+    });
+    if (memoTtl > 0) memo.set(world, { promise, expires_at: now() + memoTtl });
+    return promise;
+  };
+
   return Layer.succeed(
     ScoreSource,
     ScoreSource.of({
@@ -94,7 +140,10 @@ export function makeScoreSourceLive(cfg: LiveScoreConfig): Layer.Layer<ScoreSour
                 `no community score client wired for world '${w}' (SCORE_PURUPURU_API_KEY unset or world unmapped)`,
               );
             }
-            const page = await client.leaderboard();
+            // #13: a NON-tier rule never participates in the tier→count — skip it
+            // explicitly (observably 0), don't rely on min_tier coincidence.
+            if (rule.qualifies.source !== "tier") return 0;
+            const page = await leaderboardFor(w, client); // MEMOIZED (#9)
             const minTier = rule.qualifies.min_tier;
             let count = 0;
             for (const entry of page.wallets) {

--- a/apps/bot/src/shadow/score-source.live.ts
+++ b/apps/bot/src/shadow/score-source.live.ts
@@ -1,0 +1,109 @@
+/**
+ * shadow/score-source.live.ts — the LIVE `ScoreSource` Layer (bd-tfl).
+ *
+ * Closes the structural hole the brief named: `composition-root.ts` wired
+ * `makeRosterSourceLive / RoleWriterLive / AcvpEmitterLive / AdminAllowlistLive`
+ * but supplied NO `ScoreSource` Layer — so the substrate's
+ * `ScoreSource.latentQualified` port was unimplemented and `loadLatentCounts`
+ * had nothing to call. This is that Layer.
+ *
+ * ── WHAT IT DOES ─────────────────────────────────────────────────────────────
+ * `latentQualified(world, rule)` reads the Purupuru community leaderboard
+ * (score-api REST, via `CommunityScoreClient`) and counts wallets whose `tier`
+ * satisfies the rule's tier qualification (`rule.qualifies.min_tier`, evaluated
+ * with the grounded Purupuru tier ladder in `purupuru-tiers.ts`). That count is
+ * the per-rule "qualified members" number the substrate's `loadLatentCounts`
+ * folds into the `Discrepancy.latent_qualified` projection.
+ *
+ * ── "latent" (qualified-but-not-joined) vs "qualified" — HONEST NUANCE ────────
+ * The port name is `latentQualified` (SDD: "qualified-but-not-joined wallets").
+ * This LIVE adapter returns the QUALIFIED count (wallets at/above the rule's
+ * min_tier), NOT qualified-MINUS-joined. Computing the true latent (excluding
+ * already-joined members) requires joining score-api tiers ⋈ identity-api
+ * wallet↔discord ⋈ the live guild roster — which is exactly the per-member
+ * assign-batch path (part 2 of bd-tfl, score-tier-assignment.ts). The substrate
+ * MOCK has the same simple-count semantics; we match it here rather than
+ * silently changing the projection's meaning. The fuller "minus joined" number
+ * is a follow-up once the part-2 join is wired into a count surface.
+ *
+ * ── PROVENANCE GAP (substrate, NOT fakeable here) ────────────────────────────
+ * Even when this LIVE adapter produces the count, the substrate's
+ * `effectful/loaders.ts` HARDCODES `source: 'MOCK'` on every `LatentQualified`
+ * (read at SHA 26d11b7). So a LIVE count surfaces as `source:'MOCK'` in the
+ * Discrepancy until a freeside-worlds substrate change threads honest LIVE
+ * provenance through `loadLatentCounts`. We DO NOT fake `source:'LIVE'` (the
+ * substrate is SACRED / SHA-pinned). Tracked as a new bead — see the build
+ * report. This adapter is honest about the count; the provenance label is the
+ * substrate's to fix.
+ *
+ * ── FAIL-CLOSED ──────────────────────────────────────────────────────────────
+ * Any REST failure (403 out-of-scope key, 4xx unresolved, 5xx upstream, decode,
+ * transport) maps to a typed `ScoreError`. We NEVER return a silent 0 on error
+ * (a 0 would understate the discrepancy and could be mistaken for "nobody
+ * qualifies"). Mirrors the score-api community-resolver's own fail-closed posture.
+ */
+import { Effect, Layer } from "effect";
+import { ScoreSource, ScoreError } from "./substrate.ts";
+import type { RoleRule } from "@freeside-worlds/shadow-substrate";
+import {
+  CommunityScoreClient,
+  CommunityScoreError,
+} from "@freeside-characters/persona-engine/score/community-client";
+import { tierQualifies, type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
+
+/**
+ * Per-world wiring the LIVE ScoreSource needs: a factory that returns a
+ * `CommunityScoreClient` for the world (or undefined if this world has no LIVE
+ * score wiring — then we fail-closed with a ScoreError rather than guess).
+ */
+export interface LiveScoreConfig {
+  /** map a world slug → its community-scoped score client (undefined ⇒ no wiring). */
+  readonly clientFor: (world: string) => CommunityScoreClient | undefined;
+  /** tier ordering (defaults to the grounded Purupuru ladder). */
+  readonly tierRank?: TierRankResolver;
+}
+
+/** Map a CommunityScoreError (or any throw) to the substrate's typed ScoreError. */
+function toScoreError(e: unknown, ctx: string): ScoreError {
+  if (e instanceof CommunityScoreError) {
+    return new ScoreError({ message: `${ctx}: [${e.kind}] ${e.message}` });
+  }
+  return new ScoreError({
+    message: `${ctx}: ${e instanceof Error ? e.message : String(e)}`,
+  });
+}
+
+/**
+ * Build the LIVE `ScoreSource` Layer. The composition root supplies `clientFor`
+ * (resolved from the world manifest + the SCORE_PURUPURU_API_KEY env).
+ */
+export function makeScoreSourceLive(cfg: LiveScoreConfig): Layer.Layer<ScoreSource> {
+  const rank = cfg.tierRank ?? purupuruTierRank;
+  return Layer.succeed(
+    ScoreSource,
+    ScoreSource.of({
+      latentQualified: (world, rule: RoleRule) =>
+        Effect.tryPromise({
+          try: async (): Promise<number> => {
+            const w = world as unknown as string;
+            const client = cfg.clientFor(w);
+            if (!client) {
+              // fail-closed: no LIVE score wiring for this world. Never silently 0.
+              throw new CommunityScoreError(
+                "bad_request",
+                `no community score client wired for world '${w}' (SCORE_PURUPURU_API_KEY unset or world unmapped)`,
+              );
+            }
+            const page = await client.leaderboard();
+            const minTier = rule.qualifies.min_tier;
+            let count = 0;
+            for (const entry of page.wallets) {
+              if (tierQualifies(entry.tier, minTier, rank)) count += 1;
+            }
+            return count;
+          },
+          catch: (e) => toScoreError(e, `latentQualified(${rule.role_key})`),
+        }),
+    }),
+  );
+}

--- a/apps/bot/src/shadow/score-source.mock.ts
+++ b/apps/bot/src/shadow/score-source.mock.ts
@@ -1,0 +1,54 @@
+/**
+ * shadow/score-source.mock.ts — the MOCK `ScoreSource` Layer (bd-tfl).
+ *
+ * Mirrors the `roster-source.mock.ts` idiom (`Layer.succeed` + `seed*`/`reset*`
+ * fixtures). This is the DEFAULT ScoreSource (the SHADOW/preview path AND the
+ * fallback when `SCORE_PURUPURU_API_KEY` is unset — see composition-root.ts).
+ *
+ * Returns latent-qualified COUNTS per rule with ZERO network calls. The
+ * substrate's `loadLatentCounts` tags every count `source: 'MOCK'` (it hardcodes
+ * that — see the substrate-gap NOTE in score-source.live.ts), so a mock count
+ * and a live count are indistinguishable in provenance until the substrate
+ * carries the LIVE flag. Until then this mock is the honest default.
+ */
+import { Effect, Layer } from "effect";
+import { ScoreSource, ScoreError } from "./substrate.ts";
+import type { RoleRule } from "@freeside-worlds/shadow-substrate";
+
+/** Fixture: keyed by `${world}::${role_key}` → latent count. */
+const _fixtures = new Map<string, number>();
+let _forceFailure = false;
+
+function key(world: string, roleKey: string): string {
+  return `${world}::${roleKey}`;
+}
+
+/** Seed a latent count for a (world, role_key). */
+export function seedLatentCount(world: string, roleKey: string, count: number): void {
+  _fixtures.set(key(world, roleKey), count);
+}
+
+/** Force the next reads to fail with ScoreError (failure-path tests). */
+export function setMockScoreFailure(fail: boolean): void {
+  _forceFailure = fail;
+}
+
+/** Clear all fixtures + reset the failure flag. */
+export function resetMockScoreSource(): void {
+  _fixtures.clear();
+  _forceFailure = false;
+}
+
+export const ScoreSourceMock: Layer.Layer<ScoreSource> = Layer.succeed(
+  ScoreSource,
+  ScoreSource.of({
+    latentQualified: (world, rule: RoleRule) =>
+      Effect.suspend(() => {
+        if (_forceFailure) {
+          return Effect.fail(new ScoreError({ message: "mock score failure (forced)" }));
+        }
+        const w = world as unknown as string;
+        return Effect.succeed(_fixtures.get(key(w, rule.role_key)) ?? 0);
+      }),
+  }),
+);

--- a/apps/bot/src/shadow/score-source.test.ts
+++ b/apps/bot/src/shadow/score-source.test.ts
@@ -70,16 +70,40 @@ function failingClient() {
 }
 
 describe("purupuru-tiers — tierQualifies", () => {
-  test("ladder order: newcomer < member < devoted < core < sovereign < elder", () => {
+  test("STRENGTH ladder: newcomer < member < devoted < core < elder < sovereign", () => {
+    // crowd ascending
     expect(purupuruTierRank("newcomer")).toBeLessThan(purupuruTierRank("member")!);
-    expect(purupuruTierRank("core")).toBeLessThan(purupuruTierRank("sovereign")!);
-    expect(purupuruTierRank("sovereign")).toBeLessThan(purupuruTierRank("elder")!);
+    expect(purupuruTierRank("member")).toBeLessThan(purupuruTierRank("devoted")!);
+    expect(purupuruTierRank("devoted")).toBeLessThan(purupuruTierRank("core")!);
+    // elite OVERRIDES crowd: every elite tier > every crowd tier
+    expect(purupuruTierRank("core")).toBeLessThan(purupuruTierRank("elder")!);
+    // within elite: sovereign (rank 1-7) is STRONGER than elder (rank 8-50).
+    // NOTE: this is the OPPOSITE of score-api sort_order (which lists sovereign
+    // before elder) — sort_order is presentation, not strength.
+    expect(purupuruTierRank("elder")).toBeLessThan(purupuruTierRank("sovereign")!);
   });
 
   test(">= semantics: a wallet at-or-above min_tier qualifies", () => {
-    expect(tierQualifies("sovereign", "core")).toBe(true); // 5 >= 4
+    expect(tierQualifies("sovereign", "core")).toBe(true); // 6 >= 4
     expect(tierQualifies("core", "core")).toBe(true); // 4 >= 4 (boundary)
     expect(tierQualifies("member", "core")).toBe(false); // 2 < 4
+  });
+
+  test("elite > all crowd: a core wallet does NOT qualify an elite min_tier", () => {
+    expect(tierQualifies("core", "elder")).toBe(false); // 4 < 5
+    expect(tierQualifies("core", "sovereign")).toBe(false); // 4 < 6
+  });
+
+  test("min_tier='sovereign' qualifies ONLY sovereign (NOT elder)", () => {
+    expect(tierQualifies("sovereign", "sovereign")).toBe(true); // 6 >= 6
+    expect(tierQualifies("elder", "sovereign")).toBe(false); // 5 < 6 — elder is NOT sovereign-strong
+    expect(tierQualifies("core", "sovereign")).toBe(false);
+  });
+
+  test("min_tier='elder' qualifies elder AND sovereign (the two elite tiers)", () => {
+    expect(tierQualifies("elder", "elder")).toBe(true); // 5 >= 5
+    expect(tierQualifies("sovereign", "elder")).toBe(true); // 6 >= 5 — sovereign outranks elder
+    expect(tierQualifies("core", "elder")).toBe(false); // 4 < 5
   });
 
   test("fail-closed: null/unknown wallet tier never qualifies", () => {
@@ -104,9 +128,9 @@ describe("makeScoreSourceLive.latentQualified (no network)", () => {
 
   test("counts wallets at/above the rule min_tier", async () => {
     const client = clientReturning([
-      { wallet: "0x1", tier: "elder" },     // 6 >= 4 ✓
-      { wallet: "0x2", tier: "sovereign" }, // 5 >= 4 ✓
-      { wallet: "0x3", tier: "core" },      // 4 >= 4 ✓
+      { wallet: "0x1", tier: "elder" },     // 5 >= 4 ✓ (elite > core)
+      { wallet: "0x2", tier: "sovereign" }, // 6 >= 4 ✓ (top tier)
+      { wallet: "0x3", tier: "core" },      // 4 >= 4 ✓ (boundary)
       { wallet: "0x4", tier: "member" },    // 2 < 4 ✗
       { wallet: "0x5", tier: null },        // untiered ✗
       { wallet: "0x6", tier: "newcomer" },  // 1 < 4 ✗

--- a/apps/bot/src/shadow/score-source.test.ts
+++ b/apps/bot/src/shadow/score-source.test.ts
@@ -1,0 +1,220 @@
+/**
+ * score-source.test.ts — the LIVE + MOCK `ScoreSource` Layers (bd-tfl).
+ *
+ * Pins:
+ *   • tier qualification (>=) against the grounded Purupuru ladder, fail-closed
+ *     on unknown/null tiers.
+ *   • makeScoreSourceLive.latentQualified counts wallets at/above min_tier from a
+ *     mocked CommunityScoreClient (NO network — the client's transport is an
+ *     injected fetch).
+ *   • a REST failure surfaces a typed ScoreError (never a silent 0).
+ *   • the MOCK Layer returns seeded counts / 0 default, with a forced-failure path.
+ */
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Effect } from "effect";
+import { ScoreSource } from "./substrate.ts";
+import type { RoleRule } from "@freeside-worlds/shadow-substrate";
+import { makeScoreSourceLive, type LiveScoreConfig } from "./score-source.live.ts";
+import {
+  ScoreSourceMock,
+  seedLatentCount,
+  setMockScoreFailure,
+  resetMockScoreSource,
+} from "./score-source.mock.ts";
+import {
+  CommunityScoreClient,
+  type CommunityScoreClientConfig,
+} from "@freeside-characters/persona-engine/score/community-client";
+import { tierQualifies, purupuruTierRank } from "./purupuru-tiers.ts";
+
+// ── a rule helper (the substrate's RoleRule shape) ──────────────────────────
+function rule(role_key: string, min_tier: string): RoleRule {
+  return {
+    role_key,
+    display_name: role_key,
+    qualifies: { source: "tier", min_tier },
+    create_if_absent: true,
+  } as RoleRule;
+}
+
+// ── a CommunityScoreClient backed by an injected fetch (no network) ─────────
+function clientReturning(wallets: Array<{ wallet: string; tier: string | null }>) {
+  const body = {
+    community: "purupuru",
+    total: wallets.length,
+    wallets: wallets.map((w, i) => ({
+      wallet: w.wallet,
+      rank: i + 1,
+      combined_score: 50,
+      tier: w.tier,
+    })),
+  };
+  const fakeFetch = (async () => Response.json(body)) as unknown as typeof fetch;
+  const cfg: CommunityScoreClientConfig = {
+    baseUrl: "https://score-api.test",
+    apiKey: "sk-test",
+    community: "purupuru",
+    retry: { fetchImpl: fakeFetch, maxAttempts: 1, sleep: async () => {} },
+  };
+  return new CommunityScoreClient(cfg);
+}
+
+function failingClient() {
+  const fakeFetch = (async () => new Response("nope", { status: 403 })) as unknown as typeof fetch;
+  return new CommunityScoreClient({
+    baseUrl: "https://score-api.test",
+    apiKey: "sk-test",
+    community: "purupuru",
+    retry: { fetchImpl: fakeFetch, maxAttempts: 1, sleep: async () => {} },
+  });
+}
+
+describe("purupuru-tiers — tierQualifies", () => {
+  test("ladder order: newcomer < member < devoted < core < sovereign < elder", () => {
+    expect(purupuruTierRank("newcomer")).toBeLessThan(purupuruTierRank("member")!);
+    expect(purupuruTierRank("core")).toBeLessThan(purupuruTierRank("sovereign")!);
+    expect(purupuruTierRank("sovereign")).toBeLessThan(purupuruTierRank("elder")!);
+  });
+
+  test(">= semantics: a wallet at-or-above min_tier qualifies", () => {
+    expect(tierQualifies("sovereign", "core")).toBe(true); // 5 >= 4
+    expect(tierQualifies("core", "core")).toBe(true); // 4 >= 4 (boundary)
+    expect(tierQualifies("member", "core")).toBe(false); // 2 < 4
+  });
+
+  test("fail-closed: null/unknown wallet tier never qualifies", () => {
+    expect(tierQualifies(null, "newcomer")).toBe(false);
+    expect(tierQualifies(undefined, "newcomer")).toBe(false);
+    expect(tierQualifies("ghost-tier", "newcomer")).toBe(false);
+  });
+
+  test("fail-closed: unknown min_tier (misconfigured rule) never qualifies", () => {
+    expect(tierQualifies("sovereign", "typo-tier")).toBe(false);
+  });
+
+  test("case-insensitive on the wallet tier", () => {
+    expect(tierQualifies("SOVEREIGN", "core")).toBe(true);
+  });
+});
+
+describe("makeScoreSourceLive.latentQualified (no network)", () => {
+  const cfgFor = (client: CommunityScoreClient | undefined): LiveScoreConfig => ({
+    clientFor: () => client,
+  });
+
+  test("counts wallets at/above the rule min_tier", async () => {
+    const client = clientReturning([
+      { wallet: "0x1", tier: "elder" },     // 6 >= 4 ✓
+      { wallet: "0x2", tier: "sovereign" }, // 5 >= 4 ✓
+      { wallet: "0x3", tier: "core" },      // 4 >= 4 ✓
+      { wallet: "0x4", tier: "member" },    // 2 < 4 ✗
+      { wallet: "0x5", tier: null },        // untiered ✗
+      { wallet: "0x6", tier: "newcomer" },  // 1 < 4 ✗
+    ]);
+    const layer = makeScoreSourceLive(cfgFor(client));
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) => s.latentQualified("purupuru" as never, rule("purupuru:core", "core"))),
+        Effect.provide(layer),
+      ),
+    );
+    expect(count).toBe(3);
+  });
+
+  test("min_tier=newcomer counts every tiered wallet (lowest rung)", async () => {
+    const client = clientReturning([
+      { wallet: "0x1", tier: "newcomer" },
+      { wallet: "0x2", tier: "elder" },
+      { wallet: "0x3", tier: null }, // untiered still excluded
+    ]);
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          s.latentQualified("purupuru" as never, rule("purupuru:member", "newcomer")),
+        ),
+        Effect.provide(makeScoreSourceLive(cfgFor(client))),
+      ),
+    );
+    expect(count).toBe(2);
+  });
+
+  test("a REST 403 surfaces a typed ScoreError (never a silent 0)", async () => {
+    const layer = makeScoreSourceLive(cfgFor(failingClient()));
+    const res = await Effect.runPromise(
+      Effect.either(
+        ScoreSource.pipe(
+          Effect.flatMap((s) =>
+            s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+          ),
+          Effect.provide(layer),
+        ),
+      ),
+    );
+    expect(res._tag).toBe("Left");
+    if (res._tag === "Left") {
+      expect(res.left._tag).toBe("ScoreError");
+      expect(res.left.message).toContain("forbidden");
+    }
+  });
+
+  test("no client wired for the world → fail-closed ScoreError (not a 0)", async () => {
+    const layer = makeScoreSourceLive(cfgFor(undefined));
+    const res = await Effect.runPromise(
+      Effect.either(
+        ScoreSource.pipe(
+          Effect.flatMap((s) =>
+            s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+          ),
+          Effect.provide(layer),
+        ),
+      ),
+    );
+    expect(res._tag).toBe("Left");
+    if (res._tag === "Left") expect(res.left._tag).toBe("ScoreError");
+  });
+});
+
+describe("MOCK ScoreSource", () => {
+  beforeEach(() => resetMockScoreSource());
+
+  test("returns a seeded count", async () => {
+    seedLatentCount("purupuru", "purupuru:core", 7);
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+        ),
+        Effect.provide(ScoreSourceMock),
+      ),
+    );
+    expect(count).toBe(7);
+  });
+
+  test("unseeded rule → 0 (no network, no throw)", async () => {
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          s.latentQualified("purupuru" as never, rule("purupuru:unknown", "core")),
+        ),
+        Effect.provide(ScoreSourceMock),
+      ),
+    );
+    expect(count).toBe(0);
+  });
+
+  test("forced failure → typed ScoreError", async () => {
+    setMockScoreFailure(true);
+    const res = await Effect.runPromise(
+      Effect.either(
+        ScoreSource.pipe(
+          Effect.flatMap((s) =>
+            s.latentQualified("purupuru" as never, rule("purupuru:core", "core")),
+          ),
+          Effect.provide(ScoreSourceMock),
+        ),
+      ),
+    );
+    expect(res._tag).toBe("Left");
+    if (res._tag === "Left") expect(res.left._tag).toBe("ScoreError");
+  });
+});

--- a/apps/bot/src/shadow/score-source.test.ts
+++ b/apps/bot/src/shadow/score-source.test.ts
@@ -69,6 +69,29 @@ function failingClient() {
   });
 }
 
+/** A client whose fetch is COUNTED, to prove the per-batch leaderboard memo (#9). */
+function countingClient(
+  wallets: Array<{ wallet: string; tier: string | null }>,
+  counter: { fetches: number },
+) {
+  const body = {
+    community: "purupuru",
+    total: wallets.length,
+    truncated: false,
+    wallets: wallets.map((w, i) => ({ wallet: w.wallet, rank: i + 1, combined_score: 50, tier: w.tier })),
+  };
+  const fakeFetch = (async () => {
+    counter.fetches += 1;
+    return Response.json(body);
+  }) as unknown as typeof fetch;
+  return new CommunityScoreClient({
+    baseUrl: "https://score-api.test",
+    apiKey: "sk-test",
+    community: "purupuru",
+    retry: { fetchImpl: fakeFetch, maxAttempts: 1, sleep: async () => {} },
+  });
+}
+
 describe("purupuru-tiers — tierQualifies", () => {
   test("STRENGTH ladder: newcomer < member < devoted < core < elder < sovereign", () => {
     // crowd ascending
@@ -195,6 +218,82 @@ describe("makeScoreSourceLive.latentQualified (no network)", () => {
     );
     expect(res._tag).toBe("Left");
     if (res._tag === "Left") expect(res.left._tag).toBe("ScoreError");
+  });
+
+  // #9 — leaderboard fetched ONCE across N rules (memoized per batch)
+  test("#9: N tier rules → ONE leaderboard fetch (memoized per batch)", async () => {
+    const counter = { fetches: 0 };
+    const client = countingClient(
+      [
+        { wallet: "0x1", tier: "core" },
+        { wallet: "0x2", tier: "member" },
+        { wallet: "0x3", tier: "sovereign" },
+      ],
+      counter,
+    );
+    const layer = makeScoreSourceLive(cfgFor(client));
+    // mirror loadLatentCounts: call latentQualified once per rule, sequentially.
+    const counts = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) =>
+          Effect.gen(function* () {
+            const member = yield* s.latentQualified("purupuru" as never, rule("purupuru:member", "member"));
+            const core = yield* s.latentQualified("purupuru" as never, rule("purupuru:core", "core"));
+            const sov = yield* s.latentQualified("purupuru" as never, rule("purupuru:sov", "sovereign"));
+            return { member, core, sov };
+          }),
+        ),
+        Effect.provide(layer),
+      ),
+    );
+    // counts are right…
+    expect(counts.member).toBe(3); // core+member+sovereign all >= member
+    expect(counts.core).toBe(2); // core + sovereign
+    expect(counts.sov).toBe(1); // sovereign only
+    // …and the leaderboard was fetched exactly ONCE (not 3×).
+    expect(counter.fetches).toBe(1);
+  });
+
+  test("#9: memo expires after TTL (a later batch re-fetches)", async () => {
+    const counter = { fetches: 0 };
+    const client = countingClient([{ wallet: "0x1", tier: "core" }], counter);
+    let t = 1_000;
+    const layer = makeScoreSourceLive({ clientFor: () => client, leaderboardMemoTtlMs: 100, now: () => t });
+    const ask = () =>
+      Effect.runPromise(
+        ScoreSource.pipe(
+          Effect.flatMap((s) => s.latentQualified("purupuru" as never, rule("purupuru:core", "core"))),
+          Effect.provide(layer),
+        ),
+      );
+    await ask();
+    expect(counter.fetches).toBe(1);
+    t += 50; // within TTL → memo hit
+    await ask();
+    expect(counter.fetches).toBe(1);
+    t += 200; // past TTL → re-fetch
+    await ask();
+    expect(counter.fetches).toBe(2);
+  });
+
+  // #13 — a non-tier rule is explicitly skipped (count 0), no fetch needed
+  test("#13: a non-tier rule returns 0 (explicit skip, no leaderboard read)", async () => {
+    const counter = { fetches: 0 };
+    const client = countingClient([{ wallet: "0x1", tier: "sovereign" }], counter);
+    const nonTier = {
+      role_key: "purupuru:nft",
+      display_name: "NFT",
+      qualifies: { source: "nft", min_tier: "core" },
+      create_if_absent: true,
+    } as unknown as RoleRule;
+    const count = await Effect.runPromise(
+      ScoreSource.pipe(
+        Effect.flatMap((s) => s.latentQualified("purupuru" as never, nonTier)),
+        Effect.provide(makeScoreSourceLive(cfgFor(client))),
+      ),
+    );
+    expect(count).toBe(0);
+    expect(counter.fetches).toBe(0); // never read the leaderboard for a non-tier rule
   });
 });
 

--- a/apps/bot/src/shadow/score-tier-assignment.test.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.test.ts
@@ -43,9 +43,13 @@ import {
   assignOpId,
   assignIdempotencyKey,
   assembleAssignBatch,
+  buildCreateOps,
+  createOpId,
+  assembleGoLiveBatch,
   type WalletDiscordLink,
   type AuthorizedTransition,
 } from "./score-tier-assignment.ts";
+import type { CurrentRoster } from "@freeside-worlds/shadow-substrate";
 
 // ── fixtures ────────────────────────────────────────────────────────────────
 
@@ -146,6 +150,77 @@ describe("assignmentsToOps — op_id / idempotency_key", () => {
     expect(k3).not.toBe(k1);
     // 64-hex (sha256)
     expect(k1).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── 2b. CREATE pass (FR-4) — buildCreateOps + assembleGoLiveBatch ─────────────
+
+describe("buildCreateOps — the FR-4 create pass (via computeProposed)", () => {
+  const ROSTER_NO_MANAGED: CurrentRoster = {
+    world: "purupuru",
+    roles: [{ role_key: "Holder", members: 5, managed: false }], // pre-existing, non-managed
+  } as CurrentRoster;
+
+  test("proposes create_role ops ONLY for not-yet-created managed roles", () => {
+    const ops = buildCreateOps("purupuru", "h".repeat(64), ROLE_MAP, ROSTER_NO_MANAGED);
+    expect(ops.length).toBe(2); // both tier roles absent → both created
+    expect(ops.every((o) => o.kind === "create_role")).toBe(true);
+    expect(ops.map((o) => o.intent.role_key).sort()).toEqual(["purupuru:core", "purupuru:member"]);
+    // create_role carries display_name (CreateRoleIntent).
+    const member = ops.find((o) => o.intent.role_key === "purupuru:member")!;
+    expect((member.intent as { display_name: string }).display_name).toBe("Member");
+  });
+
+  test("SKIPS create for an already-existing managed role", () => {
+    const rosterWithCore: CurrentRoster = {
+      world: "purupuru",
+      roles: [{ role_key: "purupuru:core", members: 2, managed: true }],
+    } as CurrentRoster;
+    const ops = buildCreateOps("purupuru", "h".repeat(64), ROLE_MAP, rosterWithCore);
+    expect(ops.map((o) => o.intent.role_key)).toEqual(["purupuru:member"]); // core exists, skip
+  });
+
+  test("a disabled role-map produces zero create ops", () => {
+    const ops = buildCreateOps("purupuru", "h".repeat(64), { ...ROLE_MAP, enabled: false }, ROSTER_NO_MANAGED);
+    expect(ops.length).toBe(0);
+  });
+
+  test("create op_id + idempotency_key are deterministic + distinct from an assign for the same role", () => {
+    const cId = createOpId("purupuru", "purupuru:core");
+    expect(cId).toBe(createOpId("purupuru", "purupuru:core"));
+    expect(cId).not.toBe(assignOpId("purupuru", "purupuru:core", "100"));
+    const cKey = assignIdempotencyKey("purupuru", cId, "h".repeat(64));
+    const aKey = assignIdempotencyKey("purupuru", assignOpId("purupuru", "purupuru:core", "100"), "h".repeat(64));
+    expect(cKey).not.toBe(aKey); // create-key ≠ assign-key for same role
+    expect(cKey).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("assembleGoLiveBatch — create pass FIRST, then assign pass", () => {
+  test("orders create_role ops before assign_role ops, sharing one AuthzContext", () => {
+    const transition: AuthorizedTransition = {
+      actor: ADMIN,
+      reportHash: MAP_HASH,
+      authzDecisionId: "decision-1",
+      transitionVersion: 3,
+      tokenMetadata: { kid: "kid-1", verified_at: "2026-06-02T00:00:00Z", exp: "2026-06-02T01:00:00Z" },
+    };
+    const batch = assembleGoLiveBatch({
+      world: "purupuru",
+      transition,
+      rosterVersion: ROSTER_VERSION,
+      assignments: [{ wallet: "0xc", member_id: "100", tier: "core", role_key: "purupuru:core" }],
+      roleMap: ROLE_MAP,
+      currentRoster: { world: "purupuru", roles: [] } as CurrentRoster, // nothing exists → both created
+    });
+    const kinds = batch.ops.map((o) => o.kind);
+    // 2 creates then 1 assign; the last create index < the first assign index.
+    expect(kinds.filter((k) => k === "create_role").length).toBe(2);
+    expect(kinds.filter((k) => k === "assign_role").length).toBe(1);
+    expect(kinds.lastIndexOf("create_role")).toBeLessThan(kinds.indexOf("assign_role"));
+    // one shared AuthzContext bound to the transition.
+    expect(batch.authz.authz_decision_id).toBe("decision-1");
+    expect(batch.authz.actor).toBe(ADMIN);
   });
 });
 

--- a/apps/bot/src/shadow/score-tier-assignment.test.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.test.ts
@@ -67,6 +67,13 @@ const ROLE_MAP: RoleMapConfig = {
   ],
 } as RoleMapConfig;
 
+/** A valid 17-20-digit Discord snowflake from a short tag (post-#12 the builder
+ *  counts non-snowflake member_ids as invalid, never assigned). */
+function sf(tag: string | number): string {
+  const digits = String(tag).replace(/\D/g, "") || "0";
+  return ("8" + digits.padStart(17, "0")).slice(0, 18);
+}
+
 /** Injected link map (wallet → discord snowflake | null). */
 function linkFrom(map: Record<string, string | null>): WalletDiscordLink {
   return {
@@ -85,23 +92,23 @@ describe("buildTierAssignments — the join", () => {
         lbEntry("0xelder", "elder"),     // qualifies both → core (strongest configured)
       ],
       roleMap: ROLE_MAP,
-      link: linkFrom({ "0xcore": "100", "0xmember": "200", "0xelder": "300" }),
+      link: linkFrom({ "0xcore": sf(100), "0xmember": sf(200), "0xelder": sf(300) }),
     });
     expect(res.assignments.length).toBe(3);
     const byMember = Object.fromEntries(res.assignments.map((a) => [a.member_id, a.role_key]));
-    expect(byMember["100"]).toBe("purupuru:core");
-    expect(byMember["200"]).toBe("purupuru:member");
-    expect(byMember["300"]).toBe("purupuru:core"); // elder > core, top configured rule
+    expect(byMember[sf(100)]).toBe("purupuru:core");
+    expect(byMember[sf(200)]).toBe("purupuru:member");
+    expect(byMember[sf(300)]).toBe("purupuru:core"); // elder > core, top configured rule
   });
 
   test("a qualified-but-unlinked wallet is skipped (counted), never assigned", async () => {
     const res = await buildTierAssignments({
       leaderboard: [lbEntry("0xa", "core"), lbEntry("0xb", "core")],
       roleMap: ROLE_MAP,
-      link: linkFrom({ "0xa": "100" /* 0xb has no link */ }),
+      link: linkFrom({ "0xa": sf(100) /* 0xb has no link */ }),
     });
     expect(res.assignments.length).toBe(1);
-    expect(res.assignments[0]!.member_id).toBe("100");
+    expect(res.assignments[0]!.member_id).toBe(sf(100));
     expect(res.skipped_unlinked).toBe(1);
   });
 
@@ -109,7 +116,7 @@ describe("buildTierAssignments — the join", () => {
     const res = await buildTierAssignments({
       leaderboard: [lbEntry("0xlow", "newcomer"), lbEntry("0xnull", null)],
       roleMap: ROLE_MAP,
-      link: linkFrom({ "0xlow": "100", "0xnull": "200" }),
+      link: linkFrom({ "0xlow": sf(100), "0xnull": sf(200) }),
     });
     expect(res.assignments.length).toBe(0);
     expect(res.skipped_unqualified).toBe(2);
@@ -119,9 +126,75 @@ describe("buildTierAssignments — the join", () => {
     const res = await buildTierAssignments({
       leaderboard: [lbEntry("0xa", "core")],
       roleMap: { ...ROLE_MAP, enabled: false },
-      link: linkFrom({ "0xa": "100" }),
+      link: linkFrom({ "0xa": sf(100) }),
     });
     expect(res.assignments.length).toBe(0);
+  });
+
+  // #6 — per-MEMBER (not per-wallet) dedup
+  test("#6: two wallets linked to ONE member emit ONE op (the strongest tier)", async () => {
+    const SHARED = sf(777);
+    const res = await buildTierAssignments({
+      leaderboard: [
+        lbEntry("0xw1", "member"), // member's weaker wallet
+        lbEntry("0xw2", "core"),   // member's stronger wallet (→ should win)
+      ],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xw1": SHARED, "0xw2": SHARED }), // SAME discord member
+    });
+    expect(res.assignments.length).toBe(1); // ONE op, not two
+    expect(res.assignments[0]!.member_id).toBe(SHARED);
+    expect(res.assignments[0]!.role_key).toBe("purupuru:core"); // strongest tier wins
+    expect(res.collapsed_duplicate_members).toBe(1);
+  });
+
+  test("#6: dedup keeps the stronger tier regardless of leaderboard order", async () => {
+    const SHARED = sf(888);
+    const res = await buildTierAssignments({
+      leaderboard: [
+        lbEntry("0xstrong", "core"),  // stronger FIRST
+        lbEntry("0xweak", "member"),  // weaker SECOND
+      ],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xstrong": SHARED, "0xweak": SHARED }),
+    });
+    expect(res.assignments.length).toBe(1);
+    expect(res.assignments[0]!.role_key).toBe("purupuru:core");
+    expect(res.collapsed_duplicate_members).toBe(1);
+  });
+
+  // #12 — non-snowflake member_id counted invalid (separate from unlinked)
+  test("#12: a non-snowflake member_id is counted INVALID, never assigned", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xgood", "core"), lbEntry("0xbad", "core")],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xgood": sf(1), "0xbad": "not-a-snowflake" }),
+    });
+    expect(res.assignments.length).toBe(1);
+    expect(res.assignments[0]!.member_id).toBe(sf(1));
+    expect(res.skipped_invalid).toBe(1);
+    expect(res.skipped_unlinked).toBe(0); // invalid is NOT counted as unlinked
+  });
+
+  // #13 — non-tier rule is explicitly skipped (observable)
+  test("#13: a non-tier rule is explicitly skipped (not relied on accidental fail-close)", async () => {
+    // a role-map carrying a NON-tier rule alongside a tier rule. (The substrate
+    // types `source` as 'tier'; this fixture casts to exercise the runtime guard.)
+    const mixedMap = {
+      ...ROLE_MAP,
+      rules: [
+        { role_key: "purupuru:nft", display_name: "NFT", qualifies: { source: "nft", min_tier: "core" }, create_if_absent: true },
+        { role_key: "purupuru:core", display_name: "Core", qualifies: { source: "tier", min_tier: "core" }, create_if_absent: true },
+      ],
+    } as unknown as RoleMapConfig;
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xcore", "core")],
+      roleMap: mixedMap,
+      link: linkFrom({ "0xcore": sf(5) }),
+    });
+    // the tier rule still assigns; the non-tier rule never participates.
+    expect(res.assignments.length).toBe(1);
+    expect(res.assignments[0]!.role_key).toBe("purupuru:core");
   });
 });
 
@@ -277,7 +350,7 @@ describe("score-tier-assignment — END-TO-END through the real gate", () => {
     const assignmentsRes = await buildTierAssignments({
       leaderboard: [lbEntry("0xcore", "core"), lbEntry("0xelder", "elder")],
       roleMap: ROLE_MAP,
-      link: linkFrom({ "0xcore": "member-1", "0xelder": "member-2" }),
+      link: linkFrom({ "0xcore": sf("11"), "0xelder": sf("22") }),
     });
     expect(assignmentsRes.assignments.length).toBe(2);
 
@@ -318,7 +391,7 @@ describe("score-tier-assignment — END-TO-END through the real gate", () => {
     // exactly the two assign ops, captured by the MOCK writer (zero REAL writes).
     const assigns = capturedWrites().filter((w) => w.kind === "assign_role");
     expect(assigns.length).toBe(2);
-    expect(assigns.map((w) => w.member_id).sort()).toEqual(["member-1", "member-2"]);
+    expect(assigns.map((w) => w.member_id).sort()).toEqual([sf("11"), sf("22")].sort());
     expect(capturedWrites().filter((w) => w.kind === "create_role").length).toBe(0); // assign-only
     expect(recorder.countOf("shadow.role.applied.v1")).toBe(2);
     expect(recorder.countOf("shadow.role.rejected.v1")).toBe(0);

--- a/apps/bot/src/shadow/score-tier-assignment.test.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.test.ts
@@ -1,0 +1,288 @@
+/**
+ * score-tier-assignment.test.ts — the per-member tier→role assign-batch builder
+ * (bd-tfl part 2).
+ *
+ * Two layers of proof:
+ *   1. PURE join + assembly: leaderboard ⋈ identity-link ⋈ role-map → assignments
+ *      → WriteOp[] → WriteIntentBatch (no network, injected WalletDiscordLink).
+ *      Covers: strongest-rule selection, unlinked/unqualified skips, disabled
+ *      map, deterministic op_id/idempotency_key.
+ *   2. END-TO-END through the REAL substrate gate (mirrors shadow-loop.test):
+ *      goLive mints a cap → assembleAssignBatch builds the batch bound to the
+ *      go_live decision → gate.applyBatch writes the assign ops through the MOCK
+ *      writer (zero real Discord I/O). This proves the builder's output is a
+ *      VALID, gate-acceptable batch (the hash-binding invariants hold).
+ */
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  GateCheckedRoleWriter,
+  makeGateCheckedRoleWriter,
+  makeModeControl,
+  goLive,
+  AcvpEmitter,
+  roleMapVersionHash,
+} from "./substrate.ts";
+import { rosterFingerprint } from "@freeside-worlds/shadow-substrate";
+import type {
+  RoleMapConfig,
+  RoleMapVersionInput,
+  WorldSlug,
+  Hex64,
+  ModeControl,
+  RosterVersion,
+} from "@freeside-worlds/shadow-substrate";
+import type { CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
+import { RoleWriterMock, resetMockRoleWriter, capturedWrites } from "./role-writer.mock.ts";
+import { makeRecordingEmitter } from "./acvp-emitter.mock.ts";
+import { makeInMemoryWorldLock } from "./world-lock.ts";
+import { makeAdminAllowlistInMemory } from "./admin-allowlist.live.ts";
+import {
+  buildTierAssignments,
+  assignmentsToOps,
+  assignOpId,
+  assignIdempotencyKey,
+  assembleAssignBatch,
+  type WalletDiscordLink,
+  type AuthorizedTransition,
+} from "./score-tier-assignment.ts";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+function lbEntry(wallet: string, tier: string | null, rank = 1): CommunityLeaderboardEntry {
+  return { wallet, rank, combined_score: 50, tier } as CommunityLeaderboardEntry;
+}
+
+/** A role-map with a low + high tier rule (both Freeside-namespaced). */
+const ROLE_MAP: RoleMapConfig = {
+  enabled: true,
+  namespace_prefix: "purupuru:",
+  rules: [
+    { role_key: "purupuru:member", display_name: "Member", qualifies: { source: "tier", min_tier: "member" }, create_if_absent: true },
+    { role_key: "purupuru:core", display_name: "Core", qualifies: { source: "tier", min_tier: "core" }, create_if_absent: true },
+  ],
+} as RoleMapConfig;
+
+/** Injected link map (wallet → discord snowflake | null). */
+function linkFrom(map: Record<string, string | null>): WalletDiscordLink {
+  return {
+    resolve: async (wallet: string) => map[wallet.toLowerCase()] ?? null,
+  };
+}
+
+// ── 1. pure join ──────────────────────────────────────────────────────────────
+
+describe("buildTierAssignments — the join", () => {
+  test("assigns each linked wallet its STRONGEST qualifying tier role", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [
+        lbEntry("0xcore", "core"),       // qualifies member AND core → core (strongest)
+        lbEntry("0xmember", "member"),   // qualifies member only
+        lbEntry("0xelder", "elder"),     // qualifies both → core (strongest configured)
+      ],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xcore": "100", "0xmember": "200", "0xelder": "300" }),
+    });
+    expect(res.assignments.length).toBe(3);
+    const byMember = Object.fromEntries(res.assignments.map((a) => [a.member_id, a.role_key]));
+    expect(byMember["100"]).toBe("purupuru:core");
+    expect(byMember["200"]).toBe("purupuru:member");
+    expect(byMember["300"]).toBe("purupuru:core"); // elder > core, top configured rule
+  });
+
+  test("a qualified-but-unlinked wallet is skipped (counted), never assigned", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xa", "core"), lbEntry("0xb", "core")],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xa": "100" /* 0xb has no link */ }),
+    });
+    expect(res.assignments.length).toBe(1);
+    expect(res.assignments[0]!.member_id).toBe("100");
+    expect(res.skipped_unlinked).toBe(1);
+  });
+
+  test("a wallet below every rule (or untiered) is skipped as unqualified", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xlow", "newcomer"), lbEntry("0xnull", null)],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xlow": "100", "0xnull": "200" }),
+    });
+    expect(res.assignments.length).toBe(0);
+    expect(res.skipped_unqualified).toBe(2);
+  });
+
+  test("a disabled role-map produces zero assignments", async () => {
+    const res = await buildTierAssignments({
+      leaderboard: [lbEntry("0xa", "core")],
+      roleMap: { ...ROLE_MAP, enabled: false },
+      link: linkFrom({ "0xa": "100" }),
+    });
+    expect(res.assignments.length).toBe(0);
+  });
+});
+
+// ── 2. ops + determinism ──────────────────────────────────────────────────────
+
+describe("assignmentsToOps — op_id / idempotency_key", () => {
+  test("emits assign_role ops only (never create/remove)", () => {
+    const ops = assignmentsToOps("purupuru", "h".repeat(64), [
+      { wallet: "0xa", member_id: "100", tier: "core", role_key: "purupuru:core" },
+    ]);
+    expect(ops.length).toBe(1);
+    expect(ops[0]!.kind).toBe("assign_role");
+    expect((ops[0]!.intent as { role_key: string }).role_key).toBe("purupuru:core");
+    expect((ops[0]!.intent as { member_id: string }).member_id).toBe("100");
+  });
+
+  test("op_id + idempotency_key are deterministic (retry-safe)", () => {
+    const id1 = assignOpId("purupuru", "purupuru:core", "100");
+    const id2 = assignOpId("purupuru", "purupuru:core", "100");
+    expect(id1).toBe(id2);
+    const k1 = assignIdempotencyKey("purupuru", id1, "h".repeat(64));
+    const k2 = assignIdempotencyKey("purupuru", id2, "h".repeat(64));
+    expect(k1).toBe(k2);
+    // a different member → different key
+    const k3 = assignIdempotencyKey("purupuru", assignOpId("purupuru", "purupuru:core", "999"), "h".repeat(64));
+    expect(k3).not.toBe(k1);
+    // 64-hex (sha256)
+    expect(k1).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── 3. END-TO-END through the real gate (mirrors shadow-loop.test) ────────────
+
+const WORLD = "purupuru" as unknown as WorldSlug;
+const ADMIN = "identity:admin-1";
+const h64 = (s: string) => s as unknown as Hex64;
+
+const MAP_INPUT: RoleMapVersionInput = {
+  role_rules: [
+    { role_key: "purupuru:core", display_name: "Core", qualifies: { source: "tier", min_tier: "core" }, create_if_absent: true },
+  ],
+  scaffolding_config: { channels: [] },
+  world_config: { world_slug: "purupuru", guild_id: "111122223333444455", namespace_prefix: "purupuru:", nft_contracts: ["0xabc"] },
+};
+const MAP_HASH = roleMapVersionHash(MAP_INPUT);
+
+const EMPTY_SNAPSHOT = { member_ids: [] as string[], role_ids: [] as string[] };
+const NO_DRIFT = {
+  baseFingerprint: rosterFingerprint(EMPTY_SNAPSHOT),
+  baseSnapshot: EMPTY_SNAPSHOT,
+  freshSnapshot: EMPTY_SNAPSHOT,
+};
+
+const ROSTER_VERSION: RosterVersion = {
+  fingerprint: h64("a".repeat(64)),
+  fetched_at: "2026-06-02T00:00:00Z",
+  member_count: 0,
+};
+
+function fullStack(mode: ModeControl, emitterLayer: Layer.Layer<AcvpEmitter>, allow: readonly string[]) {
+  const allowlist = makeAdminAllowlistInMemory(new Map([[WORLD as unknown as string, allow]]));
+  const lock = makeInMemoryWorldLock();
+  const gate = makeGateCheckedRoleWriter(mode, () => MAP_HASH).pipe(
+    Layer.provide(Layer.mergeAll(RoleWriterMock, emitterLayer, lock)),
+  );
+  return Layer.mergeAll(gate, RoleWriterMock, emitterLayer, lock, allowlist);
+}
+
+beforeEach(() => resetMockRoleWriter());
+
+describe("score-tier-assignment — END-TO-END through the real gate", () => {
+  test("assembled assign-batch writes through the gate (LIVE, MOCK writer)", async () => {
+    const { layer: emitterLayer, recorder } = makeRecordingEmitter();
+
+    // The PRE-CREATED tier role the gate's writer adopts on assign (a real flow
+    // would create it via the FR-4 create pass first; the MOCK writer's assign
+    // path resolves by name, so seed it through a create captured-write would be
+    // needed — instead we rely on the MOCK writer's create-then-assign path by
+    // including the create op is NOT this builder's job; here we prove the ASSIGN
+    // op the builder emits is gate-VALID and flows). The MOCK writer captures the
+    // assign intent regardless of pre-existing roleset.
+    const assignmentsRes = await buildTierAssignments({
+      leaderboard: [lbEntry("0xcore", "core"), lbEntry("0xelder", "elder")],
+      roleMap: ROLE_MAP,
+      link: linkFrom({ "0xcore": "member-1", "0xelder": "member-2" }),
+    });
+    expect(assignmentsRes.assignments.length).toBe(2);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const mode = yield* makeModeControl("SHADOW");
+        const out = yield* goLive(mode, {
+          actor: ADMIN, world: WORLD, reportHash: h64(MAP_HASH), currentMapHash: h64(MAP_HASH),
+          transitionVersion: 5, evaluatedAt: "2026-06-02T00:00:00Z", rosterFreshness: NO_DRIFT,
+        }).pipe(Effect.provide(Layer.mergeAll(
+          makeAdminAllowlistInMemory(new Map([[WORLD as unknown as string, [ADMIN]]])),
+          emitterLayer,
+        )));
+
+        const transition: AuthorizedTransition = {
+          actor: ADMIN,
+          reportHash: MAP_HASH,
+          authzDecisionId: out.authzDecisionId,
+          transitionVersion: 5,
+          tokenMetadata: { kid: "kid-1", verified_at: "2026-06-02T00:00:00Z", exp: "2026-06-02T01:00:00Z" },
+        };
+        const batch = assembleAssignBatch({
+          world: "purupuru",
+          transition,
+          rosterVersion: ROSTER_VERSION,
+          assignments: assignmentsRes.assignments,
+        });
+
+        return yield* GateCheckedRoleWriter.pipe(
+          Effect.flatMap((g) => g.applyBatch(batch, out.capability)),
+          Effect.provide(fullStack(mode, emitterLayer, [ADMIN])),
+        );
+      }),
+    );
+
+    expect(result.status).toBe("done");
+    expect(result.progress.completed).toBe(2);
+    // exactly the two assign ops, captured by the MOCK writer (zero REAL writes).
+    const assigns = capturedWrites().filter((w) => w.kind === "assign_role");
+    expect(assigns.length).toBe(2);
+    expect(assigns.map((w) => w.member_id).sort()).toEqual(["member-1", "member-2"]);
+    expect(capturedWrites().filter((w) => w.kind === "create_role").length).toBe(0); // assign-only
+    expect(recorder.countOf("shadow.role.applied.v1")).toBe(2);
+    expect(recorder.countOf("shadow.role.rejected.v1")).toBe(0);
+  });
+
+  test("a batch with a MISBOUND report_hash is refused by the gate (hash binding)", async () => {
+    const { layer: emitterLayer } = makeRecordingEmitter();
+    const res = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const mode = yield* makeModeControl("SHADOW");
+          const out = yield* goLive(mode, {
+            actor: ADMIN, world: WORLD, reportHash: h64(MAP_HASH), currentMapHash: h64(MAP_HASH),
+            transitionVersion: 9, evaluatedAt: "2026-06-02T00:00:00Z", rosterFreshness: NO_DRIFT,
+          }).pipe(Effect.provide(Layer.mergeAll(
+            makeAdminAllowlistInMemory(new Map([[WORLD as unknown as string, [ADMIN]]])),
+            emitterLayer,
+          )));
+          // build a batch bound to the WRONG report hash (not the go_live one).
+          const transition: AuthorizedTransition = {
+            actor: ADMIN,
+            reportHash: "f".repeat(64), // ≠ MAP_HASH → gate refuses
+            authzDecisionId: out.authzDecisionId,
+            transitionVersion: 9,
+            tokenMetadata: { kid: "kid-1", verified_at: "2026-06-02T00:00:00Z", exp: "2026-06-02T01:00:00Z" },
+          };
+          const batch = assembleAssignBatch({
+            world: "purupuru",
+            transition,
+            rosterVersion: ROSTER_VERSION,
+            assignments: [{ wallet: "0xa", member_id: "m-1", tier: "core", role_key: "purupuru:core" }],
+          });
+          return yield* GateCheckedRoleWriter.pipe(
+            Effect.flatMap((g) => g.applyBatch(batch, out.capability)),
+            Effect.provide(fullStack(mode, emitterLayer, [ADMIN])),
+          );
+        }),
+      ),
+    );
+    expect(res._tag).toBe("Left"); // WriteError: authz binding mismatch
+  });
+});

--- a/apps/bot/src/shadow/score-tier-assignment.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.ts
@@ -50,6 +50,7 @@
  */
 import { sha256 } from "@noble/hashes/sha256";
 import { utf8ToBytes, bytesToHex } from "@noble/hashes/utils";
+import { computeProposed } from "./substrate.ts";
 import type {
   RoleRule,
   RoleMapConfig,
@@ -59,6 +60,7 @@ import type {
   RosterVersion,
   Hex64,
   WorldSlug,
+  CurrentRoster,
 } from "@freeside-worlds/shadow-substrate";
 import type { CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
 import { tierQualifies, type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
@@ -212,6 +214,99 @@ export function assignmentsToOps(
       intent: { role_key: a.role_key, member_id: a.member_id as never },
     };
   });
+}
+
+// ─── the CREATE pass (FR-4) — integrates with the substrate's computeProposed ─
+
+/** Deterministic op_id for a create op (stable across retries). */
+export function createOpId(world: string, roleKey: string): string {
+  return `create:${world}:${roleKey}`;
+}
+
+/**
+ * Derive the CREATE pass (FR-4): the `create_role` ops for managed tier roles
+ * that do not yet exist on the guild. This does NOT reimplement the create
+ * decision — it delegates to the substrate's PURE `computeProposed(roleMap,
+ * currentRoster)`, whose `to_create` list is the FR-4 "not-yet-created managed
+ * roles" set (a rule whose `role_key` is absent from the current roster AND
+ * `create_if_absent`). We then map each `to_create` entry → a `create_role`
+ * WriteOp with the same deterministic op_id/idempotency_key scheme the assign
+ * ops use, so the gate's check-then-create + retry reconciliation are safe.
+ *
+ * A `create_role` op MUST precede the `assign_role` op(s) for the same role_key
+ * in the SAME batch — the live writer's per-batch id-map then binds the assign to
+ * the id IT created (confused-deputy precision). `assembleGoLiveBatch` orders
+ * them creates-first.
+ */
+export function buildCreateOps(
+  world: string,
+  reportHash: string,
+  roleMap: RoleMapConfig,
+  currentRoster: CurrentRoster,
+): WriteOp[] {
+  if (!roleMap.enabled) return [];
+  const proposed = computeProposed(roleMap, currentRoster);
+  return proposed.to_create.map((c) => {
+    const op_id = createOpId(world, c.role_key);
+    return {
+      op_id,
+      // reuse the assign idempotency-key derivation (it is keyed on {world,
+      // op_id, report_hash} — op_id already encodes create-vs-assign + role_key,
+      // so the key is distinct from an assign op for the same role_key).
+      idempotency_key: assignIdempotencyKey(world, op_id, reportHash),
+      kind: "create_role" as const,
+      intent: { role_key: c.role_key, display_name: c.display_name },
+    };
+  });
+}
+
+// ─── full go_live batch assembly (CREATE pass + ASSIGN pass) ──────────────────
+
+export interface AssembleGoLiveBatchInput extends AssembleBatchInput {
+  /**
+   * the current guild roster (from the LIVE RosterSource). Drives the FR-4
+   * create pass via `computeProposed`. The role-map whose `to_create` rules are
+   * resolved against it.
+   */
+  readonly roleMap: RoleMapConfig;
+  readonly currentRoster: CurrentRoster;
+}
+
+/**
+ * Assemble the FULL gate-ready `WriteIntentBatch` for a tier→role go_live:
+ * the FR-4 CREATE pass (not-yet-created managed roles, ordered FIRST) followed by
+ * the per-member ASSIGN pass. Both passes share ONE `AuthzContext` bound to the
+ * authorized transition + roster version. The gate processes create-ops (under
+ * the WorldLock, check-then-create) then assign-ops in order; the live writer's
+ * per-batch id binding ties a same-batch assign to the role it just created.
+ *
+ * This is the COMBINED counterpart to `assembleAssignBatch` (assign-only). Use
+ * this from the go_live orchestration entrypoint when roles may not yet exist;
+ * use `assembleAssignBatch` when the caller has already run a separate create
+ * pass (e.g. the substrate go_live job) and only needs the assign batch.
+ */
+export function assembleGoLiveBatch(input: AssembleGoLiveBatchInput): WriteIntentBatch {
+  const { world, transition: t } = input;
+  const authz: AuthzContext = {
+    actor: t.actor,
+    world: world as unknown as WorldSlug,
+    report_hash: t.reportHash as unknown as Hex64,
+    token_metadata: t.tokenMetadata,
+    transition_version: t.transitionVersion,
+    authz_decision_id: t.authzDecisionId,
+    roster_version: input.rosterVersion,
+  };
+  const createOps = buildCreateOps(world, t.reportHash, input.roleMap, input.currentRoster);
+  const assignOps = assignmentsToOps(world, t.reportHash, input.assignments);
+  return {
+    world: world as unknown as WorldSlug,
+    report_hash: t.reportHash as unknown as Hex64,
+    authz,
+    // CREATE ops FIRST (FR-4), then ASSIGN ops — the gate's per-batch id binding
+    // requires the create to precede the assign for a same-role same-batch op.
+    ops: [...createOps, ...assignOps],
+    max_concurrent: input.maxConcurrent ?? 4,
+  };
 }
 
 // ─── full batch assembly (threads the goLive outputs) ────────────────────────

--- a/apps/bot/src/shadow/score-tier-assignment.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.ts
@@ -1,0 +1,272 @@
+/**
+ * shadow/score-tier-assignment.ts — the per-member tier→role ASSIGN-BATCH
+ * builder (bd-tfl part 2): "manage Discord roles by score-api tier".
+ *
+ * ── THE PATH (grounded against the substrate's write model) ──────────────────
+ *   score-api Purupuru leaderboard (wallet → tier)
+ *     ⋈ identity (wallet ↔ discord SNOWFLAKE)
+ *     ⋈ CM role-map rules (tier → role_key, via RoleRule.qualifies.min_tier)
+ *   → for each linked wallet that qualifies a rule:
+ *         AssignRoleIntent{ role_key, member_id: <discord snowflake> }
+ *   → WriteOp[] (assign_role) → WriteIntentBatch → gate.applyBatch (the SINGLE
+ *     gated write path; this module NEVER touches discord.js directly — the
+ *     cross-repo import-boundary lint forbids it).
+ *
+ * ── WHAT THIS MODULE OWNS vs THE SUBSTRATE GAPS ──────────────────────────────
+ * This module owns the PURE JOIN + the batch ASSEMBLY. It does NOT mint a
+ * `WriteCapability` and does NOT manufacture an `AuthzContext` out of thin air —
+ * BOTH come from the substrate's authorized `goLive` (the SHADOW→LIVE
+ * transition; `goLive` is SACRED / SHA-pinned and returns
+ * `{ capability, authzDecisionId }`). `assembleAssignBatch` therefore TAKES the
+ * go_live outputs + a roster-freshness `RosterVersion` and threads them into a
+ * well-formed `WriteIntentBatch` whose hash-binding invariants the gate enforces.
+ *
+ * TWO genuine seams are NOT closed here (flagged in the build report + a new
+ * bead; do NOT fake them):
+ *   1. The LIVE wallet↔discord-SNOWFLAKE adapter. The join needs a Discord
+ *      snowflake `member_id` (the gate's `assignRole` does
+ *      `guild.members.fetch(member_id)`). The repo's `WalletResolver` port
+ *      surfaces a `discord_handle` (display string), NOT a snowflake — unusable
+ *      for assignment. The freeside_auth MCP resolver DOES carry
+ *      `ResolvedWallet.discord_id` (the snowflake, from `midi_profiles`), but no
+ *      port exposes it to the shadow seam yet. So this builder takes an
+ *      INJECTABLE `WalletDiscordLink` resolver; the live adapter that reads
+ *      `discord_id` is the follow-up.
+ *   2. The orchestration that calls `goLive` (mints the cap) then this builder
+ *      then `applyBatch` is not wired into a bot entrypoint yet — `goLive`
+ *      requires an authorized admin + roster-freshness inputs (the lens/CM
+ *      flow). This module provides the reusable pieces; the entrypoint that
+ *      sequences them is the next layer.
+ *
+ * ── SAFETY ───────────────────────────────────────────────────────────────────
+ *   • assign-ONLY (FR-6 of the brief). This builder NEVER emits a create_role op
+ *     and NEVER a role REMOVAL — shadow-onboarding never strips users (R-6). It
+ *     assigns the highest-qualifying tier role per member.
+ *   • namespace: every `role_key` comes from the CM role-map rules (already
+ *     Freeside-namespaced); the gate's writer re-enforces the namespace guard.
+ *   • idempotent: deterministic `op_id`/`idempotency_key` per (world, report,
+ *     role_key, member_id) so a retried batch is safe (the gate dedups assigns;
+ *     a held role is a Discord no-op).
+ */
+import { sha256 } from "@noble/hashes/sha256";
+import { utf8ToBytes, bytesToHex } from "@noble/hashes/utils";
+import type {
+  RoleRule,
+  RoleMapConfig,
+  WriteOp,
+  WriteIntentBatch,
+  AuthzContext,
+  RosterVersion,
+  Hex64,
+  WorldSlug,
+} from "@freeside-worlds/shadow-substrate";
+import type { CommunityLeaderboardEntry } from "@freeside-characters/persona-engine/score/community-client";
+import { tierQualifies, type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
+
+// ─── identity link port (the wallet ↔ discord-snowflake seam) ────────────────
+
+/**
+ * Resolve a wallet → its Discord snowflake `member_id`, or null when the wallet
+ * is not linked. INJECTABLE: tests provide a map; the LIVE adapter (follow-up,
+ * see header gap #1) reads `ResolvedWallet.discord_id` from the freeside_auth /
+ * identity-api source. A null link means the wallet is QUALIFIED-but-not-linked
+ * (counted in `skipped_unlinked`), never assigned.
+ */
+export interface WalletDiscordLink {
+  /** wallet (any case) → discord snowflake, or null if not linked. */
+  resolve(wallet: string): Promise<string | null>;
+}
+
+// ─── the pure join → assign ops ──────────────────────────────────────────────
+
+/** One resolved assignment (pre-WriteOp), for legibility + testing. */
+export interface TierAssignment {
+  readonly wallet: string;
+  readonly member_id: string;
+  readonly tier: string;
+  readonly role_key: string;
+}
+
+export interface BuildAssignmentsInput {
+  readonly leaderboard: ReadonlyArray<CommunityLeaderboardEntry>;
+  readonly roleMap: RoleMapConfig;
+  readonly link: WalletDiscordLink;
+  readonly tierRank?: TierRankResolver;
+}
+
+export interface BuildAssignmentsResult {
+  readonly assignments: ReadonlyArray<TierAssignment>;
+  /** qualified wallets with NO discord link (counted, never assigned). */
+  readonly skipped_unlinked: number;
+  /** wallets that qualified no rule (below every rule's min_tier / untiered). */
+  readonly skipped_unqualified: number;
+}
+
+/**
+ * Pick the STRONGEST rule a wallet's tier qualifies (highest min_tier rank). A
+ * wallet gets at most ONE managed tier role — the top one it earns. Returns the
+ * winning rule or undefined when the wallet qualifies none.
+ */
+function strongestQualifyingRule(
+  tier: string | null,
+  rules: ReadonlyArray<RoleRule>,
+  rank: TierRankResolver,
+): RoleRule | undefined {
+  let best: RoleRule | undefined;
+  let bestRank = -Infinity;
+  for (const rule of rules) {
+    if (!tierQualifies(tier, rule.qualifies.min_tier, rank)) continue;
+    const r = rank(rule.qualifies.min_tier) ?? -Infinity;
+    if (r > bestRank) {
+      best = rule;
+      bestRank = r;
+    }
+  }
+  return best;
+}
+
+/**
+ * Build the per-member assignments by joining the leaderboard ⋈ identity links ⋈
+ * role-map rules. Pure except for the injected `link.resolve` (async). Emits at
+ * most one assignment per linked, qualified wallet (its strongest tier role).
+ * Disabled role-maps (`enabled:false`) produce zero assignments.
+ */
+export async function buildTierAssignments(
+  input: BuildAssignmentsInput,
+): Promise<BuildAssignmentsResult> {
+  const rank = input.tierRank ?? purupuruTierRank;
+  if (!input.roleMap.enabled) {
+    return { assignments: [], skipped_unlinked: 0, skipped_unqualified: 0 };
+  }
+  const rules = input.roleMap.rules;
+  const assignments: TierAssignment[] = [];
+  let skipped_unlinked = 0;
+  let skipped_unqualified = 0;
+
+  for (const entry of input.leaderboard) {
+    const rule = strongestQualifyingRule(entry.tier, rules, rank);
+    if (!rule) {
+      skipped_unqualified += 1;
+      continue;
+    }
+    const memberId = await input.link.resolve(entry.wallet);
+    if (memberId === null || memberId.length === 0) {
+      skipped_unlinked += 1;
+      continue;
+    }
+    assignments.push({
+      wallet: entry.wallet,
+      member_id: memberId,
+      // entry.tier is non-null here (strongestQualifyingRule returned a rule).
+      tier: entry.tier as string,
+      role_key: rule.role_key,
+    });
+  }
+
+  return { assignments, skipped_unlinked, skipped_unqualified };
+}
+
+// ─── op_id / idempotency_key (deterministic, retry-safe) ─────────────────────
+
+/**
+ * Stable JSON (sorted keys) for the hash inputs. The inputs are flat objects of
+ * strings, so a sorted-key serialize is a sufficient canonical form (a full RFC
+ * 8785 JCS is overkill for primitive-only maps and would add a dep apps/bot
+ * doesn't carry). Determinism is the requirement; this delivers it.
+ */
+function stableStringify(obj: Record<string, string>): string {
+  const keys = Object.keys(obj).sort();
+  return JSON.stringify(Object.fromEntries(keys.map((k) => [k, obj[k]])));
+}
+
+function sha256Hex(input: string): string {
+  return bytesToHex(sha256(utf8ToBytes(input)));
+}
+
+/** Deterministic op_id for an assign op (stable across retries). */
+export function assignOpId(world: string, roleKey: string, memberId: string): string {
+  return `assign:${world}:${roleKey}:${memberId}`;
+}
+
+/** = sha256(stableJSON({world, op_id, report_hash})) — the gate's retry key. */
+export function assignIdempotencyKey(
+  world: string,
+  opId: string,
+  reportHash: string,
+): Hex64 {
+  return sha256Hex(stableStringify({ world, op_id: opId, report_hash: reportHash })) as unknown as Hex64;
+}
+
+/** Map resolved assignments → substrate `WriteOp[]` (assign_role only). */
+export function assignmentsToOps(
+  world: string,
+  reportHash: string,
+  assignments: ReadonlyArray<TierAssignment>,
+): WriteOp[] {
+  return assignments.map((a) => {
+    const op_id = assignOpId(world, a.role_key, a.member_id);
+    return {
+      op_id,
+      idempotency_key: assignIdempotencyKey(world, op_id, reportHash),
+      kind: "assign_role" as const,
+      intent: { role_key: a.role_key, member_id: a.member_id as never },
+    };
+  });
+}
+
+// ─── full batch assembly (threads the goLive outputs) ────────────────────────
+
+/**
+ * The pieces the substrate's authorized `goLive` hands back (its `GoLiveOutput`
+ * carries `authzDecisionId`; the caller already knows `reportHash` /
+ * `transitionVersion` it passed in). We take them as inputs rather than
+ * recomputing — the gate binds all four of {current map hash, cap report_hash,
+ * batch report_hash, authz report_hash} + decision_id + transition_version.
+ */
+export interface AuthorizedTransition {
+  readonly actor: string;
+  readonly reportHash: string;
+  readonly authzDecisionId: string;
+  readonly transitionVersion: number;
+  readonly tokenMetadata: { readonly kid: string; readonly verified_at: string; readonly exp: string };
+}
+
+export interface AssembleBatchInput {
+  readonly world: string;
+  readonly transition: AuthorizedTransition;
+  readonly rosterVersion: RosterVersion;
+  readonly assignments: ReadonlyArray<TierAssignment>;
+  /** intra-batch in-flight cap (gate default 4). */
+  readonly maxConcurrent?: number;
+}
+
+/**
+ * Assemble a gate-ready `WriteIntentBatch` of assign ops from resolved
+ * assignments + an authorized transition. The returned batch is what
+ * `GateCheckedRoleWriter.applyBatch(batch, cap)` consumes — the cap being the one
+ * `goLive` minted for the SAME `{reportHash, authzDecisionId, transitionVersion}`.
+ *
+ * NOTE: this builds the assign-only batch. If the namespaced tier roles don't yet
+ * exist on the guild, a SEPARATE create-role pass (the substrate's go_live /
+ * computeProposed flow, FR-4) must precede it — this builder is the ASSIGN half
+ * (per the brief: "per-member tier→role assign-batch").
+ */
+export function assembleAssignBatch(input: AssembleBatchInput): WriteIntentBatch {
+  const { world, transition: t } = input;
+  const authz: AuthzContext = {
+    actor: t.actor,
+    world: world as unknown as WorldSlug,
+    report_hash: t.reportHash as unknown as Hex64,
+    token_metadata: t.tokenMetadata,
+    transition_version: t.transitionVersion,
+    authz_decision_id: t.authzDecisionId,
+    roster_version: input.rosterVersion,
+  };
+  return {
+    world: world as unknown as WorldSlug,
+    report_hash: t.reportHash as unknown as Hex64,
+    authz,
+    ops: assignmentsToOps(world, t.reportHash, input.assignments),
+    max_concurrent: input.maxConcurrent ?? 4,
+  };
+}

--- a/apps/bot/src/shadow/score-tier-assignment.ts
+++ b/apps/bot/src/shadow/score-tier-assignment.ts
@@ -102,21 +102,54 @@ export interface BuildAssignmentsResult {
   readonly skipped_unlinked: number;
   /** wallets that qualified no rule (below every rule's min_tier / untiered). */
   readonly skipped_unqualified: number;
+  /**
+   * qualified+linked wallets whose member_id was NOT a valid Discord snowflake
+   * (Bridgebuilder #12 — counted SEPARATELY from unlinked, never assigned).
+   */
+  readonly skipped_invalid: number;
+  /**
+   * extra (wallet → same member) assignments collapsed by the per-member dedup
+   * (Bridgebuilder #6). N wallets linked to ONE member emit ONE op; the N-1
+   * collapsed are counted here. 0 in the common one-wallet-per-member case.
+   */
+  readonly collapsed_duplicate_members: number;
 }
+
+/**
+ * Discord snowflakes are 17-20 digit decimal ids. A member_id that is not
+ * snowflake-shaped can never `guild.members.fetch` — it is INVALID, not an
+ * assignment (Bridgebuilder #12). The live link adapter already rejects malformed
+ * ids at the source; this is the builder's defense-in-depth (a test double or a
+ * future source could still hand one through).
+ */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
 
 /**
  * Pick the STRONGEST rule a wallet's tier qualifies (highest min_tier rank). A
  * wallet gets at most ONE managed tier role — the top one it earns. Returns the
  * winning rule or undefined when the wallet qualifies none.
+ *
+ * Bridgebuilder #13: a NON-tier rule (`qualifies.source !== 'tier'`) is skipped
+ * EXPLICITLY — we do not rely on `min_tier===undefined` accidentally fail-closing
+ * through `tierQualifies`. The substrate's `RoleRule` currently types `source` as
+ * the literal `'tier'`, but this guard is defense-in-depth against a future
+ * widening or unvalidated config; `skippedNonTier` makes the skip observable.
  */
 function strongestQualifyingRule(
   tier: string | null,
   rules: ReadonlyArray<RoleRule>,
   rank: TierRankResolver,
-): RoleRule | undefined {
+): { rule: RoleRule | undefined; skippedNonTier: number } {
   let best: RoleRule | undefined;
   let bestRank = -Infinity;
+  let skippedNonTier = 0;
   for (const rule of rules) {
+    // EXPLICIT non-tier skip (#13): only tier-sourced rules participate in the
+    // tier→role join. Anything else is observably skipped, not silently dropped.
+    if (rule.qualifies.source !== "tier") {
+      skippedNonTier += 1;
+      continue;
+    }
     if (!tierQualifies(tier, rule.qualifies.min_tier, rank)) continue;
     const r = rank(rule.qualifies.min_tier) ?? -Infinity;
     if (r > bestRank) {
@@ -124,7 +157,7 @@ function strongestQualifyingRule(
       bestRank = r;
     }
   }
-  return best;
+  return { rule: best, skippedNonTier };
 }
 
 /**
@@ -138,15 +171,29 @@ export async function buildTierAssignments(
 ): Promise<BuildAssignmentsResult> {
   const rank = input.tierRank ?? purupuruTierRank;
   if (!input.roleMap.enabled) {
-    return { assignments: [], skipped_unlinked: 0, skipped_unqualified: 0 };
+    return {
+      assignments: [],
+      skipped_unlinked: 0,
+      skipped_unqualified: 0,
+      skipped_invalid: 0,
+      collapsed_duplicate_members: 0,
+    };
   }
   const rules = input.roleMap.rules;
-  const assignments: TierAssignment[] = [];
   let skipped_unlinked = 0;
   let skipped_unqualified = 0;
+  let skipped_invalid = 0;
+
+  // PER-MEMBER (not per-wallet) dedup (Bridgebuilder #6): a Discord member may
+  // own MULTIPLE wallets (the freeside_auth `additional_wallets` fan-in resolves
+  // them all to ONE snowflake). Two qualifying wallets for one member must emit
+  // ONE assign op for that member's STRONGEST tier — not two competing ops. We
+  // resolve the link FIRST, then key the winner by member_id.
+  const byMember = new Map<string, TierAssignment>();
+  let collapsed_duplicate_members = 0;
 
   for (const entry of input.leaderboard) {
-    const rule = strongestQualifyingRule(entry.tier, rules, rank);
+    const { rule } = strongestQualifyingRule(entry.tier, rules, rank);
     if (!rule) {
       skipped_unqualified += 1;
       continue;
@@ -156,16 +203,39 @@ export async function buildTierAssignments(
       skipped_unlinked += 1;
       continue;
     }
-    assignments.push({
+    // #12 (count side): a non-snowflake member_id is INVALID — counted apart from
+    // unlinked, never assigned.
+    if (!SNOWFLAKE_RE.test(memberId)) {
+      skipped_invalid += 1;
+      continue;
+    }
+
+    const candidate: TierAssignment = {
       wallet: entry.wallet,
       member_id: memberId,
       // entry.tier is non-null here (strongestQualifyingRule returned a rule).
       tier: entry.tier as string,
       role_key: rule.role_key,
-    });
+    };
+    const existing = byMember.get(memberId);
+    if (!existing) {
+      byMember.set(memberId, candidate);
+      continue;
+    }
+    // SAME member, two wallets → keep the STRONGER tier; the other is collapsed.
+    collapsed_duplicate_members += 1;
+    const existingRank = rank(existing.tier) ?? -Infinity;
+    const candidateRank = rank(candidate.tier) ?? -Infinity;
+    if (candidateRank > existingRank) byMember.set(memberId, candidate);
   }
 
-  return { assignments, skipped_unlinked, skipped_unqualified };
+  return {
+    assignments: [...byMember.values()],
+    skipped_unlinked,
+    skipped_unqualified,
+    skipped_invalid,
+    collapsed_duplicate_members,
+  };
 }
 
 // ─── op_id / idempotency_key (deterministic, retry-safe) ─────────────────────

--- a/apps/bot/src/shadow/substrate.ts
+++ b/apps/bot/src/shadow/substrate.ts
@@ -33,6 +33,7 @@ export {
   rollback,
   resolveAuthz,
   resolveReader,
+  rosterFingerprint,
   // ── Pure compute core ──
   roleMapVersionHash,
   computeProposed,

--- a/apps/bot/src/shadow/wallet-discord-link.live.test.ts
+++ b/apps/bot/src/shadow/wallet-discord-link.live.test.ts
@@ -1,0 +1,181 @@
+/**
+ * wallet-discord-link.live.test.ts — the LIVE `WalletDiscordLink` adapter
+ * (bd-m2v SEAM 1). All network-free: the freeside_auth batch resolver is
+ * INJECTED (a pure map-backed double), zero pg / zero MCP.
+ *
+ * Proves:
+ *   • wallet → snowflake when midi_profiles has a found row with discord_id;
+ *   • FAIL-CLOSED → null when not found, or found-but-no-discord_id (skipped,
+ *     never assigned by the builder);
+ *   • case-insensitive wallet matching (the source normalizes lowercase);
+ *   • BATCHING: an N-wallet flush coalesces into a bounded number of underlying
+ *     calls (request-coalescing), not O(N);
+ *   • CACHING: a repeat resolve() within TTL does NOT re-hit the resolver;
+ *   • a resolver THROW is fail-closed (null this run) and NOT cached;
+ *   • the MOCK helper.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  makeWalletDiscordLinkLive,
+  makeWalletDiscordLinkMock,
+  type BatchWalletResolver,
+  type ResolvedWalletLike,
+} from "./wallet-discord-link.live.ts";
+
+/** Build an injectable batch resolver from a wallet→(discord_id|null) map. */
+function resolverFrom(
+  map: Record<string, string | null>,
+  counter?: { calls: number; batches: string[][] },
+): BatchWalletResolver {
+  return async (wallets) => {
+    if (counter) {
+      counter.calls += 1;
+      counter.batches.push([...wallets]);
+    }
+    return wallets.map((w): ResolvedWalletLike => {
+      const key = w.toLowerCase();
+      const has = Object.prototype.hasOwnProperty.call(map, key);
+      const discord = has ? map[key]! : null;
+      return { wallet: key, found: has, discord_id: discord ?? null };
+    });
+  };
+}
+
+describe("makeWalletDiscordLinkLive — resolution", () => {
+  test("resolves wallet → discord snowflake when midi_profiles has the link", async () => {
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom({ "0xabc": "123456789012345678" }),
+    });
+    expect(await link.resolve("0xABC")).toBe("123456789012345678"); // case-insensitive
+  });
+
+  test("FAIL-CLOSED → null when the wallet is not found (skipped, never assigned)", async () => {
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom({ "0xabc": "111" }),
+    });
+    expect(await link.resolve("0xnotlinked")).toBeNull();
+  });
+
+  test("FAIL-CLOSED → null when found but discord_id is null/empty", async () => {
+    const resolver: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({ wallet: w.toLowerCase(), found: true, discord_id: null }));
+    const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolver });
+    expect(await link.resolve("0xfoundnodiscord")).toBeNull();
+
+    const resolverEmpty: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({ wallet: w.toLowerCase(), found: true, discord_id: "" }));
+    const link2 = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolverEmpty });
+    expect(await link2.resolve("0xfoundempty")).toBeNull();
+  });
+
+  test("empty / whitespace wallet → null without hitting the resolver", async () => {
+    const counter = { calls: 0, batches: [] as string[][] };
+    const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolverFrom({}, counter) });
+    expect(await link.resolve("   ")).toBeNull();
+    expect(counter.calls).toBe(0);
+  });
+});
+
+describe("makeWalletDiscordLinkLive — batching + caching", () => {
+  test("coalesces concurrent resolves into ONE underlying batch call (not O(N))", async () => {
+    const counter = { calls: 0, batches: [] as string[][] };
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom(
+        { "0xa": "1", "0xb": "2", "0xc": "3" },
+        counter,
+      ),
+    });
+    // Fire all three in the SAME tick (mirrors the builder's loop awaiting later).
+    const [a, b, c] = await Promise.all([
+      link.resolve("0xa"),
+      link.resolve("0xb"),
+      link.resolve("0xc"),
+    ]);
+    expect([a, b, c]).toEqual(["1", "2", "3"]);
+    expect(counter.calls).toBe(1); // ONE batched lookup, not three
+    expect(counter.batches[0]!.sort()).toEqual(["0xa", "0xb", "0xc"]);
+  });
+
+  test("respects batchSize (chunks a large flush)", async () => {
+    const counter = { calls: 0, batches: [] as string[][] };
+    const map: Record<string, string> = {};
+    const wallets: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const w = `0x${i}`;
+      map[w] = `snow-${i}`;
+      wallets.push(w);
+    }
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom(map, counter),
+      batchSize: 2,
+    });
+    const out = await Promise.all(wallets.map((w) => link.resolve(w)));
+    expect(out).toEqual(["snow-0", "snow-1", "snow-2", "snow-3", "snow-4"]);
+    // 5 distinct wallets / batchSize 2 → 3 underlying slices.
+    expect(counter.calls).toBe(3);
+  });
+
+  test("caches a resolved link — a repeat resolve does NOT re-hit the resolver", async () => {
+    const counter = { calls: 0, batches: [] as string[][] };
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom({ "0xa": "1" }, counter),
+    });
+    expect(await link.resolve("0xa")).toBe("1");
+    expect(await link.resolve("0xa")).toBe("1"); // served from cache
+    expect(counter.calls).toBe(1);
+  });
+
+  test("caches resolved-null too (a known-unlinked wallet is not re-queried)", async () => {
+    const counter = { calls: 0, batches: [] as string[][] };
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom({ "0xa": "1" }, counter),
+    });
+    expect(await link.resolve("0xmissing")).toBeNull();
+    expect(await link.resolve("0xmissing")).toBeNull();
+    expect(counter.calls).toBe(1); // resolved-null cached
+  });
+
+  test("a resolver THROW is fail-closed (null this run) and NOT cached (retries)", async () => {
+    let throwOnce = true;
+    const counter = { calls: 0 };
+    const resolver: BatchWalletResolver = async (wallets) => {
+      counter.calls += 1;
+      if (throwOnce) {
+        throwOnce = false;
+        throw new Error("midi_profiles unavailable");
+      }
+      return wallets.map((w) => ({ wallet: w.toLowerCase(), found: true, discord_id: "9" }));
+    };
+    const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolver });
+    expect(await link.resolve("0xa")).toBeNull(); // first flush throws → fail-closed null
+    expect(await link.resolve("0xa")).toBe("9"); // NOT cached as null → retried, now resolves
+    expect(counter.calls).toBe(2);
+  });
+
+  test("expires cache after TTL (re-queries with an injected clock)", async () => {
+    const counter = { calls: 0, batches: [] as string[][] };
+    let t = 1_000;
+    const link = makeWalletDiscordLinkLive({
+      resolveWalletsImpl: resolverFrom({ "0xa": "1" }, counter),
+      cacheTtlMs: 100,
+      now: () => t,
+    });
+    expect(await link.resolve("0xa")).toBe("1");
+    expect(counter.calls).toBe(1);
+    t += 50; // within TTL
+    expect(await link.resolve("0xa")).toBe("1");
+    expect(counter.calls).toBe(1);
+    t += 200; // past TTL → re-query
+    expect(await link.resolve("0xa")).toBe("1");
+    expect(counter.calls).toBe(2);
+  });
+});
+
+describe("makeWalletDiscordLinkMock", () => {
+  test("returns mapped snowflake, case-insensitive; null when absent", async () => {
+    const link = makeWalletDiscordLinkMock({ "0xAaa": "555", "0xbbb": null });
+    expect(await link.resolve("0xaaa")).toBe("555");
+    expect(await link.resolve("0xBBB")).toBeNull();
+    expect(await link.resolve("0xccc")).toBeNull();
+  });
+});

--- a/apps/bot/src/shadow/wallet-discord-link.live.test.ts
+++ b/apps/bot/src/shadow/wallet-discord-link.live.test.ts
@@ -18,9 +18,17 @@ import { describe, expect, test } from "bun:test";
 import {
   makeWalletDiscordLinkLive,
   makeWalletDiscordLinkMock,
+  LinkResolutionError,
   type BatchWalletResolver,
   type ResolvedWalletLike,
 } from "./wallet-discord-link.live.ts";
+
+/** A valid 17-20-digit Discord snowflake from a short tag (post-#12 the live
+ *  adapter rejects non-snowflake ids, so fixtures must be well-formed). */
+function sf(tag: string | number): string {
+  const digits = String(tag).replace(/\D/g, "") || "0";
+  return ("9" + digits.padStart(17, "0")).slice(0, 18);
+}
 
 /** Build an injectable batch resolver from a wallet→(discord_id|null) map. */
 function resolverFrom(
@@ -51,7 +59,7 @@ describe("makeWalletDiscordLinkLive — resolution", () => {
 
   test("FAIL-CLOSED → null when the wallet is not found (skipped, never assigned)", async () => {
     const link = makeWalletDiscordLinkLive({
-      resolveWalletsImpl: resolverFrom({ "0xabc": "111" }),
+      resolveWalletsImpl: resolverFrom({ "0xabc": sf("111") }),
     });
     expect(await link.resolve("0xnotlinked")).toBeNull();
   });
@@ -81,7 +89,7 @@ describe("makeWalletDiscordLinkLive — batching + caching", () => {
     const counter = { calls: 0, batches: [] as string[][] };
     const link = makeWalletDiscordLinkLive({
       resolveWalletsImpl: resolverFrom(
-        { "0xa": "1", "0xb": "2", "0xc": "3" },
+        { "0xa": sf(1), "0xb": sf(2), "0xc": sf(3) },
         counter,
       ),
     });
@@ -91,7 +99,7 @@ describe("makeWalletDiscordLinkLive — batching + caching", () => {
       link.resolve("0xb"),
       link.resolve("0xc"),
     ]);
-    expect([a, b, c]).toEqual(["1", "2", "3"]);
+    expect([a, b, c]).toEqual([sf(1), sf(2), sf(3)]);
     expect(counter.calls).toBe(1); // ONE batched lookup, not three
     expect(counter.batches[0]!.sort()).toEqual(["0xa", "0xb", "0xc"]);
   });
@@ -102,7 +110,7 @@ describe("makeWalletDiscordLinkLive — batching + caching", () => {
     const wallets: string[] = [];
     for (let i = 0; i < 5; i++) {
       const w = `0x${i}`;
-      map[w] = `snow-${i}`;
+      map[w] = sf(`10${i}`); // distinct valid snowflakes
       wallets.push(w);
     }
     const link = makeWalletDiscordLinkLive({
@@ -110,7 +118,7 @@ describe("makeWalletDiscordLinkLive — batching + caching", () => {
       batchSize: 2,
     });
     const out = await Promise.all(wallets.map((w) => link.resolve(w)));
-    expect(out).toEqual(["snow-0", "snow-1", "snow-2", "snow-3", "snow-4"]);
+    expect(out).toEqual([sf("100"), sf("101"), sf("102"), sf("103"), sf("104")]);
     // 5 distinct wallets / batchSize 2 → 3 underlying slices.
     expect(counter.calls).toBe(3);
   });
@@ -118,24 +126,24 @@ describe("makeWalletDiscordLinkLive — batching + caching", () => {
   test("caches a resolved link — a repeat resolve does NOT re-hit the resolver", async () => {
     const counter = { calls: 0, batches: [] as string[][] };
     const link = makeWalletDiscordLinkLive({
-      resolveWalletsImpl: resolverFrom({ "0xa": "1" }, counter),
+      resolveWalletsImpl: resolverFrom({ "0xa": sf(1) }, counter),
     });
-    expect(await link.resolve("0xa")).toBe("1");
-    expect(await link.resolve("0xa")).toBe("1"); // served from cache
+    expect(await link.resolve("0xa")).toBe(sf(1));
+    expect(await link.resolve("0xa")).toBe(sf(1)); // served from cache
     expect(counter.calls).toBe(1);
   });
 
   test("caches resolved-null too (a known-unlinked wallet is not re-queried)", async () => {
     const counter = { calls: 0, batches: [] as string[][] };
     const link = makeWalletDiscordLinkLive({
-      resolveWalletsImpl: resolverFrom({ "0xa": "1" }, counter),
+      resolveWalletsImpl: resolverFrom({ "0xa": sf(1) }, counter),
     });
     expect(await link.resolve("0xmissing")).toBeNull();
     expect(await link.resolve("0xmissing")).toBeNull();
     expect(counter.calls).toBe(1); // resolved-null cached
   });
 
-  test("a resolver THROW is fail-closed (null this run) and NOT cached (retries)", async () => {
+  test("a resolver THROW is fail-closed by REJECTING (#7) and NOT cached (retries)", async () => {
     let throwOnce = true;
     const counter = { calls: 0 };
     const resolver: BatchWalletResolver = async (wallets) => {
@@ -144,29 +152,85 @@ describe("makeWalletDiscordLinkLive — batching + caching", () => {
         throwOnce = false;
         throw new Error("midi_profiles unavailable");
       }
-      return wallets.map((w) => ({ wallet: w.toLowerCase(), found: true, discord_id: "9" }));
+      return wallets.map((w) => ({
+        wallet: w.toLowerCase(),
+        found: true,
+        discord_id: "123456789012345678",
+      }));
     };
     const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolver });
-    expect(await link.resolve("0xa")).toBeNull(); // first flush throws → fail-closed null
-    expect(await link.resolve("0xa")).toBe("9"); // NOT cached as null → retried, now resolves
+    // first flush throws → REJECT (NOT a silent null — that was the #7 fail-open bug).
+    await expect(link.resolve("0xa")).rejects.toBeInstanceOf(LinkResolutionError);
+    // NOT cached → a later resolve retries, now resolves.
+    expect(await link.resolve("0xa")).toBe("123456789012345678");
     expect(counter.calls).toBe(2);
+  });
+
+  // #7 — db_unavailable must FAIL the run, not be treated as confirmed-unlinked
+  test("FAIL-CLOSED #7: a `db_unavailable` resolution REJECTS (not a silent skip)", async () => {
+    const resolver: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({
+        wallet: w.toLowerCase(),
+        found: false,
+        discord_id: null,
+        resolved_via: "db_unavailable", // the identity DB was down — NOT confirmed-unlinked
+      }));
+    const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolver });
+    await expect(link.resolve("0xa")).rejects.toBeInstanceOf(LinkResolutionError);
+  });
+
+  test("a confirmed `unknown` (not db_unavailable) is null, NOT a reject (#7 boundary)", async () => {
+    const resolver: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({
+        wallet: w.toLowerCase(),
+        found: false,
+        discord_id: null,
+        resolved_via: "unknown", // genuinely not in midi_profiles
+      }));
+    const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolver });
+    expect(await link.resolve("0xa")).toBeNull(); // confirmed-unlinked → skipped, never throws
+  });
+
+  // #12 — snowflake-shape validation
+  test("FAIL-CLOSED #12: a NON-SNOWFLAKE discord_id is invalid → null (never assigned)", async () => {
+    const resolver: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({
+        wallet: w.toLowerCase(),
+        found: true,
+        discord_id: "not-a-snowflake", // a handle leaked into the column
+        resolved_via: "direct",
+      }));
+    const link = makeWalletDiscordLinkLive({ resolveWalletsImpl: resolver });
+    expect(await link.resolve("0xbad")).toBeNull();
+
+    // a too-short numeric value is also rejected.
+    const shortResolver: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({ wallet: w.toLowerCase(), found: true, discord_id: "12345" }));
+    const link2 = makeWalletDiscordLinkLive({ resolveWalletsImpl: shortResolver });
+    expect(await link2.resolve("0xshort")).toBeNull();
+
+    // a well-formed 18-digit snowflake passes.
+    const okResolver: BatchWalletResolver = async (wallets) =>
+      wallets.map((w) => ({ wallet: w.toLowerCase(), found: true, discord_id: "123456789012345678" }));
+    const link3 = makeWalletDiscordLinkLive({ resolveWalletsImpl: okResolver });
+    expect(await link3.resolve("0xok")).toBe("123456789012345678");
   });
 
   test("expires cache after TTL (re-queries with an injected clock)", async () => {
     const counter = { calls: 0, batches: [] as string[][] };
     let t = 1_000;
     const link = makeWalletDiscordLinkLive({
-      resolveWalletsImpl: resolverFrom({ "0xa": "1" }, counter),
+      resolveWalletsImpl: resolverFrom({ "0xa": sf(1) }, counter),
       cacheTtlMs: 100,
       now: () => t,
     });
-    expect(await link.resolve("0xa")).toBe("1");
+    expect(await link.resolve("0xa")).toBe(sf(1));
     expect(counter.calls).toBe(1);
     t += 50; // within TTL
-    expect(await link.resolve("0xa")).toBe("1");
+    expect(await link.resolve("0xa")).toBe(sf(1));
     expect(counter.calls).toBe(1);
     t += 200; // past TTL → re-query
-    expect(await link.resolve("0xa")).toBe("1");
+    expect(await link.resolve("0xa")).toBe(sf(1));
     expect(counter.calls).toBe(2);
   });
 });

--- a/apps/bot/src/shadow/wallet-discord-link.live.ts
+++ b/apps/bot/src/shadow/wallet-discord-link.live.ts
@@ -1,0 +1,240 @@
+/**
+ * shadow/wallet-discord-link.live.ts — the LIVE `WalletDiscordLink` adapter
+ * (bd-m2v SEAM 1): wallet → Discord SNOWFLAKE `member_id` | null.
+ *
+ * ── WHY THIS SOURCE (freeside_auth midi_profiles, NOT identity-api /v1/profile,
+ *    NOT the WalletResolver port) ───────────────────────────────────────────
+ * The assign builder (`score-tier-assignment.ts`) needs a Discord SNOWFLAKE for
+ * `member_id` — the gate's `assignRole` does `guild.members.fetch(member_id)`, so
+ * a handle/nym is useless. Three candidate sources exist in this repo:
+ *
+ *   1. `ambient/ports/wallet-resolver.port.ts` (WalletResolver) — surfaces
+ *      `discord_handle` (a DISPLAY string), NOT the snowflake. UNUSABLE here.
+ *   2. identity-api `/v1/profile?world=…&wallet=…` — surfaces a `nym`
+ *      (display name per world), NOT the Discord snowflake. UNUSABLE here.
+ *   3. `orchestrator/freeside_auth/server.ts` (`resolveWallet`/`resolveWallets`)
+ *      — reads `midi_profiles` directly (Railway Postgres) and returns
+ *      `ResolvedWallet.discord_id` = the SNOWFLAKE (from `wallet_address` direct
+ *      OR the `additional_wallets` jsonb fan-in). It is ALREADY batched
+ *      (`resolveWallets`) and 5-min cached in-process. This is the ONE source
+ *      that carries the snowflake AND is already wired in this repo (the persona
+ *      narration path consumes it), so it adds NO new dependency.
+ *
+ * So this adapter wraps `freeside_auth`'s batch resolver. We depend on it through
+ * an INJECTED function (`resolveWalletsImpl`) — not a static import of the MCP
+ * server module — so:
+ *   • tests inject a pure map (zero pg, zero MCP) — the conformance + assign
+ *     tests stay network-free (a hard constraint of the dispatch);
+ *   • the production default lazily imports `resolveWallets` from the
+ *     freeside_auth server, which fail-softs to `db_unavailable` (→ null link →
+ *     skipped) when `RAILWAY_MIBERA_DATABASE_URL` is unset. A wallet with no
+ *     link is QUALIFIED-but-not-linked: counted in `skipped_unlinked`, NEVER
+ *     assigned (FAIL-CLOSED, per the builder contract).
+ *
+ * ── BATCH + CACHE (the leaderboard can be large) ─────────────────────────────
+ * The builder calls `link.resolve(wallet)` once PER leaderboard entry. A naive
+ * adapter would issue one pg round-trip per wallet. Instead this adapter:
+ *   • COALESCES per-wallet `resolve()` calls within a short flush window into ONE
+ *     batched `resolveWallets([...])` call (request-coalescing), so an N-wallet
+ *     leaderboard is O(ceil(N / batchSize)) round-trips, not O(N);
+ *   • CACHES the wallet→snowflake|null result in-process with a TTL, so a
+ *     re-preview / retried batch within the window reuses prior resolutions.
+ * The underlying freeside_auth resolver ALSO caches (5-min), so this layer's
+ * cache is a cheap coalescing + the-builder-asked-twice guard, not the only one.
+ *
+ * NOTE: this module performs NO discord.js role mutation (only an identity read
+ * + the injected resolver) — it is OUTSIDE the import-boundary lint's concern
+ * (role READS / identity reads are allowed everywhere; only role MUTATIONS are
+ * confined to `role-writer.live.ts`).
+ */
+import type { WalletDiscordLink } from "./score-tier-assignment.ts";
+
+/**
+ * The minimal shape this adapter consumes from a `freeside_auth`-style batch
+ * resolver. Matches `resolveWallets(wallets) → ResolvedWallet[]` where each
+ * carries `wallet` (echoed, normalized lowercase) + `discord_id` (snowflake|null)
+ * + `found`. We read ONLY these three fields, so any compatible resolver (the
+ * real MCP-backed `resolveWallets`, or a test double) satisfies the seam.
+ */
+export interface ResolvedWalletLike {
+  readonly wallet: string;
+  readonly found: boolean;
+  readonly discord_id: string | null;
+}
+
+/** The injected batch resolver: a list of wallets → their resolutions. */
+export type BatchWalletResolver = (
+  wallets: ReadonlyArray<string>,
+) => Promise<ReadonlyArray<ResolvedWalletLike>>;
+
+export interface LiveWalletDiscordLinkConfig {
+  /**
+   * The batch resolver. PRODUCTION: omit it and the adapter lazily imports
+   * `resolveWallets` from `orchestrator/freeside_auth/server.ts`. TESTS: inject a
+   * pure map-backed resolver (zero I/O).
+   */
+  readonly resolveWalletsImpl?: BatchWalletResolver;
+  /** cache TTL in ms for a resolved wallet→link (default 5min, matches upstream). */
+  readonly cacheTtlMs?: number;
+  /** max wallets per underlying batch call (default 100). */
+  readonly batchSize?: number;
+  /** injectable clock (tests). */
+  readonly now?: () => number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_BATCH_SIZE = 100;
+
+interface CacheEntry {
+  /** the resolved snowflake, or null when the wallet is not linked. */
+  link: string | null;
+  expires_at: number;
+}
+
+/**
+ * Lazily import the real freeside_auth resolver (production default). Kept behind
+ * a function so the MCP-server module (which lazily constructs a pg Pool only on
+ * first `getPool()`, not at module load) is only pulled when actually used —
+ * tests inject `resolveWalletsImpl` and never reach this. The server exports a
+ * SINGLE-wallet `resolveWallet` (the batch `resolve_wallets` MCP tool just
+ * `Promise.all`s it); the underlying resolver is 5-min cached, so mapping it over
+ * the slice is cheap. We map it here to satisfy the batch seam.
+ */
+async function defaultBatchResolver(
+  wallets: ReadonlyArray<string>,
+): Promise<ReadonlyArray<ResolvedWalletLike>> {
+  const mod = await import("@freeside-characters/persona-engine/orchestrator/freeside_auth/server");
+  return Promise.all([...wallets].map((w) => mod.resolveWallet(w)));
+}
+
+/**
+ * Build the LIVE `WalletDiscordLink`. Coalesces per-wallet `resolve()` calls into
+ * batched underlying lookups + caches results (TTL). FAIL-CLOSED: any wallet that
+ * does not resolve to a non-empty `discord_id` returns null (→ skipped_unlinked,
+ * never assigned). A resolver THROW is also treated fail-closed as null for THAT
+ * flush (logged) — a single transient lookup error must not assign nor crash the
+ * whole batch; the wallet is simply skipped this run.
+ */
+export function makeWalletDiscordLinkLive(
+  cfg: LiveWalletDiscordLinkConfig = {},
+): WalletDiscordLink {
+  const resolveImpl = cfg.resolveWalletsImpl ?? defaultBatchResolver;
+  const ttlMs = cfg.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const batchSize = Math.max(1, cfg.batchSize ?? DEFAULT_BATCH_SIZE);
+  const now = cfg.now ?? (() => Date.now());
+
+  const cache = new Map<string, CacheEntry>();
+  // In-flight coalescing: wallet (lowercased) → the promise resolving its link.
+  // A second resolve() for the same wallet while a batch is in flight joins it.
+  const inflight = new Map<string, Promise<string | null>>();
+  // The pending queue: wallets awaiting the next flush + their resolvers.
+  let pending: Array<{ wallet: string; resolve: (v: string | null) => void }> = [];
+  let flushScheduled = false;
+
+  const cacheGet = (wallet: string): string | null | undefined => {
+    const hit = cache.get(wallet);
+    if (!hit) return undefined;
+    if (hit.expires_at <= now()) {
+      cache.delete(wallet);
+      return undefined;
+    }
+    return hit.link;
+  };
+
+  const cachePut = (wallet: string, link: string | null): void => {
+    cache.set(wallet, { link, expires_at: now() + ttlMs });
+  };
+
+  /** Run one batched lookup over a slice of distinct wallets; cache + settle. */
+  const runBatch = async (
+    batch: Array<{ wallet: string; resolve: (v: string | null) => void }>,
+  ): Promise<void> => {
+    // distinct wallets for the underlying call (the builder may repeat a wallet)
+    const distinct = [...new Set(batch.map((b) => b.wallet))];
+    let bySnowflake = new Map<string, string | null>();
+    try {
+      for (let i = 0; i < distinct.length; i += batchSize) {
+        const slice = distinct.slice(i, i + batchSize);
+        const resolved = await resolveImpl(slice);
+        for (const r of resolved) {
+          const w = r.wallet.toLowerCase();
+          // FAIL-CLOSED: only a found row with a non-empty snowflake is a link.
+          const link = r.found && r.discord_id && r.discord_id.length > 0 ? r.discord_id : null;
+          bySnowflake.set(w, link);
+        }
+      }
+    } catch (e) {
+      // A transient resolver failure ⇒ this whole flush resolves to null
+      // (fail-closed: skip, never assign). Do NOT cache a null-on-error (so a
+      // later flush retries); log for operator visibility.
+      console.warn(
+        `[wallet-discord-link] batch resolve failed (${distinct.length} wallets) — treating as unlinked this run: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      for (const item of batch) {
+        inflight.delete(item.wallet);
+        item.resolve(null);
+      }
+      return;
+    }
+    for (const item of batch) {
+      const link = bySnowflake.has(item.wallet) ? bySnowflake.get(item.wallet)! : null;
+      cachePut(item.wallet, link); // cache resolved results (incl. resolved-null)
+      inflight.delete(item.wallet);
+      item.resolve(link);
+    }
+  };
+
+  const scheduleFlush = (): void => {
+    if (flushScheduled) return;
+    flushScheduled = true;
+    // microtask flush: coalesce all synchronous resolve() calls the builder's
+    // loop issues in one tick into a single batched lookup, then settle.
+    queueMicrotask(() => {
+      const batch = pending;
+      pending = [];
+      flushScheduled = false;
+      void runBatch(batch);
+    });
+  };
+
+  return {
+    resolve(walletInput: string): Promise<string | null> {
+      const wallet = walletInput.trim().toLowerCase();
+      if (wallet.length === 0) return Promise.resolve(null);
+
+      const cached = cacheGet(wallet);
+      if (cached !== undefined) return Promise.resolve(cached);
+
+      const existing = inflight.get(wallet);
+      if (existing) return existing;
+
+      const p = new Promise<string | null>((resolve) => {
+        pending.push({ wallet, resolve });
+      });
+      inflight.set(wallet, p);
+      scheduleFlush();
+      return p;
+    },
+  };
+}
+
+/**
+ * A pure in-memory `WalletDiscordLink` for tests (zero I/O). Mirrors the
+ * `roster-source.mock` / `score-source.mock` idiom. Keys are matched
+ * case-insensitively (the live source normalizes lowercase).
+ */
+export function makeWalletDiscordLinkMock(
+  links: Record<string, string | null>,
+): WalletDiscordLink {
+  const norm = new Map<string, string | null>(
+    Object.entries(links).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return {
+    resolve: async (wallet: string) => {
+      const v = norm.get(wallet.trim().toLowerCase());
+      return v ?? null;
+    },
+  };
+}

--- a/apps/bot/src/shadow/wallet-discord-link.live.ts
+++ b/apps/bot/src/shadow/wallet-discord-link.live.ts
@@ -12,16 +12,27 @@
  *      `discord_handle` (a DISPLAY string), NOT the snowflake. UNUSABLE here.
  *   2. identity-api `/v1/profile?world=…&wallet=…` — surfaces a `nym`
  *      (display name per world), NOT the Discord snowflake. UNUSABLE here.
- *   3. `orchestrator/freeside_auth/server.ts` (`resolveWallet`/`resolveWallets`)
+ *   3. `orchestrator/freeside_auth/server.ts` (`resolveWallet`)
  *      — reads `midi_profiles` directly (Railway Postgres) and returns
  *      `ResolvedWallet.discord_id` = the SNOWFLAKE (from `wallet_address` direct
- *      OR the `additional_wallets` jsonb fan-in). It is ALREADY batched
- *      (`resolveWallets`) and 5-min cached in-process. This is the ONE source
- *      that carries the snowflake AND is already wired in this repo (the persona
- *      narration path consumes it), so it adds NO new dependency.
+ *      OR the `additional_wallets` jsonb fan-in). It is 5-min cached in-process.
+ *      This is the ONE source that carries the snowflake AND is already wired in
+ *      this repo (the persona narration path consumes it), so it adds NO new
+ *      dependency.
  *
- * So this adapter wraps `freeside_auth`'s batch resolver. We depend on it through
- * an INJECTED function (`resolveWalletsImpl`) — not a static import of the MCP
+ * ⚠ NOTE (Bridgebuilder #11, grounded against server.ts @ this SHA): the header's
+ * earlier claim that freeside_auth exports a TRUE batch `resolveWallets` is WRONG
+ * — `server.ts` exports only the SINGLE-wallet `resolveWallet` (the `resolve_wallets`
+ * MCP *tool* just `Promise.all`s it internally; no SQL `WHERE wallet = ANY($1)`
+ * fan-in exists). So `defaultBatchResolver` below maps `resolveWallet` over the
+ * slice — a TRUE batched SQL resolver is follow-up work on bead bd-m2v (it lives
+ * in persona-engine, not this adapter; hand-rolling a `midi_profiles` query here
+ * would duplicate the SoR + violate the seam). This adapter still COALESCES +
+ * DEDUPES per-wallet calls so the upstream is hit at most once per distinct
+ * wallet per flush — the right consumer-side discipline regardless.
+ *
+ * So this adapter wraps `freeside_auth`'s resolver. We depend on it through an
+ * INJECTED function (`resolveWalletsImpl`) — not a static import of the MCP
  * server module — so:
  *   • tests inject a pure map (zero pg, zero MCP) — the conformance + assign
  *     tests stay network-free (a hard constraint of the dispatch);
@@ -51,21 +62,56 @@ import type { WalletDiscordLink } from "./score-tier-assignment.ts";
 
 /**
  * The minimal shape this adapter consumes from a `freeside_auth`-style batch
- * resolver. Matches `resolveWallets(wallets) → ResolvedWallet[]` where each
- * carries `wallet` (echoed, normalized lowercase) + `discord_id` (snowflake|null)
- * + `found`. We read ONLY these three fields, so any compatible resolver (the
- * real MCP-backed `resolveWallets`, or a test double) satisfies the seam.
+ * resolver. Matches the `ResolvedWallet` rows `resolveWallet`/`resolveWallets`
+ * return: `wallet` (echoed, normalized lowercase) + `discord_id` (snowflake|null)
+ * + `found` + `resolved_via` (the resolution PATH — load-bearing for fail-closed:
+ * `'db_unavailable'` means the pg pool was missing OR the query threw, which is
+ * NOT a confirmed-unlinked wallet). We read ONLY these fields, so any compatible
+ * resolver (the real `resolveWallet`/`resolveWallets`, or a test double)
+ * satisfies the seam.
  */
 export interface ResolvedWalletLike {
   readonly wallet: string;
   readonly found: boolean;
   readonly discord_id: string | null;
+  /**
+   * the resolution path. `'db_unavailable'` is a FAILURE (no pg pool / query
+   * threw), distinct from a confirmed `'unknown'` (the wallet is genuinely not in
+   * midi_profiles). Optional so a minimal test double can omit it (absence ⇒ NOT
+   * a db outage — treated as a normal resolution).
+   */
+  readonly resolved_via?: string;
 }
 
 /** The injected batch resolver: a list of wallets → their resolutions. */
 export type BatchWalletResolver = (
   wallets: ReadonlyArray<string>,
 ) => Promise<ReadonlyArray<ResolvedWalletLike>>;
+
+/**
+ * Discord snowflakes are 17-20 digit decimal ids (the gate's `assignRole` does
+ * `guild.members.fetch(member_id)`; a non-snowflake value can never resolve).
+ * Bridgebuilder #12: a found row carrying a malformed `discord_id` is counted
+ * INVALID (separate from unlinked), never emitted as an assignment.
+ */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
+/**
+ * Thrown when a wallet's link could NOT be determined because the identity DB was
+ * unavailable (pool missing or query threw). This is NOT a confirmed-unlinked
+ * wallet — a LIVE run that swallowed it would "succeed" with everyone skipped
+ * while still creating roles (Bridgebuilder #7). The orchestrator lets this fail
+ * the run rather than treating it as unlinked.
+ */
+export class LinkResolutionError extends Error {
+  constructor(
+    message: string,
+    public readonly wallets: ReadonlyArray<string>,
+  ) {
+    super(message);
+    this.name = "LinkResolutionError";
+  }
+}
 
 export interface LiveWalletDiscordLinkConfig {
   /**
@@ -96,9 +142,10 @@ interface CacheEntry {
  * a function so the MCP-server module (which lazily constructs a pg Pool only on
  * first `getPool()`, not at module load) is only pulled when actually used —
  * tests inject `resolveWalletsImpl` and never reach this. The server exports a
- * SINGLE-wallet `resolveWallet` (the batch `resolve_wallets` MCP tool just
- * `Promise.all`s it); the underlying resolver is 5-min cached, so mapping it over
- * the slice is cheap. We map it here to satisfy the batch seam.
+ * SINGLE-wallet `resolveWallet` (there is no true batch SQL — see header NOTE +
+ * bd-m2v); the underlying resolver is 5-min cached, so mapping it over the slice
+ * is cheap. The `resolved_via` field flows through unchanged so the adapter can
+ * distinguish a genuine `'db_unavailable'` outage from a confirmed-unlinked row.
  */
 async function defaultBatchResolver(
   wallets: ReadonlyArray<string>,
@@ -127,8 +174,14 @@ export function makeWalletDiscordLinkLive(
   // In-flight coalescing: wallet (lowercased) → the promise resolving its link.
   // A second resolve() for the same wallet while a batch is in flight joins it.
   const inflight = new Map<string, Promise<string | null>>();
-  // The pending queue: wallets awaiting the next flush + their resolvers.
-  let pending: Array<{ wallet: string; resolve: (v: string | null) => void }> = [];
+  // The pending queue: wallets awaiting the next flush + their settle handles.
+  // `reject` lets a fail-closed flush (#7) REJECT (throw) rather than coerce to
+  // null — the orchestrator's LIVE path then fails the run.
+  let pending: Array<{
+    wallet: string;
+    resolve: (v: string | null) => void;
+    reject: (e: unknown) => void;
+  }> = [];
   let flushScheduled = false;
 
   const cacheGet = (wallet: string): string | null | undefined => {
@@ -145,37 +198,84 @@ export function makeWalletDiscordLinkLive(
     cache.set(wallet, { link, expires_at: now() + ttlMs });
   };
 
+  /**
+   * Settle every pending resolver of this flush with `err` (a rejection). Used
+   * for fail-closed paths: a DB outage MUST surface as a thrown
+   * `LinkResolutionError` (so a LIVE run fails rather than silently skipping
+   * everyone — Bridgebuilder #7), and a resolver THROW likewise propagates. We do
+   * NOT cache on a failure (a later flush retries).
+   */
+  const rejectFlush = (
+    batch: Array<{ wallet: string; resolve: (v: string | null) => void; reject: (e: unknown) => void }>,
+    err: unknown,
+  ): void => {
+    for (const item of batch) {
+      inflight.delete(item.wallet);
+      item.reject(err);
+    }
+  };
+
   /** Run one batched lookup over a slice of distinct wallets; cache + settle. */
   const runBatch = async (
-    batch: Array<{ wallet: string; resolve: (v: string | null) => void }>,
+    batch: Array<{ wallet: string; resolve: (v: string | null) => void; reject: (e: unknown) => void }>,
   ): Promise<void> => {
     // distinct wallets for the underlying call (the builder may repeat a wallet)
     const distinct = [...new Set(batch.map((b) => b.wallet))];
     let bySnowflake = new Map<string, string | null>();
+    const dbDown: string[] = [];
     try {
       for (let i = 0; i < distinct.length; i += batchSize) {
         const slice = distinct.slice(i, i + batchSize);
         const resolved = await resolveImpl(slice);
         for (const r of resolved) {
           const w = r.wallet.toLowerCase();
-          // FAIL-CLOSED: only a found row with a non-empty snowflake is a link.
-          const link = r.found && r.discord_id && r.discord_id.length > 0 ? r.discord_id : null;
+          // FAIL-CLOSED #7: a `db_unavailable` resolution is NOT a confirmed
+          // unlinked wallet — the identity DB could not answer. Collect them;
+          // ANY db_unavailable fails the whole flush (a LIVE run must refuse,
+          // not skip-then-create-roles).
+          if (r.resolved_via === "db_unavailable") {
+            dbDown.push(w);
+            continue;
+          }
+          // FAIL-CLOSED #12: only a found row with a SNOWFLAKE-SHAPED discord_id
+          // is a link. A found-but-malformed id (e.g. a handle leaked into the
+          // column, or a truncated value) can never `guild.members.fetch` — it is
+          // INVALID, not a link → null (skipped), logged distinctly.
+          let link: string | null = null;
+          if (r.found && r.discord_id && r.discord_id.length > 0) {
+            if (SNOWFLAKE_RE.test(r.discord_id)) {
+              link = r.discord_id;
+            } else {
+              console.warn(
+                `[wallet-discord-link] wallet ${w} has a NON-SNOWFLAKE discord_id (${JSON.stringify(
+                  r.discord_id,
+                )}) — treating as invalid (skipped, never assigned)`,
+              );
+            }
+          }
           bySnowflake.set(w, link);
         }
       }
     } catch (e) {
-      // A transient resolver failure ⇒ this whole flush resolves to null
-      // (fail-closed: skip, never assign). Do NOT cache a null-on-error (so a
-      // later flush retries); log for operator visibility.
-      console.warn(
-        `[wallet-discord-link] batch resolve failed (${distinct.length} wallets) — treating as unlinked this run: ${
+      // A resolver THROW (the injected resolver rejected) ⇒ fail-closed: REJECT
+      // the flush (LIVE refuses; SHADOW likewise — the safest default). Do NOT
+      // cache. NOT coerced to null any more (that was the #7 fail-OPEN bug).
+      rejectFlush(batch, new LinkResolutionError(
+        `[wallet-discord-link] batch resolve threw (${distinct.length} wallets): ${
           e instanceof Error ? e.message : String(e)
         }`,
-      );
-      for (const item of batch) {
-        inflight.delete(item.wallet);
-        item.resolve(null);
-      }
+        distinct,
+      ));
+      return;
+    }
+    if (dbDown.length > 0) {
+      // FAIL-CLOSED #7: the identity DB was unavailable for at least one wallet
+      // in this flush. Refuse the whole flush — a LIVE run MUST NOT proceed with
+      // a partial / empty link set (it would create roles + assign nobody).
+      rejectFlush(batch, new LinkResolutionError(
+        `[wallet-discord-link] identity DB unavailable for ${dbDown.length} wallet(s) — refusing (a partial link set would under-assign; fail the run)`,
+        dbDown,
+      ));
       return;
     }
     for (const item of batch) {
@@ -210,8 +310,8 @@ export function makeWalletDiscordLinkLive(
       const existing = inflight.get(wallet);
       if (existing) return existing;
 
-      const p = new Promise<string | null>((resolve) => {
-        pending.push({ wallet, resolve });
+      const p = new Promise<string | null>((resolve, reject) => {
+        pending.push({ wallet, resolve, reject });
       });
       inflight.set(wallet, p);
       scheduleFlush();

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -14,6 +14,7 @@
     "./score/index": "./src/score/index.ts",
     "./score/types": "./src/score/types.ts",
     "./score/client": "./src/score/client.ts",
+    "./score/community-client": "./src/score/community-client.ts",
     "./compose/digest": "./src/compose/digest.ts",
     "./compose/voice-brief": "./src/compose/voice-brief.ts",
     "./compose/voice-memory": "./src/compose/voice-memory.ts",

--- a/packages/persona-engine/package.json
+++ b/packages/persona-engine/package.json
@@ -10,6 +10,7 @@
     "./config": "./src/config.ts",
     "./orchestrator": "./src/orchestrator/index.ts",
     "./orchestrator/imagegen": "./src/orchestrator/imagegen/index.ts",
+    "./orchestrator/freeside_auth/server": "./src/orchestrator/freeside_auth/server.ts",
     "./score": "./src/score/index.ts",
     "./score/index": "./src/score/index.ts",
     "./score/types": "./src/score/types.ts",

--- a/packages/persona-engine/src/config.ts
+++ b/packages/persona-engine/src/config.ts
@@ -56,6 +56,19 @@ const ConfigSchema = z.object({
    *  `TENANT_SCORE_API_KEY` env. Unset = direct route (no gateway gate). */
   SCORE_BEARER: z.string().optional(),
 
+  // ─── shadow-onboarding LIVE ScoreSource (bd-tfl) ──────────────────────
+  /**
+   * Community-scoped score-api key for the Purupuru tier read (x-api-key). Its
+   * `api_key_community_scope.allowedCommunities` must include `purupuru`. This
+   * is the LIVE/MOCK FLAG for the shadow ScoreSource adapter:
+   *   set   → LIVE ScoreSource (reads real Purupuru tiers from score-api REST)
+   *   unset → MOCK ScoreSource (default; shadow preview works with no
+   *           score-api provisioning).
+   * See apps/bot/src/shadow/score-source.live.ts + composition-root.ts. */
+  SCORE_PURUPURU_API_KEY: z.string().optional(),
+  /** Community slug for the LIVE ScoreSource read. Defaults to `purupuru`. */
+  SCORE_PURUPURU_COMMUNITY: z.string().default('purupuru'),
+
   // ─── codex-mcp (gumi — mibera-codex lookup, public, no auth) ──────────
   /**
    * HTTP base URL of the codex MCP server. When set, the orchestrator

--- a/packages/persona-engine/src/score/community-client.test.ts
+++ b/packages/persona-engine/src/score/community-client.test.ts
@@ -1,0 +1,146 @@
+/**
+ * community-client.test.ts — the LIVE REST community score client (bd-tfl).
+ *
+ * Pure: injected fetch (response factories), injected sleep (records delays,
+ * never waits). No network. Pins the grounded score-api community contract:
+ *   - leaderboard parse (wallet + tier)
+ *   - x-api-key auth header
+ *   - fail-closed classification (403 forbidden / 404 not_found / 4xx bad / 5xx
+ *     upstream / decode / transport) — NEVER a silent empty result.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CommunityScoreClient,
+  CommunityScoreError,
+} from "./community-client.ts";
+import type { FetchRetryOptions } from "./retry.ts";
+
+const noWait: Pick<FetchRetryOptions, "sleep" | "random"> = {
+  sleep: async () => {},
+  random: () => 0.5,
+};
+
+/** Build a client whose transport is the supplied fake fetch. */
+function client(
+  fakeFetch: typeof fetch,
+  over: Partial<{ community: string; apiKey: string; baseUrl: string }> = {},
+) {
+  return new CommunityScoreClient({
+    baseUrl: over.baseUrl ?? "https://score-api.test",
+    apiKey: over.apiKey ?? "sk-test-key",
+    community: over.community ?? "purupuru",
+    retry: { ...noWait, fetchImpl: fakeFetch, maxAttempts: 1 },
+  });
+}
+
+/** A fake fetch returning a single Response and capturing the request. */
+function once(resp: Response, sink?: { url?: string; init?: RequestInit }) {
+  return (async (url: string, init: RequestInit) => {
+    if (sink) {
+      sink.url = url;
+      sink.init = init;
+    }
+    return resp;
+  }) as unknown as typeof fetch;
+}
+
+const COMMUNITY_BODY = {
+  community: "purupuru",
+  total: 3,
+  cohort_total: 3,
+  truncated: false,
+  meta: { foo: "bar" }, // extra/tolerated
+  wallets: [
+    { wallet: "0xaaa", rank: 1, combined_score: 98, tier: "sovereign", og_score: 50, nft_score: 30, onchain_score: 18 },
+    { wallet: "0xbbb", rank: 12, combined_score: 70, tier: "devoted" },
+    { wallet: "0xccc", rank: null, combined_score: null, tier: null },
+  ],
+};
+
+describe("CommunityScoreClient.leaderboard", () => {
+  test("parses the community leaderboard + sends x-api-key", async () => {
+    const sink: { url?: string; init?: RequestInit } = {};
+    const c = client(once(Response.json(COMMUNITY_BODY), sink));
+    const page = await c.leaderboard();
+
+    expect(page.community).toBe("purupuru");
+    expect(page.wallets.length).toBe(3);
+    expect(page.wallets[0]!.wallet).toBe("0xaaa");
+    expect(page.wallets[0]!.tier).toBe("sovereign");
+    expect(page.wallets[2]!.tier).toBeNull(); // untiered wallet preserved
+
+    // grounded auth + URL shape
+    expect(sink.url).toBe("https://score-api.test/v1/leaderboard?community=purupuru");
+    const headers = sink.init!.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("sk-test-key");
+  });
+
+  test("tolerates additive upstream fields (open struct)", async () => {
+    const body = {
+      community: "purupuru",
+      total: 1,
+      wallets: [{ wallet: "0xddd", rank: 2, combined_score: 80, tier: "core", new_future_field: "x" }],
+    };
+    const c = client(once(Response.json(body)));
+    const page = await c.leaderboard();
+    expect(page.wallets[0]!.tier).toBe("core");
+  });
+
+  test("403 → forbidden (out-of-scope key, fail-closed)", async () => {
+    const c = client(once(new Response("nope", { status: 403 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect(res).toBeInstanceOf(CommunityScoreError);
+    expect((res as CommunityScoreError).kind).toBe("forbidden");
+    expect((res as CommunityScoreError).status).toBe(403);
+  });
+
+  test("404 → not_found", async () => {
+    const c = client(once(new Response("gone", { status: 404 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("not_found");
+  });
+
+  test("400 → bad_request (unresolved community)", async () => {
+    const c = client(once(new Response("bad", { status: 400 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("bad_request");
+  });
+
+  test("500 → upstream", async () => {
+    const c = client(once(new Response("boom", { status: 500 })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("upstream");
+  });
+
+  test("malformed body → decode (never a silent empty result)", async () => {
+    const c = client(once(Response.json({ not: "a leaderboard" })));
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("decode");
+  });
+
+  test("network throw → transport", async () => {
+    const throwing = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const c = client(throwing);
+    const res = await c.leaderboard().catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("transport");
+  });
+});
+
+describe("CommunityScoreClient.walletProfile", () => {
+  test("parses a single wallet profile + correct URL", async () => {
+    const sink: { url?: string; init?: RequestInit } = {};
+    const c = client(once(Response.json({ wallet: "0xaaa", tier: "elder" }), sink));
+    const p = await c.walletProfile("0xAAA");
+    expect(p.wallet).toBe("0xaaa");
+    expect(p.tier).toBe("elder");
+    expect(sink.url).toBe("https://score-api.test/v1/wallets/0xAAA?community=purupuru");
+  });
+
+  test("403 fail-closed on single profile too", async () => {
+    const c = client(once(new Response("nope", { status: 403 })));
+    const res = await c.walletProfile("0xaaa").catch((e) => e);
+    expect((res as CommunityScoreError).kind).toBe("forbidden");
+  });
+});

--- a/packages/persona-engine/src/score/community-client.test.ts
+++ b/packages/persona-engine/src/score/community-client.test.ts
@@ -128,6 +128,77 @@ describe("CommunityScoreClient.leaderboard", () => {
   });
 });
 
+describe("CommunityScoreClient.leaderboard — fail-closed safety guards", () => {
+  // #4 — community match
+  test("REFUSES a community mismatch (foreign tiers would poison assignment)", async () => {
+    const foreign = {
+      community: "mibera", // ← gateway/default-community fallback bug
+      total: 1,
+      wallets: [{ wallet: "0xaaa", rank: 1, combined_score: 98, tier: "sovereign" }],
+    };
+    const c = client(once(Response.json(foreign))); // client asks for "purupuru"
+    const res = await c.leaderboard().catch((e) => e);
+    expect(res).toBeInstanceOf(CommunityScoreError);
+    expect((res as CommunityScoreError).kind).toBe("decode");
+    expect((res as CommunityScoreError).message).toContain("community mismatch");
+  });
+
+  test("accepts a matching community (no false positive)", async () => {
+    const c = client(once(Response.json(COMMUNITY_BODY)));
+    const page = await c.leaderboard();
+    expect(page.community).toBe("purupuru");
+  });
+
+  // #5 — truncation
+  test("REFUSES a TRUNCATED page (partial roster would under-assign roles)", async () => {
+    const truncated = {
+      community: "purupuru",
+      total: 500,
+      truncated: true, // ← only a partial page returned
+      wallets: [{ wallet: "0xaaa", rank: 1, combined_score: 98, tier: "sovereign" }],
+    };
+    const c = client(once(Response.json(truncated)));
+    const res = await c.leaderboard().catch((e) => e);
+    expect(res).toBeInstanceOf(CommunityScoreError);
+    expect((res as CommunityScoreError).kind).toBe("decode");
+    expect((res as CommunityScoreError).message).toContain("TRUNCATED");
+  });
+
+  test("truncated:false (or absent) is accepted (the normal full-page case)", async () => {
+    const c1 = client(once(Response.json({ ...COMMUNITY_BODY, truncated: false })));
+    expect((await c1.leaderboard()).wallets.length).toBe(3);
+    // absent field (older score-api build) ⇒ treated NOT truncated.
+    const noField = { community: "purupuru", total: 1, wallets: [{ wallet: "0xddd", rank: 2, combined_score: 80, tier: "core" }] };
+    const c2 = client(once(Response.json(noField)));
+    expect((await c2.leaderboard()).wallets.length).toBe(1);
+  });
+
+  // #10 — request timeout
+  test("aborts a hung request after the deadline → transport error", async () => {
+    // a fetch that never resolves UNTIL its signal aborts (mirrors a hung upstream).
+    const hung = ((url: string, init: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init.signal as AbortSignal | undefined;
+        if (signal) {
+          if (signal.aborted) return reject(new DOMException("aborted", "AbortError"));
+          signal.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }
+      })) as unknown as typeof fetch;
+    const c = new CommunityScoreClient({
+      baseUrl: "https://score-api.test",
+      apiKey: "sk-test-key",
+      community: "purupuru",
+      requestTimeoutMs: 5, // tiny deadline
+      retry: { ...noWait, fetchImpl: hung, maxAttempts: 1 },
+    });
+    const res = await c.leaderboard().catch((e) => e);
+    expect(res).toBeInstanceOf(CommunityScoreError);
+    expect((res as CommunityScoreError).kind).toBe("transport");
+  });
+});
+
 describe("CommunityScoreClient.walletProfile", () => {
   test("parses a single wallet profile + correct URL", async () => {
     const sink: { url?: string; init?: RequestInit } = {};

--- a/packages/persona-engine/src/score/community-client.ts
+++ b/packages/persona-engine/src/score/community-client.ts
@@ -1,0 +1,242 @@
+/**
+ * score/community-client.ts — the LIVE REST client for score-api's
+ * per-community leaderboard surface (cycle-032 #229/#231/#232, MERGED to
+ * score-api main).
+ *
+ * ── WHY A NEW SURFACE (not the existing client.ts) ───────────────────────────
+ * `client.ts` is the score-MCP transport (`get_zone_digest` / `get_recent_*`
+ * over StreamableHTTP + SSE). This is a DIFFERENT surface: a plain JSON REST
+ * read of the community leaderboard / single-wallet community profile, with
+ * `x-api-key` auth. It shares the transport-hardening (`fetchWithRetry` from
+ * `retry.ts`: honors Retry-After, backs off on 429/5xx) but speaks the REST
+ * contract, not JSON-RPC. The shadow ScoreSource adapter
+ * (apps/bot/src/shadow/score-source.live.ts) is the consumer.
+ *
+ * ── CONTRACT GROUNDING (score-api origin/main, read 2026-06-03) ──────────────
+ *   - GET {SCORE_API_URL}/v1/leaderboard?community={slug}
+ *       → 200 { community, wallets: CommunityLeaderboardEntry[], total, meta,
+ *               cohort_total, truncated }
+ *       (score-api packages/score-api-types entities/leaderboard-entry.ts:
+ *        `communityLeaderboardResponseSchema` + `communityLeaderboardEntrySchema`,
+ *        which extends `leaderboardEntrySchema` with combined_score:number|null
+ *        + tier:string|null.)
+ *   - GET {SCORE_API_URL}/v1/wallets/{address}?community={slug}
+ *       → 200 a single community wallet profile (tier + per-dim tiers).
+ *   - Auth: `x-api-key: <key>` whose `api_key_community_scope.allowedCommunities`
+ *     includes the community (or its `defaultCommunityId` is the community).
+ *     FAIL-CLOSED (score-api src/middleware/community-resolver.ts):
+ *       out-of-scope → 403, unresolved → 4xx, non-active → 404, NEVER a silent
+ *       Mibera read. A community-bound key never falls back to Mibera.
+ *
+ * ── WHY A HAND-MIRRORED SCHEMA, NOT `@0xhoneyjar/score-api-types` ─────────────
+ * `@0xhoneyjar/score-api-types` is published to the GitHub npm registry
+ * (`npm.pkg.github.com`, restricted/authed) as a BUILT `dist/` and lives in a
+ * SUBDIRECTORY of the score-api repo (`packages/score-api-types`) — a bun
+ * git-tarball source (the cluster's sovereign-distribution channel) cannot
+ * target a repo subpath, and the package ships compiled dist rather than source.
+ * Adding it as a dep would require a GH-authed registry + a postinstall build in
+ * a headless dispatch. So we MIRROR the exact community shapes here (via
+ * `@effect/schema`, matching the shadow seam's validation idiom), grounded
+ * against score-api origin/main. This is the SAME precedent already established
+ * in this repo's `apps/bot/src/auth-bridge.ts` (Lock-9: local `JWTClaim` mirrors
+ * the canonical schema "until the bot workspace links the published package").
+ * If/when the typed package becomes consumable, swap these schemas for its
+ * re-exports — the response field names are byte-identical to the upstream.
+ */
+
+import { Schema as S } from '@effect/schema';
+import { fetchWithRetry, type FetchRetryOptions } from './retry.ts';
+
+// ─── Hand-mirrored community contract (grounded: score-api origin/main) ──────
+
+/**
+ * One community leaderboard row. Mirrors score-api
+ * `communityLeaderboardEntrySchema` = base `leaderboardEntrySchema` extended
+ * with `combined_score`/`tier`. We model only the fields this client consumes +
+ * the load-bearing identity/score fields; `@effect/schema` Struct is OPEN here
+ * (we do NOT `.strict()`) so additive upstream fields (display_name, ens_name,
+ * …) never break the read — the consumer reads `wallet`/`tier` and ignores the
+ * rest. Reading is the read-amplification-safe posture: tolerate-extra on a
+ * contract we mirror rather than own.
+ */
+export const CommunityLeaderboardEntry = S.Struct({
+  /** 0x-prefixed EVM address (lowercase per score-api wallet_scores). */
+  wallet: S.String,
+  /** rank-1 is best; null when score-but-no-rank (live-mode rows). */
+  rank: S.NullOr(S.Number),
+  og_score: S.optional(S.NullOr(S.Number)),
+  nft_score: S.optional(S.NullOr(S.Number)),
+  onchain_score: S.optional(S.NullOr(S.Number)),
+  combined_score: S.NullOr(S.Number),
+  /** the community's OWN lore tier name (e.g. "sovereign"); null = untiered. */
+  tier: S.NullOr(S.String),
+});
+export type CommunityLeaderboardEntry = S.Schema.Type<typeof CommunityLeaderboardEntry>;
+
+/**
+ * The `GET /v1/leaderboard?community=` response envelope. Mirrors score-api
+ * `communityLeaderboardResponseSchema`. We validate the load-bearing fields
+ * (`community`, `wallets`) and tolerate the rest (`total`, `meta`,
+ * `cohort_total`, `truncated`).
+ */
+export const CommunityLeaderboardResponse = S.Struct({
+  community: S.String,
+  wallets: S.Array(CommunityLeaderboardEntry),
+});
+export type CommunityLeaderboardResponse = S.Schema.Type<typeof CommunityLeaderboardResponse>;
+
+/**
+ * The `GET /v1/wallets/{address}?community=` single-profile response. score-api
+ * returns the community wallet profile with a `tier` (+ per-dim tiers we don't
+ * consume here). Modeled tolerant-of-extra; we read `wallet` + `tier`.
+ */
+export const CommunityWalletProfile = S.Struct({
+  wallet: S.String,
+  tier: S.optional(S.NullOr(S.String)),
+});
+export type CommunityWalletProfile = S.Schema.Type<typeof CommunityWalletProfile>;
+
+const decodeLeaderboard = S.decodeUnknownEither(CommunityLeaderboardResponse);
+const decodeProfile = S.decodeUnknownEither(CommunityWalletProfile);
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+/** A typed failure from the REST community surface. Mirrors the fail-closed
+ *  posture: 403 = out-of-scope key, 4xx = unresolved/bad request, 5xx = upstream.
+ *  The shadow adapter maps this to the substrate's `ScoreError`. */
+export class CommunityScoreError extends Error {
+  constructor(
+    public readonly kind:
+      | 'forbidden'        // 403 — key not scoped for this community (fail-closed)
+      | 'not_found'        // 404 — community paused/disabled or wallet absent
+      | 'bad_request'      // other 4xx — unresolved community / bad params
+      | 'upstream'         // 5xx after bounded retry
+      | 'decode'           // response did not match the mirrored contract
+      | 'transport',       // network throw
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'CommunityScoreError';
+  }
+}
+
+export interface CommunityScoreClientConfig {
+  /** base URL, e.g. https://score-api-production.up.railway.app (no trailing slash needed). */
+  readonly baseUrl: string;
+  /** the community-scoped score-api key (x-api-key). REQUIRED for the LIVE path. */
+  readonly apiKey: string;
+  /** the community slug, e.g. "purupuru". */
+  readonly community: string;
+  /** retry tuning (tests inject fetchImpl/sleep/random). */
+  readonly retry?: FetchRetryOptions;
+}
+
+/**
+ * The community-scoped REST client. Two reads:
+ *   - `leaderboard()`  → the full community roster (wallet → tier).
+ *   - `walletProfile(address)` → a single wallet's community tier.
+ *
+ * Fail-closed: any non-2xx maps to a typed `CommunityScoreError` (never a silent
+ * empty/Mibera result). A 403 specifically signals the key is out-of-scope.
+ */
+export class CommunityScoreClient {
+  constructor(private readonly cfg: CommunityScoreClientConfig) {}
+
+  private headers(): Record<string, string> {
+    return {
+      Accept: 'application/json',
+      // score-api community-resolver reads `x-api-key` (Vary: X-API-Key).
+      'x-api-key': this.cfg.apiKey,
+    };
+  }
+
+  private base(): string {
+    return this.cfg.baseUrl.replace(/\/+$/, '');
+  }
+
+  /** classify a non-OK Response into a typed error (after the body is consumed). */
+  private async fail(res: Response): Promise<never> {
+    const body = await res.text().catch(() => '');
+    const snippet = body.slice(0, 200);
+    const s = res.status;
+    if (s === 403) {
+      throw new CommunityScoreError(
+        'forbidden',
+        `score-api 403 — key not scoped for community '${this.cfg.community}' (fail-closed): ${snippet}`,
+        s,
+      );
+    }
+    if (s === 404) {
+      throw new CommunityScoreError(
+        'not_found',
+        `score-api 404 — community '${this.cfg.community}' unavailable or wallet absent: ${snippet}`,
+        s,
+      );
+    }
+    if (s >= 400 && s < 500) {
+      throw new CommunityScoreError(
+        'bad_request',
+        `score-api ${s} — unresolved community / bad request: ${snippet}`,
+        s,
+      );
+    }
+    throw new CommunityScoreError(
+      'upstream',
+      `score-api ${s} — upstream error after bounded retry: ${snippet}`,
+      s,
+    );
+  }
+
+  /** GET /v1/leaderboard?community=<slug> — the full community roster. */
+  async leaderboard(): Promise<CommunityLeaderboardResponse> {
+    const url = `${this.base()}/v1/leaderboard?community=${encodeURIComponent(this.cfg.community)}`;
+    let res: Response;
+    try {
+      res = await fetchWithRetry(url, { method: 'GET', headers: this.headers() }, this.cfg.retry);
+    } catch (e) {
+      throw new CommunityScoreError(
+        'transport',
+        `score-api leaderboard transport error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (!res.ok) return this.fail(res);
+    const json = await res.json().catch((e) => {
+      throw new CommunityScoreError('decode', `score-api leaderboard: invalid JSON: ${String(e)}`);
+    });
+    const decoded = decodeLeaderboard(json);
+    if (decoded._tag === 'Left') {
+      throw new CommunityScoreError(
+        'decode',
+        `score-api leaderboard response did not match the community contract: ${String(decoded.left)}`,
+      );
+    }
+    return decoded.right;
+  }
+
+  /** GET /v1/wallets/<address>?community=<slug> — a single wallet's tier. */
+  async walletProfile(address: string): Promise<CommunityWalletProfile> {
+    const url = `${this.base()}/v1/wallets/${encodeURIComponent(address)}?community=${encodeURIComponent(this.cfg.community)}`;
+    let res: Response;
+    try {
+      res = await fetchWithRetry(url, { method: 'GET', headers: this.headers() }, this.cfg.retry);
+    } catch (e) {
+      throw new CommunityScoreError(
+        'transport',
+        `score-api wallet-profile transport error: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (!res.ok) return this.fail(res);
+    const json = await res.json().catch((e) => {
+      throw new CommunityScoreError('decode', `score-api wallet-profile: invalid JSON: ${String(e)}`);
+    });
+    const decoded = decodeProfile(json);
+    if (decoded._tag === 'Left') {
+      throw new CommunityScoreError(
+        'decode',
+        `score-api wallet-profile did not match the community contract: ${String(decoded.left)}`,
+      );
+    }
+    return decoded.right;
+  }
+}

--- a/packages/persona-engine/src/score/community-client.ts
+++ b/packages/persona-engine/src/score/community-client.ts
@@ -76,12 +76,19 @@ export type CommunityLeaderboardEntry = S.Schema.Type<typeof CommunityLeaderboar
 /**
  * The `GET /v1/leaderboard?community=` response envelope. Mirrors score-api
  * `communityLeaderboardResponseSchema`. We validate the load-bearing fields
- * (`community`, `wallets`) and tolerate the rest (`total`, `meta`,
- * `cohort_total`, `truncated`).
+ * (`community`, `wallets`) AND the SAFETY fields (`truncated`, `total`) — a
+ * truncated page silently under-assigns roles, so it must be visible to the
+ * client (Bridgebuilder #5). `truncated`/`total` are OPTIONAL with safe defaults
+ * (older score-api builds may omit them; absence ⇒ NOT truncated). `meta` /
+ * `cohort_total` remain tolerated-but-unread.
  */
 export const CommunityLeaderboardResponse = S.Struct({
   community: S.String,
   wallets: S.Array(CommunityLeaderboardEntry),
+  /** total wallets in the cohort (before truncation). undefined on older builds. */
+  total: S.optional(S.NullOr(S.Number)),
+  /** TRUE ⇒ `wallets` is a partial page (score-api capped the result set). */
+  truncated: S.optional(S.NullOr(S.Boolean)),
 });
 export type CommunityLeaderboardResponse = S.Schema.Type<typeof CommunityLeaderboardResponse>;
 
@@ -130,7 +137,18 @@ export interface CommunityScoreClientConfig {
   readonly community: string;
   /** retry tuning (tests inject fetchImpl/sleep/random). */
   readonly retry?: FetchRetryOptions;
+  /**
+   * per-request deadline in ms (an `AbortController` aborts the fetch). A hung
+   * upstream would otherwise stall the whole go_live (Bridgebuilder #10). An
+   * abort is classified `transport` (the retry layer treats it as a network
+   * throw and may back off, then the client surfaces a typed transport error).
+   * Default 10s. Set 0/negative to disable.
+   */
+  readonly requestTimeoutMs?: number;
 }
+
+/** Default per-request deadline (ms). */
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * The community-scoped REST client. Two reads:
@@ -153,6 +171,30 @@ export class CommunityScoreClient {
 
   private base(): string {
     return this.cfg.baseUrl.replace(/\/+$/, '');
+  }
+
+  /**
+   * fetch with retry UNDER a per-request deadline. An `AbortController` fires
+   * after `requestTimeoutMs` so a hung upstream cannot stall the caller forever
+   * (Bridgebuilder #10). The injected `retry.signal` (if any) is preserved by
+   * merging — but the common case is no caller signal, only the deadline. The
+   * abort surfaces as a thrown `AbortError` from `fetchWithRetry`, which the
+   * caller classifies as `transport`.
+   */
+  private async fetchWithDeadline(url: string): Promise<Response> {
+    const timeoutMs = this.cfg.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    const init: RequestInit = { method: 'GET', headers: this.headers() };
+    if (!(timeoutMs > 0)) {
+      // deadline disabled — plain retry fetch.
+      return fetchWithRetry(url, init, this.cfg.retry);
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetchWithRetry(url, { ...init, signal: controller.signal }, this.cfg.retry);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /** classify a non-OK Response into a typed error (after the body is consumed). */
@@ -193,7 +235,7 @@ export class CommunityScoreClient {
     const url = `${this.base()}/v1/leaderboard?community=${encodeURIComponent(this.cfg.community)}`;
     let res: Response;
     try {
-      res = await fetchWithRetry(url, { method: 'GET', headers: this.headers() }, this.cfg.retry);
+      res = await this.fetchWithDeadline(url);
     } catch (e) {
       throw new CommunityScoreError(
         'transport',
@@ -211,7 +253,31 @@ export class CommunityScoreClient {
         `score-api leaderboard response did not match the community contract: ${String(decoded.left)}`,
       );
     }
-    return decoded.right;
+    const page = decoded.right;
+    // FAIL-CLOSED COMMUNITY MATCH (Bridgebuilder #4): the response MUST be for the
+    // community we asked about. A gateway/default-community bug (e.g. a key that
+    // silently falls back to Mibera) would otherwise feed NON-Purupuru tiers into
+    // Purupuru role assignment. score-api echoes `community` in the envelope; we
+    // refuse a mismatch rather than trust the request param.
+    if (page.community !== this.cfg.community) {
+      throw new CommunityScoreError(
+        'decode',
+        `score-api leaderboard community mismatch: requested '${this.cfg.community}' but response is for '${page.community}' (refusing — would feed foreign tiers into '${this.cfg.community}' assignment)`,
+      );
+    }
+    // FAIL-CLOSED TRUNCATION GUARD (Bridgebuilder #5): a truncated page is a
+    // PARTIAL roster — assigning from it silently under-assigns roles (qualified
+    // members beyond the page get no role). The client does NOT paginate (the
+    // score-api community surface exposes no cursor/offset at this SHA), so we
+    // REFUSE rather than under-assign. If/when a paginated surface lands, this is
+    // the seam to loop.
+    if (page.truncated === true) {
+      throw new CommunityScoreError(
+        'decode',
+        `score-api leaderboard is TRUNCATED (${page.wallets.length} of ${page.total ?? 'unknown'} total) — refusing a partial roster (would under-assign roles); pagination is not yet supported on this surface`,
+      );
+    }
+    return page;
   }
 
   /** GET /v1/wallets/<address>?community=<slug> — a single wallet's tier. */
@@ -219,7 +285,7 @@ export class CommunityScoreClient {
     const url = `${this.base()}/v1/wallets/${encodeURIComponent(address)}?community=${encodeURIComponent(this.cfg.community)}`;
     let res: Response;
     try {
-      res = await fetchWithRetry(url, { method: 'GET', headers: this.headers() }, this.cfg.retry);
+      res = await this.fetchWithDeadline(url);
     } catch (e) {
       throw new CommunityScoreError(
         'transport',


### PR DESCRIPTION
## What

The full Purupuru tier to Discord-role feature for the characters bot: read score-api per-community tiers, join to Discord members via identity, and assign namespaced roles shadow-first through the gate. Consolidates bd-tfl (Part 1) + bd-m2v (Part 2) + the multi-model review hardening into one branch.

This supersedes #164 (Part 1 only); the commits there are included here.

## Architecture (the belt)

```
score-api /v1/leaderboard?community=purupuru (wallet -> tier)
  |> identity (wallet -> Discord snowflake, via freeside_auth midi_profiles)
  |> CM role-map rules (tier -> role_key, strongest per member)
  |> shadow diff (current vs proposed)
  |> GateCheckedRoleWriter.applyBatch  (SHADOW = zero writes, LIVE = gated writes)
```

The SHA-pinned `@freeside-worlds/shadow-substrate` is consumed, never modified.

## What landed

- **Part 1 (bd-tfl):** REST `CommunityScoreClient`, `makeScoreSourceLive` wired into the composition, the grounded Purupuru tier ladder.
- **Part 2 (bd-m2v):** `wallet-discord-link.live.ts` (wallet to snowflake via the existing freeside_auth resolver, batched/cached, fail-closed), `go-live-orchestrator.ts` (`runTierRoleGoLive`: authorize, goLive, read, FR-4 create-pass via the substrate's `computeProposed`, assign-pass, `applyBatch`), and the per-member assign-batch builder.
- **Hardening:** all 13 findings from a two-model CLI Bridgebuilder review (Opus + codex) fixed test-first.

## Review and hardening (multi-model, CLI)

Two independent reviewer passes (claude CLI + codex CLI) on each part, reconciled. Both initially returned "do not merge"; the 13 findings are now fixed:

- HIGH: SHADOW preview now authorizes before any read (no snowflake-bearing batch for a denied actor); roster-freshness requires a fingerprint+snapshot pair and asserts they match; the LIVE apply path fails closed when score wiring is absent (was mock-fallback); the leaderboard read asserts `community` matches and refuses a truncated page.
- MED: per-member dedup (two wallets on one member now collapse to the strongest tier); auth-DB outage fails the run instead of silently skipping everyone; LIVE requires a leaderboard reader; the leaderboard is fetched once per batch (was once per rule); requests have an AbortController timeout.
- LOW: Discord snowflake-shape validation; explicit skip of non-tier rules.

The unifying rule: the LIVE apply path is strictly fail-closed; SHADOW is the only forgiving path and it authorizes first.

## Tests

shadow suite 124 pass, persona-engine score 34 pass / 1 pre-existing skip, both typechecks clean, import-boundary lint clean, substrate conformance clean. All tests are network-free and Discord-free (injected deps, MOCK writer, fake fetch, fake clock).

## Not in this PR (tracked)

- `bd-glb` (freeside-worlds, SACRED): the substrate `LatentQualified` provenance hardcoded to MOCK, and a roster-identity-snapshot method on the `RosterSource` port (this PR injects a `RosterIdentityReader` as the seam; the live impl needs that port).
- `bd-m2v` follow-up: a true batched `resolveWallets` in freeside_auth (today's resolver fans out per wallet; the adapter coalesces + dedupes so each distinct wallet hits upstream once per flush).

## Go-live (operator, after merge)

`purupuru.yaml` (guild_id + admin_principals), a Purupuru-scoped score-api key, the live RosterIdentityReader (bd-glb), then `SCORE_PURUPURU_API_KEY` + `CONFIG_SERVICE_URL` on the characters Railway env to flip mock to live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
