### PR TITLE
feat(shadow): voiceless /role-sync trigger + boot-wiring — runnable SHADOW tier→role on Purupuru (bd-71y + bd-atm)

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -79,6 +79,11 @@ import {
   RECALL_WEDGE_LIVE_DEMO_COMMAND_NAME,
   handleRecallWedgeLiveDemoInteraction,
 } from './recall-wedge-live-demo.ts';
+import { ROLE_SYNC_COMMAND_NAME } from '../shadow/role-sync-trigger.ts';
+import {
+  handleRoleSyncInteraction,
+  type RoleSyncInteractionDeps,
+} from '../shadow/role-sync-interaction.ts';
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const DISCORD_CHAR_LIMIT = 2000;
@@ -145,6 +150,28 @@ export function setQuestRuntime(runtime: QuestRuntime): void {
 
 export function getActiveQuestRuntime(): QuestRuntime {
   return activeQuestRuntime;
+}
+
+/**
+ * Module-level role-sync deps (bd-71y) — the deploy wires this at boot via
+ * `setRoleSyncDeps()` (world, role-map reader, orchestration invoker, world
+ * config, token metadata, transition version, clock). UNSET ⇒ the `/role-sync`
+ * command is not available (the trigger is opt-in: a deployment that does not
+ * run the onboarding/role-dispenser building simply never wires it). Mirrors the
+ * quest-runtime composition seam: dispatch owns routing, the deps own behavior.
+ *
+ * The trigger code itself is VOICELESS (no persona-engine import); only this
+ * router file — which already imports persona-engine for the chat path — knows
+ * the command name.
+ */
+let roleSyncDeps: RoleSyncInteractionDeps | undefined;
+
+export function setRoleSyncDeps(deps: RoleSyncInteractionDeps): void {
+  roleSyncDeps = deps;
+}
+
+export function getRoleSyncDeps(): RoleSyncInteractionDeps | undefined {
+  return roleSyncDeps;
 }
 
 /**
@@ -319,6 +346,24 @@ export async function dispatchSlashCommand(
   // not character-bound).
   if (isQuest) {
     return handleQuestInteraction(interaction, activeQuestRuntime);
+  }
+
+  // ─── bd-71y — voiceless CM tier→role sync trigger (`/role-sync`) ────
+  // A system (NOT character-bound) admin command. Routed here — after the
+  // auth-bridge attach (so the verified AuthContext / claims.sub is the
+  // resolved CM actor) and before per-character resolution. Authz against
+  // admin_principals happens INSIDE runTierRoleGoLive (deny ⇒ refuse, no
+  // reads); a non-verified invoker is refused by the trigger core. The whole
+  // path is VOICELESS — the response is the structural CV2 render. The command
+  // is available only when the deployment wired `setRoleSyncDeps()`.
+  if (interaction.data?.name === ROLE_SYNC_COMMAND_NAME) {
+    const deps = getRoleSyncDeps();
+    if (!deps) {
+      return ephemeralReply(
+        'the role-sync trigger is not configured on this deployment.',
+      );
+    }
+    return handleRoleSyncInteraction(interaction, interactionCtx.auth, deps);
   }
 
 // —— Resolve target command + handler ————————————————————————

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -40,7 +40,8 @@ import {
   startInteractionServer,
   type InteractionServerHandle,
 } from './discord-interactions/server.ts';
-import { setQuestRuntime } from './discord-interactions/dispatch.ts';
+import { setQuestRuntime, setRoleSyncDeps } from './discord-interactions/dispatch.ts';
+import { buildRoleSyncBootDepsFromEnv } from './shadow/role-sync-boot.ts';
 import { buildMemoryDevQuestRuntime } from './quest-runtime-bootstrap.ts';
 import {
   buildEnvTenantPgPoolFactory,
@@ -493,6 +494,42 @@ async function main(): Promise<void> {
     console.log(
       'events:         DISABLED (set NATS_URL to enable cross-cell mint subscriber)',
     );
+  }
+
+  // ─── bd-atm — voiceless CM `/role-sync` boot-wire (SHADOW-first) ──────────
+  // Compose the LIVE role-sync deps and wire them into the dispatcher, so
+  // `/role-sync` actually RUNS (bd-71y built the command + bd-m2v built the
+  // orchestrator; this is the composition that calls setRoleSyncDeps).
+  //
+  // FAIL-CLOSED + OPT-IN: buildRoleSyncBootDepsFromEnv returns null unless
+  // ROLE_SYNC_ENABLED is truthy AND the vendored world manifest
+  // (apps/bot/worlds/<world>.yaml) is readable with guild_id + namespace_prefix.
+  // When null, `/role-sync` reports "not configured on this deployment" — a
+  // clean refusal, never a silent partial wire. The onboarding/role-dispenser
+  // is a SEPARABLE, VOICELESS building: a deployment that does not run it simply
+  // never sets ROLE_SYNC_ENABLED. The actor is resolved via identity-api,
+  // INDEPENDENT of AUTH_BACKEND (see shadow/identity-actor-resolver.ts).
+  try {
+    const roleSyncDeps = buildRoleSyncBootDepsFromEnv(() => getBotClient(config));
+    if (roleSyncDeps) {
+      setRoleSyncDeps(roleSyncDeps);
+      console.log(
+        `role-sync:      wired · world=${roleSyncDeps.world} · ` +
+          `manifest=apps/bot/worlds/${roleSyncDeps.world}.yaml · ` +
+          `score=${process.env.SCORE_PURUPURU_API_KEY ? 'LIVE' : 'MOCK (SHADOW preview shows creates only)'} · ` +
+          `config-service=${process.env.CONFIG_SERVICE_URL ? 'wired' : 'seed-map fallback'} · ` +
+          `actor=identity-api (${process.env.IDENTITY_API_URL?.trim() || 'identity.0xhoneyjar.xyz'}, AUTH_BACKEND-independent)`,
+      );
+    } else {
+      console.log(
+        'role-sync:      DISABLED (set ROLE_SYNC_ENABLED=1 + ensure apps/bot/worlds/<world>.yaml exists)',
+      );
+    }
+  } catch (err) {
+    // A composition error must NOT crash the bot — the role-dispenser is an
+    // optional, separable building. Log + continue (the command stays "not
+    // configured" until the misconfig is fixed).
+    console.error('role-sync:      wiring failed (command stays unconfigured):', err);
   }
 
   // V0.7-A.0: Discord Interactions endpoint for slash commands.

--- a/apps/bot/src/shadow/config-service-client.test.ts
+++ b/apps/bot/src/shadow/config-service-client.test.ts
@@ -147,3 +147,48 @@ describe("F5 — every config-service RPC has a bounded deadline", () => {
     await expect(c.getOnboardingLifecycle("purupuru", "cm-1")).rejects.toThrow(/ECONNREFUSED/);
   });
 });
+
+describe("bd-71y — getRoleMap (the role-sync trigger's CM-authored-map read)", () => {
+  test("unwired (no CONFIG_SERVICE_URL) ⇒ null (caller uses the default seed)", async () => {
+    const c = new ConfigServiceClient({ baseUrl: undefined, getToken: () => null });
+    expect(await c.getRoleMap("purupuru")).toBeNull();
+  });
+
+  test("LIVE: GET routes to /v1/config/:world/role-map (world-scoped, no cm param) with bearer", async () => {
+    let seenUrl = "";
+    let seenAuth = "";
+    const c = new ConfigServiceClient({
+      baseUrl: "https://config.example",
+      getToken: () => "tok-abc",
+      fetchImpl: fakeFetch((url, init) => {
+        seenUrl = url;
+        seenAuth = String((init?.headers as Record<string, string>)?.authorization ?? "");
+        return new Response(JSON.stringify({ envelope: { enabled: true, namespace_prefix: "purupuru:", rules: [] }, version: 3 }), { status: 200 });
+      }),
+    });
+    const got = await c.getRoleMap<{ namespace_prefix: string }>("purupuru");
+    expect(seenUrl).toContain("/v1/config/purupuru/role-map");
+    expect(seenUrl).not.toContain("cm="); // world-scoped, not per-CM
+    expect(seenAuth).toBe("Bearer tok-abc");
+    expect(got?.version).toBe(3);
+    expect(got?.envelope.namespace_prefix).toBe("purupuru:");
+  });
+
+  test("404 (no map authored) ⇒ null (caller uses the seed)", async () => {
+    const c = new ConfigServiceClient({
+      baseUrl: "https://config.example",
+      getToken: () => "t",
+      fetchImpl: fakeFetch(() => new Response("", { status: 404 })),
+    });
+    expect(await c.getRoleMap("purupuru")).toBeNull();
+  });
+
+  test("a 5xx THROWS (a real outage is never silently treated as 'no map')", async () => {
+    const c = new ConfigServiceClient({
+      baseUrl: "https://config.example",
+      getToken: () => "t",
+      fetchImpl: fakeFetch(() => new Response("boom", { status: 503 })),
+    });
+    await expect(c.getRoleMap("purupuru")).rejects.toThrow(/role-map 503/);
+  });
+});

--- a/apps/bot/src/shadow/config-service-client.ts
+++ b/apps/bot/src/shadow/config-service-client.ts
@@ -105,6 +105,30 @@ export class ConfigServiceClient {
   }
 
   /**
+   * GET the world's `role-map` surface (the CM-authored tier→role map). Returns
+   * null when config-service is unwired (no baseUrl) OR on 404 (no map authored
+   * yet) — the CALLER falls back to the default seed map (bd-71y). Throws on
+   * transport / 5xx so a real service error is never silently treated as "no map"
+   * (which would mask an outage as a seed-map run).
+   *
+   * The `role-map` surface follows the same `/v1/config/:world/<surface>` shape
+   * as `onboarding-lifecycle`. It is a WORLD-scoped surface (NOT per-CM): the map
+   * belongs to the world, not the individual CM, so there is no `cm` query param.
+   */
+  async getRoleMap<T = unknown>(world: string): Promise<SurfaceEnvelope<T> | null> {
+    if (!this.baseUrl) return null; // unwired ⇒ caller uses the default seed
+    const url = `${this.baseUrl}/v1/config/${encodeURIComponent(world)}/role-map`;
+    const res = await this.fetchWithDeadline("GET role-map", url, {
+      headers: { ...(await this.authHeader()) },
+    });
+    if (res.status === 404) return null; // no map authored ⇒ caller uses the seed
+    if (!res.ok) {
+      throw new Error(`config-service GET role-map ${res.status}: ${await res.text().catch(() => "")}`);
+    }
+    return (await res.json()) as SurfaceEnvelope<T>;
+  }
+
+  /**
    * GET the per-CM onboarding-lifecycle record. Returns null on 404 (default →
    * the lens treats apply_mode as SHADOW). Throws on transport / 5xx.
    */

--- a/apps/bot/src/shadow/identity-actor-resolver.test.ts
+++ b/apps/bot/src/shadow/identity-actor-resolver.test.ts
@@ -1,0 +1,148 @@
+/**
+ * identity-actor-resolver.test.ts — the ISOLATED actor resolver for `/role-sync`
+ * (bd-atm). NETWORK-FREE: `fetch` is injected.
+ *
+ * Proves (the isolation + fail-closed gates):
+ *   • a 200 { user_id } hit ⇒ { actor: user_id } — the value runTierRoleGoLive
+ *     authzs against admin_principals.
+ *   • a 404 (unlinked discord) ⇒ null ⇒ the trigger refuses (fail-closed).
+ *   • a non-2xx / transport error / malformed body ⇒ null (fail-closed).
+ *   • a missing / malformed invoking id ⇒ null WITHOUT any HTTP call.
+ *   • the request hits `/v1/resolve/account/discord/{id}` (the identity-api
+ *     route), INDEPENDENT of any AUTH_BACKEND / AuthContext.
+ *   • the optional service token is sent as `x-service-token` when configured.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  resolveActorFromDiscordId,
+  makeIdentityActorResolverFor,
+} from "./identity-actor-resolver.ts";
+
+const BASE = "https://identity.example.test";
+const DISCORD_ID = "700000000000000001"; // a valid 18-digit snowflake
+const USER_ID = "ae0558c7-aeb2-48f0-906d-ad0a50108b19";
+
+/** A fake fetch that records the URL+init and returns a fixed Response. */
+function fakeFetch(
+  res: Response,
+  record?: (url: string, init?: RequestInit) => void,
+): typeof fetch {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    record?.(String(url), init);
+    return res;
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("bd-atm — resolveActorFromDiscordId: identity-api lookup, AUTH_BACKEND-independent", () => {
+  test("200 { user_id } ⇒ { actor: user_id } and hits /v1/resolve/account/discord/{id}", async () => {
+    let seenUrl = "";
+    const r = await resolveActorFromDiscordId(
+      { baseUrl: BASE, fetchImpl: fakeFetch(jsonResponse(200, { user_id: USER_ID }), (u) => (seenUrl = u)) },
+      DISCORD_ID,
+    );
+    expect(r).toEqual({ actor: USER_ID });
+    expect(seenUrl).toBe(`${BASE}/v1/resolve/account/discord/${DISCORD_ID}`);
+  });
+
+  test("404 (unlinked discord) ⇒ null (fail-closed → trigger refuses)", async () => {
+    const r = await resolveActorFromDiscordId(
+      { baseUrl: BASE, fetchImpl: fakeFetch(jsonResponse(404, { code: "not_found" })) },
+      DISCORD_ID,
+    );
+    expect(r).toBeNull();
+  });
+
+  test("non-2xx (500) ⇒ null (fail-closed)", async () => {
+    const r = await resolveActorFromDiscordId(
+      { baseUrl: BASE, fetchImpl: fakeFetch(jsonResponse(500, { error: "boom" })) },
+      DISCORD_ID,
+    );
+    expect(r).toBeNull();
+  });
+
+  test("transport error (fetch throws) ⇒ null (fail-closed)", async () => {
+    const throwing = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const r = await resolveActorFromDiscordId({ baseUrl: BASE, fetchImpl: throwing }, DISCORD_ID);
+    expect(r).toBeNull();
+  });
+
+  test("malformed body (no user_id) ⇒ null (fail-closed)", async () => {
+    const r = await resolveActorFromDiscordId(
+      { baseUrl: BASE, fetchImpl: fakeFetch(jsonResponse(200, { not_user_id: "x" })) },
+      DISCORD_ID,
+    );
+    expect(r).toBeNull();
+  });
+
+  test("missing invoking id ⇒ null WITHOUT any HTTP call", async () => {
+    let called = false;
+    const r = await resolveActorFromDiscordId(
+      { baseUrl: BASE, fetchImpl: fakeFetch(jsonResponse(200, { user_id: USER_ID }), () => (called = true)) },
+      undefined,
+    );
+    expect(r).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  test("malformed invoking id ('unknown') ⇒ null WITHOUT any HTTP call", async () => {
+    let called = false;
+    const r = await resolveActorFromDiscordId(
+      { baseUrl: BASE, fetchImpl: fakeFetch(jsonResponse(200, { user_id: USER_ID }), () => (called = true)) },
+      "unknown",
+    );
+    expect(r).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  test("service token, when set, is sent as x-service-token", async () => {
+    let seenHeaders: Record<string, string> = {};
+    await resolveActorFromDiscordId(
+      {
+        baseUrl: BASE,
+        serviceToken: "svc-tok-123",
+        fetchImpl: fakeFetch(jsonResponse(200, { user_id: USER_ID }), (_u, init) => {
+          seenHeaders = (init?.headers as Record<string, string>) ?? {};
+        }),
+      },
+      DISCORD_ID,
+    );
+    expect(seenHeaders["x-service-token"]).toBe("svc-tok-123");
+  });
+
+  test("a trailing slash on baseUrl is normalized (no double slash)", async () => {
+    let seenUrl = "";
+    await resolveActorFromDiscordId(
+      { baseUrl: `${BASE}/`, fetchImpl: fakeFetch(jsonResponse(200, { user_id: USER_ID }), (u) => (seenUrl = u)) },
+      DISCORD_ID,
+    );
+    expect(seenUrl).toBe(`${BASE}/v1/resolve/account/discord/${DISCORD_ID}`);
+  });
+});
+
+describe("bd-atm — makeIdentityActorResolverFor: ActorResolver factory keyed on discord id", () => {
+  test("the curried factory binds config once + resolves per discord id", async () => {
+    const factory = makeIdentityActorResolverFor({
+      baseUrl: BASE,
+      fetchImpl: fakeFetch(jsonResponse(200, { user_id: USER_ID })),
+    });
+    const resolver = factory(DISCORD_ID);
+    expect(await resolver()).toEqual({ actor: USER_ID });
+  });
+
+  test("an unresolved id ⇒ the resolver yields null (the trigger refuses)", async () => {
+    const factory = makeIdentityActorResolverFor({
+      baseUrl: BASE,
+      fetchImpl: fakeFetch(jsonResponse(404, {})),
+    });
+    expect(await factory(DISCORD_ID)()).toBeNull();
+  });
+});

--- a/apps/bot/src/shadow/identity-actor-resolver.ts
+++ b/apps/bot/src/shadow/identity-actor-resolver.ts
@@ -1,0 +1,123 @@
+/**
+ * shadow/identity-actor-resolver.ts — the ISOLATED actor resolver for the
+ * voiceless `/role-sync` trigger (bd-atm, isolation principle).
+ *
+ * ── WHY ISOLATED (NOT via the auth-bridge AuthContext) ───────────────────────
+ * The trigger's default `actorResolverFromAuth` reads the per-interaction
+ * `AuthContext` the auth-bridge attaches — which only yields a `verified` actor
+ * when the GLOBAL `AUTH_BACKEND=freeside-jwt` is flipped (the persona daemon's
+ * auth). The onboarding/role-dispenser is a SEPARABLE, voiceless building (see
+ * grimoires/.../onboarding-as-separable-voiceless-building.md): it MUST NOT
+ * infer its identity system from the persona daemon's auth backend. A community
+ * could mount the role-dispenser WITHOUT the persona daemon.
+ *
+ * So `/role-sync` resolves the invoking CM's actor ITSELF, independent of
+ * AUTH_BACKEND:
+ *   invoking Discord user id → identity-api `GET /v1/resolve/account/discord/{id}`
+ *     → 200 { user_id } ⇒ actor = user_id (the value runTierRoleGoLive authzs
+ *                          against admin_principals)
+ *     → 404            ⇒ no linked account ⇒ REFUSE (fail-closed)
+ *
+ * ── FAIL-CLOSED ──────────────────────────────────────────────────────────────
+ * No invoking discord id, a 404 (unlinked), a non-2xx, a transport error, or a
+ * malformed body ALL resolve to null ⇒ the trigger core refuses BEFORE any read
+ * (it cannot authz an unresolved actor). A clear structural message is surfaced
+ * by the trigger's refusal path.
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * This module imports NOTHING from persona-engine. It is a thin identity-api
+ * read (one HTTP GET) behind an injected `fetch`, so tests are network-free.
+ *
+ * ── GROUNDING (freeside-auth, read 2026-06-04) ───────────────────────────────
+ * The identity-api route is `GET /v1/resolve/account/:provider/:externalId`
+ * (freeside-auth src/api/__tests__/routes.test.ts:232) — provider "discord",
+ * externalId = the Discord user snowflake. 200 ⇒ { user_id }, 404 ⇒ not_found.
+ */
+import type { ResolvedActor } from "./role-sync-trigger.ts";
+
+/**
+ * Config for the isolated identity-api actor resolver. `fetchImpl` is injected so
+ * tests are network-free; production omits it (uses global `fetch`).
+ */
+export interface IdentityActorResolverConfig {
+  /** identity-api base URL (e.g. https://identity.0xhoneyjar.xyz). REQUIRED. */
+  readonly baseUrl: string;
+  /**
+   * optional service token (sent as `x-service-token`) — the role-dispenser's
+   * read credential for identity-api. Resolve is a public read in the canonical
+   * routes today, but a deployment MAY gate it; the token is sent when present.
+   */
+  readonly serviceToken?: string;
+  /** injectable fetch (tests). */
+  readonly fetchImpl?: typeof fetch;
+  /** per-request deadline in ms (default 10s). */
+  readonly timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Discord user snowflakes are 17-20 digit decimal ids. */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
+/**
+ * Resolve the invoking CM's actor from a Discord user id via identity-api,
+ * INDEPENDENT of the global AUTH_BACKEND. Returns the {@link ResolvedActor}
+ * (`{ actor: user_id }`) on a 200 hit, or null on ANY failure (no discord id,
+ * 404 unlinked, non-2xx, transport, malformed body) — fail-closed. The trigger
+ * core refuses a null actor before any read.
+ */
+export async function resolveActorFromDiscordId(
+  cfg: IdentityActorResolverConfig,
+  discordId: string | undefined,
+): Promise<ResolvedActor | null> {
+  const id = (discordId ?? "").trim();
+  // A missing / malformed invoking id can never resolve — fail closed.
+  if (!SNOWFLAKE_RE.test(id)) return null;
+
+  const base = cfg.baseUrl.replace(/\/+$/, "");
+  const url = `${base}/v1/resolve/account/discord/${encodeURIComponent(id)}`;
+  const doFetch = cfg.fetchImpl ?? fetch;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let res: Response;
+  try {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (cfg.serviceToken && cfg.serviceToken.length > 0) {
+      headers["x-service-token"] = cfg.serviceToken;
+    }
+    res = await doFetch(url, { method: "GET", headers, signal: controller.signal });
+  } catch {
+    // transport error / abort (deadline) — fail closed (null ⇒ refuse).
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // 404 (unlinked) and any non-2xx ⇒ fail closed.
+  if (!res.ok) return null;
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return null; // malformed body ⇒ fail closed.
+  }
+  const userId = (body as { user_id?: unknown } | null)?.user_id;
+  if (typeof userId !== "string" || userId.length === 0) return null;
+  return { actor: userId };
+}
+
+/**
+ * Build an {@link ActorResolver}-shaped factory keyed on the invoking Discord
+ * user id. The interaction adapter calls this with the id it reads from the
+ * interaction; the returned thunk performs the identity-api lookup. Curried so
+ * the boot composition can bind the config once and the adapter supplies the id
+ * per interaction.
+ */
+export function makeIdentityActorResolverFor(
+  cfg: IdentityActorResolverConfig,
+): (discordId: string | undefined) => () => Promise<ResolvedActor | null> {
+  return (discordId) => () => resolveActorFromDiscordId(cfg, discordId);
+}

--- a/apps/bot/src/shadow/role-sync-boot.test.ts
+++ b/apps/bot/src/shadow/role-sync-boot.test.ts
@@ -1,0 +1,193 @@
+/**
+ * role-sync-boot.test.ts — the LIVE `/role-sync` boot composition (bd-atm).
+ * NETWORK-FREE: the bot client, fetch, wallet link, and role-map reader are all
+ * injected; the only real I/O is reading the VENDORED apps/bot/worlds/purupuru.yaml
+ * (a checked-in file, the FR-10 admin_principals + guild_id source).
+ *
+ * Proves (the bd-atm wiring gates):
+ *   • env-present (ROLE_SYNC_ENABLED + a readable manifest) ⇒ deps compose, and
+ *     the SHADOW invocation runs through the REAL substrate gate with ZERO writes.
+ *   • env-absent (ROLE_SYNC_ENABLED unset) ⇒ buildRoleSyncBootDeps returns null
+ *     (fail-closed; `/role-sync` is "not configured").
+ *   • the isolated actor resolver refuses an unresolved (404) discord ⇒ the
+ *     trigger refuses BEFORE any read (no orchestration), via the wired
+ *     actorResolverFor.
+ *   • manifestPathForWorld resolves to the vendored copy + that file carries the
+ *     expected admin_principals (the bare-uuid actor resolveAuthz matches).
+ *   • LIVE apply fails CLOSED (audit deps not wired) with a clear message.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import {
+  buildRoleSyncBootDeps,
+  manifestPathForWorld,
+  type RoleSyncBootEnv,
+  type RoleSyncBootSeams,
+} from "./role-sync-boot.ts";
+import { handleRoleSyncInteraction } from "./role-sync-interaction.ts";
+import { makeWalletDiscordLinkMock } from "./wallet-discord-link.live.ts";
+import type { DiscordInteraction } from "../discord-interactions/types.ts";
+import { InteractionResponseType, MessageFlags } from "../discord-interactions/types.ts";
+import { IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+
+const ADMIN_UUID = "ae0558c7-aeb2-48f0-906d-ad0a50108b19";
+const PURUPURU_GUILD = "1495534680617910396";
+const INVOKER_DISCORD_ID = "700000000000000001"; // a valid 18-digit snowflake
+
+/** A fake fetch returning a fixed identity-api Response (network-free). */
+function identityFetch(status: number, body: unknown): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+/** Seams with NO live discord client (SHADOW uses mock roster, zero writes). */
+function seams(overrides: Partial<RoleSyncBootSeams> = {}): RoleSyncBootSeams {
+  return {
+    getBotClient: async () => null,
+    walletDiscordLink: makeWalletDiscordLinkMock({}),
+    readRoleMap: () => null, // ⇒ default seed
+    ...overrides,
+  };
+}
+
+/** A `/role-sync` interaction (SHADOW by default) invoked by INVOKER_DISCORD_ID. */
+function interaction(modeValue?: string): DiscordInteraction {
+  return {
+    type: 2,
+    id: "999000111222333444",
+    application_id: "app",
+    token: "tok",
+    guild_id: PURUPURU_GUILD,
+    member: { user: { id: INVOKER_DISCORD_ID, username: "soju" } },
+    data: {
+      id: "cmd",
+      name: "role-sync",
+      options: modeValue !== undefined ? [{ name: "mode", type: 3, value: modeValue }] : [],
+    },
+  } as unknown as DiscordInteraction;
+}
+
+describe("bd-atm — manifestPathForWorld + the vendored manifest", () => {
+  test("resolves to the vendored apps/bot/worlds/<slug>.yaml", () => {
+    const p = manifestPathForWorld("purupuru");
+    expect(p.endsWith("apps/bot/worlds/purupuru.yaml")).toBe(true);
+  });
+
+  test("the vendored manifest carries the expected admin_principals (FR-10)", () => {
+    const doc = parseYaml(readFileSync(manifestPathForWorld("purupuru"), "utf8")) as {
+      shadow_onboarding?: { admin_principals?: unknown; guild_id?: unknown; namespace_prefix?: unknown };
+    };
+    expect(doc.shadow_onboarding?.admin_principals).toEqual([ADMIN_UUID]);
+    expect(doc.shadow_onboarding?.guild_id).toBe(PURUPURU_GUILD);
+    expect(doc.shadow_onboarding?.namespace_prefix).toBe("purupuru:");
+  });
+
+  test("an unsafe slug is refused (no path traversal into the manifest read)", () => {
+    expect(() => manifestPathForWorld("../etc/passwd")).toThrow();
+  });
+});
+
+describe("bd-atm — buildRoleSyncBootDeps: env gate (fail-closed)", () => {
+  test("env-absent (ROLE_SYNC_ENABLED unset) ⇒ null (not configured)", () => {
+    const deps = buildRoleSyncBootDeps({}, seams());
+    expect(deps).toBeNull();
+  });
+
+  test("ROLE_SYNC_ENABLED falsey ⇒ null", () => {
+    const deps = buildRoleSyncBootDeps({ ROLE_SYNC_ENABLED: "0" } as RoleSyncBootEnv, seams());
+    expect(deps).toBeNull();
+  });
+
+  test("env-present ⇒ deps compose (world + worldConfig from the manifest)", () => {
+    const deps = buildRoleSyncBootDeps({ ROLE_SYNC_ENABLED: "1" } as RoleSyncBootEnv, seams());
+    expect(deps).not.toBeNull();
+    expect(deps!.world).toBe("purupuru");
+    expect(deps!.worldConfig.guild_id).toBe(PURUPURU_GUILD);
+    expect(deps!.worldConfig.namespace_prefix).toBe("purupuru:");
+    expect(typeof deps!.invokeOrchestration).toBe("function");
+    expect(typeof deps!.actorResolverFor).toBe("function");
+  });
+});
+
+describe("bd-atm — end-to-end: SHADOW runs through the gate with ZERO writes", () => {
+  test("a resolved CM (200) runs SHADOW preview → EPHEMERAL CV2, zero writes", async () => {
+    const deps = buildRoleSyncBootDeps(
+      { ROLE_SYNC_ENABLED: "1" } as RoleSyncBootEnv,
+      seams({ fetchImpl: identityFetch(200, { user_id: ADMIN_UUID }) }),
+    )!;
+
+    const res = await handleRoleSyncInteraction(interaction(), undefined, deps);
+
+    // SHADOW preview through the REAL substrate gate (mock writer) → a CV2
+    // EPHEMERAL render. The gate rejected every op (zero inner writes) — the
+    // orchestrator recovers that into the preview result, so the outcome is a
+    // `rendered` CV2 payload (not an error).
+    expect(res.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE);
+    const flags = (res.data as { flags?: number }).flags ?? 0;
+    expect(flags & IS_COMPONENTS_V2).toBe(IS_COMPONENTS_V2);
+    expect(flags & MessageFlags.EPHEMERAL).toBe(MessageFlags.EPHEMERAL);
+    expect((res.data as { content?: string }).content).toBeUndefined();
+  });
+});
+
+describe("bd-atm — isolated actor resolution refuses an unlinked CM (fail-closed)", () => {
+  test("an unresolved (404) discord ⇒ refusal, orchestration NEVER called", async () => {
+    let invoked = false;
+    const deps = buildRoleSyncBootDeps(
+      { ROLE_SYNC_ENABLED: "1" } as RoleSyncBootEnv,
+      seams({ fetchImpl: identityFetch(404, { code: "not_found" }) }),
+    )!;
+    // wrap the invoker to detect any orchestration call
+    const wrapped = {
+      ...deps,
+      invokeOrchestration: async (...args: Parameters<typeof deps.invokeOrchestration>) => {
+        invoked = true;
+        return deps.invokeOrchestration(...args);
+      },
+    };
+
+    const res = await handleRoleSyncInteraction(interaction("live"), undefined, wrapped);
+    expect(invoked).toBe(false); // refused BEFORE any read
+    const data = res.data as { content?: string; components?: unknown };
+    expect(data.content).toBeDefined();
+    expect(data.content).toContain("verified identity");
+    expect(data.components).toBeUndefined(); // a plain refusal, not CV2
+  });
+
+  test("isolation: the actor comes from identity-api, NOT the AuthContext (auth ignored)", async () => {
+    // Pass a `verified` AuthContext with a DIFFERENT sub — the isolated resolver
+    // must use the identity-api result, proving independence from AUTH_BACKEND.
+    const deps = buildRoleSyncBootDeps(
+      { ROLE_SYNC_ENABLED: "1" } as RoleSyncBootEnv,
+      seams({ fetchImpl: identityFetch(404, {}) }), // identity-api says unlinked
+    )!;
+    const res = await handleRoleSyncInteraction(
+      interaction(),
+      { kind: "verified", jwt: "x", claims: { sub: "some-other-jwt-sub" } as never },
+      deps,
+    );
+    // Despite a verified AuthContext, the identity-api 404 wins → refused.
+    expect((res.data as { content?: string }).content).toContain("verified identity");
+  });
+});
+
+describe("bd-atm — LIVE apply fails CLOSED (audit deps not wired)", () => {
+  test("a LIVE invocation surfaces a clear structural error (no write)", async () => {
+    const deps = buildRoleSyncBootDeps(
+      { ROLE_SYNC_ENABLED: "1", SCORE_PURUPURU_API_KEY: "k" } as RoleSyncBootEnv,
+      seams({
+        fetchImpl: identityFetch(200, { user_id: ADMIN_UUID }),
+      }),
+    )!;
+    const res = await handleRoleSyncInteraction(interaction("live"), undefined, deps);
+    const data = res.data as { content?: string };
+    // The boot composition throws requireLiveAudit() for LIVE → the trigger maps
+    // it to a voiceless error outcome.
+    expect(data.content).toContain("failed");
+    expect(data.content).toContain("LIVE");
+  });
+});

--- a/apps/bot/src/shadow/role-sync-boot.ts
+++ b/apps/bot/src/shadow/role-sync-boot.ts
@@ -1,0 +1,402 @@
+/**
+ * shadow/role-sync-boot.ts — the LIVE boot composition for the voiceless
+ * `/role-sync` trigger (bd-atm). This is the missing wiring: bd-71y built the
+ * command + adapter and bd-m2v built `runTierRoleGoLive`, but nothing composed
+ * the live deps + called `setRoleSyncDeps()`. THIS module is that composition.
+ *
+ * ── WHAT IT BUILDS ───────────────────────────────────────────────────────────
+ *   • manifestPath(world) → the VENDORED apps/bot/worlds/<slug>.yaml (the FR-10
+ *     admin_principals + guild_id source the LIVE AdminAllowlistSource reads).
+ *   • an OrchestrationInvoker that, per `/role-sync` invocation:
+ *       - builds the SHADOW-preview Layer stack (mock writer + roster, zero
+ *         Discord writes) — or the LIVE-apply stack (gated writer) for LIVE;
+ *       - runs `runTierRoleGoLive(deps, input)` against that Layer via Effect;
+ *       - wires its sources: score (resolveScoreWiring → CommunityScoreClient →
+ *         leaderboardReader), wallet↔discord link (wallet-discord-link.live),
+ *         RosterSource (live, READ-only), and a SHADOW rosterIdentity snapshot.
+ *   • the isolated actor-resolver factory (identity-api, NOT AUTH_BACKEND).
+ *   • the deploy-resolved worldConfig (guild_id + nft_contracts from the manifest).
+ *
+ * ── SHADOW-FIRST + FAIL-CLOSED ───────────────────────────────────────────────
+ * `buildRoleSyncBootDeps` returns null when the REQUIRED env is absent (the
+ * trigger then never wires → `/role-sync` is "not configured" — a clean refusal).
+ * SHADOW preview runs on the mock writer + roster (zero writes). LIVE apply needs
+ * the LIVE score wiring; the composition-root's `resolveScoreLayer` fails CLOSED
+ * (LiveScoreWiringMissingError) for a LIVE run without a score key. The wallet
+ * link + rosterIdentity reads are fail-closed in the orchestrator (a DB outage or
+ * a snapshot read failure surfaces as a RosterError that refuses the run).
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * The ONLY persona-engine touch in this module is the `CommunityScoreClient`
+ * score DATA client (the documented isolation-debt seam — community-client lives
+ * in persona-engine only because the MCP score client does; the onboarding
+ * building will move it on extraction). There is NO persona / voice / narration
+ * import. The leaderboard read is pure data.
+ *
+ * ── ISOLATION-DEBT NOTE (bd-glb) ─────────────────────────────────────────────
+ * The full LIVE `rosterIdentity` (member-id ⊕ role-id snapshot for the B1
+ * roster-freshness fingerprint) is bd-glb — the substrate RosterSource port does
+ * not carry it and the LIVE roster adapter does not yet produce it. For the
+ * SHADOW path (driftThreshold 0, no base) the orchestrator does not gate on
+ * freshness, so this module supplies a minimal DERIVED snapshot (read from the
+ * live guild member/role ids when a bot client is available, else an empty one).
+ * The full LIVE rosterIdentity is bd-glb; LIVE apply must wait for it.
+ */
+import { Effect, Layer } from "effect";
+import { resolve as pathResolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import type { Client } from "discord.js";
+import type { ApplyMode } from "@freeside-worlds/shadow-substrate";
+import {
+  shadowPreviewLayer,
+  liveApplyLayer,
+  buildModeControl,
+  RoleWriterMock,
+  makeInMemoryWorldLock,
+  makeAdminAllowlistLive,
+  type ShadowDeps,
+  type WorldWiring,
+  type WorldScoreWiring,
+  type LiveAuditDeps,
+} from "./composition-root.ts";
+import { makeRecordingEmitter } from "./acvp-emitter.mock.ts";
+import {
+  runTierRoleGoLive,
+  type GoLiveOrchestrationInput,
+  type GoLiveOrchestrationResult,
+  type OrchestrationContext,
+  type OrchestrationError,
+  type RosterIdentityReader,
+  type RosterIdentitySnapshot,
+  type LeaderboardReader,
+} from "./go-live-orchestrator.ts";
+import type { RoleMapReader, OrchestrationInvoker } from "./role-sync-trigger.ts";
+import type { RoleSyncInteractionDeps } from "./role-sync-interaction.ts";
+import { makeWalletDiscordLinkLive } from "./wallet-discord-link.live.ts";
+import type { WalletDiscordLink } from "./score-tier-assignment.ts";
+import { makeIdentityActorResolverFor } from "./identity-actor-resolver.ts";
+import { configServiceClientFromEnv } from "./config-service-client.ts";
+import type { RoleMapConfig } from "./substrate.ts";
+import { CommunityScoreClient } from "@freeside-characters/persona-engine/score/community-client";
+
+/**
+ * The directory the vendored world manifests live in (apps/bot/worlds/). The
+ * convention: ONE `<slug>.yaml` per world, a vendored copy of the canonical
+ * freeside-worlds manifest. Resolved relative to this module's location so it is
+ * stable regardless of the process CWD (the bot may boot from the repo root or
+ * apps/bot). `import.meta.dir` is apps/bot/src/shadow; the manifests dir is
+ * apps/bot/worlds → `../../worlds`.
+ */
+export const WORLDS_DIR = pathResolve(import.meta.dir, "../../worlds");
+
+/**
+ * Resolve a world slug → its VENDORED manifest path. Slug is validated to a safe
+ * filename segment (no path traversal) — the slug feeds a filesystem path the
+ * AdminAllowlistSource reads.
+ */
+export function manifestPathForWorld(world: string): string {
+  if (!/^[A-Za-z0-9_-]+$/.test(world)) {
+    throw new Error(`role-sync-boot: refusing unsafe world slug '${world}' for manifest path`);
+  }
+  return pathResolve(WORLDS_DIR, `${world}.yaml`);
+}
+
+/**
+ * The env the boot composition reads. Surfaced as an interface so tests inject a
+ * fixture env (network-free) and the production path reads `process.env`.
+ */
+export interface RoleSyncBootEnv {
+  /** the world this deployment's role-dispenser targets (default "purupuru"). */
+  readonly ROLE_SYNC_WORLD?: string;
+  /** the master gate: when not truthy, `/role-sync` is NOT wired (clean refusal). */
+  readonly ROLE_SYNC_ENABLED?: string;
+  /** identity-api base URL for the isolated actor resolver. */
+  readonly IDENTITY_API_URL?: string;
+  /** optional identity-api read service token (x-service-token). */
+  readonly IDENTITY_API_SERVICE_TOKEN?: string;
+  /** score-api base URL (for the LIVE leaderboard / score read). */
+  readonly SCORE_API_URL?: string;
+  /** the Purupuru community-scoped score-api key. Present ⇒ LIVE score; absent ⇒ MOCK. */
+  readonly SCORE_PURUPURU_API_KEY?: string;
+  /** the Purupuru community slug (default "purupuru"). */
+  readonly SCORE_PURUPURU_COMMUNITY?: string;
+  /** config-service base URL for the CM-authored role-map read (optional → seed fallback). */
+  readonly CONFIG_SERVICE_URL?: string;
+}
+
+/** Default identity-api base (matches the mint-subscriber default in index.ts). */
+const DEFAULT_IDENTITY_API_URL = "https://identity.0xhoneyjar.xyz";
+/** Default score-api base (the live Railway deployment). */
+const DEFAULT_SCORE_API_URL = "https://score-api-production.up.railway.app";
+
+/**
+ * The injectable seams for `buildRoleSyncBootDeps` — production omits them
+ * (uses the real bot client + global fetch); tests inject fakes for a
+ * network-free composition assertion.
+ */
+export interface RoleSyncBootSeams {
+  /** the bot Gateway client factory (live roster reads). */
+  readonly getBotClient: () => Promise<Client | null>;
+  /** injectable fetch for the identity-api resolver (tests). */
+  readonly fetchImpl?: typeof fetch;
+  /** injectable wallet↔discord link (tests inject a pure map; prod uses the live adapter). */
+  readonly walletDiscordLink?: WalletDiscordLink;
+  /** injectable role-map reader (tests); prod uses the config-service client + seed fallback. */
+  readonly readRoleMap?: RoleMapReader;
+  /** injectable identity-api token getter for the config-service role-map read. */
+  readonly configServiceToken?: () => Promise<string | null> | string | null;
+}
+
+/**
+ * Resolve the per-world `WorldWiring` (guild_id + namespace_prefix) for the
+ * composition root. Read from the vendored manifest at boot so the LIVE roster
+ * reader + writer target the right guild. We parse the same `shadow_onboarding`
+ * block the AdminAllowlistSource reads.
+ */
+function readShadowOnboarding(
+  world: string,
+): { guild_id?: unknown; namespace_prefix?: unknown; nft_contracts?: unknown } | undefined {
+  let text: string;
+  try {
+    text = readFileSync(manifestPathForWorld(world), "utf8");
+  } catch {
+    return undefined;
+  }
+  const doc = parseYaml(text) as { shadow_onboarding?: unknown } | undefined;
+  const so = doc?.shadow_onboarding;
+  return so && typeof so === "object" ? (so as Record<string, unknown>) : undefined;
+}
+
+function readWorldWiring(world: string): WorldWiring | undefined {
+  const so = readShadowOnboarding(world);
+  const guild_id = typeof so?.guild_id === "string" ? so.guild_id : "";
+  const namespace_prefix = typeof so?.namespace_prefix === "string" ? so.namespace_prefix : "";
+  if (guild_id.length === 0 || namespace_prefix.length === 0) return undefined;
+  return { guild_id, namespace_prefix };
+}
+
+/** Read the manifest's `nft_contracts` (FR-7 worldConfig hash input). */
+function readNftContracts(world: string): readonly string[] {
+  const so = readShadowOnboarding(world);
+  const list = so?.nft_contracts;
+  return Array.isArray(list) ? list.filter((x): x is string => typeof x === "string") : [];
+}
+
+/**
+ * A minimal DERIVED `rosterIdentity` reader for the SHADOW path. The full LIVE
+ * snapshot (member-id ⊕ role-id sets for the B1 fingerprint) is bd-glb. For
+ * SHADOW (driftThreshold 0, no base) the orchestrator never gates on freshness,
+ * so a best-effort snapshot is sufficient: read the live guild's member/role ids
+ * when a bot client is available, else an empty snapshot. NEVER used for LIVE
+ * (LIVE needs the bd-glb full reader).
+ */
+function makeShadowRosterIdentityReader(
+  getBotClient: () => Promise<Client | null>,
+  resolveWorld: (world: string) => WorldWiring | undefined,
+): RosterIdentityReader {
+  return async (world: string): Promise<RosterIdentitySnapshot> => {
+    const wiring = resolveWorld(world);
+    const client = wiring ? await getBotClient() : null;
+    if (!wiring || !client) {
+      // No live guild access → an empty snapshot. SHADOW does not gate on it.
+      return { member_ids: [], role_ids: [] };
+    }
+    const guild = await client.guilds.fetch(wiring.guild_id);
+    const members = await guild.members.fetch();
+    const roles = await guild.roles.fetch();
+    return {
+      member_ids: [...members.values()].map((m) => m.id),
+      role_ids: [...roles.values()].map((r) => r.id),
+    };
+  };
+}
+
+/** Build the per-world score wiring resolver from env (presence of the key ⇒ LIVE). */
+function makeResolveScoreWiring(
+  env: RoleSyncBootEnv,
+  world: string,
+): (w: string) => WorldScoreWiring | undefined {
+  return (w: string) => {
+    if (w !== world) return undefined;
+    return {
+      scoreApiUrl: env.SCORE_API_URL?.trim() || DEFAULT_SCORE_API_URL,
+      community: env.SCORE_PURUPURU_COMMUNITY?.trim() || "purupuru",
+      apiKey: env.SCORE_PURUPURU_API_KEY?.trim() || undefined,
+    };
+  };
+}
+
+/**
+ * Build a LeaderboardReader from the score wiring (LIVE only — when the key is
+ * present). Returns undefined when there is no LIVE score key: the orchestrator
+ * then sees no reader and (for SHADOW) treats the leaderboard as empty (zero
+ * assignments) — a SHADOW preview with no score key shows the CREATE pass only.
+ * For LIVE the orchestrator FAILS CLOSED if no reader (Bridgebuilder #8).
+ */
+function makeLeaderboardReader(wiring: WorldScoreWiring | undefined): LeaderboardReader | undefined {
+  if (!wiring || !wiring.apiKey || wiring.apiKey.length === 0) return undefined;
+  const client = new CommunityScoreClient({
+    baseUrl: wiring.scoreApiUrl,
+    apiKey: wiring.apiKey,
+    community: wiring.community,
+  });
+  return async () => (await client.leaderboard()).wallets;
+}
+
+/**
+ * Build the LIVE `/role-sync` boot deps, or null when the master gate is off /
+ * the required env is missing (fail-closed — `/role-sync` is then "not
+ * configured" rather than silently degraded). When non-null, the caller passes
+ * the result to `setRoleSyncDeps()` at boot.
+ *
+ * REQUIRED to wire: `ROLE_SYNC_ENABLED` truthy AND a readable vendored manifest
+ * for the target world (guild_id + namespace_prefix). Everything else degrades
+ * gracefully (no score key ⇒ SHADOW preview shows creates only; no
+ * CONFIG_SERVICE_URL ⇒ the seed role-map; identity-api defaults to the canonical
+ * host).
+ */
+export function buildRoleSyncBootDeps(
+  env: RoleSyncBootEnv,
+  seams: RoleSyncBootSeams,
+): RoleSyncInteractionDeps | null {
+  const enabled = (env.ROLE_SYNC_ENABLED ?? "").trim().toLowerCase();
+  if (enabled !== "1" && enabled !== "true" && enabled !== "yes") return null;
+
+  const world = env.ROLE_SYNC_WORLD?.trim() || "purupuru";
+
+  // FAIL-CLOSED: the vendored manifest MUST exist + carry guild_id +
+  // namespace_prefix (the LIVE roster + the allowlist read both need it).
+  const wiring = readWorldWiring(world);
+  if (!wiring) return null;
+  const resolveWorld = (w: string): WorldWiring | undefined =>
+    w === world ? wiring : undefined;
+
+  const nftContracts = readNftContracts(world);
+  const resolveScoreWiring = makeResolveScoreWiring(env, world);
+
+  // ── the isolated actor resolver (identity-api, NOT AUTH_BACKEND) ───────────
+  const identityBaseUrl = env.IDENTITY_API_URL?.trim() || DEFAULT_IDENTITY_API_URL;
+  const actorResolverFactory = makeIdentityActorResolverFor({
+    baseUrl: identityBaseUrl,
+    serviceToken: env.IDENTITY_API_SERVICE_TOKEN?.trim() || undefined,
+    fetchImpl: seams.fetchImpl,
+  });
+
+  // ── the role-map reader: config-service (CM-authored) with seed fallback ───
+  // config-service.getRoleMap returns a SurfaceEnvelope; the trigger expects a
+  // RoleMapConfig|null. Unwrap the envelope; null (unwired / 404) ⇒ seed fallback.
+  const readRoleMap: RoleMapReader =
+    seams.readRoleMap ??
+    (async (w: string): Promise<RoleMapConfig | null> => {
+      const client = configServiceClientFromEnv(seams.configServiceToken ?? (() => null), seams.fetchImpl);
+      const env0 = await client.getRoleMap<RoleMapConfig>(w);
+      return env0 ? env0.envelope : null;
+    });
+
+  // ── the wallet↔discord link (bd-m2v live adapter; tests inject a map) ──────
+  const link: WalletDiscordLink = seams.walletDiscordLink ?? makeWalletDiscordLinkLive();
+
+  // ── the SHADOW rosterIdentity snapshot reader (bd-glb is the LIVE full one) ─
+  const shadowRosterIdentity = makeShadowRosterIdentityReader(seams.getBotClient, resolveWorld);
+
+  // The composition-root ShadowDeps (the Layer factory inputs).
+  const shadowDeps: ShadowDeps = {
+    getBotClient: seams.getBotClient,
+    resolveWorld,
+    manifestPath: manifestPathForWorld,
+    world,
+    initialMode: "SHADOW" as ApplyMode,
+    resolveScoreWiring,
+  };
+
+  // ── the OrchestrationInvoker: build the Layer + run runTierRoleGoLive ──────
+  const invokeOrchestration: OrchestrationInvoker = async (
+    input: GoLiveOrchestrationInput,
+  ): Promise<GoLiveOrchestrationResult> => {
+    const mode = await Effect.runPromise(buildModeControl(shadowDeps.initialMode));
+    const currentMapHash = () => input.currentMapHash as unknown as string;
+    const scoreWiring = resolveScoreWiring(world);
+    const leaderboardReader = makeLeaderboardReader(scoreWiring);
+
+    // The orchestration's `applyBatch` RE-RESOLVES RoleWriter | WorldLock |
+    // AdminAllowlistSource | AcvpEmitter at the write boundary (server-side authz
+    // re-check + write-after-audit), so those bare services must be in context at
+    // the orchestration level — not only provided INTO the gate. The
+    // composition-root helper provides them into the gate; we ALSO merge the SAME
+    // instances at the top so the re-resolution sees them (mirrors the orchestrator
+    // test's full stack). One shared emitter/lock so the gate + the re-check agree.
+    let layer;
+    if (input.applyMode === "LIVE") {
+      // LIVE needs the real NATS audit deps + the bd-glb full rosterIdentity —
+      // operator-boundary follow-ups. requireLiveAudit() fails CLOSED here.
+      layer = liveApplyLayer(shadowDeps, requireLiveAudit(), mode, currentMapHash);
+    } else {
+      const emitterLayer = makeRecordingEmitter().layer;
+      const worldLock = makeInMemoryWorldLock();
+      const allowlist = makeAdminAllowlistLive({ manifestPath: manifestPathForWorld, ttlMs: 10_000 });
+      const gateStack = shadowPreviewLayer(shadowDeps, mode, currentMapHash, emitterLayer);
+      // merge the bare write-boundary services the gate's applyBatch re-resolves.
+      layer = Layer.mergeAll(gateStack, RoleWriterMock, emitterLayer, worldLock, allowlist);
+    }
+
+    // SHADOW uses the best-effort derived snapshot (bd-glb is the LIVE full one).
+    const rosterIdentity = shadowRosterIdentity;
+
+    const program: Effect.Effect<GoLiveOrchestrationResult, OrchestrationError, OrchestrationContext> =
+      runTierRoleGoLive(
+        { mode, link, rosterIdentity },
+        { ...input, leaderboardReader: input.leaderboardReader ?? leaderboardReader },
+      );
+
+    return Effect.runPromise(program.pipe(Effect.provide(layer as Layer.Layer<OrchestrationContext>)));
+  };
+
+  return {
+    world,
+    readRoleMap,
+    invokeOrchestration,
+    worldConfig: {
+      guild_id: wiring.guild_id,
+      nft_contracts: nftContracts,
+      namespace_prefix: wiring.namespace_prefix,
+    },
+    now: () => new Date().toISOString(),
+    // The token metadata the batch AuthzContext carries. The actor authz is the
+    // load-bearing gate (admin_principals); this is descriptive provenance the
+    // gate records. A real verified-token-metadata source is a LIVE follow-up
+    // (the config-service token path); for now it is stamped at invocation.
+    tokenMetadata: {
+      kid: "role-sync-boot",
+      verified_at: new Date().toISOString(),
+      exp: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    },
+    transitionVersion: 1,
+    actorResolverFor: actorResolverFactory,
+  };
+}
+
+/**
+ * LIVE apply requires real NATS audit deps (signer + publish) for the gate's
+ * write-after-audit. Those are an OPERATOR boundary (bd-glb / LIVE rollout) and
+ * are NOT wired in this SHADOW-first composition. A LIVE invocation therefore
+ * fails CLOSED with a clear structural message rather than writing without an
+ * audit trail. SHADOW never reaches this.
+ */
+function requireLiveAudit(): LiveAuditDeps {
+  throw new Error(
+    "role-sync LIVE apply is not yet wired — the LIVE NATS AcvpEmitter audit deps " +
+      "(signer + publish) and the full bd-glb rosterIdentity reader are operator-boundary " +
+      "follow-ups. SHADOW preview is fully wired; run /role-sync with mode SHADOW.",
+  );
+}
+
+/**
+ * Convenience: build the deps from `process.env` + the real bot client. Returns
+ * null when not configured (the caller skips `setRoleSyncDeps`).
+ */
+export function buildRoleSyncBootDepsFromEnv(
+  getBotClient: () => Promise<Client | null>,
+): RoleSyncInteractionDeps | null {
+  return buildRoleSyncBootDeps(process.env as RoleSyncBootEnv, { getBotClient });
+}

--- a/apps/bot/src/shadow/role-sync-interaction.test.ts
+++ b/apps/bot/src/shadow/role-sync-interaction.test.ts
@@ -1,0 +1,167 @@
+/**
+ * role-sync-interaction.test.ts — the Discord-interaction ADAPTER for the
+ * voiceless tier→role sync trigger (bd-71y). NETWORK-FREE: the orchestration +
+ * role-map reader are injected; the AuthContext is a fixture.
+ *
+ * Proves:
+ *   • actorResolverFromAuth yields the actor (claims.sub) ONLY for a `verified`
+ *     context; anon / anon-fallback / missing ⇒ null (the core refuses).
+ *   • a verified CM's SHADOW invocation renders the CV2 payload as an EPHEMERAL
+ *     response (IS_COMPONENTS_V2 | EPHEMERAL flags, no content/embeds).
+ *   • an anon CM is refused with a plain ephemeral status (no CV2, no write).
+ *   • the LIVE option flows through (explicit choice).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  handleRoleSyncInteraction,
+  actorResolverFromAuth,
+  roleSyncOutcomeToResponse,
+  type RoleSyncInteractionDeps,
+} from "./role-sync-interaction.ts";
+import { InteractionResponseType, MessageFlags } from "../discord-interactions/types.ts";
+import type { DiscordInteraction } from "../discord-interactions/types.ts";
+import type { AuthContext, JWTClaim } from "../auth-bridge.ts";
+import { IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import type {
+  GoLiveOrchestrationInput,
+  GoLiveOrchestrationResult,
+} from "./go-live-orchestrator.ts";
+import type { WriteIntentBatch } from "@freeside-worlds/shadow-substrate";
+
+const WORLD = "purupuru";
+
+function verifiedAuth(sub: string): AuthContext {
+  return {
+    kind: "verified",
+    jwt: "jwt.token.value",
+    claims: { sub } as unknown as JWTClaim,
+  };
+}
+
+function fakeResult(applyMode: "SHADOW" | "LIVE"): GoLiveOrchestrationResult {
+  const batch = { ops: [{ op_id: "c0", kind: "create_role", intent: { role_key: "purupuru:member" } }] } as unknown as WriteIntentBatch;
+  return {
+    applyMode,
+    batch,
+    job: { status: "failed", progress: { total: 1, completed: 0, failed: 1 }, roles_created: [], op_status: [{ op_id: "c0", status: "failed" }] },
+    createCount: 1,
+    assignCount: 0,
+    skippedUnlinked: 0,
+    skippedUnqualified: 0,
+    skippedInvalid: 0,
+    collapsedDuplicateMembers: 0,
+  } as GoLiveOrchestrationResult;
+}
+
+function interactionDeps(
+  capture?: (input: GoLiveOrchestrationInput) => void,
+): RoleSyncInteractionDeps {
+  return {
+    world: WORLD,
+    readRoleMap: () => null, // ⇒ default seed
+    invokeOrchestration: async (input) => {
+      capture?.(input);
+      return fakeResult(input.applyMode);
+    },
+    worldConfig: { guild_id: "111122223333444455", nft_contracts: ["0xabc"] },
+    now: () => "2026-06-04T00:00:00Z",
+    tokenMetadata: { kid: "k", verified_at: "2026-06-04T00:00:00Z", exp: "2026-06-04T01:00:00Z" },
+    transitionVersion: 7,
+  };
+}
+
+function interaction(modeValue?: string): DiscordInteraction {
+  return {
+    type: 2,
+    id: "999000111222333444",
+    application_id: "app",
+    token: "tok",
+    guild_id: "111122223333444455",
+    data: {
+      id: "cmd",
+      name: "role-sync",
+      options: modeValue !== undefined ? [{ name: "mode", type: 3, value: modeValue }] : [],
+    },
+  } as unknown as DiscordInteraction;
+}
+
+describe("bd-71y — actorResolverFromAuth: actor only from a verified context", () => {
+  test("verified ⇒ actor = claims.sub", async () => {
+    const r = await actorResolverFromAuth(verifiedAuth("identity:cm-1"))();
+    expect(r).toEqual({ actor: "identity:cm-1" });
+  });
+  test("anon ⇒ null", async () => {
+    const r = await actorResolverFromAuth({ kind: "anon", discord_id: "5" })();
+    expect(r).toBeNull();
+  });
+  test("anon-fallback ⇒ null", async () => {
+    const r = await actorResolverFromAuth({ kind: "anon-fallback", discord_id: "5", reason: "no-tenant" })();
+    expect(r).toBeNull();
+  });
+  test("undefined auth ⇒ null", async () => {
+    const r = await actorResolverFromAuth(undefined)();
+    expect(r).toBeNull();
+  });
+  test("verified but empty sub ⇒ null", async () => {
+    const r = await actorResolverFromAuth(verifiedAuth(""))();
+    expect(r).toBeNull();
+  });
+});
+
+describe("bd-71y — handleRoleSyncInteraction: verified CM SHADOW → ephemeral CV2", () => {
+  test("a verified CM (default mode) gets an EPHEMERAL CV2 response", async () => {
+    let seenMode: string | undefined;
+    const res = await handleRoleSyncInteraction(
+      interaction(), // no mode ⇒ SHADOW
+      verifiedAuth("identity:cm-1"),
+      interactionDeps((i) => (seenMode = i.applyMode)),
+    );
+    expect(seenMode).toBe("SHADOW");
+    expect(res.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE);
+    // flags = IS_COMPONENTS_V2 | EPHEMERAL; no content/embeds on a CV2 message.
+    const flags = (res.data as { flags?: number }).flags ?? 0;
+    expect(flags & IS_COMPONENTS_V2).toBe(IS_COMPONENTS_V2);
+    expect(flags & MessageFlags.EPHEMERAL).toBe(MessageFlags.EPHEMERAL);
+    expect((res.data as { content?: string }).content).toBeUndefined();
+    expect(Array.isArray((res.data as { components?: unknown[] }).components)).toBe(true);
+  });
+
+  test("LIVE option flows through (explicit choice)", async () => {
+    let seenMode: string | undefined;
+    await handleRoleSyncInteraction(
+      interaction("live"),
+      verifiedAuth("identity:cm-1"),
+      interactionDeps((i) => (seenMode = i.applyMode)),
+    );
+    expect(seenMode).toBe("LIVE");
+  });
+});
+
+describe("bd-71y — handleRoleSyncInteraction: anon CM refused (no CV2, no invoke)", () => {
+  test("an anon invoker gets a plain ephemeral refusal; orchestration never called", async () => {
+    let invoked = false;
+    const deps = interactionDeps(() => (invoked = true));
+    const res = await handleRoleSyncInteraction(
+      interaction("live"), // even explicit LIVE
+      { kind: "anon", discord_id: "5" },
+      deps,
+    );
+    expect(invoked).toBe(false);
+    expect(res.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE);
+    const data = res.data as { content?: string; flags?: number; components?: unknown };
+    expect(data.content).toBeDefined();
+    expect(data.content).toContain("verified identity");
+    expect((data.flags ?? 0) & MessageFlags.EPHEMERAL).toBe(MessageFlags.EPHEMERAL);
+    // a refusal is a plain string, NOT a CV2 component message.
+    expect(data.components).toBeUndefined();
+  });
+});
+
+describe("bd-71y — roleSyncOutcomeToResponse mapping", () => {
+  test("error outcome ⇒ plain ephemeral content (voiceless)", () => {
+    const res = roleSyncOutcomeToResponse({ kind: "error", message: "Tier→role sync (LIVE) failed: boom" });
+    const data = res.data as { content?: string; flags?: number };
+    expect(data.content).toContain("failed");
+    expect((data.flags ?? 0) & MessageFlags.EPHEMERAL).toBe(MessageFlags.EPHEMERAL);
+  });
+});

--- a/apps/bot/src/shadow/role-sync-interaction.ts
+++ b/apps/bot/src/shadow/role-sync-interaction.ts
@@ -1,0 +1,123 @@
+/**
+ * shadow/role-sync-interaction.ts — the Discord-interaction ADAPTER for the
+ * voiceless tier→role sync trigger (bd-71y).
+ *
+ * Maps a Discord `APPLICATION_COMMAND` interaction (`/role-sync`) onto the
+ * testable trigger CORE (`role-sync-trigger.ts::runRoleSyncTrigger`):
+ *   • reads the `mode` option (SHADOW preview default | LIVE apply) — SAFE-BY-
+ *     DEFAULT via `parseRoleSyncMode`;
+ *   • resolves the CM's actor from the VERIFIED AuthContext the auth-bridge
+ *     attached (`claims.sub` = identity-api user_id) — a non-verified invocation
+ *     is refused by the core before any read;
+ *   • runs the trigger and maps the structured outcome → a Discord response.
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * This adapter has NO persona-engine import and emits NO persona voice. On a
+ * `rendered` outcome it sends the STRUCTURAL CV2 payload verbatim (flags +
+ * components from `role-sync-result-cv2`); on `refused`/`error` it sends a plain
+ * ephemeral status string. The structural render owns the message shape.
+ *
+ * ── IMPORT-BOUNDARY ──────────────────────────────────────────────────────────
+ * This module performs NO discord.js role mutation — it only reads the
+ * interaction + builds a response payload. All role writes happen INSIDE the
+ * INJECTED `OrchestrationInvoker` (runTierRoleGoLive → the substrate gate →
+ * `role-writer.live.ts`, the single gated adapter).
+ */
+import type {
+  DiscordInteraction,
+  DiscordInteractionResponse,
+} from "../discord-interactions/types.ts";
+import { InteractionResponseType, MessageFlags } from "../discord-interactions/types.ts";
+import type { AuthContext } from "../auth-bridge.ts";
+import {
+  runRoleSyncTrigger,
+  parseRoleSyncMode,
+  ROLE_SYNC_MODE_OPTION,
+  type RoleSyncTriggerDeps,
+  type ActorResolver,
+  type RoleSyncOutcome,
+} from "./role-sync-trigger.ts";
+
+/**
+ * Build an {@link ActorResolver} from the bot's existing per-interaction
+ * AuthContext. ONLY a `verified` context yields an actor (its `claims.sub` is the
+ * identity-api user_id). anon / anon-fallback ⇒ null ⇒ the core refuses. This is
+ * the existing identity path the bot uses for verify — NOT a new surface.
+ */
+export function actorResolverFromAuth(auth: AuthContext | undefined): ActorResolver {
+  return () => {
+    if (!auth || auth.kind !== "verified") return null;
+    const sub = auth.claims.sub;
+    if (typeof sub !== "string" || sub.length === 0) return null;
+    return { actor: sub };
+  };
+}
+
+/** Read the `mode` string option from the interaction (SHADOW/LIVE; default SHADOW). */
+function readModeOption(interaction: DiscordInteraction): string | undefined {
+  const opt = interaction.data?.options?.find((o) => o.name === ROLE_SYNC_MODE_OPTION);
+  if (!opt || typeof opt.value !== "string") return undefined;
+  return opt.value;
+}
+
+/**
+ * The deps the interaction adapter needs beyond the per-interaction AuthContext:
+ * the trigger-core deps WITHOUT `resolveActor` (the adapter supplies that from
+ * the AuthContext) — everything else (world, role-map reader, orchestration
+ * invoker, world-config, token metadata, transition version, clock) is
+ * deploy-provided.
+ */
+export type RoleSyncInteractionDeps = Omit<RoleSyncTriggerDeps, "resolveActor">;
+
+/**
+ * Handle a `/role-sync` APPLICATION_COMMAND interaction. Resolves the actor from
+ * `auth`, parses the mode (SAFE-BY-DEFAULT SHADOW), runs the trigger core, and
+ * maps the outcome → a Discord response (ephemeral — a CM admin action is
+ * invoker-only). PURE w.r.t. discord.js: builds a response payload, never writes.
+ */
+export async function handleRoleSyncInteraction(
+  interaction: DiscordInteraction,
+  auth: AuthContext | undefined,
+  deps: RoleSyncInteractionDeps,
+): Promise<DiscordInteractionResponse> {
+  const mode = parseRoleSyncMode(readModeOption(interaction));
+
+  const outcome: RoleSyncOutcome = await runRoleSyncTrigger(
+    { ...deps, resolveActor: actorResolverFromAuth(auth) },
+    mode,
+  );
+
+  return roleSyncOutcomeToResponse(outcome);
+}
+
+/**
+ * Map a {@link RoleSyncOutcome} → a Discord interaction response. EPHEMERAL on
+ * every path (a CM admin action is invoker-only). `rendered` sends the structural
+ * CV2 payload (merging the EPHEMERAL flag with the CV2 IS_COMPONENTS_V2 flag);
+ * `refused`/`error` send a plain voiceless status string.
+ */
+export function roleSyncOutcomeToResponse(outcome: RoleSyncOutcome): DiscordInteractionResponse {
+  if (outcome.kind === "rendered") {
+    // CV2 payloads MUST NOT carry content/embeds. Merge the EPHEMERAL flag into
+    // the CV2 flags (IS_COMPONENTS_V2 | EPHEMERAL) so the admin preview is
+    // invoker-only AND renders as components.
+    const data = {
+      ...outcome.payload,
+      flags: outcome.payload.flags | MessageFlags.EPHEMERAL,
+    } as unknown as DiscordInteractionResponse["data"];
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data,
+    };
+  }
+
+  const message = outcome.kind === "refused" ? outcome.message : outcome.message;
+  return {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      content: message,
+      flags: MessageFlags.EPHEMERAL,
+      allowed_mentions: { parse: [] },
+    },
+  };
+}

--- a/apps/bot/src/shadow/role-sync-interaction.ts
+++ b/apps/bot/src/shadow/role-sync-interaction.ts
@@ -27,7 +27,11 @@ import type {
   DiscordInteraction,
   DiscordInteractionResponse,
 } from "../discord-interactions/types.ts";
-import { InteractionResponseType, MessageFlags } from "../discord-interactions/types.ts";
+import {
+  InteractionResponseType,
+  MessageFlags,
+  interactionInvoker,
+} from "../discord-interactions/types.ts";
 import type { AuthContext } from "../auth-bridge.ts";
 import {
   runRoleSyncTrigger,
@@ -62,12 +66,32 @@ function readModeOption(interaction: DiscordInteraction): string | undefined {
 
 /**
  * The deps the interaction adapter needs beyond the per-interaction AuthContext:
- * the trigger-core deps WITHOUT `resolveActor` (the adapter supplies that from
- * the AuthContext) — everything else (world, role-map reader, orchestration
- * invoker, world-config, token metadata, transition version, clock) is
- * deploy-provided.
+ * the trigger-core deps WITHOUT `resolveActor` (the adapter supplies that) —
+ * everything else (world, role-map reader, orchestration invoker, world-config,
+ * token metadata, transition version, clock) is deploy-provided.
+ *
+ * ── ISOLATED ACTOR RESOLUTION (bd-atm, OPTIONAL) ─────────────────────────────
+ * `actorResolverFor` — when the deploy wires it — makes `/role-sync` resolve the
+ * invoking CM's actor ITSELF (invoking Discord user id → identity-api
+ * `GET /v1/resolve/account/discord/{id}` → user_id), INDEPENDENT of the global
+ * `AUTH_BACKEND`. The onboarding/role-dispenser is a separable, voiceless
+ * building (onboarding-as-voiceless-building brief) — it MUST NOT infer its
+ * identity system from the persona daemon's auth backend.
+ *
+ * When `actorResolverFor` is ABSENT, the adapter falls back to the legacy
+ * `actorResolverFromAuth(auth)` (the per-interaction verified AuthContext). The
+ * boot composition (role-sync-boot.ts) supplies the isolated factory; the legacy
+ * path remains for tests / deployments that already run the freeside-jwt backend.
  */
-export type RoleSyncInteractionDeps = Omit<RoleSyncTriggerDeps, "resolveActor">;
+export type RoleSyncInteractionDeps = Omit<RoleSyncTriggerDeps, "resolveActor"> & {
+  /**
+   * OPTIONAL isolated actor-resolver factory keyed on the invoking Discord user
+   * id. The adapter reads the id from the interaction and calls this; the
+   * returned thunk performs the identity-api lookup (fail-closed → null ⇒ refuse).
+   * Independent of AUTH_BACKEND. When omitted, the adapter uses the AuthContext.
+   */
+  readonly actorResolverFor?: (discordId: string | undefined) => ActorResolver;
+};
 
 /**
  * Handle a `/role-sync` APPLICATION_COMMAND interaction. Resolves the actor from
@@ -82,8 +106,17 @@ export async function handleRoleSyncInteraction(
 ): Promise<DiscordInteractionResponse> {
   const mode = parseRoleSyncMode(readModeOption(interaction));
 
+  // ── ISOLATED actor resolution (bd-atm) takes precedence when the deploy wired
+  //    `actorResolverFor`: resolve the invoking CM's actor from the invoking
+  //    Discord user id → identity-api, INDEPENDENT of AUTH_BACKEND. The legacy
+  //    AuthContext path is the fallback (deployments already on freeside-jwt).
+  const { actorResolverFor, ...triggerDeps } = deps;
+  const resolveActor: ActorResolver = actorResolverFor
+    ? actorResolverFor(interactionInvoker(interaction).id)
+    : actorResolverFromAuth(auth);
+
   const outcome: RoleSyncOutcome = await runRoleSyncTrigger(
-    { ...deps, resolveActor: actorResolverFromAuth(auth) },
+    { ...triggerDeps, resolveActor },
     mode,
   );
 

--- a/apps/bot/src/shadow/role-sync-result-cv2.test.ts
+++ b/apps/bot/src/shadow/role-sync-result-cv2.test.ts
@@ -1,0 +1,98 @@
+/**
+ * role-sync-result-cv2.test.ts — the VOICELESS structural render of a
+ * GoLiveOrchestrationResult (bd-71y). Proves: the CV2 grammar (container 17 /
+ * text 10 / separator 14), inert mentions, counts/role-lists surfaced, the
+ * default-seed flag, and the injection guard (attacker role name neutralized).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  renderRoleSyncResultCV2,
+  roleSyncResultCV2Payload,
+} from "./role-sync-result-cv2.ts";
+import { IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import type { GoLiveOrchestrationResult } from "./go-live-orchestrator.ts";
+import type { WriteIntentBatch } from "@freeside-worlds/shadow-substrate";
+
+function result(applyMode: "SHADOW" | "LIVE", roleKeys: { create: string[]; assign: Array<[string, string]> }): GoLiveOrchestrationResult {
+  const ops = [
+    ...roleKeys.create.map((role_key, i) => ({ op_id: `c${i}`, kind: "create_role" as const, intent: { role_key } })),
+    ...roleKeys.assign.map(([role_key, member_id], i) => ({ op_id: `a${i}`, kind: "assign_role" as const, intent: { role_key, member_id } })),
+  ];
+  const batch = { ops } as unknown as WriteIntentBatch;
+  return {
+    applyMode,
+    batch,
+    job: { status: applyMode === "SHADOW" ? "failed" : "done", progress: { total: ops.length, completed: applyMode === "SHADOW" ? 0 : ops.length, failed: applyMode === "SHADOW" ? ops.length : 0 }, roles_created: [], op_status: ops.map((o) => ({ op_id: o.op_id, status: applyMode === "SHADOW" ? ("failed" as const) : ("ok" as const) })) },
+    createCount: roleKeys.create.length,
+    assignCount: roleKeys.assign.length,
+    skippedUnlinked: 3,
+    skippedUnqualified: 5,
+    skippedInvalid: 1,
+    collapsedDuplicateMembers: 2,
+  } as GoLiveOrchestrationResult;
+}
+
+describe("bd-71y — role-sync result CV2 render (structural, voiceless)", () => {
+  test("CV2 grammar: container 17, text 10, separator 14", () => {
+    const c = renderRoleSyncResultCV2(
+      result("SHADOW", { create: ["purupuru:member"], assign: [["purupuru:core", "700000000000000001"]] }),
+      { world: "purupuru", mapSource: "default-seed" },
+    );
+    expect(c.type).toBe(17);
+    expect(typeof c.accent_color).toBe("number");
+    const types = c.components.map((x) => x.type);
+    expect(types).toContain(10); // text
+    expect(types).toContain(14); // separator
+  });
+
+  test("payload: IS_COMPONENTS_V2 flag + inert mentions, no content/embeds", () => {
+    const p = roleSyncResultCV2Payload(
+      result("SHADOW", { create: [], assign: [] }),
+      { world: "purupuru", mapSource: "config-service" },
+    );
+    expect(p.flags & IS_COMPONENTS_V2).toBe(IS_COMPONENTS_V2);
+    expect(p.allowed_mentions).toEqual({ parse: [] });
+    expect((p as { content?: string }).content).toBeUndefined();
+  });
+
+  test("counts + role lists + skip breakdown surfaced", () => {
+    const c = renderRoleSyncResultCV2(
+      result("LIVE", { create: ["purupuru:member", "purupuru:core"], assign: [["purupuru:core", "700000000000000001"], ["purupuru:core", "700000000000000002"]] }),
+      { world: "purupuru", mapSource: "config-service" },
+    );
+    const text = JSON.stringify(c.components);
+    expect(text).toContain("LIVE apply");
+    expect(text).toContain("Roles to create (2)");
+    expect(text).toContain("Assignments (2)");
+    // assign aggregated by role: purupuru:core — 2 members
+    expect(text).toContain("2 members");
+    expect(text).toContain("3 qualified but"); // skippedUnlinked
+    expect(text).toContain("5 below every rule"); // skippedUnqualified
+    expect(text).toContain("1 invalid member id"); // skippedInvalid
+    expect(text).toContain("2 duplicate"); // collapsedDuplicateMembers
+  });
+
+  test("default-seed provenance is flagged for the CM", () => {
+    const c = renderRoleSyncResultCV2(
+      result("SHADOW", { create: [], assign: [] }),
+      { world: "purupuru", mapSource: "default-seed" },
+    );
+    expect(JSON.stringify(c.components)).toContain("DEFAULT SEED");
+  });
+
+  test("INJECTION GUARD: an attacker role name (@everyone, markdown) is neutralized", () => {
+    const c = renderRoleSyncResultCV2(
+      result("SHADOW", { create: ["@everyone"], assign: [["**bold** `code`", "700000000000000001"]] }),
+      { world: "purupuru", mapSource: "config-service" },
+    );
+    // inspect the RAW component content (not JSON.stringify, which double-escapes).
+    const contents = c.components
+      .filter((x): x is { type: 10; content: string } => x.type === 10)
+      .map((x) => x.content)
+      .join("\n");
+    // the literal "@everyone" must NOT appear unbroken (zero-width inserted after @).
+    expect(contents).not.toContain("@everyone");
+    // markdown control chars escaped (backslash-escaped in the rendered name).
+    expect(contents).toContain("\\*\\*bold\\*\\*");
+  });
+});

--- a/apps/bot/src/shadow/role-sync-result-cv2.ts
+++ b/apps/bot/src/shadow/role-sync-result-cv2.ts
@@ -1,0 +1,188 @@
+/**
+ * shadow/role-sync-result-cv2.ts — VOICELESS structural render of a
+ * `GoLiveOrchestrationResult` as a Discord Components-V2 (CV2) message (bd-71y).
+ *
+ * ── WHY THIS, NOT discrepancy-cv2.ts ─────────────────────────────────────────
+ * `discrepancy-cv2.ts` renders the substrate's `Discrepancy` read-model (a
+ * before/after roster diff produced by the pure `diff`). The role-sync TRIGGER
+ * invokes `runTierRoleGoLive`, which returns a `GoLiveOrchestrationResult` — the
+ * assembled WriteIntentBatch (create + assign ops) + the gate's job state +
+ * structural counts (created / assigned / skipped_unlinked / skipped_unqualified
+ * / skipped_invalid / collapsed). That is what a CM needs to SEE after running
+ * the sync: who'd get / has which role, how many, what was skipped and why. This
+ * module renders THAT result structurally, reusing the EXACT CV2 grammar +
+ * injection guards as discrepancy-cv2.ts.
+ *
+ * ── VOICELESS (the load-bearing constraint, bd-71y / voiceless-building brief) ─
+ * This is a PURE render function (`GoLiveOrchestrationResult` → CV2 component
+ * JSON). It holds NO persona, NO voice, NO narration, NO onboarding logic, fires
+ * no events, makes no Discord call. Every string is a structural label or a
+ * count. There is no persona-engine import anywhere in this module. The CM
+ * controls the real messaging via config; this is the substrate-truth structural
+ * render only.
+ *
+ * ── INJECTION GUARD (mirrors discrepancy-cv2.ts) ─────────────────────────────
+ * Role NAMES (`role_key`) flow from the role-map (CM-authored or seed) AND from
+ * the live roster — attacker-controllable in the general case. We reuse
+ * `escapeRoleName` + clamp + `allowed_mentions: { parse: [] }` so a malicious
+ * role name cannot spoof the layout or fire a mass-ping.
+ */
+import { escapeRoleName, IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import type { GoLiveOrchestrationResult } from "./go-live-orchestrator.ts";
+import type { RoleMapSource } from "./role-sync-seed-map.ts";
+
+/** Accent: warm honey for a SHADOW preview, applied-amber for a LIVE run. */
+const ACCENT_SHADOW = 0x6f4ea1;
+const ACCENT_LIVE = 0xe0a83d;
+
+/** Max rendered role-name length before truncation (defense vs a pathological name). */
+const MAX_ROLE_NAME_CHARS = 64;
+/** Conservative per-text-component char budget (well under Discord's ~4000). */
+const MAX_TEXT_COMPONENT_CHARS = 3500;
+
+function clampRoleName(name: string): string {
+  return name.length > MAX_ROLE_NAME_CHARS ? `${name.slice(0, MAX_ROLE_NAME_CHARS - 1)}…` : name;
+}
+
+/** Render a raw (attacker-controllable) role name → a safe inline code span. */
+function codeName(raw: string): string {
+  return `\`${clampRoleName(escapeRoleName(raw))}\``;
+}
+
+/**
+ * Join already-rendered lines with `joiner`, stopping once the running length
+ * would exceed `maxChars`, appending a `…and N more` affordance for the omitted
+ * remainder. Mirrors `boundedJoin` in discrepancy-cv2.ts (a many-role guild must
+ * not produce an oversized text component Discord silently rejects).
+ */
+function boundedJoin(items: readonly string[], joiner: string, maxChars: number, empty: string): string {
+  if (items.length === 0) return empty;
+  const kept: string[] = [];
+  let len = 0;
+  for (let i = 0; i < items.length; i++) {
+    const piece = items[i]!;
+    const remaining = items.length - i;
+    const moreSuffix = `${joiner}…and ${remaining} more`;
+    const projected = len + (kept.length ? joiner.length : 0) + piece.length;
+    if (projected > maxChars && kept.length > 0) {
+      return kept.join(joiner) + moreSuffix;
+    }
+    kept.push(piece);
+    len = projected;
+  }
+  return kept.join(joiner);
+}
+
+type TextComponent = { type: 10; content: string };
+type SeparatorComponent = { type: 14 };
+type ContainerComponent = {
+  type: 17;
+  accent_color: number;
+  components: Array<TextComponent | SeparatorComponent>;
+};
+
+function text(content: string): TextComponent {
+  return { type: 10, content };
+}
+const sep: SeparatorComponent = { type: 14 };
+
+/** Extra context the structural render carries beyond the orchestration result. */
+export interface RoleSyncRenderContext {
+  readonly world: string;
+  /** provenance of the role-map: CM-authored ("config-service") vs default seed. */
+  readonly mapSource: RoleMapSource;
+}
+
+/**
+ * Render a `GoLiveOrchestrationResult` as a CV2 container component (the single
+ * top-level component). The caller wraps it via {@link roleSyncResultCV2Payload}.
+ *
+ * STRUCTURAL ONLY: headings, role lists (create pass + assign pass), counts, and
+ * the skip breakdown. No persona, no voice, no narration.
+ */
+export function renderRoleSyncResultCV2(
+  result: GoLiveOrchestrationResult,
+  ctx: RoleSyncRenderContext,
+): ContainerComponent {
+  const isLive = result.applyMode === "LIVE";
+  const accent = isLive ? ACCENT_LIVE : ACCENT_SHADOW;
+
+  // CREATE pass — managed tier roles the batch would create.
+  const createOps = result.batch.ops.filter((o) => o.kind === "create_role");
+  const createLines = boundedJoin(
+    createOps.map((o) => `• 🆕 ${codeName(o.intent.role_key)}`),
+    "\n",
+    MAX_TEXT_COMPONENT_CHARS,
+    "_(no roles to create)_",
+  );
+
+  // ASSIGN pass — per-role assignment counts (who'd get / has which role).
+  // Aggregate assign ops by role_key → count (structural; member ids are NOT
+  // rendered — only counts, the voiceless structural view).
+  const assignByRole = new Map<string, number>();
+  for (const o of result.batch.ops) {
+    if (o.kind !== "assign_role") continue;
+    const key = o.intent.role_key;
+    assignByRole.set(key, (assignByRole.get(key) ?? 0) + 1);
+  }
+  const assignLines = boundedJoin(
+    [...assignByRole.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([role, n]) => `• ${codeName(role)} — ${n} member${n === 1 ? "" : "s"}`),
+    "\n",
+    MAX_TEXT_COMPONENT_CHARS,
+    "_(no members to assign)_",
+  );
+
+  // SKIP breakdown — qualified-but-unlinked / below-every-rule / invalid id /
+  // collapsed duplicate members. Every count is structural provenance.
+  const skipLines = [
+    `• ${result.skippedUnlinked} qualified but **unlinked** (no wallet↔discord link)`,
+    `• ${result.skippedUnqualified} below every rule (untiered / too low)`,
+    `• ${result.skippedInvalid} invalid member id (non-snowflake)`,
+    `• ${result.collapsedDuplicateMembers} duplicate wallet→member assignments collapsed`,
+  ].join("\n");
+
+  const verb = isLive ? "LIVE apply" : "SHADOW preview";
+  const modeNote = isLive
+    ? "_Roles were written through the gate (LIVE)._"
+    : "_Preview only — ZERO writes (gate rejected every op under SHADOW)._";
+
+  const mapNote =
+    ctx.mapSource === "default-seed"
+      ? "_Role-map: **DEFAULT SEED** (CM-overridable — author the real map in the dashboard / config-service)._"
+      : "_Role-map: CM-authored (config-service)._";
+
+  return {
+    type: 17,
+    accent_color: accent,
+    components: [
+      text(`# Tier→role sync — \`${ctx.world}\` (${verb})`),
+      text(`${modeNote}\n${mapNote}`),
+      sep,
+      text(`## Roles to create (${result.createCount})\n${createLines}`),
+      text(`## Assignments (${result.assignCount})\n${assignLines}`),
+      sep,
+      text(`## Skipped\n${skipLines}`),
+      text(`Gate job: \`${result.job.status}\` · ${result.job.progress.completed}/${result.job.progress.total} applied · ${result.job.progress.failed} not-applied`),
+    ],
+  };
+}
+
+/** The full CV2 message payload (flags + components + inert mentions) ready to send. */
+export function roleSyncResultCV2Payload(
+  result: GoLiveOrchestrationResult,
+  ctx: RoleSyncRenderContext,
+): {
+  flags: number;
+  components: ContainerComponent[];
+  allowed_mentions: { parse: never[] };
+} {
+  return {
+    flags: IS_COMPONENTS_V2,
+    components: [renderRoleSyncResultCV2(result, ctx)],
+    // INJECTION GUARD: make every mention inert — an attacker-named role surfaced
+    // in the create/assign lists cannot fire an @everyone / role / user ping.
+    allowed_mentions: { parse: [] },
+  };
+}

--- a/apps/bot/src/shadow/role-sync-seed-map.test.ts
+++ b/apps/bot/src/shadow/role-sync-seed-map.test.ts
@@ -1,0 +1,59 @@
+/**
+ * role-sync-seed-map.test.ts — the CM-overridable DEFAULT seed role-map (bd-71y).
+ * Proves the seed is a valid `RoleMapConfig`: one namespaced role per Purupuru
+ * tier, each create_if_absent, qualifying at >= that tier. NETWORK-FREE.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  buildPurupuruSeedRoleMap,
+  PURUPURU_NAMESPACE_PREFIX,
+} from "./role-sync-seed-map.ts";
+import { PURUPURU_TIER_RANK } from "./purupuru-tiers.ts";
+
+describe("bd-71y — Purupuru seed role-map", () => {
+  test("one namespaced role per tier, all create_if_absent, qualifying at that tier", () => {
+    const map = buildPurupuruSeedRoleMap();
+    expect(map.enabled).toBe(true);
+    expect(map.namespace_prefix).toBe(PURUPURU_NAMESPACE_PREFIX);
+
+    const tiers = Object.keys(PURUPURU_TIER_RANK);
+    expect(map.rules.length).toBe(tiers.length);
+
+    for (const rule of map.rules) {
+      expect(rule.role_key.startsWith(PURUPURU_NAMESPACE_PREFIX)).toBe(true);
+      const tier = rule.role_key.slice(PURUPURU_NAMESPACE_PREFIX.length);
+      expect(tiers).toContain(tier);
+      expect(rule.qualifies).toEqual({ source: "tier", min_tier: tier });
+      expect(rule.create_if_absent).toBe(true);
+      expect(rule.display_name.length).toBeGreaterThan(0);
+    }
+    // covers exactly the ladder: newcomer..sovereign
+    expect(map.rules.map((r) => r.role_key.slice(PURUPURU_NAMESPACE_PREFIX.length)).sort()).toEqual(
+      tiers.slice().sort(),
+    );
+  });
+
+  test("rules are emitted in ascending strength order (deterministic)", () => {
+    const map = buildPurupuruSeedRoleMap();
+    const ranks = map.rules.map((r) => PURUPURU_TIER_RANK[r.role_key.slice(PURUPURU_NAMESPACE_PREFIX.length)]!);
+    const sorted = [...ranks].sort((a, b) => a - b);
+    expect(ranks).toEqual(sorted);
+  });
+
+  test("the seed has exactly the RoleMapConfig top-level keys (no extras the closed schema rejects)", () => {
+    const map = buildPurupuruSeedRoleMap();
+    // the substrate RoleMapConfig is a CLOSED @effect/schema Struct
+    // (enabled, namespace_prefix, rules, scaffolding?). The seed must carry no
+    // extra keys (we assert structurally — the orchestrator's own test decodes
+    // through the real schema end-to-end).
+    expect(Object.keys(map).sort()).toEqual(["enabled", "namespace_prefix", "rules"]);
+    for (const rule of map.rules) {
+      expect(Object.keys(rule).sort()).toEqual([
+        "create_if_absent",
+        "display_name",
+        "qualifies",
+        "role_key",
+      ]);
+    }
+  });
+});

--- a/apps/bot/src/shadow/role-sync-seed-map.ts
+++ b/apps/bot/src/shadow/role-sync-seed-map.ts
@@ -1,0 +1,80 @@
+/**
+ * shadow/role-sync-seed-map.ts — the CM-OVERRIDABLE DEFAULT seed role-map for
+ * the voiceless tier→role sync trigger (bd-71y).
+ *
+ * ── WHY A SEED EXISTS ────────────────────────────────────────────────────────
+ * The tier→role map is CM-OWNED config: the community manager authors it via the
+ * dashboard role-map editor → config-service, and the bot READS it (per the
+ * onboarding-as-voiceless-building brief — "CM has full control of the tier→role
+ * map"). But the first test of the sync must be runnable BEFORE a CM has authored
+ * anything: when config-service is unwired (CONFIG_SERVICE_URL unset) or returns
+ * no `role-map` surface, this seed is the fallback so the trigger can produce a
+ * SHADOW preview against a sensible Purupuru default.
+ *
+ * ── THIS IS A DEFAULT, NOT THE TRUTH ─────────────────────────────────────────
+ * The CM's authored map ALWAYS wins. This seed is marked clearly as a default in
+ * the structural render (`mapSource: "default-seed"`) so a CM never mistakes it
+ * for their real map. The moment the CM authors a map in config-service, the read
+ * path returns that map and this seed is never used.
+ *
+ * ── GROUNDING (purupuru-tiers.ts, read 2026-06-03) ───────────────────────────
+ * One namespaced role per Purupuru tier on the strength ladder
+ * (newcomer < member < devoted < core < elder < sovereign), each rule
+ * `qualifies: { source: 'tier', min_tier: <that tier> }` with
+ * `create_if_absent: true`. The `min_tier` values are the OPAQUE tier ids the
+ * score-api owns (#221); the ordering lives in purupuru-tiers.ts. The
+ * `namespace_prefix` "purupuru:" is the FR-9 managed-role boundary.
+ *
+ * VOICELESS: this module is pure data + a builder. No persona, no voice, no I/O.
+ */
+import type { RoleMapConfig } from "./substrate.ts";
+import { PURUPURU_TIER_RANK } from "./purupuru-tiers.ts";
+
+/** The FR-9 namespace prefix for the Purupuru managed-role set. */
+export const PURUPURU_NAMESPACE_PREFIX = "purupuru:";
+
+/**
+ * Human-readable display names for each seed tier role. PLACEHOLDERS (the lore
+ * names are calibrated elsewhere — see purupuru-tiers.ts header); the CM's
+ * authored map supplies the real display names. Title-cased tier id by default.
+ */
+function seedDisplayName(tier: string): string {
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+/**
+ * Build the CM-overridable DEFAULT seed role-map for Purupuru: ONE namespaced
+ * role per tier on the strength ladder, each a `create_if_absent: true` rule
+ * qualifying at >= that tier. Deterministic (tier order follows the ladder rank).
+ *
+ * The returned map satisfies the substrate's `RoleMapConfig` schema exactly
+ * (`enabled`, `namespace_prefix`, `rules`); it is a plain object the orchestrator
+ * + the FR-7 `roleMapVersionHash` consume directly.
+ */
+export function buildPurupuruSeedRoleMap(): RoleMapConfig {
+  // order tiers by ascending strength rank (deterministic, matches the ladder).
+  const tiers = Object.entries(PURUPURU_TIER_RANK)
+    .sort((a, b) => a[1] - b[1])
+    .map(([tier]) => tier);
+
+  const rules = tiers.map((tier) => ({
+    role_key: `${PURUPURU_NAMESPACE_PREFIX}${tier}`,
+    display_name: seedDisplayName(tier),
+    qualifies: { source: "tier" as const, min_tier: tier },
+    create_if_absent: true,
+  }));
+
+  return {
+    enabled: true,
+    namespace_prefix: PURUPURU_NAMESPACE_PREFIX,
+    rules,
+  } as RoleMapConfig;
+}
+
+/**
+ * The provenance of the role-map the trigger ran against — surfaced in the
+ * structural render so a CM can tell the authored map from the default seed.
+ *   • "config-service" — the CM's authored map (read from config-service).
+ *   • "default-seed"   — this module's fallback (config-service unwired/empty).
+ */
+export type RoleMapSource = "config-service" | "default-seed";

--- a/apps/bot/src/shadow/role-sync-trigger.test.ts
+++ b/apps/bot/src/shadow/role-sync-trigger.test.ts
@@ -1,0 +1,302 @@
+/**
+ * role-sync-trigger.test.ts — the VOICELESS CM tier→role sync trigger CORE
+ * (bd-71y). NETWORK-FREE: the actor resolver, role-map reader, and orchestration
+ * invoker are all INJECTED. Never touches discord.js, the network, or the real
+ * substrate gate (the orchestration is a fake — the orchestrator itself has its
+ * own end-to-end test against the real gate).
+ *
+ * Proves (the bd-71y gates):
+ *   • not-verified CM is REFUSED before any read (no role-map read, no invoke).
+ *   • a denied CM (orchestration authz-deny) surfaces as a voiceless error,
+ *     ZERO writes (the fake records that applyMode reached it but threw).
+ *   • SHADOW is the DEFAULT — an absent/typo mode never selects LIVE; the
+ *     SHADOW invoke renders the structural result with zero writes.
+ *   • the DEFAULT SEED map is used when config-service returns null (empty).
+ *   • the CM-authored map is used when config-service returns one (mapSource).
+ *   • LIVE requires the EXPLICIT choice — parseRoleSyncMode + the input.applyMode
+ *     the orchestration sees is exactly the chosen mode.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  runRoleSyncTrigger,
+  parseRoleSyncMode,
+  computeMapHash,
+  ROLE_SYNC_COMMAND_NAME,
+  type RoleSyncTriggerDeps,
+  type RoleSyncMode,
+} from "./role-sync-trigger.ts";
+import { buildPurupuruSeedRoleMap } from "./role-sync-seed-map.ts";
+import type {
+  GoLiveOrchestrationInput,
+  GoLiveOrchestrationResult,
+} from "./go-live-orchestrator.ts";
+import type { RoleMapConfig, WriteIntentBatch } from "@freeside-worlds/shadow-substrate";
+
+const WORLD = "purupuru";
+const ACTOR = "identity:cm-1";
+
+const WORLD_CONFIG = {
+  guild_id: "111122223333444455",
+  nft_contracts: ["0xabc"],
+} as const;
+
+const TOKEN_META = {
+  kid: "kid-1",
+  verified_at: "2026-06-04T00:00:00Z",
+  exp: "2026-06-04T01:00:00Z",
+};
+
+/** A fake batch with one create + N assign ops (structural only). */
+function fakeBatch(creates: string[], assigns: Array<[string, string]>): WriteIntentBatch {
+  const ops = [
+    ...creates.map((role_key, i) => ({
+      op_id: `c${i}`,
+      kind: "create_role" as const,
+      intent: { role_key },
+    })),
+    ...assigns.map(([role_key, member_id], i) => ({
+      op_id: `a${i}`,
+      kind: "assign_role" as const,
+      intent: { role_key, member_id },
+    })),
+  ];
+  return { ops } as unknown as WriteIntentBatch;
+}
+
+/** A fake orchestration result (SHADOW preview shape: zero applied). */
+function fakeResult(
+  applyMode: RoleSyncMode,
+  overrides: Partial<GoLiveOrchestrationResult> = {},
+): GoLiveOrchestrationResult {
+  const batch = fakeBatch(["purupuru:member", "purupuru:core"], [["purupuru:core", "700000000000000001"]]);
+  return {
+    applyMode,
+    batch,
+    job: {
+      status: applyMode === "SHADOW" ? "failed" : "done",
+      progress: {
+        total: batch.ops.length,
+        completed: applyMode === "SHADOW" ? 0 : batch.ops.length,
+        failed: applyMode === "SHADOW" ? batch.ops.length : 0,
+      },
+      roles_created: [],
+      op_status: batch.ops.map((o) => ({
+        op_id: o.op_id,
+        status: applyMode === "SHADOW" ? ("failed" as const) : ("ok" as const),
+      })),
+    },
+    createCount: 2,
+    assignCount: 1,
+    skippedUnlinked: 1,
+    skippedUnqualified: 2,
+    skippedInvalid: 0,
+    collapsedDuplicateMembers: 0,
+    ...overrides,
+  } as GoLiveOrchestrationResult;
+}
+
+/** Build trigger deps with injected ports; capture the orchestration input. */
+function makeDeps(opts: {
+  actor?: string | null;
+  authoredMap?: RoleMapConfig | null;
+  invoke: (input: GoLiveOrchestrationInput) => Promise<GoLiveOrchestrationResult>;
+}): { deps: RoleSyncTriggerDeps } {
+  const deps: RoleSyncTriggerDeps = {
+    world: WORLD,
+    resolveActor: () => (opts.actor === null ? null : { actor: opts.actor ?? ACTOR }),
+    readRoleMap: () => opts.authoredMap ?? null,
+    invokeOrchestration: opts.invoke,
+    worldConfig: WORLD_CONFIG,
+    now: () => "2026-06-04T00:00:00Z",
+    tokenMetadata: TOKEN_META,
+    transitionVersion: 7,
+  };
+  return { deps };
+}
+
+describe("bd-71y — role-sync trigger: SAFE-BY-DEFAULT mode parsing", () => {
+  test("absent / undefined / null ⇒ SHADOW", () => {
+    expect(parseRoleSyncMode(undefined)).toBe("SHADOW");
+    expect(parseRoleSyncMode(null)).toBe("SHADOW");
+    expect(parseRoleSyncMode("")).toBe("SHADOW");
+  });
+  test("a typo or anything-not-live ⇒ SHADOW (LIVE never selected accidentally)", () => {
+    expect(parseRoleSyncMode("liv")).toBe("SHADOW");
+    expect(parseRoleSyncMode("LIVE ")).toBe("LIVE"); // trimmed
+    expect(parseRoleSyncMode("preview")).toBe("SHADOW");
+    expect(parseRoleSyncMode("shadow")).toBe("SHADOW");
+  });
+  test("the explicit (case-insensitive) 'live' ⇒ LIVE", () => {
+    expect(parseRoleSyncMode("live")).toBe("LIVE");
+    expect(parseRoleSyncMode("LIVE")).toBe("LIVE");
+    expect(parseRoleSyncMode("Live")).toBe("LIVE");
+  });
+});
+
+describe("bd-71y — role-sync trigger: not-verified CM is REFUSED before any read", () => {
+  test("a null actor ⇒ refused; the role-map reader + orchestration are NEVER called", async () => {
+    let readCalled = false;
+    let invokeCalled = false;
+    const { deps } = makeDeps({
+      actor: null,
+      invoke: async () => {
+        invokeCalled = true;
+        return fakeResult("SHADOW");
+      },
+    });
+    const outcome = await runRoleSyncTrigger(
+      { ...deps, readRoleMap: () => ((readCalled = true), null) },
+      "LIVE", // even an explicit LIVE is refused with no actor
+    );
+    expect(outcome.kind).toBe("refused");
+    if (outcome.kind === "refused") expect(outcome.reason).toBe("not_verified");
+    expect(readCalled).toBe(false);
+    expect(invokeCalled).toBe(false);
+  });
+});
+
+describe("bd-71y — role-sync trigger: SHADOW renders structural result, zero writes", () => {
+  test("default mode is SHADOW; the orchestration sees applyMode SHADOW; result rendered", async () => {
+    let seenMode: RoleSyncMode | undefined;
+    const { deps } = makeDeps({
+      invoke: async (input) => {
+        seenMode = input.applyMode;
+        return fakeResult("SHADOW");
+      },
+    });
+    // no explicit mode ⇒ default SHADOW
+    const outcome = await runRoleSyncTrigger(deps);
+    expect(seenMode).toBe("SHADOW");
+    expect(outcome.kind).toBe("rendered");
+    if (outcome.kind === "rendered") {
+      expect(outcome.applyMode).toBe("SHADOW");
+      // SHADOW job = zero completed (zero writes), every op rejected.
+      expect(outcome.result.job.status).toBe("failed");
+      expect(outcome.result.job.progress.completed).toBe(0);
+      // CV2 payload: components + inert mentions, no content/embeds.
+      expect(outcome.payload.flags).toBeGreaterThan(0);
+      expect(outcome.payload.allowed_mentions).toEqual({ parse: [] });
+      expect(Array.isArray(outcome.payload.components)).toBe(true);
+      // structural render mentions the mode + the SHADOW preview note.
+      const text = JSON.stringify(outcome.payload.components);
+      expect(text).toContain("SHADOW preview");
+      expect(text).toContain("ZERO writes");
+    }
+  });
+});
+
+describe("bd-71y — role-sync trigger: DEFAULT SEED map vs CM-authored map", () => {
+  test("config-service empty (null) ⇒ DEFAULT SEED map; the seed reaches the orchestration", async () => {
+    let seenMap: RoleMapConfig | undefined;
+    const { deps } = makeDeps({
+      authoredMap: null, // config empty
+      invoke: async (input) => {
+        seenMap = input.roleMap;
+        return fakeResult("SHADOW");
+      },
+    });
+    const outcome = await runRoleSyncTrigger(deps);
+    expect(outcome.kind).toBe("rendered");
+    if (outcome.kind === "rendered") expect(outcome.mapSource).toBe("default-seed");
+    // the seed map (one namespaced role per Purupuru tier) reached the orchestration.
+    const seed = buildPurupuruSeedRoleMap();
+    expect(seenMap?.namespace_prefix).toBe("purupuru:");
+    expect(seenMap?.rules.map((r) => r.role_key).sort()).toEqual(
+      seed.rules.map((r) => r.role_key).sort(),
+    );
+    // every seed rule is create_if_absent (unblocks the first test).
+    expect(seenMap?.rules.every((r) => r.create_if_absent === true)).toBe(true);
+    // the structural render flags the seed as a CM-overridable default.
+    const text = JSON.stringify((outcome as { payload: unknown }).payload);
+    expect(text).toContain("DEFAULT SEED");
+  });
+
+  test("config-service returns a map ⇒ CM-authored is used (mapSource config-service)", async () => {
+    const authored: RoleMapConfig = {
+      enabled: true,
+      namespace_prefix: "purupuru:",
+      rules: [
+        {
+          role_key: "purupuru:vip",
+          display_name: "VIP",
+          qualifies: { source: "tier", min_tier: "core" },
+          create_if_absent: true,
+        },
+      ],
+    } as RoleMapConfig;
+    let seenMap: RoleMapConfig | undefined;
+    const { deps } = makeDeps({
+      authoredMap: authored,
+      invoke: async (input) => {
+        seenMap = input.roleMap;
+        return fakeResult("SHADOW");
+      },
+    });
+    const outcome = await runRoleSyncTrigger(deps);
+    expect(outcome.kind).toBe("rendered");
+    if (outcome.kind === "rendered") expect(outcome.mapSource).toBe("config-service");
+    expect(seenMap?.rules.map((r) => r.role_key)).toEqual(["purupuru:vip"]);
+  });
+});
+
+describe("bd-71y — role-sync trigger: LIVE requires the explicit choice", () => {
+  test("an explicit LIVE flows applyMode:LIVE into the orchestration", async () => {
+    let seenMode: RoleSyncMode | undefined;
+    const { deps } = makeDeps({
+      invoke: async (input) => {
+        seenMode = input.applyMode;
+        return fakeResult("LIVE");
+      },
+    });
+    const outcome = await runRoleSyncTrigger(deps, "LIVE");
+    expect(seenMode).toBe("LIVE");
+    expect(outcome.kind).toBe("rendered");
+    if (outcome.kind === "rendered") {
+      expect(outcome.applyMode).toBe("LIVE");
+      const text = JSON.stringify(outcome.payload.components);
+      expect(text).toContain("LIVE apply");
+    }
+  });
+
+  test("the reportHash == currentMapHash (an unchanged map) and matches computeMapHash", async () => {
+    let seenInput: GoLiveOrchestrationInput | undefined;
+    const { deps } = makeDeps({
+      invoke: async (input) => {
+        seenInput = input;
+        return fakeResult("SHADOW");
+      },
+    });
+    await runRoleSyncTrigger(deps);
+    expect(seenInput).toBeDefined();
+    // an unchanged map: report == current.
+    expect(seenInput!.reportHash).toBe(seenInput!.currentMapHash);
+    // and it equals the deterministic hash of the seed map + world-config.
+    const expected = computeMapHash(buildPurupuruSeedRoleMap(), WORLD, WORLD_CONFIG);
+    expect(seenInput!.reportHash).toBe(expected);
+  });
+});
+
+describe("bd-71y — role-sync trigger: a denied/erroring orchestration ⇒ voiceless error", () => {
+  test("an orchestration throw (authz deny) surfaces as kind:error, no render", async () => {
+    let invoked = false;
+    const { deps } = makeDeps({
+      invoke: async () => {
+        invoked = true;
+        throw new Error("actor 'identity:cm-1' is not allowlisted for world 'purupuru' (not_allowlisted) — preview refused before any read");
+      },
+    });
+    const outcome = await runRoleSyncTrigger(deps, "LIVE");
+    expect(invoked).toBe(true); // authz happens INSIDE the orchestration
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("failed");
+      expect(outcome.message).toContain("not allowlisted");
+    }
+  });
+});
+
+describe("bd-71y — command name constant", () => {
+  test("the command a CM invokes is /role-sync", () => {
+    expect(ROLE_SYNC_COMMAND_NAME).toBe("role-sync");
+  });
+});

--- a/apps/bot/src/shadow/role-sync-trigger.ts
+++ b/apps/bot/src/shadow/role-sync-trigger.ts
@@ -1,0 +1,266 @@
+/**
+ * shadow/role-sync-trigger.ts — the VOICELESS, CM-facing INVOKER for the
+ * Purupuru tier→role sync (bd-71y).
+ *
+ * ── WHAT THIS CLOSES ─────────────────────────────────────────────────────────
+ * `go-live-orchestrator.ts::runTierRoleGoLive` is the RUNTIME entrypoint for
+ * per-member tier→role assignment — but nothing INVOKES it. This module is that
+ * invoker: a Discord admin slash command (`/role-sync`) an authorized community
+ * manager (CM) uses to run the sync, SHADOW preview (default) → LIVE apply.
+ *
+ * ── THE FLOW (bd-71y) ────────────────────────────────────────────────────────
+ *   1. CM invokes `/role-sync` with an explicit `mode` (SHADOW preview | LIVE
+ *      apply). DEFAULT is SHADOW — safe-by-default; LIVE requires the explicit
+ *      choice AND passes through runTierRoleGoLive's authz + goLive.
+ *   2. Resolve the CM's ACTOR — the invoking CM's identity-api `user_id`, taken
+ *      from the existing verified `AuthContext` the bot's auth-bridge attaches
+ *      (`claims.sub`). A non-verified invocation is REFUSED before any read (we
+ *      cannot authz an anon actor). The actor flows to runTierRoleGoLive, which
+ *      calls `resolveAuthz` against `admin_principals` (deny ⇒ refuse, no reads).
+ *   3. Read the tier→role map (`RoleMapConfig`) from config-service. If
+ *      config-service is unwired/empty, fall back to the CM-OVERRIDABLE DEFAULT
+ *      SEED map for Purupuru (role-sync-seed-map.ts).
+ *   4. Call runTierRoleGoLive with the chosen apply_mode (the INJECTED
+ *      orchestration port — the live wiring provides the real Effect run + the
+ *      composition-root layer; tests inject a fake).
+ *   5. Respond with the STRUCTURAL CV2 render of the result (role-sync-result-cv2)
+ *      — who'd get / has which role, counts, skip breakdown. STRUCTURAL ONLY.
+ *
+ * ── VOICELESS (bd-71y / onboarding-as-voiceless-building brief) ───────────────
+ * NO persona voice anywhere. The response is the structural result render +
+ * plain status. There is NO import of any persona-engine voice/narration module
+ * in this file (the score read path lives behind the INJECTED orchestration
+ * port; this module never imports persona-engine at all). Messaging/components
+ * come from config or the structural render — never persona-inferred.
+ *
+ * ── SAFE-BY-DEFAULT ──────────────────────────────────────────────────────────
+ * The mode defaults to SHADOW (preview, zero writes). LIVE is reachable ONLY
+ * when the CM passes `mode: LIVE` explicitly, and even then every write goes
+ * through runTierRoleGoLive → goLive (authz + roster-freshness + the gate). This
+ * trigger NEVER writes a role directly — the single gated write path
+ * (`role-writer.live.ts` behind the substrate gate) is untouched.
+ */
+import type { RoleMapConfig, Hex64, RoleMapVersionInput } from "@freeside-worlds/shadow-substrate";
+import { roleMapVersionHash } from "./substrate.ts";
+import type {
+  GoLiveOrchestrationInput,
+  GoLiveOrchestrationResult,
+} from "./go-live-orchestrator.ts";
+import {
+  buildPurupuruSeedRoleMap,
+  type RoleMapSource,
+} from "./role-sync-seed-map.ts";
+import {
+  roleSyncResultCV2Payload,
+  type RoleSyncRenderContext,
+} from "./role-sync-result-cv2.ts";
+
+/** The CM's resolved actor — the invoking CM's identity-api user_id. */
+export interface ResolvedActor {
+  /** identity-api `user_id` (claims.sub) — the value runTierRoleGoLive authzs. */
+  readonly actor: string;
+}
+
+/**
+ * Resolve the invoking CM's actor (identity-api user_id) from the request.
+ * Returns null when the CM is NOT verified (anon / anon-fallback) — the trigger
+ * refuses such an invocation before any read (we cannot authz an anon actor).
+ *
+ * The live wiring supplies this from the bot's existing verified `AuthContext`
+ * (auth-bridge `claims.sub`); tests inject a fake. This is the existing identity
+ * path the bot already uses for verify — NOT a new identity surface.
+ */
+export type ActorResolver = () => Promise<ResolvedActor | null> | ResolvedActor | null;
+
+/**
+ * Read the world's CM-authored tier→role map. Returns null when no map is
+ * authored / config-service is unwired (caller falls back to the seed). The live
+ * wiring backs this with `ConfigServiceClient.getRoleMap`; tests inject a fake.
+ */
+export type RoleMapReader = (world: string) => Promise<RoleMapConfig | null> | RoleMapConfig | null;
+
+/**
+ * Invoke the orchestration. INJECTED so the testable core is network-free: the
+ * live wiring runs `runTierRoleGoLive(deps, input)` against the composition-root
+ * layer (SHADOW preview = mock stack, LIVE apply = gated stack) and returns the
+ * result; tests inject a fake that returns a fixed result (or throws to exercise
+ * the failure path). The port surface is the orchestration INPUT (the trigger
+ * builds it) → the orchestration RESULT.
+ */
+export type OrchestrationInvoker = (
+  input: GoLiveOrchestrationInput,
+) => Promise<GoLiveOrchestrationResult>;
+
+/** The deploy-/test-provided ports the trigger core depends on. */
+export interface RoleSyncTriggerDeps {
+  /** the world this trigger targets (e.g. "purupuru"). */
+  readonly world: string;
+  /** resolve the invoking CM's actor (identity-api user_id) — null ⇒ not verified. */
+  readonly resolveActor: ActorResolver;
+  /** read the CM-authored role-map — null ⇒ use the default seed. */
+  readonly readRoleMap: RoleMapReader;
+  /** invoke runTierRoleGoLive against the composition-root layer. */
+  readonly invokeOrchestration: OrchestrationInvoker;
+  /**
+   * the FR-7 world-config hash fields (guild_id + nft_contracts + namespace) the
+   * `roleMapVersionHash` covers. Deploy-resolved from the world manifest; tests
+   * supply a fixture. The role-map's `namespace_prefix` is used when this omits
+   * one, but the guild_id + nft_contracts MUST come from the manifest.
+   */
+  readonly worldConfig: {
+    readonly guild_id: string;
+    readonly nft_contracts: ReadonlyArray<string>;
+    /** optional override; defaults to the role-map's namespace_prefix. */
+    readonly namespace_prefix?: string;
+  };
+  /** caller-supplied evaluation timestamp (no clock read in the core). */
+  readonly now: () => string;
+  /** verified token metadata for the batch AuthzContext (deploy-provided). */
+  readonly tokenMetadata: GoLiveOrchestrationInput["tokenMetadata"];
+  /** the FR-7 go_live transition version (deploy-/lifecycle-provided). */
+  readonly transitionVersion: number;
+}
+
+/** The CM's chosen action — SHADOW preview (default) or LIVE apply. */
+export type RoleSyncMode = "SHADOW" | "LIVE";
+
+/** The trigger's structured outcome. `payload` is the CV2 message to send. */
+export type RoleSyncOutcome =
+  | {
+      readonly kind: "rendered";
+      /** the CV2 message payload (flags + components + inert mentions). */
+      readonly payload: ReturnType<typeof roleSyncResultCV2Payload>;
+      /** the apply_mode the run executed under (echoes the gate's Ref). */
+      readonly applyMode: RoleSyncMode;
+      /** the role-map provenance (CM-authored vs default seed). */
+      readonly mapSource: RoleMapSource;
+      readonly result: GoLiveOrchestrationResult;
+    }
+  | {
+      readonly kind: "refused";
+      /** machine reason: why the trigger refused (no write, no read happened). */
+      readonly reason: "not_verified";
+      /** a plain, voiceless status string for the CM. */
+      readonly message: string;
+    }
+  | {
+      readonly kind: "error";
+      /** the orchestration failed (authz deny, roster error, etc). */
+      readonly message: string;
+    };
+
+/**
+ * Compute the FR-7 `roleMapVersionHash` for a (role-map, world-config) pair. The
+ * trigger uses the same value for `reportHash` and `currentMapHash` (an unchanged
+ * map at invocation time — the gate's binding guard compares them).
+ */
+export function computeMapHash(
+  roleMap: RoleMapConfig,
+  worldSlug: string,
+  worldConfig: RoleSyncTriggerDeps["worldConfig"],
+): Hex64 {
+  const namespace = worldConfig.namespace_prefix ?? roleMap.namespace_prefix;
+  const input: RoleMapVersionInput = {
+    role_rules: roleMap.rules,
+    scaffolding_config: roleMap.scaffolding,
+    world_config: {
+      world_slug: worldSlug,
+      guild_id: worldConfig.guild_id,
+      namespace_prefix: namespace,
+      nft_contracts: worldConfig.nft_contracts,
+    },
+  };
+  return roleMapVersionHash(input);
+}
+
+/**
+ * Run the voiceless tier→role sync trigger. The TESTABLE CORE — network-free:
+ * actor resolution, role-map read, orchestration invocation, and config-service
+ * read are all INJECTED ports. Returns a structured {@link RoleSyncOutcome}; the
+ * Discord-interaction wiring (below / in the live module) maps it to a response.
+ *
+ * SAFE-BY-DEFAULT: `mode` defaults to SHADOW. Authz happens INSIDE
+ * runTierRoleGoLive (the actor → admin_principals check); a not-verified CM is
+ * refused HERE, before any read, because there is no actor to authz.
+ */
+export async function runRoleSyncTrigger(
+  deps: RoleSyncTriggerDeps,
+  mode: RoleSyncMode = "SHADOW",
+): Promise<RoleSyncOutcome> {
+  // (1) Resolve the CM's actor — REFUSE a non-verified invocation before any
+  //     read. We cannot authz an anon; runTierRoleGoLive needs a real
+  //     identity-api user_id to resolve against admin_principals.
+  const resolved = await deps.resolveActor();
+  if (!resolved) {
+    return {
+      kind: "refused",
+      reason: "not_verified",
+      message:
+        "Refused: this command requires a verified identity. Run /verify to link your identity, then try again. (No data was read.)",
+    };
+  }
+
+  // (2) Read the CM-authored role-map; fall back to the CM-overridable seed.
+  const authored = await deps.readRoleMap(deps.world);
+  const roleMap: RoleMapConfig = authored ?? buildPurupuruSeedRoleMap();
+  const mapSource: RoleMapSource = authored ? "config-service" : "default-seed";
+
+  // (3) The FR-7 hash binds the run to the map it was computed against.
+  const mapHash = computeMapHash(roleMap, deps.world, deps.worldConfig);
+
+  // (4) Build the orchestration input + invoke. The chosen `mode` is the
+  //     shadow/apply switch (SHADOW ⇒ no goLive, gate rejects → zero writes;
+  //     LIVE ⇒ goLive flips + the gate writes through the gated adapter).
+  const input: GoLiveOrchestrationInput = {
+    world: deps.world,
+    applyMode: mode,
+    actor: resolved.actor,
+    reportHash: mapHash,
+    currentMapHash: mapHash,
+    transitionVersion: deps.transitionVersion,
+    evaluatedAt: deps.now(),
+    roleMap,
+    tokenMetadata: deps.tokenMetadata,
+  };
+
+  let result: GoLiveOrchestrationResult;
+  try {
+    result = await deps.invokeOrchestration(input);
+  } catch (e) {
+    // authz deny, roster error, score error, etc — all surface as a voiceless
+    // structural error. NO write occurred for an authz-deny (it fails before the
+    // mint); a LIVE error after the gate is reflected in the message.
+    return {
+      kind: "error",
+      message: `Tier→role sync (${mode}) failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  // (5) STRUCTURAL CV2 render of the result — voiceless.
+  const ctx: RoleSyncRenderContext = { world: deps.world, mapSource };
+  return {
+    kind: "rendered",
+    payload: roleSyncResultCV2Payload(result, ctx),
+    applyMode: result.applyMode,
+    mapSource,
+    result,
+  };
+}
+
+// ─── Discord-interaction surface (the slash command name + mode parsing) ──────
+
+/** The slash command name a CM invokes to run the sync. */
+export const ROLE_SYNC_COMMAND_NAME = "role-sync";
+/** The option name carrying the SHADOW/LIVE choice. */
+export const ROLE_SYNC_MODE_OPTION = "mode";
+
+/**
+ * Parse the CM's chosen mode from a raw option value. SAFE-BY-DEFAULT: anything
+ * that is not exactly the (case-insensitive) string "live" resolves to SHADOW.
+ * An absent option ⇒ SHADOW. The LIVE path requires the explicit, unambiguous
+ * choice; a typo or absent value can NEVER silently select LIVE.
+ */
+export function parseRoleSyncMode(raw: string | undefined | null): RoleSyncMode {
+  if (typeof raw !== "string") return "SHADOW";
+  return raw.trim().toLowerCase() === "live" ? "LIVE" : "SHADOW";
+}

--- a/apps/bot/worlds/purupuru.yaml
+++ b/apps/bot/worlds/purupuru.yaml
@@ -1,0 +1,78 @@
+# ─── VENDORED WORLD MANIFEST (bd-atm role-sync boot-wire) ─────────────────────
+# This is a VENDORED COPY of the canonical freeside-worlds manifest at
+#   freeside-worlds/packages/registry/worlds/purupuru.yaml
+# KEEP IN SYNC with the canonical copy. The deployed onboarding/role-dispenser
+# building depends only on the SHA-pinned @freeside-worlds/shadow-substrate (the
+# gate + pure core), NOT on the registry package — so it needs a LOCAL copy of
+# the world manifest to read `shadow_onboarding.admin_principals` (FR-10) and the
+# guild_id / namespace_prefix at runtime.
+#
+# The bot's boot composition resolves this file by world slug:
+#   manifestPath("purupuru") → apps/bot/worlds/purupuru.yaml
+# (see apps/bot/src/shadow/role-sync-boot.ts). The LIVE AdminAllowlistSource
+# (admin-allowlist.live.ts) reads `shadow_onboarding.admin_principals` from this
+# path; the substrate's resolveAuthz grants/denies CMs by EXACT membership
+# (resolve-authz.ts:99 `principals.includes(actor)`), where `actor` is the
+# identity-api user_id (claims.sub) the role-sync trigger resolves.
+#
+# ⚠ The four operator-precondition fields below mirror the canonical manifest
+#   verbatim. An EMPTY admin_principals is deny-all (fail-safe). DO NOT diverge
+#   this copy from the canonical without also updating freeside-worlds.
+# ──────────────────────────────────────────────────────────────────────────────
+schema_version: "1.3"
+slug: purupuru
+name: "Purupuru"
+repo: "0xHoneyJar/freeside-worlds"
+description: "Purupuru — the 1→2 scale test ground for the shadow-mode onboarding substrate (cycle shadow-onboarding-substrate, G-6). The shadow substrate (@freeside-worlds/shadow-substrate) governs role assignment+creation+scaffolding shadow-first; freeside-characters supplies the voiceless Discord I/O Layers (RosterSource/RoleWriter) + the CV2 render; freeside-dashboard is the web before/after lens. Latent-member data is MOCKED for the MVP (score-api is NOT ours — #164/#221). This manifest is SCAFFOLDED: the preconditions only the operator has (guild snowflake, NFT contracts, the holder set, and the FR-10 admin allowlist) are TODO(operator) placeholders — the substrate fails CLOSED (deny-all) until admin_principals is populated."
+
+# ─── shadow-mode onboarding substrate (cycle shadow-onboarding-substrate, S4) ──
+# Consumed by @freeside-worlds/shadow-substrate's AdminAllowlistSource (FR-10) +
+# the freeside-characters LIVE RosterSource/RoleWriter Layers (Sprint 405).
+shadow_onboarding:
+  # The canonical Purupuru Discord guild snowflake (17-20 digits). The LIVE
+  # RosterSource/RoleWriter resolve roles+members against this guild.
+  guild_id: "1495534680617910396"  # Purupuru test guild (operator-confirmed 2026-06-03)
+
+  # The Freeside-managed role-name prefix. Freeside touches ONLY roles whose name
+  # starts with this prefix (FR-9 coexistence — Collab.Land roles never contended).
+  namespace_prefix: "purupuru:"
+
+  # TODO(operator): the NFT contract address(es) qualifying members hold. Feeds the
+  #   (MOCKED for MVP) latent-member surface. Real qualification is a Phase-2 gate
+  #   (score-api is not ours — #164/#221). Fill with the real Purupuru contract(s).
+  nft_contracts: []  # TODO(operator): ["0x…"]
+
+  # The FR-10 ALLOWLIST — identity-api user_id (claims.sub) of each CM authorized
+  #   to bind the role-map + go_live for Purupuru. The substrate's resolveAuthz
+  #   grants/denies by MEMBERSHIP against this list; an EMPTY list is deny-all
+  #   (fail-safe). This is the deploy-bound write authority — it lives HERE (the
+  #   manifest), NEVER in a config surface, so the write path can never self-grant
+  #   (SKP-007).
+  # soju (zksoju) — identity-api user_id (claims.sub), resolved from wallet
+  #   0x79092A805f1cf9B0F5bE3c5A296De6e51c1DEd34 via GET /v1/resolve/wallet/.
+  #   resolveAuthz matches claims.sub EXACTLY (bare uuid, NOT identity:-prefixed —
+  #   resolve-authz.ts:99 `principals.includes(input.actor)`).
+  admin_principals: ["ae0558c7-aeb2-48f0-906d-ad0a50108b19"]
+
+  # TODO(operator): the member/holder set used for shadow-PREVIEW on mocked data
+  #   (member snowflakes or wallet identifiers). The preview renders the before/
+  #   after on this set with an honest MOCK provenance flag. The real holder set is
+  #   an operator precondition; leave empty to preview against an empty roster.
+  member_set: []  # TODO(operator): ["<member_snowflake_or_wallet>", ...]
+
+# ─── deploy / hosting ─────────────────────────────────────────────────────────
+hosting:
+  type: ECSHosting
+  cpu: 256
+  memory: 512
+
+env_vars: {}
+
+secrets: []
+
+compose_with:
+  # The shadow substrate is consumed git-source / SHA-pinned by the lenses
+  # (freeside-characters S4, freeside-dashboard S3) per the substrate-sha.lock
+  # cross-repo version contract (B7). This world is the first to declare it.
+  - slug: shadow-substrate
+    relationship: "Shadow-mode onboarding governor · @freeside-worlds/shadow-substrate (pure core + GateCheckedRoleWriter gate + FR-10 resolveAuthz). The lenses supply RosterSource/RoleWriter/AcvpEmitter/AdminAllowlistSource/WorldLock Layers; the substrate owns the gate. SHA-pinned per grimoires/loa/cycles/shadow-onboarding-substrate/substrate-sha.lock."


### PR DESCRIPTION
## What

Makes the Purupuru tier to role onboarding actually RUNNABLE: a voiceless `/role-sync` Discord command (bd-71y) plus the boot composition that wires it end to end to run in SHADOW on Purupuru (bd-atm). Stacks on the merged tier to role feature (#165).

## The two pieces

- **`/role-sync` trigger (bd-71y):** a CM-facing slash command, `mode` SHADOW (default) or LIVE. Voiceless. It renders the structural discrepancy (counts + per-member assignments), never persona voice. SHADOW-default + LIVE-explicit. The gate is the only write path.
- **Boot-wiring (bd-atm):** composes `shadowPreviewLayer`/`liveApplyLayer` + an OrchestrationInvoker that runs `runTierRoleGoLive`. Vendors `apps/bot/worlds/purupuru.yaml` (the deployed bot deps only the SHA-pinned substrate, not the registry, so it needs a local manifest). Resolves the CM actor independently of `AUTH_BACKEND`.

## Isolation (operator direction)

The onboarding/role-dispenser is a separable, voiceless building. This honors it:
- **Zero persona-voice imports** in the new code (only the score data-client is shared, tracked as isolation-debt for the eventual `freeside-onboarding` extraction).
- **Actor resolution is self-contained:** invoking discord id, then `GET /v1/resolve/account/discord/{id}`, then `user_id` = the authz actor, independent of the persona daemon's `AUTH_BACKEND`.
- **A role-sync composition error cannot crash the daemon** (wrapped, fail-closed).

## Fail-closed posture

- `ROLE_SYNC_ENABLED` master gate: unset means `/role-sync` reports "not configured" and nothing is wired.
- Unresolved/unlinked actor, missing manifest, or missing env give a clean refusal, never a silent pass or write.
- LIVE apply is intentionally gated off (`requireLiveAudit` throws) until the live NATS audit emitter + the full roster-identity snapshot (`bd-glb`) land. SHADOW is the deliverable.

## Auth grant

`apps/bot/worlds/purupuru.yaml` `admin_principals: ["ae0558c7-aeb2-48f0-906d-ad0a50108b19"]` (the operator's identity-api user_id, resolved from their wallet, bare uuid because `resolve-authz` exact-matches `claims.sub`). `guild_id: "1495534680617910396"`.

## Tests

620 `apps/bot/src` tests pass (+42 trigger, +21 bootwire). Both typechecks clean. Import-boundary lint clean. Substrate conformance clean.

## Review

Multi-model review across the build chain (Opus CLI + codex CLI). The security-critical loci (isolated actor auth, boot fail-closed, manifest traversal guard, LIVE gated off) were re-read against source. Does NOT modify the SHA-pinned `@freeside-worlds/shadow-substrate`.

## Not in this PR (tracked)

`bd-glb` (freeside-worlds): full live roster-identity snapshot + LatentQualified provenance. `bd-q2h`: extract the onboarding unit into a standalone `freeside-onboarding` building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
