### PR TITLE
feat(bot): member-centric tier→role SHADOW CM dashboard (bd-l08)

### DIFF
--- a/apps/bot/src/discord-interactions/dispatch.ts
+++ b/apps/bot/src/discord-interactions/dispatch.ts
@@ -1338,7 +1338,9 @@ async function runRoleSyncDeferred(
 ): Promise<void> {
   try {
     const outcome = await computeRoleSyncOutcome(interaction, auth, deps);
-    if (outcome.kind === 'rendered') {
+    // BOTH CV2 render paths (leaderboard-centric `rendered` + member-centric
+    // `rendered-members`, bd-l08) PATCH @original with the structural payload.
+    if (outcome.kind === 'rendered' || outcome.kind === 'rendered-members') {
       await patchOriginalData(interaction, {
         ...(outcome.payload as unknown as Record<string, unknown>),
         flags: (outcome.payload.flags as number) | MessageFlags.EPHEMERAL,

--- a/apps/bot/src/shadow/member-dashboard-cv2.test.ts
+++ b/apps/bot/src/shadow/member-dashboard-cv2.test.ts
@@ -1,0 +1,144 @@
+/**
+ * member-dashboard-cv2.test.ts — the VOICELESS member-centric CM dashboard render
+ * (bd-l08). Proves the CV2 grammar, inert mentions, the summary counts, the
+ * per-member before→after rows grouped by indicator, the default-seed flag, and
+ * the injection guard (attacker nick / role name neutralized).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  renderMemberDashboardCV2,
+  memberDashboardCV2Payload,
+  type MemberDashboardContext,
+} from "./member-dashboard-cv2.ts";
+import { IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import { summarize, type MemberTierRow, type MemberRosterResult } from "./member-roster.ts";
+
+function rosterOf(rows: MemberTierRow[]): MemberRosterResult {
+  return { rows, summary: summarize(rows) };
+}
+
+const CTX: MemberDashboardContext = { world: "purupuru", mapSource: "default-seed" };
+
+const ADD_ROW: MemberTierRow = {
+  discord_id: "700000000000000001",
+  display_name: "soju",
+  linked: true,
+  wallet: "0xabc",
+  tier: "member",
+  proposed_role_key: "purupuru:member",
+  current_managed_roles: [],
+  change: "ADD",
+};
+const KEEP_ROW: MemberTierRow = {
+  discord_id: "700000000000000004",
+  display_name: "keeper",
+  linked: true,
+  wallet: "0xdef",
+  tier: "core",
+  proposed_role_key: "purupuru:core",
+  current_managed_roles: ["purupuru:core"],
+  change: "KEEP",
+};
+const UNLINKED_ROW: MemberTierRow = {
+  discord_id: "700000000000000002",
+  display_name: "nolink",
+  linked: false,
+  current_managed_roles: [],
+  change: "UNLINKED",
+};
+
+describe("bd-l08 — member-centric dashboard CV2 render (structural, voiceless)", () => {
+  test("CV2 grammar: container 17, text 10, separator 14", () => {
+    const c = renderMemberDashboardCV2(rosterOf([ADD_ROW]), CTX);
+    expect(c.type).toBe(17);
+    expect(typeof c.accent_color).toBe("number");
+    const types = c.components.map((x) => x.type);
+    expect(types).toContain(10);
+    expect(types).toContain(14);
+  });
+
+  test("payload: IS_COMPONENTS_V2 flag + inert mentions, no content/embeds", () => {
+    const p = memberDashboardCV2Payload(rosterOf([]), CTX);
+    expect(p.flags & IS_COMPONENTS_V2).toBe(IS_COMPONENTS_V2);
+    expect(p.allowed_mentions).toEqual({ parse: [] });
+    expect((p as { content?: string }).content).toBeUndefined();
+  });
+
+  test("summary counts surfaced in the header", () => {
+    const c = renderMemberDashboardCV2(rosterOf([ADD_ROW, KEEP_ROW, UNLINKED_ROW]), CTX);
+    const txt = JSON.stringify(c.components);
+    expect(txt).toContain("3** members");
+    expect(txt).toContain("2** linked");
+    expect(txt).toContain("1** would-add");
+    expect(txt).toContain("1** keep");
+    expect(txt).toContain("1** unlinked");
+  });
+
+  test("per-member before→after row: current → proposed with the tier note", () => {
+    const c = renderMemberDashboardCV2(rosterOf([ADD_ROW]), CTX);
+    const contents = c.components
+      .filter((x): x is { type: 10; content: string } => x.type === 10)
+      .map((x) => x.content)
+      .join("\n");
+    // operator-style row: soju (tier member) · (none) → purupuru:member, ADD group.
+    expect(contents).toContain("Would add (1)");
+    expect(contents).toContain("soju");
+    expect(contents).toContain("purupuru:member");
+    expect(contents).toContain("→");
+  });
+
+  test("groups are actionable-first: ADD heading precedes KEEP heading", () => {
+    const c = renderMemberDashboardCV2(rosterOf([KEEP_ROW, ADD_ROW]), CTX);
+    const headings = c.components
+      .filter((x): x is { type: 10; content: string } => x.type === 10)
+      .map((x) => x.content);
+    const addIdx = headings.findIndex((h) => h.includes("Would add"));
+    const keepIdx = headings.findIndex((h) => h.includes("Keep"));
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(keepIdx).toBeGreaterThan(addIdx);
+  });
+
+  test("default-seed provenance flagged for the CM", () => {
+    const c = renderMemberDashboardCV2(rosterOf([ADD_ROW]), CTX);
+    expect(JSON.stringify(c.components)).toContain("DEFAULT SEED");
+  });
+
+  test("unlinked row renders an (unlinked) proposed cell", () => {
+    const c = renderMemberDashboardCV2(rosterOf([UNLINKED_ROW]), CTX);
+    const contents = c.components
+      .filter((x): x is { type: 10; content: string } => x.type === 10)
+      .map((x) => x.content)
+      .join("\n");
+    expect(contents).toContain("Unlinked");
+    expect(contents).toContain("nolink");
+  });
+
+  test("INJECTION GUARD: an attacker nick / role name is neutralized", () => {
+    const evil: MemberTierRow = {
+      discord_id: "700000000000000009",
+      display_name: "@everyone",
+      linked: true,
+      wallet: "0x1",
+      tier: "core",
+      proposed_role_key: "**bold** `code`",
+      current_managed_roles: [],
+      change: "ADD",
+    };
+    const c = renderMemberDashboardCV2(rosterOf([evil]), CTX);
+    const contents = c.components
+      .filter((x): x is { type: 10; content: string } => x.type === 10)
+      .map((x) => x.content)
+      .join("\n");
+    // @everyone broken (zero-width inserted after @).
+    expect(contents).not.toContain("@everyone");
+    // markdown control chars escaped.
+    expect(contents).toContain("\\*\\*bold\\*\\*");
+  });
+
+  test("empty roster renders header + summary, no row groups", () => {
+    const c = renderMemberDashboardCV2(rosterOf([]), CTX);
+    const txt = JSON.stringify(c.components);
+    expect(txt).toContain("0** members");
+    expect(txt).not.toContain("Would add");
+  });
+});

--- a/apps/bot/src/shadow/member-dashboard-cv2.ts
+++ b/apps/bot/src/shadow/member-dashboard-cv2.ts
@@ -1,0 +1,195 @@
+/**
+ * shadow/member-dashboard-cv2.ts — the VOICELESS, MEMBER-CENTRIC CM dashboard
+ * render: a `MemberRosterResult` → a Discord Components-V2 (CV2) message (bd-l08).
+ *
+ * ── WHY THIS, NOT role-sync-result-cv2.ts ────────────────────────────────────
+ * `role-sync-result-cv2.ts` renders the LEADERBOARD-centric
+ * `GoLiveOrchestrationResult` (per-role create/assign counts) — the latent/growth
+ * view. The CM asked to "manage roles for the MEMBERS of our server by their
+ * tier", which is a MEMBER-centric before→after table: per member, their current
+ * managed role(s) → the proposed tier role + a change indicator. This module is
+ * that render. The leaderboard render stays for the LIVE-apply follow-up.
+ *
+ * ── A CM DASHBOARD (the operator asked for "as clear as possible") ────────────
+ * The layout is a community-manager dashboard:
+ *   • a header (world + SHADOW-preview note + role-map provenance);
+ *   • summary counts (N members · N linked · N would-add · N unlinked · N untiered);
+ *   • a per-member before→after list, grouped by change indicator so the
+ *     actionable rows (ADD) lead, then KEEP, then the non-actionable
+ *     (UNTIERED / UNLINKED / NO-CHANGE). Each row reads:
+ *       <indicator> <member> · <current role(s)> → <proposed role>
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * Pure render (`MemberRosterResult` → CV2 component JSON). NO persona, NO voice,
+ * NO narration, no Discord call, no event. There is no persona-engine import.
+ * Every string is a structural label or a count.
+ *
+ * ── INJECTION GUARD (mirrors role-sync-result-cv2.ts / discrepancy-cv2.ts) ────
+ * Member DISPLAY NAMES and role KEYS are attacker-controllable (a member sets
+ * their own nick; a low-priv member can create a guild role named `@everyone`).
+ * We reuse `escapeRoleName` (neutralizes mention syntax + markdown) + clamp +
+ * `allowed_mentions: { parse: [] }` so a malicious name cannot spoof the layout
+ * or fire a mass-ping.
+ */
+import { escapeRoleName, IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import type { MemberRosterResult, MemberTierRow, MemberChange } from "./member-roster.ts";
+import type { RoleMapSource } from "./role-sync-seed-map.ts";
+
+/** Warm honey for a SHADOW preview (this render is SHADOW-only). */
+const ACCENT_SHADOW = 0x6f4ea1;
+
+/** Max rendered name length before truncation (defense vs a pathological name). */
+const MAX_NAME_CHARS = 48;
+/** Conservative per-text-component char budget (well under Discord's ~4000). */
+const MAX_TEXT_COMPONENT_CHARS = 3500;
+/** Max member rows rendered PER change group before a `…and N more` affordance. */
+const MAX_ROWS_PER_GROUP = 40;
+
+/** Per-indicator glyph + label, ordered actionable-first for a CM. */
+const CHANGE_META: ReadonlyArray<{ change: MemberChange; glyph: string; label: string }> = [
+  { change: "ADD", glyph: "➕", label: "Would add" },
+  { change: "KEEP", glyph: "✅", label: "Keep (already has the role)" },
+  { change: "UNTIERED", glyph: "➖", label: "Untiered (no qualifying tier)" },
+  { change: "UNLINKED", glyph: "🔗", label: "Unlinked (no linked wallet)" },
+  { change: "NO-CHANGE", glyph: "·", label: "No change" },
+];
+
+function clamp(name: string, max: number): string {
+  return name.length > max ? `${name.slice(0, max - 1)}…` : name;
+}
+
+/** Render an attacker-controllable display name → a safe inline string. */
+function safeName(raw: string | undefined, discordId: string): string {
+  const base = raw && raw.length > 0 ? raw : `member ${discordId}`;
+  return clamp(escapeRoleName(base), MAX_NAME_CHARS);
+}
+
+/** Render an attacker-controllable role key → a safe inline code span. */
+function codeRole(raw: string): string {
+  return `\`${clamp(escapeRoleName(raw), MAX_NAME_CHARS)}\``;
+}
+
+/** Render the "current managed role(s)" cell (the BEFORE side). */
+function renderCurrent(row: MemberTierRow): string {
+  if (row.current_managed_roles.length === 0) return "_(none)_";
+  return row.current_managed_roles.map(codeRole).join(", ");
+}
+
+/** Render the "proposed role" cell (the AFTER side). */
+function renderProposed(row: MemberTierRow): string {
+  if (row.proposed_role_key) return codeRole(row.proposed_role_key);
+  if (!row.linked) return "_(unlinked)_";
+  return "_(no role)_";
+}
+
+/** Render one member row: `<glyph> <name> · <current> → <proposed>`. */
+function renderRow(row: MemberTierRow): string {
+  const glyph = CHANGE_META.find((m) => m.change === row.change)?.glyph ?? "·";
+  const name = safeName(row.display_name, row.discord_id);
+  const tierNote = row.tier ? ` (tier ${codeRole(row.tier)})` : "";
+  return `${glyph} **${name}**${tierNote} · ${renderCurrent(row)} → ${renderProposed(row)}`;
+}
+
+/**
+ * Join already-rendered rows, stopping once `maxRows` or `maxChars` is hit,
+ * appending a `…and N more` affordance. Mirrors `boundedJoin` in the sibling
+ * renders (a large guild must not produce an oversized text component Discord
+ * silently rejects).
+ */
+function boundedRows(rows: readonly string[], maxRows: number, maxChars: number): string {
+  if (rows.length === 0) return "_(none)_";
+  const kept: string[] = [];
+  let len = 0;
+  for (let i = 0; i < rows.length; i++) {
+    const piece = rows[i]!;
+    const remaining = rows.length - i;
+    if ((kept.length >= maxRows || len + piece.length + 1 > maxChars) && kept.length > 0) {
+      return `${kept.join("\n")}\n…and ${remaining} more`;
+    }
+    kept.push(piece);
+    len += piece.length + 1;
+  }
+  return kept.join("\n");
+}
+
+type TextComponent = { type: 10; content: string };
+type SeparatorComponent = { type: 14 };
+type ContainerComponent = {
+  type: 17;
+  accent_color: number;
+  components: Array<TextComponent | SeparatorComponent>;
+};
+
+function text(content: string): TextComponent {
+  return { type: 10, content };
+}
+const sep: SeparatorComponent = { type: 14 };
+
+/** Context the dashboard carries beyond the roster result. */
+export interface MemberDashboardContext {
+  readonly world: string;
+  /** provenance of the role-map: CM-authored ("config-service") vs default seed. */
+  readonly mapSource: RoleMapSource;
+}
+
+/**
+ * Render a `MemberRosterResult` as a CV2 container component (the single
+ * top-level component). The caller wraps it via {@link memberDashboardCV2Payload}.
+ *
+ * STRUCTURAL ONLY: header, summary counts, and per-member before→after rows
+ * grouped by change indicator. No persona, no voice, no narration. SHADOW-only.
+ */
+export function renderMemberDashboardCV2(
+  result: MemberRosterResult,
+  ctx: MemberDashboardContext,
+): ContainerComponent {
+  const s = result.summary;
+
+  const mapNote =
+    ctx.mapSource === "default-seed"
+      ? "_Role-map: **DEFAULT SEED** (CM-overridable — author the real map in the dashboard / config-service)._"
+      : "_Role-map: CM-authored (config-service)._";
+
+  const summaryLine =
+    `**${s.members}** members · **${s.linked}** linked · ` +
+    `**${s.would_add}** would-add · **${s.keep}** keep · ` +
+    `**${s.unlinked}** unlinked · **${s.untiered}** untiered`;
+
+  const components: Array<TextComponent | SeparatorComponent> = [
+    text(`# Member roles — \`${ctx.world}\` (SHADOW preview)`),
+    text(
+      `_Preview only — ZERO writes. Each server member → their tier → their role._\n${mapNote}`,
+    ),
+    sep,
+    text(`## Summary\n${summaryLine}`),
+    sep,
+  ];
+
+  // group rows by change indicator, actionable-first.
+  for (const meta of CHANGE_META) {
+    const group = result.rows.filter((r) => r.change === meta.change);
+    if (group.length === 0) continue;
+    const body = boundedRows(group.map(renderRow), MAX_ROWS_PER_GROUP, MAX_TEXT_COMPONENT_CHARS);
+    components.push(text(`## ${meta.glyph} ${meta.label} (${group.length})\n${body}`));
+  }
+
+  return { type: 17, accent_color: ACCENT_SHADOW, components };
+}
+
+/** The full CV2 message payload (flags + components + inert mentions). */
+export function memberDashboardCV2Payload(
+  result: MemberRosterResult,
+  ctx: MemberDashboardContext,
+): {
+  flags: number;
+  components: ContainerComponent[];
+  allowed_mentions: { parse: never[] };
+} {
+  return {
+    flags: IS_COMPONENTS_V2,
+    components: [renderMemberDashboardCV2(result, ctx)],
+    // INJECTION GUARD: every mention is inert — an attacker-named role / nick
+    // surfaced in the rows cannot fire an @everyone / role / user ping.
+    allowed_mentions: { parse: [] },
+  };
+}

--- a/apps/bot/src/shadow/member-identity-client.test.ts
+++ b/apps/bot/src/shadow/member-identity-client.test.ts
@@ -1,0 +1,157 @@
+/**
+ * member-identity-client.test.ts — the two-read MEMBER-CENTRIC identity client
+ * (bd-l08). Proves the discord-id → user_id → primary_wallet chain, the wallet
+ * fallback, and FAIL-SOFT at every step (404 / non-2xx / transport / malformed
+ * never throws — a bad member resolves to unlinked/no_wallet). Network-free
+ * (injected fetch).
+ */
+import { describe, expect, test } from "bun:test";
+import { MemberIdentityClient, extractWallet } from "./member-identity-client.ts";
+
+/** A tiny fetch double keyed on a URL substring → a {status, body} response. */
+function fakeFetch(
+  routes: Array<{ match: string; status: number; body?: unknown }>,
+): typeof fetch {
+  return (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const hit = routes.find((r) => url.includes(r.match));
+    if (!hit) return new Response("not found", { status: 404 });
+    const init = { status: hit.status } as ResponseInit;
+    if (hit.body === undefined) return new Response(null, init);
+    return new Response(JSON.stringify(hit.body), init);
+  }) as unknown as typeof fetch;
+}
+
+const cfg = (fetchImpl: typeof fetch) => ({
+  baseUrl: "https://identity.test",
+  world: "purupuru",
+  fetchImpl,
+  timeoutMs: 0, // disable the deadline in tests (no real timers).
+});
+
+const DISCORD_ID = "700000000000000001";
+const USER_ID = "ae0558c7-aeb2-48f0-906d-ad0a50108b19";
+const WALLET = "0x79092A805f1cf9B0F5bE3c5A296De6e51c1DEd34";
+
+describe("bd-l08 — member-identity-client (member-centric, fail-soft)", () => {
+  test("linked: discord id → user_id → primary_wallet (lowercased)", async () => {
+    const client = new MemberIdentityClient(
+      cfg(
+        fakeFetch([
+          { match: "/v1/resolve/account/discord/", status: 200, body: { user_id: USER_ID } },
+          {
+            match: "/v1/profile",
+            status: 200,
+            body: { identity: { user_id: USER_ID, primary_wallet: WALLET, wallets: [] } },
+          },
+        ]),
+      ),
+    );
+    const out = await client.resolveMember(DISCORD_ID);
+    expect(out.kind).toBe("linked");
+    if (out.kind === "linked") {
+      expect(out.user_id).toBe(USER_ID);
+      expect(out.wallet).toBe(WALLET.toLowerCase());
+    }
+  });
+
+  test("unlinked: resolve 404 ⇒ unlinked (no profile call needed)", async () => {
+    const client = new MemberIdentityClient(
+      cfg(fakeFetch([{ match: "/v1/resolve/account/discord/", status: 404 }])),
+    );
+    const out = await client.resolveMember(DISCORD_ID);
+    expect(out.kind).toBe("unlinked");
+  });
+
+  test("no_wallet: linked user but profile 404 (primary_wallet_missing) ⇒ no_wallet", async () => {
+    const client = new MemberIdentityClient(
+      cfg(
+        fakeFetch([
+          { match: "/v1/resolve/account/discord/", status: 200, body: { user_id: USER_ID } },
+          { match: "/v1/profile", status: 404, body: { reason: "primary_wallet_missing" } },
+        ]),
+      ),
+    );
+    const out = await client.resolveMember(DISCORD_ID);
+    expect(out.kind).toBe("no_wallet");
+    if (out.kind === "no_wallet") expect(out.user_id).toBe(USER_ID);
+  });
+
+  test("wallet fallback: no primary_wallet ⇒ first non-unlinked wallets[] entry", async () => {
+    const client = new MemberIdentityClient(
+      cfg(
+        fakeFetch([
+          { match: "/v1/resolve/account/discord/", status: 200, body: { user_id: USER_ID } },
+          {
+            match: "/v1/profile",
+            status: 200,
+            body: {
+              identity: {
+                primary_wallet: null,
+                wallets: [
+                  { wallet_address: "0xOLD", unlinked_at: "2026-01-01T00:00:00Z" },
+                  { wallet_address: WALLET, unlinked_at: null },
+                ],
+              },
+            },
+          },
+        ]),
+      ),
+    );
+    const out = await client.resolveMember(DISCORD_ID);
+    expect(out.kind).toBe("linked");
+    if (out.kind === "linked") expect(out.wallet).toBe(WALLET.toLowerCase());
+  });
+
+  test("fail-soft: a malformed (non-snowflake) discord id ⇒ unlinked, no fetch", async () => {
+    let calls = 0;
+    const counting = (async () => {
+      calls += 1;
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = new MemberIdentityClient(cfg(counting));
+    const out = await client.resolveMember("not-a-snowflake");
+    expect(out.kind).toBe("unlinked");
+    expect(calls).toBe(0);
+  });
+
+  test("fail-soft: a transport throw ⇒ unlinked (never propagates)", async () => {
+    const throwing = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const client = new MemberIdentityClient(cfg(throwing));
+    const out = await client.resolveMember(DISCORD_ID);
+    expect(out.kind).toBe("unlinked");
+  });
+
+  test("fail-soft: a 200 with malformed JSON ⇒ unlinked", async () => {
+    const badJson = (async () =>
+      new Response("{not json", { status: 200 })) as unknown as typeof fetch;
+    const client = new MemberIdentityClient(cfg(badJson));
+    const out = await client.resolveMember(DISCORD_ID);
+    expect(out.kind).toBe("unlinked");
+  });
+
+  describe("extractWallet", () => {
+    test("prefers primary_wallet (lowercased)", () => {
+      expect(extractWallet({ identity: { primary_wallet: WALLET, wallets: [] } })).toBe(
+        WALLET.toLowerCase(),
+      );
+    });
+    test("null body / no identity ⇒ null", () => {
+      expect(extractWallet(null)).toBeNull();
+      expect(extractWallet({})).toBeNull();
+      expect(extractWallet({ identity: null })).toBeNull();
+    });
+    test("skips unlinked wallets in the fallback", () => {
+      expect(
+        extractWallet({
+          identity: {
+            primary_wallet: null,
+            wallets: [{ wallet_address: "0xDEAD", unlinked_at: "x" }],
+          },
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/bot/src/shadow/member-identity-client.ts
+++ b/apps/bot/src/shadow/member-identity-client.ts
@@ -1,0 +1,181 @@
+/**
+ * shadow/member-identity-client.ts — the MEMBER-CENTRIC identity reads for the
+ * voiceless `/role-sync` CM dashboard (bd-l08).
+ *
+ * ── WHY (the member-centric pivot) ───────────────────────────────────────────
+ * The leaderboard-centric path (`score-tier-assignment.ts`) starts from the
+ * score-api leaderboard (top wallets) and joins DOWN to discord — but the
+ * Purupuru leaderboard top-50 are NOT discord-linked, while a real server member
+ * (the operator) IS scored + linked yet sits at rank 3329, so the leaderboard
+ * view never surfaces actual members. The CM dashboard must start from the
+ * GUILD MEMBERS and walk UP to their tier:
+ *
+ *   discord member id
+ *     → identity-api GET /v1/resolve/account/discord/{id}  → { user_id }
+ *       (404 ⇒ no linked account ⇒ "unlinked")
+ *     → identity-api GET /v1/profile?world={world}&userId={user_id}
+ *       → { identity: { primary_wallet, wallets:[{wallet_address}] } }
+ *       (404 / primary_wallet_missing ⇒ linked-but-no-wallet)
+ *     → score-api walletProfile(primary_wallet) → { tier } (done by the roster
+ *       builder via the score community-client — NOT this module).
+ *
+ * This module owns the TWO identity-api reads. The score read stays in the
+ * community-client (the documented isolation-debt seam). Step 1 (resolve) is the
+ * SAME route the isolated actor resolver uses (identity-actor-resolver.ts).
+ *
+ * ── FAIL-SOFT (per-member, never abort the batch) ────────────────────────────
+ * Every read is fail-soft: a 404, a non-2xx, a transport error, a deadline, or a
+ * malformed body resolves to a typed null-ish outcome (`unlinked` /
+ * `no_wallet`), NEVER a throw that aborts the whole roster. A member whose
+ * lookup fails simply shows as unlinked / untiered in the dashboard.
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * This module imports NOTHING from persona-engine. It is a thin pair of HTTP
+ * GETs behind an injected `fetch`, so tests are network-free.
+ *
+ * ── GROUNDING (freeside-auth, read 2026-06-04) ───────────────────────────────
+ *   • GET /v1/resolve/account/:provider/:externalId — provider "discord",
+ *     externalId = the discord snowflake; 200 ⇒ { user_id }, 404 ⇒ not_found
+ *     (src/api/routes — same route identity-actor-resolver.ts grounds against).
+ *   • GET /v1/profile?world=&userId= — 200 ⇒ { identity: { user_id,
+ *     primary_wallet, wallets:[{ wallet_address, ... }], ... }, ... }; a userId
+ *     with no primary_wallet ⇒ 404 { reason: "primary_wallet_missing" }
+ *     (src/api/routes/profile.ts + src/api/__tests__/profile-route.test.ts).
+ */
+
+/** Discord user snowflakes are 17-20 digit decimal ids. */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
+/** Default per-request deadline (ms). */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** The outcome of resolving a member's identity (fail-soft, never throws). */
+export type MemberIdentity =
+  /** the discord id has no linked identity-api account (404 on resolve). */
+  | { readonly kind: "unlinked" }
+  /** linked to a user_id but no usable primary wallet (404 / missing on profile). */
+  | { readonly kind: "no_wallet"; readonly user_id: string }
+  /** fully resolved: a linked account with a usable wallet. */
+  | {
+      readonly kind: "linked";
+      readonly user_id: string;
+      /** the member's primary wallet (lowercased), or the first linked wallet. */
+      readonly wallet: string;
+    };
+
+export interface MemberIdentityClientConfig {
+  /** identity-api base URL (e.g. https://identity.0xhoneyjar.xyz). REQUIRED. */
+  readonly baseUrl: string;
+  /** the world slug for the /v1/profile read (e.g. "purupuru"). REQUIRED. */
+  readonly world: string;
+  /** optional service token (x-service-token) — the role-dispenser's read cred. */
+  readonly serviceToken?: string;
+  /** injectable fetch (tests). production omits it (global fetch). */
+  readonly fetchImpl?: typeof fetch;
+  /** per-request deadline in ms (default 10s; <=0 disables). */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * The two-read member-identity client. Reads are fail-soft: a member whose
+ * lookup fails resolves to `unlinked` / `no_wallet`, never a throw — so one bad
+ * member can never abort the roster batch.
+ */
+export class MemberIdentityClient {
+  constructor(private readonly cfg: MemberIdentityClientConfig) {}
+
+  private base(): string {
+    return this.cfg.baseUrl.replace(/\/+$/, "");
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { Accept: "application/json" };
+    if (this.cfg.serviceToken && this.cfg.serviceToken.length > 0) {
+      h["x-service-token"] = this.cfg.serviceToken;
+    }
+    return h;
+  }
+
+  /** GET under a per-request deadline; null on ANY non-2xx / transport / abort. */
+  private async getJson(url: string): Promise<unknown | null> {
+    const doFetch = this.cfg.fetchImpl ?? fetch;
+    const timeoutMs = this.cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+    let res: Response;
+    try {
+      res = await doFetch(url, {
+        method: "GET",
+        headers: this.headers(),
+        signal: timeoutMs > 0 ? controller.signal : undefined,
+      });
+    } catch {
+      return null; // transport error / abort (deadline) ⇒ fail-soft.
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    if (!res.ok) return null; // 404 (unlinked / no-wallet) + any non-2xx ⇒ fail-soft.
+    try {
+      return await res.json();
+    } catch {
+      return null; // malformed body ⇒ fail-soft.
+    }
+  }
+
+  /**
+   * Resolve a guild member's discord id → their {@link MemberIdentity}. Fail-soft
+   * at every step:
+   *   • bad/missing discord id        ⇒ `unlinked`
+   *   • resolve 404 / no user_id      ⇒ `unlinked`
+   *   • profile 404 / no wallet       ⇒ `no_wallet`
+   *   • profile OK with a wallet      ⇒ `linked`
+   */
+  async resolveMember(discordId: string | undefined): Promise<MemberIdentity> {
+    const id = (discordId ?? "").trim();
+    if (!SNOWFLAKE_RE.test(id)) return { kind: "unlinked" };
+
+    // (1) discord id → user_id.
+    const resolveUrl = `${this.base()}/v1/resolve/account/discord/${encodeURIComponent(id)}`;
+    const resolveBody = await this.getJson(resolveUrl);
+    const userId = (resolveBody as { user_id?: unknown } | null)?.user_id;
+    if (typeof userId !== "string" || userId.length === 0) return { kind: "unlinked" };
+
+    // (2) user_id → primary_wallet (+ wallets[] fallback).
+    const profileUrl =
+      `${this.base()}/v1/profile?world=${encodeURIComponent(this.cfg.world)}` +
+      `&userId=${encodeURIComponent(userId)}`;
+    const profileBody = await this.getJson(profileUrl);
+    const wallet = extractWallet(profileBody);
+    if (!wallet) return { kind: "no_wallet", user_id: userId };
+
+    return { kind: "linked", user_id: userId, wallet };
+  }
+}
+
+/**
+ * Extract a usable wallet from a /v1/profile body. Prefers `identity.primary_wallet`;
+ * falls back to the first non-unlinked `identity.wallets[].wallet_address`. Returns
+ * a lowercased address, or null when none is usable. Tolerant of the exact shape
+ * (a missing `identity`, a null primary_wallet, an empty wallets list ⇒ null).
+ */
+export function extractWallet(body: unknown): string | null {
+  const identity = (body as { identity?: unknown } | null)?.identity as
+    | { primary_wallet?: unknown; wallets?: unknown }
+    | undefined;
+  if (!identity || typeof identity !== "object") return null;
+
+  const primary = identity.primary_wallet;
+  if (typeof primary === "string" && primary.length > 0) return primary.toLowerCase();
+
+  const wallets = identity.wallets;
+  if (Array.isArray(wallets)) {
+    for (const w of wallets) {
+      const addr = (w as { wallet_address?: unknown; unlinked_at?: unknown } | null)?.wallet_address;
+      const unlinked = (w as { unlinked_at?: unknown } | null)?.unlinked_at;
+      if (typeof addr === "string" && addr.length > 0 && unlinked == null) {
+        return addr.toLowerCase();
+      }
+    }
+  }
+  return null;
+}

--- a/apps/bot/src/shadow/member-roster.test.ts
+++ b/apps/bot/src/shadow/member-roster.test.ts
@@ -1,0 +1,207 @@
+/**
+ * member-roster.test.ts — the MEMBER-CENTRIC roster builder (bd-l08). Proves the
+ * per-member chain (member → identity → wallet → tier → proposed role), the
+ * change indicators (ADD / KEEP / UNLINKED / UNTIERED / NO-CHANGE), the summary
+ * counts, fail-soft per member, and the operator-style case (linked, tier
+ * "member" → purupuru:member, ADD). Network-free (all I/O injected).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  buildMemberRoster,
+  computeChange,
+  summarize,
+  type GuildMemberRef,
+  type MemberIdentityResolver,
+  type MemberTierReader,
+  type MemberTierRow,
+} from "./member-roster.ts";
+import { buildPurupuruSeedRoleMap } from "./role-sync-seed-map.ts";
+
+const ROLE_MAP = buildPurupuruSeedRoleMap();
+
+/** Build a roster from fixed members + a discord-id→identity map + a wallet→tier map. */
+function build(
+  members: GuildMemberRef[],
+  identities: Record<string, ReturnType<MemberIdentityResolver> extends Promise<infer T> ? T : never>,
+  tiers: Record<string, string | null>,
+) {
+  const resolveIdentity: MemberIdentityResolver = async (id) =>
+    identities[id] ?? { kind: "unlinked" };
+  const readTier: MemberTierReader = async (wallet) => tiers[wallet.toLowerCase()] ?? null;
+  return buildMemberRoster({
+    world: "purupuru",
+    roleMap: ROLE_MAP,
+    members: async () => members,
+    resolveIdentity,
+    readTier,
+  });
+}
+
+const A = "700000000000000001"; // operator-style: linked, tier member, ADD
+const B = "700000000000000002"; // unlinked
+const C = "700000000000000003"; // linked, untiered
+const D = "700000000000000004"; // linked, tier core, already holds the role → KEEP
+const WALLET_A = "0xaaa0000000000000000000000000000000000001";
+const WALLET_C = "0xccc0000000000000000000000000000000000003";
+const WALLET_D = "0xddd0000000000000000000000000000000000004";
+
+describe("bd-l08 — member-centric roster builder", () => {
+  test("operator-style: linked + tier 'member' → purupuru:member, change ADD", async () => {
+    const { rows } = await build(
+      [{ discord_id: A, display_name: "soju", current_managed_roles: [] }],
+      { [A]: { kind: "linked", user_id: "u-a", wallet: WALLET_A } },
+      { [WALLET_A]: "member" },
+    );
+    expect(rows).toHaveLength(1);
+    const r = rows[0]!;
+    expect(r.linked).toBe(true);
+    expect(r.wallet).toBe(WALLET_A);
+    expect(r.tier).toBe("member");
+    expect(r.proposed_role_key).toBe("purupuru:member");
+    expect(r.change).toBe("ADD");
+  });
+
+  test("unlinked member ⇒ linked:false, UNLINKED row, no assignment", async () => {
+    const { rows } = await build(
+      [{ discord_id: B, display_name: "nolink", current_managed_roles: [] }],
+      { [B]: { kind: "unlinked" } },
+      {},
+    );
+    const r = rows[0]!;
+    expect(r.linked).toBe(false);
+    expect(r.wallet).toBeUndefined();
+    expect(r.proposed_role_key).toBeUndefined();
+    expect(r.change).toBe("UNLINKED");
+  });
+
+  test("linked but untiered (null tier) ⇒ UNTIERED, no proposed role", async () => {
+    const { rows } = await build(
+      [{ discord_id: C, display_name: "untiered", current_managed_roles: ["purupuru:devoted"] }],
+      { [C]: { kind: "linked", user_id: "u-c", wallet: WALLET_C } },
+      { [WALLET_C]: null },
+    );
+    const r = rows[0]!;
+    expect(r.linked).toBe(true);
+    expect(r.tier).toBeUndefined();
+    expect(r.proposed_role_key).toBeUndefined();
+    expect(r.change).toBe("UNTIERED");
+  });
+
+  test("already holds the proposed role ⇒ KEEP", async () => {
+    const { rows } = await build(
+      [{ discord_id: D, display_name: "keeper", current_managed_roles: ["purupuru:core"] }],
+      { [D]: { kind: "linked", user_id: "u-d", wallet: WALLET_D } },
+      { [WALLET_D]: "core" },
+    );
+    const r = rows[0]!;
+    expect(r.proposed_role_key).toBe("purupuru:core");
+    expect(r.change).toBe("KEEP");
+  });
+
+  test("linked, no_wallet (primary_wallet_missing) ⇒ treated untiered (no managed roles ⇒ NO-CHANGE)", async () => {
+    const { rows } = await build(
+      [{ discord_id: A, display_name: "nowallet", current_managed_roles: [] }],
+      { [A]: { kind: "no_wallet", user_id: "u-a" } },
+      {},
+    );
+    const r = rows[0]!;
+    expect(r.linked).toBe(true);
+    expect(r.wallet).toBeUndefined();
+    expect(r.change).toBe("NO-CHANGE");
+  });
+
+  test("summary counts across a mixed roster", async () => {
+    const { rows, summary } = await build(
+      [
+        { discord_id: A, display_name: "soju", current_managed_roles: [] }, // ADD
+        { discord_id: B, display_name: "nolink", current_managed_roles: [] }, // UNLINKED
+        { discord_id: C, display_name: "untiered", current_managed_roles: ["purupuru:devoted"] }, // UNTIERED
+        { discord_id: D, display_name: "keeper", current_managed_roles: ["purupuru:core"] }, // KEEP
+      ],
+      {
+        [A]: { kind: "linked", user_id: "u-a", wallet: WALLET_A },
+        [B]: { kind: "unlinked" },
+        [C]: { kind: "linked", user_id: "u-c", wallet: WALLET_C },
+        [D]: { kind: "linked", user_id: "u-d", wallet: WALLET_D },
+      },
+      { [WALLET_A]: "member", [WALLET_C]: null, [WALLET_D]: "core" },
+    );
+    expect(rows).toHaveLength(4);
+    expect(summary.members).toBe(4);
+    expect(summary.linked).toBe(3);
+    expect(summary.would_add).toBe(1);
+    expect(summary.keep).toBe(1);
+    expect(summary.unlinked).toBe(1);
+    expect(summary.untiered).toBe(1);
+  });
+
+  test("FAIL-SOFT: an identity throw for one member does NOT abort the batch", async () => {
+    const resolveIdentity: MemberIdentityResolver = async (id) => {
+      if (id === B) throw new Error("identity-api 500");
+      return { kind: "linked", user_id: "u-a", wallet: WALLET_A };
+    };
+    const readTier: MemberTierReader = async () => "member";
+    const { rows, summary } = await buildMemberRoster({
+      world: "purupuru",
+      roleMap: ROLE_MAP,
+      members: async () => [
+        { discord_id: A, current_managed_roles: [] },
+        { discord_id: B, current_managed_roles: [] },
+      ],
+      resolveIdentity,
+      readTier,
+    });
+    expect(rows).toHaveLength(2);
+    // the throwing member is treated unlinked, the other still resolves ADD.
+    expect(rows.find((r) => r.discord_id === B)!.change).toBe("UNLINKED");
+    expect(rows.find((r) => r.discord_id === A)!.change).toBe("ADD");
+    expect(summary.unlinked).toBe(1);
+  });
+
+  test("FAIL-SOFT: a score-read throw ⇒ that member is untiered, batch continues", async () => {
+    const resolveIdentity: MemberIdentityResolver = async () => ({
+      kind: "linked",
+      user_id: "u",
+      wallet: WALLET_A,
+    });
+    const readTier: MemberTierReader = async () => {
+      throw new Error("score-api 503");
+    };
+    const { rows } = await buildMemberRoster({
+      world: "purupuru",
+      roleMap: ROLE_MAP,
+      members: async () => [{ discord_id: A, current_managed_roles: [] }],
+      resolveIdentity,
+      readTier,
+    });
+    expect(rows[0]!.change).toBe("NO-CHANGE"); // untiered + no managed roles
+    expect(rows[0]!.tier).toBeUndefined();
+  });
+
+  describe("computeChange (pure)", () => {
+    test("not linked ⇒ UNLINKED", () => {
+      expect(computeChange(false, undefined, [])).toBe("UNLINKED");
+    });
+    test("linked, no proposal, no managed roles ⇒ NO-CHANGE", () => {
+      expect(computeChange(true, undefined, [])).toBe("NO-CHANGE");
+    });
+    test("linked, no proposal, holds a stale managed role ⇒ UNTIERED", () => {
+      expect(computeChange(true, undefined, ["purupuru:core"])).toBe("UNTIERED");
+    });
+    test("proposed role not held ⇒ ADD", () => {
+      expect(computeChange(true, "purupuru:member", [])).toBe("ADD");
+    });
+    test("proposed role already held ⇒ KEEP", () => {
+      expect(computeChange(true, "purupuru:core", ["purupuru:core"])).toBe("KEEP");
+    });
+  });
+
+  test("summarize is consistent with the rows", () => {
+    const rows: MemberTierRow[] = [
+      { discord_id: A, linked: true, change: "ADD", current_managed_roles: [] },
+      { discord_id: B, linked: false, change: "UNLINKED", current_managed_roles: [] },
+    ];
+    const s = summarize(rows);
+    expect(s).toEqual({ members: 2, linked: 1, would_add: 1, keep: 0, unlinked: 1, untiered: 0 });
+  });
+});

--- a/apps/bot/src/shadow/member-roster.ts
+++ b/apps/bot/src/shadow/member-roster.ts
@@ -1,0 +1,311 @@
+/**
+ * shadow/member-roster.ts — the MEMBER-CENTRIC roster builder for the voiceless
+ * `/role-sync` CM dashboard (bd-l08).
+ *
+ * ── THE PIVOT (member-centric, not leaderboard-centric) ──────────────────────
+ * `score-tier-assignment.ts` builds the roster FROM the score-api leaderboard
+ * (top wallets → discord). For "manage roles for the MEMBERS of our server by
+ * their tier" that is the wrong frame: the Purupuru leaderboard top-50 are not
+ * discord-linked, while real members (the operator) ARE scored + linked but rank
+ * far below the top page — so the leaderboard view never shows actual members.
+ *
+ * This builder starts from the GUILD MEMBERS and walks UP to each one's tier:
+ *
+ *   for each guild member (discord id + display name + current purupuru:* roles):
+ *     → member-identity-client.resolveMember(discordId)
+ *         unlinked  ⇒ row {linked:false}                    (skip assignment)
+ *         no_wallet ⇒ row {linked:true, wallet:undefined}   (skip assignment)
+ *         linked    ⇒ continue with the resolved wallet
+ *     → scoreTier(wallet)  (the score community-client walletProfile read)
+ *         null tier ⇒ "untiered"                            (skip assignment)
+ *     → tier → strongest qualifying rule → proposed_role_key (seed/role-map)
+ *   → MemberTierRow with a change indicator (ADD / KEEP / NO-CHANGE / UNLINKED /
+ *     UNTIERED).
+ *
+ * ── SHADOW ONLY · ZERO WRITES ────────────────────────────────────────────────
+ * This module performs NO discord.js role mutation — it only READS (guild member
+ * list + their current roles), identity-api, and score-api, and produces a pure
+ * read-model. The single gated write path (`role-writer.live.ts`) is untouched.
+ * Role READS / identity reads / score reads are explicitly OUTSIDE the cross-repo
+ * import-boundary lint (which confines only role MUTATIONS to the gated adapter).
+ *
+ * ── FAIL-SOFT PER MEMBER (never abort the batch) ─────────────────────────────
+ * Each member is resolved independently. A failed identity / score lookup for one
+ * member produces an `unlinked` / `untiered` row (never a throw), so one bad
+ * member can never abort the roster. The score read is wrapped: any thrown
+ * `CommunityScoreError` (or anything) for a member ⇒ that member is untiered.
+ *
+ * ── COST NOTE ────────────────────────────────────────────────────────────────
+ * This is O(N) identity reads (1-2 per linked member) + O(N) score reads (1 per
+ * linked+walleted member). Fine for a TEST guild (a few dozen members). The
+ * identity reads coalesce per discord-id via the per-member resolve; the score
+ * read is cached per wallet within a single build (a member may share a wallet).
+ * A batched/streamed version for a large production guild is a follow-up.
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * No persona-engine voice import. The score DATA client (community-client) is the
+ * documented isolation-debt seam — data, not voice.
+ */
+import type { RoleRule, RoleMapConfig } from "@freeside-worlds/shadow-substrate";
+import { tierQualifies, type TierRankResolver, purupuruTierRank } from "./purupuru-tiers.ts";
+
+/** One guild member as seen by the builder (the discord read, injected). */
+export interface GuildMemberRef {
+  /** the member's discord snowflake. */
+  readonly discord_id: string;
+  /** the member's display name (server nick / global name / username). */
+  readonly display_name?: string;
+  /**
+   * the member's CURRENT Freeside-managed (namespaced) role keys — the
+   * `<namespace_prefix>*` role NAMES they currently hold. Empty when they hold
+   * none. Used to compute the before→after change indicator.
+   */
+  readonly current_managed_roles: ReadonlyArray<string>;
+}
+
+/**
+ * Read the configured guild's members (+ display name + current managed roles).
+ * INJECTED so the builder is network-free in tests; the live adapter reads the
+ * bot's discord.js Gateway client (guild.members.fetch()) — a READ, not a write.
+ */
+export type MemberSource = (world: string) => Promise<ReadonlyArray<GuildMemberRef>>;
+
+/**
+ * Resolve a wallet → its community tier (or null when untiered / the wallet is
+ * absent). INJECTED — the live wiring backs it with the score community-client
+ * `walletProfile(wallet).tier`; tests inject a pure map. MUST be fail-soft: a
+ * throw is treated as untiered for that member (logged), never aborting the batch.
+ */
+export type MemberTierReader = (wallet: string) => Promise<string | null>;
+
+/** The before→after change indicator for one member row. */
+export type MemberChange =
+  /** no linked identity-api account (no wallet to score). */
+  | "UNLINKED"
+  /** linked (+wallet) but no qualifying tier ⇒ would get no managed role. */
+  | "UNTIERED"
+  /** has a proposed tier role they do NOT currently hold ⇒ would gain it. */
+  | "ADD"
+  /** has a proposed tier role they ALREADY hold ⇒ unchanged. */
+  | "KEEP"
+  /** fully resolved, no proposed role AND holds no managed role ⇒ clean no-op. */
+  | "NO-CHANGE";
+
+/** One member-centric dashboard row (the CM's per-member before→after view). */
+export interface MemberTierRow {
+  readonly discord_id: string;
+  readonly display_name?: string;
+  /** has a linked identity-api account (false ⇒ UNLINKED). */
+  readonly linked: boolean;
+  /** the resolved primary wallet (absent when unlinked / no usable wallet). */
+  readonly wallet?: string;
+  /** the resolved community tier (absent when unlinked / untiered). */
+  readonly tier?: string;
+  /** the role this member's tier maps to (absent when unlinked / untiered). */
+  readonly proposed_role_key?: string;
+  /** the member's CURRENT managed (namespaced) roles. */
+  readonly current_managed_roles: ReadonlyArray<string>;
+  /** the before→after change indicator. */
+  readonly change: MemberChange;
+}
+
+/** Summary counts for the dashboard header (derived from the rows). */
+export interface MemberRosterSummary {
+  readonly members: number;
+  readonly linked: number;
+  readonly would_add: number;
+  readonly keep: number;
+  readonly unlinked: number;
+  readonly untiered: number;
+}
+
+export interface MemberRosterResult {
+  readonly rows: ReadonlyArray<MemberTierRow>;
+  readonly summary: MemberRosterSummary;
+}
+
+/**
+ * The resolver the builder uses to turn a discord id into an identity outcome.
+ * Matches `MemberIdentityClient.resolveMember`'s return; injected so the builder
+ * is network-free in tests.
+ */
+export type MemberIdentityResolver = (
+  discordId: string,
+) => Promise<
+  | { kind: "unlinked" }
+  | { kind: "no_wallet"; user_id: string }
+  | { kind: "linked"; user_id: string; wallet: string }
+>;
+
+export interface BuildMemberRosterInput {
+  readonly world: string;
+  readonly roleMap: RoleMapConfig;
+  readonly members: MemberSource;
+  readonly resolveIdentity: MemberIdentityResolver;
+  readonly readTier: MemberTierReader;
+  readonly tierRank?: TierRankResolver;
+}
+
+/**
+ * Pick the STRONGEST rule a member's tier qualifies (highest min_tier rank). A
+ * member maps to at most ONE managed tier role — the top one their tier earns.
+ * Returns the winning rule's `role_key`, or undefined when none qualifies.
+ * FAIL-CLOSED: a null/unknown tier qualifies nothing; a non-tier rule is skipped.
+ */
+function proposedRoleForTier(
+  tier: string | null,
+  rules: ReadonlyArray<RoleRule>,
+  rank: TierRankResolver,
+): string | undefined {
+  let bestKey: string | undefined;
+  let bestRank = -Infinity;
+  for (const rule of rules) {
+    if (rule.qualifies.source !== "tier") continue;
+    if (!tierQualifies(tier, rule.qualifies.min_tier, rank)) continue;
+    const r = rank(rule.qualifies.min_tier) ?? -Infinity;
+    if (r > bestRank) {
+      bestKey = rule.role_key;
+      bestRank = r;
+    }
+  }
+  return bestKey;
+}
+
+/**
+ * Compute the change indicator for one member from its resolved state. Pure.
+ */
+export function computeChange(
+  linked: boolean,
+  proposedRoleKey: string | undefined,
+  currentManagedRoles: ReadonlyArray<string>,
+): MemberChange {
+  if (!linked) return "UNLINKED";
+  if (!proposedRoleKey) {
+    // linked but no qualifying tier role. UNTIERED unless they already hold
+    // nothing managed AND nothing is proposed — then it is a clean NO-CHANGE.
+    return currentManagedRoles.length === 0 ? "NO-CHANGE" : "UNTIERED";
+  }
+  return currentManagedRoles.includes(proposedRoleKey) ? "KEEP" : "ADD";
+}
+
+/**
+ * Build the member-centric roster. Reads the guild members, resolves each
+ * member's identity → wallet → tier → proposed role, and produces a
+ * {@link MemberTierRow} per member plus summary counts. SHADOW-only, zero writes,
+ * fail-soft per member.
+ */
+export async function buildMemberRoster(
+  input: BuildMemberRosterInput,
+): Promise<MemberRosterResult> {
+  const rank = input.tierRank ?? purupuruTierRank;
+  const rules = input.roleMap.enabled ? input.roleMap.rules : [];
+  const members = await input.members(input.world);
+
+  // cache score reads per wallet within this build (members may share a wallet).
+  const tierCache = new Map<string, string | null>();
+  const readTierCached = async (wallet: string): Promise<string | null> => {
+    const key = wallet.toLowerCase();
+    if (tierCache.has(key)) return tierCache.get(key)!;
+    let tier: string | null;
+    try {
+      tier = await input.readTier(wallet);
+    } catch (e) {
+      // FAIL-SOFT: a score lookup throw ⇒ untiered for this member (logged).
+      console.warn(
+        `[member-roster] score read failed for wallet ${key} — treating member as untiered: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      tier = null;
+    }
+    tierCache.set(key, tier);
+    return tier;
+  };
+
+  const rows: MemberTierRow[] = [];
+  for (const m of members) {
+    const current = m.current_managed_roles ?? [];
+    let identity:
+      | { kind: "unlinked" }
+      | { kind: "no_wallet"; user_id: string }
+      | { kind: "linked"; user_id: string; wallet: string };
+    try {
+      identity = await input.resolveIdentity(m.discord_id);
+    } catch (e) {
+      // FAIL-SOFT: an identity throw ⇒ unlinked for this member (logged).
+      console.warn(
+        `[member-roster] identity resolve failed for member ${m.discord_id} — treating as unlinked: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      identity = { kind: "unlinked" };
+    }
+
+    if (identity.kind === "unlinked") {
+      rows.push({
+        discord_id: m.discord_id,
+        display_name: m.display_name,
+        linked: false,
+        current_managed_roles: current,
+        change: "UNLINKED",
+      });
+      continue;
+    }
+
+    if (identity.kind === "no_wallet") {
+      // linked but no usable wallet ⇒ can't be scored ⇒ untiered.
+      rows.push({
+        discord_id: m.discord_id,
+        display_name: m.display_name,
+        linked: true,
+        current_managed_roles: current,
+        change: computeChange(true, undefined, current),
+      });
+      continue;
+    }
+
+    // linked + wallet ⇒ read the tier.
+    const tier = await readTierCached(identity.wallet);
+    const proposed = proposedRoleForTier(tier, rules, rank);
+    rows.push({
+      discord_id: m.discord_id,
+      display_name: m.display_name,
+      linked: true,
+      wallet: identity.wallet,
+      tier: tier ?? undefined,
+      proposed_role_key: proposed,
+      current_managed_roles: current,
+      change: computeChange(true, proposed, current),
+    });
+  }
+
+  return { rows, summary: summarize(rows) };
+}
+
+/** Derive the dashboard summary counts from the rows. */
+export function summarize(rows: ReadonlyArray<MemberTierRow>): MemberRosterSummary {
+  let linked = 0;
+  let would_add = 0;
+  let keep = 0;
+  let unlinked = 0;
+  let untiered = 0;
+  for (const r of rows) {
+    if (r.linked) linked += 1;
+    switch (r.change) {
+      case "ADD":
+        would_add += 1;
+        break;
+      case "KEEP":
+        keep += 1;
+        break;
+      case "UNLINKED":
+        unlinked += 1;
+        break;
+      case "UNTIERED":
+        untiered += 1;
+        break;
+      // NO-CHANGE counts toward none of the action buckets.
+    }
+  }
+  return { members: rows.length, linked, would_add, keep, unlinked, untiered };
+}

--- a/apps/bot/src/shadow/member-source.live.ts
+++ b/apps/bot/src/shadow/member-source.live.ts
@@ -1,0 +1,82 @@
+/**
+ * shadow/member-source.live.ts — the LIVE `MemberSource` for the member-centric
+ * `/role-sync` CM dashboard (bd-l08).
+ *
+ * Reads the configured guild's MEMBERS (+ display name + their current
+ * Freeside-managed role NAMES) via the bot's existing discord.js Gateway client
+ * (`getBotClient`). Produces `GuildMemberRef[]` the member-roster builder
+ * consumes.
+ *
+ * ── READ-ONLY — NOT a role mutation ──────────────────────────────────────────
+ * This adapter only READS (`guild.members.fetch()` + each member's role names).
+ * Discord member/role *reads* are explicitly OUTSIDE the cross-repo
+ * import-boundary lint (which forbids only role *mutations*). The single gated
+ * adapter (`role-writer.live.ts`) is the only module that mutates. The
+ * GuildMembers gateway intent is now requested (commit 39496ea) so
+ * `guild.members.fetch()` returns the full member list.
+ *
+ * ── managed roles (the BEFORE side) ──────────────────────────────────────────
+ * A member's "current managed roles" are the role NAMES they hold that start
+ * with the world's `namespace_prefix` (e.g. `purupuru:`). Pre-existing /
+ * Collab.Land roles are NOT included — the dashboard only reasons about Freeside
+ * managed roles (FR-9 coexistence; mirrors roster-source.live.ts D2).
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * No persona-engine import. A pure discord read → a structural read-model.
+ */
+import type { Client, Guild } from "discord.js";
+import type { GuildMemberRef, MemberSource } from "./member-roster.ts";
+
+/** Per-world wiring the live member reader needs: the guild snowflake + prefix. */
+export interface LiveMemberSourceConfig {
+  /** map a world slug → its Discord guild snowflake + namespace prefix. */
+  readonly resolve: (
+    world: string,
+  ) => { readonly guild_id: string; readonly namespace_prefix: string } | undefined;
+}
+
+/**
+ * Build the LIVE `MemberSource`. `getBotClient` is the existing bot Gateway
+ * client factory (returns null when DISCORD_BOT_TOKEN is unset → throws a clear
+ * error so the trigger surfaces a voiceless "member roster failed"). Reads the
+ * guild's members + each member's current managed (namespaced) role names.
+ */
+export function makeMemberSourceLive(
+  getBotClient: () => Promise<Client | null>,
+  cfg: LiveMemberSourceConfig,
+): MemberSource {
+  return async (world: string): Promise<ReadonlyArray<GuildMemberRef>> => {
+    const wiring = cfg.resolve(world);
+    if (!wiring) {
+      throw new Error(`member-source: no guild wiring for world '${world}'`);
+    }
+    const client = await getBotClient();
+    if (!client) {
+      throw new Error(
+        "member-source: discord bot client unavailable (DISCORD_BOT_TOKEN unset) — cannot read guild members",
+      );
+    }
+    const guild: Guild = await client.guilds.fetch(wiring.guild_id);
+    // READ the full member list (requires the GuildMembers gateway intent, now
+    // requested). Each member's `.roles.cache` carries the role objects.
+    const members = await guild.members.fetch();
+
+    return [...members.values()].map((m): GuildMemberRef => {
+      // current managed roles = role NAMES starting with the namespace prefix.
+      const current_managed_roles = [...m.roles.cache.values()]
+        .map((r) => r.name)
+        .filter((name) => name.startsWith(wiring.namespace_prefix));
+      // display name: server nick > global display name > username.
+      const display_name =
+        m.nickname ??
+        (m.user.globalName as string | null | undefined) ??
+        m.user.username ??
+        undefined;
+      return {
+        discord_id: m.id,
+        display_name: display_name ?? undefined,
+        current_managed_roles,
+      };
+    });
+  };
+}

--- a/apps/bot/src/shadow/role-sync-boot.test.ts
+++ b/apps/bot/src/shadow/role-sync-boot.test.ts
@@ -30,10 +30,12 @@ import { makeWalletDiscordLinkMock } from "./wallet-discord-link.live.ts";
 import type { DiscordInteraction } from "../discord-interactions/types.ts";
 import { InteractionResponseType, MessageFlags } from "../discord-interactions/types.ts";
 import { IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import type { Client } from "discord.js";
 
 const ADMIN_UUID = "ae0558c7-aeb2-48f0-906d-ad0a50108b19";
 const PURUPURU_GUILD = "1495534680617910396";
 const INVOKER_DISCORD_ID = "700000000000000001"; // a valid 18-digit snowflake
+const ADMIN_WALLET = "0x79092a805f1cf9b0f5be3c5a296de6e51c1ded34";
 
 /** A fake fetch returning a fixed identity-api Response (network-free). */
 function identityFetch(status: number, body: unknown): typeof fetch {
@@ -42,6 +44,44 @@ function identityFetch(status: number, body: unknown): typeof fetch {
       status,
       headers: { "content-type": "application/json" },
     })) as unknown as typeof fetch;
+}
+
+/**
+ * A route-aware fetch double for the member-centric SHADOW path: the resolve
+ * call (`/v1/resolve/account/discord/`) → { user_id }, the profile call
+ * (`/v1/profile`) → { identity: { primary_wallet } }. Network-free.
+ */
+function memberIdentityFetch(): typeof fetch {
+  return (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+    if (url.includes("/v1/resolve/account/discord/")) return json({ user_id: ADMIN_UUID });
+    if (url.includes("/v1/profile")) {
+      return json({ identity: { user_id: ADMIN_UUID, primary_wallet: ADMIN_WALLET, wallets: [] } });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+/**
+ * A minimal fake discord.js Client exposing only `guilds.fetch().members.fetch()`
+ * with the shape `makeMemberSourceLive` reads (id, roles.cache, nickname, user).
+ * One member: the operator-style invoker, holding NO managed roles yet.
+ */
+function fakeBotClient(): Client {
+  const member = {
+    id: INVOKER_DISCORD_ID,
+    nickname: "soju",
+    user: { globalName: "soju", username: "soju" },
+    roles: { cache: new Map() },
+  };
+  const guild = {
+    members: { fetch: async () => new Map([[member.id, member]]) },
+  };
+  return {
+    guilds: { fetch: async () => guild },
+  } as unknown as Client;
 }
 
 /** Seams with NO live discord client (SHADOW uses mock roster, zero writes). */
@@ -113,24 +153,56 @@ describe("bd-atm — buildRoleSyncBootDeps: env gate (fail-closed)", () => {
   });
 });
 
-describe("bd-atm — end-to-end: SHADOW runs through the gate with ZERO writes", () => {
-  test("a resolved CM (200) runs SHADOW preview → EPHEMERAL CV2, zero writes", async () => {
+describe("bd-l08 — end-to-end: SHADOW runs the MEMBER-CENTRIC dashboard, ZERO writes", () => {
+  test("a resolved CM (200) runs the member-centric SHADOW dashboard → EPHEMERAL CV2", async () => {
+    // The boot composition wires memberCentric: a SHADOW run reads guild members
+    // (fake client) → identity (resolve+profile) → tier → the CM dashboard.
     const deps = buildRoleSyncBootDeps(
       { ROLE_SYNC_ENABLED: "1" } as RoleSyncBootEnv,
-      seams({ fetchImpl: identityFetch(200, { user_id: ADMIN_UUID }) }),
+      seams({ getBotClient: async () => fakeBotClient(), fetchImpl: memberIdentityFetch() }),
     )!;
 
     const res = await handleRoleSyncInteraction(interaction(), undefined, deps);
 
-    // SHADOW preview through the REAL substrate gate (mock writer) → a CV2
-    // EPHEMERAL render. The gate rejected every op (zero inner writes) — the
-    // orchestrator recovers that into the preview result, so the outcome is a
-    // `rendered` CV2 payload (not an error).
+    // SHADOW preview → the member-centric CV2 dashboard, EPHEMERAL, zero writes
+    // (the member path never calls the orchestration / gate).
     expect(res.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE);
     const flags = (res.data as { flags?: number }).flags ?? 0;
     expect(flags & IS_COMPONENTS_V2).toBe(IS_COMPONENTS_V2);
     expect(flags & MessageFlags.EPHEMERAL).toBe(MessageFlags.EPHEMERAL);
     expect((res.data as { content?: string }).content).toBeUndefined();
+    // the member-centric dashboard header + summary surface the operator's member.
+    const text = JSON.stringify((res.data as { components?: unknown }).components);
+    expect(text).toContain("Member roles");
+    expect(text).toContain("soju");
+    expect(text).toContain("1** members");
+  });
+
+  test("with a score key, the operator-style member resolves tier 'member' → ADD", async () => {
+    // route-aware fetch: identity reads + the score wallet-profile read (tier).
+    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const json = (body: unknown) =>
+        new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+      if (url.includes("/v1/resolve/account/discord/")) return json({ user_id: ADMIN_UUID });
+      if (url.includes("/v1/profile")) {
+        return json({ identity: { primary_wallet: ADMIN_WALLET, wallets: [] } });
+      }
+      // score-api GET /v1/wallets/{wallet}?community=purupuru → { wallet, tier }
+      if (url.includes("/v1/wallets/")) return json({ wallet: ADMIN_WALLET, tier: "member" });
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const deps = buildRoleSyncBootDeps(
+      { ROLE_SYNC_ENABLED: "1", SCORE_PURUPURU_API_KEY: "k" } as RoleSyncBootEnv,
+      seams({ getBotClient: async () => fakeBotClient(), fetchImpl }),
+    )!;
+    const res = await handleRoleSyncInteraction(interaction(), undefined, deps);
+    const text = JSON.stringify((res.data as { components?: unknown }).components);
+    // operator-style: linked, tier member → purupuru:member, in the "Would add" group.
+    expect(text).toContain("Would add");
+    expect(text).toContain("purupuru:member");
+    expect(text).toContain("tier");
   });
 });
 

--- a/apps/bot/src/shadow/role-sync-boot.ts
+++ b/apps/bot/src/shadow/role-sync-boot.ts
@@ -79,6 +79,12 @@ import { makeIdentityActorResolverFor } from "./identity-actor-resolver.ts";
 import { configServiceClientFromEnv } from "./config-service-client.ts";
 import type { RoleMapConfig } from "./substrate.ts";
 import { CommunityScoreClient } from "@freeside-characters/persona-engine/score/community-client";
+import { MemberIdentityClient } from "./member-identity-client.ts";
+import { makeMemberSourceLive } from "./member-source.live.ts";
+import type {
+  MemberCentricShadowDeps,
+} from "./role-sync-trigger.ts";
+import type { MemberTierReader, MemberIdentityResolver } from "./member-roster.ts";
 
 /**
  * The directory the vendored world manifests live in (apps/bot/worlds/). The
@@ -245,6 +251,70 @@ function makeLeaderboardReader(wiring: WorldScoreWiring | undefined): Leaderboar
 }
 
 /**
+ * Build the per-member tier reader (bd-l08) from the score wiring: a single
+ * wallet → its community tier via `walletProfile(wallet).tier`. When there is no
+ * LIVE score key, returns a reader that yields `null` (untiered) for every member
+ * — the member-centric SHADOW dashboard still renders (linked/unlinked + "no
+ * role"), and the operator sets `SCORE_PURUPURU_API_KEY` to surface tiers. The
+ * builder wraps each call fail-soft (a throw ⇒ untiered for that member), so this
+ * reader may throw freely (e.g. a 404 for an absent wallet) — it surfaces as
+ * untiered, never aborting the batch.
+ */
+function makeMemberTierReader(
+  wiring: WorldScoreWiring | undefined,
+  fetchImpl?: typeof fetch,
+): MemberTierReader {
+  if (!wiring || !wiring.apiKey || wiring.apiKey.length === 0) {
+    return async () => null;
+  }
+  const client = new CommunityScoreClient({
+    baseUrl: wiring.scoreApiUrl,
+    apiKey: wiring.apiKey,
+    community: wiring.community,
+    // thread the injected fetch (tests) through the retry transport.
+    retry: fetchImpl ? { fetchImpl } : undefined,
+  });
+  return async (wallet: string): Promise<string | null> => {
+    const profile = await client.walletProfile(wallet);
+    return profile.tier ?? null;
+  };
+}
+
+/**
+ * Build the member-centric SHADOW deps (bd-l08): the live guild member READ, the
+ * two identity-api reads (resolve account + profile), and the per-member score
+ * tier read. All fail-soft per member (the builder catches throws). This is the
+ * SHADOW-only CM dashboard wiring; LIVE apply still flows through the leaderboard
+ * orchestration.
+ */
+function buildMemberCentricDeps(
+  env: RoleSyncBootEnv,
+  seams: RoleSyncBootSeams,
+  world: string,
+  resolveWorld: (w: string) => WorldWiring | undefined,
+  identityBaseUrl: string,
+  resolveScoreWiring: (w: string) => WorldScoreWiring | undefined,
+): MemberCentricShadowDeps {
+  // live guild member READ (members + display name + current managed roles).
+  const memberSource = makeMemberSourceLive(seams.getBotClient, { resolve: resolveWorld });
+
+  // the two identity-api reads (discord id → user_id → primary_wallet).
+  const identityClient = new MemberIdentityClient({
+    baseUrl: identityBaseUrl,
+    world,
+    serviceToken: env.IDENTITY_API_SERVICE_TOKEN?.trim() || undefined,
+    fetchImpl: seams.fetchImpl,
+  });
+  const resolveIdentity: MemberIdentityResolver = (discordId) =>
+    identityClient.resolveMember(discordId);
+
+  // per-member score tier read.
+  const readTier = makeMemberTierReader(resolveScoreWiring(world), seams.fetchImpl);
+
+  return { members: memberSource, resolveIdentity, readTier };
+}
+
+/**
  * Build the LIVE `/role-sync` boot deps, or null when the master gate is off /
  * the required env is missing (fail-closed — `/role-sync` is then "not
  * configured" rather than silently degraded). When non-null, the caller passes
@@ -373,6 +443,19 @@ export function buildRoleSyncBootDeps(
     },
     transitionVersion: 1,
     actorResolverFor: actorResolverFactory,
+    // ── MEMBER-CENTRIC SHADOW (bd-l08) ──────────────────────────────────────
+    // When the run is SHADOW, the trigger produces the member-centric CM
+    // dashboard (each guild member → their tier → their role) from these deps
+    // instead of the leaderboard-centric orchestration. LIVE apply still flows
+    // through the orchestration (member path is SHADOW-only in this build).
+    memberCentric: buildMemberCentricDeps(
+      env,
+      seams,
+      world,
+      resolveWorld,
+      identityBaseUrl,
+      resolveScoreWiring,
+    ),
   };
 }
 

--- a/apps/bot/src/shadow/role-sync-interaction.ts
+++ b/apps/bot/src/shadow/role-sync-interaction.ts
@@ -142,7 +142,11 @@ export async function handleRoleSyncInteraction(
  * `refused`/`error` send a plain voiceless status string.
  */
 export function roleSyncOutcomeToResponse(outcome: RoleSyncOutcome): DiscordInteractionResponse {
-  if (outcome.kind === "rendered") {
+  // BOTH CV2 render paths (leaderboard-centric `rendered` + member-centric
+  // `rendered-members`, bd-l08) carry the same structural payload shape (flags +
+  // components + inert mentions). Send the payload verbatim with the EPHEMERAL
+  // flag merged in (a CM admin preview is invoker-only).
+  if (outcome.kind === "rendered" || outcome.kind === "rendered-members") {
     // CV2 payloads MUST NOT carry content/embeds. Merge the EPHEMERAL flag into
     // the CV2 flags (IS_COMPONENTS_V2 | EPHEMERAL) so the admin preview is
     // invoker-only AND renders as components.

--- a/apps/bot/src/shadow/role-sync-trigger.test.ts
+++ b/apps/bot/src/shadow/role-sync-trigger.test.ts
@@ -300,3 +300,106 @@ describe("bd-71y — command name constant", () => {
     expect(ROLE_SYNC_COMMAND_NAME).toBe("role-sync");
   });
 });
+
+// ─── bd-l08 — member-centric SHADOW routing ──────────────────────────────────
+import type { MemberCentricShadowDeps } from "./role-sync-trigger.ts";
+
+const MEMBER_A = "700000000000000001"; // operator-style: linked, tier member, ADD
+const WALLET_A = "0xaaa0000000000000000000000000000000000001";
+
+function memberCentricDeps(): MemberCentricShadowDeps {
+  return {
+    members: async () => [
+      { discord_id: MEMBER_A, display_name: "soju", current_managed_roles: [] },
+      { discord_id: "700000000000000002", display_name: "nolink", current_managed_roles: [] },
+    ],
+    resolveIdentity: async (id) =>
+      id === MEMBER_A
+        ? { kind: "linked", user_id: "u-a", wallet: WALLET_A }
+        : { kind: "unlinked" },
+    readTier: async (wallet) => (wallet.toLowerCase() === WALLET_A ? "member" : null),
+  };
+}
+
+describe("bd-l08 — role-sync trigger: member-centric SHADOW dashboard", () => {
+  test("when memberCentric is wired + mode SHADOW ⇒ rendered-members, NO orchestration call", async () => {
+    let invoked = false;
+    const { deps } = makeDeps({
+      invoke: async () => {
+        invoked = true;
+        return fakeResult("SHADOW");
+      },
+    });
+    const outcome = await runRoleSyncTrigger(
+      { ...deps, memberCentric: memberCentricDeps() },
+      "SHADOW",
+    );
+    // the leaderboard-centric orchestration is NEVER called on the member path.
+    expect(invoked).toBe(false);
+    expect(outcome.kind).toBe("rendered-members");
+    if (outcome.kind === "rendered-members") {
+      expect(outcome.applyMode).toBe("SHADOW");
+      expect(outcome.payload.allowed_mentions).toEqual({ parse: [] });
+      const text = JSON.stringify(outcome.payload.components);
+      // member-centric dashboard headings + the operator-style ADD row.
+      expect(text).toContain("Member roles");
+      expect(text).toContain("Would add");
+      expect(text).toContain("soju");
+      expect(text).toContain("purupuru:member");
+      // summary counts surfaced.
+      expect(text).toContain("2** members");
+      expect(text).toContain("1** would-add");
+      expect(text).toContain("1** unlinked");
+    }
+  });
+
+  test("not-verified CM is STILL refused before the member roster read", async () => {
+    let membersRead = false;
+    const mc = memberCentricDeps();
+    const { deps } = makeDeps({ actor: null, invoke: async () => fakeResult("SHADOW") });
+    const outcome = await runRoleSyncTrigger(
+      {
+        ...deps,
+        memberCentric: { ...mc, members: async (w) => ((membersRead = true), mc.members(w)) },
+      },
+      "SHADOW",
+    );
+    expect(outcome.kind).toBe("refused");
+    expect(membersRead).toBe(false);
+  });
+
+  test("LIVE still flows through the orchestration (member path is SHADOW-only)", async () => {
+    let invoked = false;
+    const { deps } = makeDeps({
+      invoke: async (input) => {
+        invoked = true;
+        return fakeResult(input.applyMode);
+      },
+    });
+    const outcome = await runRoleSyncTrigger(
+      { ...deps, memberCentric: memberCentricDeps() },
+      "LIVE",
+    );
+    expect(invoked).toBe(true);
+    expect(outcome.kind).toBe("rendered"); // leaderboard-centric render, not member.
+  });
+
+  test("a total guild-members read failure ⇒ voiceless error (zero writes)", async () => {
+    const mc = memberCentricDeps();
+    const { deps } = makeDeps({ invoke: async () => fakeResult("SHADOW") });
+    const outcome = await runRoleSyncTrigger(
+      {
+        ...deps,
+        memberCentric: {
+          ...mc,
+          members: async () => {
+            throw new Error("guild fetch 503");
+          },
+        },
+      },
+      "SHADOW",
+    );
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.message).toContain("Member roster");
+  });
+});

--- a/apps/bot/src/shadow/role-sync-trigger.ts
+++ b/apps/bot/src/shadow/role-sync-trigger.ts
@@ -54,6 +54,16 @@ import {
   roleSyncResultCV2Payload,
   type RoleSyncRenderContext,
 } from "./role-sync-result-cv2.ts";
+import {
+  buildMemberRoster,
+  type MemberSource,
+  type MemberIdentityResolver,
+  type MemberTierReader,
+} from "./member-roster.ts";
+import {
+  memberDashboardCV2Payload,
+  type MemberDashboardContext,
+} from "./member-dashboard-cv2.ts";
 
 /** The CM's resolved actor — the invoking CM's identity-api user_id. */
 export interface ResolvedActor {
@@ -119,6 +129,31 @@ export interface RoleSyncTriggerDeps {
   readonly tokenMetadata: GoLiveOrchestrationInput["tokenMetadata"];
   /** the FR-7 go_live transition version (deploy-/lifecycle-provided). */
   readonly transitionVersion: number;
+  /**
+   * OPTIONAL member-centric SHADOW wiring (bd-l08). When present AND the run is
+   * SHADOW, the trigger produces the MEMBER-CENTRIC CM dashboard (each guild
+   * member → their tier → their role + a before→after change indicator) instead
+   * of the leaderboard-centric orchestration result. When absent OR the run is
+   * LIVE, the trigger uses the existing orchestration path (preserved for the
+   * LIVE-apply follow-up). Authz is unchanged — the actor is still resolved +
+   * refused BEFORE any read.
+   */
+  readonly memberCentric?: MemberCentricShadowDeps;
+}
+
+/**
+ * The member-centric SHADOW deps (bd-l08). All I/O is injected so the build is
+ * network-free in tests; the boot composition backs `members` with the bot's
+ * guild member READ, `resolveIdentity` with the two identity-api reads, and
+ * `readTier` with the score community-client `walletProfile`.
+ */
+export interface MemberCentricShadowDeps {
+  /** read the configured guild's members (+ display name + current managed roles). */
+  readonly members: MemberSource;
+  /** discord id → identity outcome (unlinked / no_wallet / linked + wallet). */
+  readonly resolveIdentity: MemberIdentityResolver;
+  /** wallet → community tier (or null when untiered). fail-soft per member. */
+  readonly readTier: MemberTierReader;
 }
 
 /** The CM's chosen action — SHADOW preview (default) or LIVE apply. */
@@ -135,6 +170,15 @@ export type RoleSyncOutcome =
       /** the role-map provenance (CM-authored vs default seed). */
       readonly mapSource: RoleMapSource;
       readonly result: GoLiveOrchestrationResult;
+    }
+  | {
+      readonly kind: "rendered-members";
+      /** the member-centric dashboard CV2 payload (flags + components + inert mentions). */
+      readonly payload: ReturnType<typeof memberDashboardCV2Payload>;
+      /** SHADOW (the member-centric view is SHADOW-only in this build). */
+      readonly applyMode: "SHADOW";
+      /** the role-map provenance (CM-authored vs default seed). */
+      readonly mapSource: RoleMapSource;
     }
   | {
       readonly kind: "refused";
@@ -204,6 +248,41 @@ export async function runRoleSyncTrigger(
   const authored = await deps.readRoleMap(deps.world);
   const roleMap: RoleMapConfig = authored ?? buildPurupuruSeedRoleMap();
   const mapSource: RoleMapSource = authored ? "config-service" : "default-seed";
+
+  // (2b) MEMBER-CENTRIC SHADOW (bd-l08): when the deploy wired the member-centric
+  //      deps AND the run is SHADOW, produce the CM dashboard (each guild member →
+  //      their tier → their role + a before→after indicator) instead of the
+  //      leaderboard-centric orchestration. SHADOW-only + ZERO writes (this path
+  //      never calls the orchestration / gate). The actor is already resolved +
+  //      authz'd against admin_principals is the LIVE concern; for the SHADOW
+  //      READ-ONLY preview the verified-actor refusal above is the gate. LIVE
+  //      still flows through the existing orchestration path below.
+  if (deps.memberCentric && mode === "SHADOW") {
+    try {
+      const roster = await buildMemberRoster({
+        world: deps.world,
+        roleMap,
+        members: deps.memberCentric.members,
+        resolveIdentity: deps.memberCentric.resolveIdentity,
+        readTier: deps.memberCentric.readTier,
+      });
+      const ctx: MemberDashboardContext = { world: deps.world, mapSource };
+      return {
+        kind: "rendered-members",
+        payload: memberDashboardCV2Payload(roster, ctx),
+        applyMode: "SHADOW",
+        mapSource,
+      };
+    } catch (e) {
+      // The member roster read (guild members) failed entirely — a voiceless
+      // structural error (fail-soft is per-member; a total guild-read failure
+      // surfaces here). NO write occurred (SHADOW read-only).
+      return {
+        kind: "error",
+        message: `Member roster (SHADOW) failed: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  }
 
   // (3) The FR-7 hash binds the run to the map it was computed against.
   const mapHash = computeMapHash(roleMap, deps.world, deps.worldConfig);


### PR DESCRIPTION
## What

Pivots the `/role-sync` SHADOW preview to a **member-centric** CM dashboard: each guild member, their tier, the `purupuru:*` role they'd get, next to the role they hold now. This is the correct frame for "manage roles for the members of our server." The prior leaderboard-centric view found top-50 qualified wallets (none Discord-linked); real members like the operator are scored but not top-50.

## The chain (all grounded live)

Per guild member discord id: `resolve/account/discord/{id}` gives `user_id`, then `/v1/profile?world=purupuru&userId={user_id}` gives `primary_wallet`, then score-api `walletProfile(wallet)` gives `tier`, then tier maps to the `purupuru:<tier>` role.

## The dashboard (Components V2, voiceless)

Header plus a summary line (`N members, N linked, N would-add, N keep, N unlinked, N untiered`), then per-member rows grouped actionable-first (Would add, Keep, Untiered, Unlinked, No change) with change indicators. Injection-guarded, `allowed_mentions:[]`.

## Safety

SHADOW-only (zero Discord writes; the member path never touches the gate). Deferral preserved (the network-heavy compute runs in the background after the 3s ACK). Authz unchanged (isolated identity actor vs `admin_principals`). Zero persona-voice imports. Does NOT modify the SHA-pinned substrate. LIVE apply (the Apply button plus bd-glb roster-identity plus audit) is the next pass; gate machinery left intact.

## Tests

762 bot tests pass, including the operator-style case (linked member, tier `member`, maps to `purupuru:member`, ADD). Both typechecks, import-boundary lint, substrate conformance all clean.

## Notes

O(N) identity and score reads per member (cached per-wallet), fine for the test guild; a batch variant is a follow-up. Without `SCORE_PURUPURU_API_KEY` every member reads as untiered (fail-soft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
