### PR TITLE
feat(bot): public world-themed live role board + post harness (#verify experiment)

### DIFF
--- a/apps/bot/scripts/post-role-board.ts
+++ b/apps/bot/scripts/post-role-board.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env bun
+/**
+ * post-role-board.ts — the EXPERIMENT HARNESS for the public live role board
+ * (cycle public-role-board). Builds the member roster from the LIVE role-sync
+ * boot composition, renders the PUBLIC, world-themed, voiceless CV2 board, and
+ * POSTs it to a target channel — or EDITs an existing message in place when a
+ * MESSAGE_ID is supplied (the "live" debounced single-persistent-message model).
+ *
+ * ── WHAT IT DOES (thin orchestration over existing, tested seams) ─────────────
+ *   1. loadConfig() + getBotClient() — the real discord.js Gateway client.
+ *   2. buildRoleSyncBootDepsFromEnv(getBotClient) — the SAME composition the bot
+ *      uses for /role-sync (member-source READ + identity-api reads + score tier
+ *      reads + the config-service role-map reader with seed fallback). Returns
+ *      null unless ROLE_SYNC_ENABLED is truthy + the world manifest is readable.
+ *   3. read the role-map (config-service, else the CM-overridable seed).
+ *   4. buildMemberRoster(...) — the pure SHADOW read-model (ZERO writes).
+ *   5. publicRoleBoardCV2Payload(...) — the public render.
+ *   6. POST (new) or PATCH (edit MESSAGE_ID) the CV2 message; print message_id.
+ *
+ * ── ZERO ROLE MUTATIONS ──────────────────────────────────────────────────────
+ * This script READS (guild members, identity-api, score) + renders + posts ONE
+ * message. It performs NO discord.js role mutation — no create/add/set/remove/
+ * delete/edit on any role. The import-boundary lint confirms it. The roster
+ * builder (member-roster.ts) is documented SHADOW-only zero-writes; this harness
+ * adds only a message POST/PATCH (a channel write, not a role write).
+ *
+ * ── "LIVE" = DEBOUNCED-BY-DESIGN (rate-limit reality) ────────────────────────
+ * Discord message-edit rate limits (≈5 edits / 5s per channel; tighter under
+ * global limits) make literal per-role-change editing infeasible. The honest
+ * "real-time" is: a single PERSISTENT message edited in place on demand (this
+ * script) or on a periodic tick / after an apply. Pass the printed MESSAGE_ID
+ * back on the next run to EDIT the same message rather than spamming new posts.
+ * This pass does NOT wire per-event auto-update — the script is run on demand and
+ * could later be cron'd. (The CV2 POST/PATCH helpers already do bounded 429
+ * retry, so a burst of refreshes degrades gracefully rather than throwing.)
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * No persona-engine VOICE import. The roster build reaches the score DATA client
+ * transitively through the boot composition (the documented isolation-debt seam,
+ * data not voice); the render module imports no persona. This is the operating
+ * surface, not a character.
+ *
+ * Run (post a NEW board to #verify):
+ *   CHANNEL_ID=1497405192503689316 \
+ *   ROLE_SYNC_ENABLED=1 \
+ *   railway run bun run apps/bot/scripts/post-role-board.ts
+ *
+ * Run (EDIT the existing board in place — debounced "live" refresh):
+ *   CHANNEL_ID=1497405192503689316 MESSAGE_ID=<printed id> \
+ *   ROLE_SYNC_ENABLED=1 \
+ *   railway run bun run apps/bot/scripts/post-role-board.ts
+ *
+ * Channel / message can also be passed as positional args:
+ *   bun run apps/bot/scripts/post-role-board.ts <CHANNEL_ID> [MESSAGE_ID]
+ *
+ * Required env (beyond the standard bot env DISCORD_BOT_TOKEN, identity/score):
+ *   CHANNEL_ID         — the target channel (or argv[2]).
+ *   ROLE_SYNC_ENABLED  — must be truthy (the role-sync boot gate).
+ * Optional:
+ *   MESSAGE_ID         — edit this message in place (or argv[3]).
+ *   ROLE_SYNC_WORLD    — defaults to "purupuru".
+ *   BOARD_ACCENT       — hex (e.g. 0xe0a83d) world accent; defaults to honey-gold.
+ */
+import { loadConfig, getBotClient, postToChannel } from "@freeside-characters/persona-engine";
+import { buildRoleSyncBootDepsFromEnv } from "../src/shadow/role-sync-boot.ts";
+import { buildMemberRoster } from "../src/shadow/member-roster.ts";
+import { buildPurupuruSeedRoleMap } from "../src/shadow/role-sync-seed-map.ts";
+import {
+  publicRoleBoardCV2Payload,
+  type PublicRoleBoardContext,
+} from "../src/shadow/public-role-board-cv2.ts";
+import type { RoleMapConfig } from "../src/shadow/substrate.ts";
+
+const CHANNEL_ID = (process.env.CHANNEL_ID ?? process.argv[2] ?? "").trim();
+const MESSAGE_ID = (process.env.MESSAGE_ID ?? process.argv[3] ?? "").trim();
+const BOARD_ACCENT = (process.env.BOARD_ACCENT ?? "").trim();
+
+function die(msg: string): never {
+  console.error(`post-role-board: ${msg}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  if (CHANNEL_ID.length === 0) {
+    die("CHANNEL_ID is required (env CHANNEL_ID or argv[2]). e.g. CHANNEL_ID=1497405192503689316");
+  }
+  // validate the snowflakes before any network call (defense; they feed a URL).
+  if (!/^\d{17,20}$/.test(CHANNEL_ID)) die(`CHANNEL_ID '${CHANNEL_ID}' is not a valid snowflake`);
+  if (MESSAGE_ID.length > 0 && !/^\d{17,20}$/.test(MESSAGE_ID)) {
+    die(`MESSAGE_ID '${MESSAGE_ID}' is not a valid snowflake`);
+  }
+
+  const config = loadConfig();
+  const client = await getBotClient(config);
+  if (!client) die("no discord client — DISCORD_BOT_TOKEN is unset (run under `railway run`).");
+  const token = client.token;
+  if (!token) die("discord client has no token.");
+
+  // The SAME composition the bot uses for /role-sync (member READ + identity +
+  // score + role-map reader). Returns null unless ROLE_SYNC_ENABLED + a readable
+  // world manifest. ZERO writes — the boot deps' member-centric path is SHADOW.
+  const deps = buildRoleSyncBootDepsFromEnv(async () => client);
+  if (!deps) {
+    die(
+      "role-sync boot is not configured — set ROLE_SYNC_ENABLED=1 and ensure the world " +
+        "manifest (apps/bot/worlds/<world>.yaml) carries guild_id + namespace_prefix.",
+    );
+  }
+  if (!deps.memberCentric) {
+    die("role-sync boot produced no member-centric deps — the SHADOW roster cannot be built.");
+  }
+
+  console.log(`post-role-board: building roster for world '${deps.world}' …`);
+
+  // read the CM-authored role-map; fall back to the CM-overridable seed (the same
+  // fallback the trigger uses) so the ladder has lore names + ordering.
+  const authored = await deps.readRoleMap(deps.world);
+  const roleMap: RoleMapConfig = authored ?? buildPurupuruSeedRoleMap();
+  const mapSource = authored ? "config-service" : "default-seed";
+
+  // build the SHADOW read-model (ZERO writes). fail-soft per member.
+  const roster = await buildMemberRoster({
+    world: deps.world,
+    roleMap,
+    members: deps.memberCentric.members,
+    resolveIdentity: deps.memberCentric.resolveIdentity,
+    readTier: deps.memberCentric.readTier,
+  });
+
+  console.log(
+    `post-role-board: roster — ${roster.summary.members} members, ${roster.summary.linked} linked ` +
+      `(role-map: ${mapSource}).`,
+  );
+
+  const ctx: PublicRoleBoardContext = {
+    world: deps.world,
+    roleMap,
+    accent: BOARD_ACCENT.length > 0 ? Number(BOARD_ACCENT) : undefined,
+    generatedAt: new Date().toISOString(),
+  };
+  const payload = publicRoleBoardCV2Payload(roster, ctx);
+
+  if (MESSAGE_ID.length > 0) {
+    // EDIT-IN-PLACE (the debounced "live" refresh): PATCH the existing message.
+    // postToChannel only POSTs; the edit path is a raw REST PATCH with the SAME
+    // CV2 wire shape (?with_components=true, flags + components, inert mentions).
+    const messageId = await editComponentsV2(
+      `https://discord.com/api/v10/channels/${CHANNEL_ID}/messages/${MESSAGE_ID}?with_components=true`,
+      { flags: payload.flags, components: payload.components, allowed_mentions: payload.allowed_mentions },
+      `Bot ${token}`,
+    );
+    console.log(`post-role-board: EDITED in place. message_id=${messageId}`);
+    console.log(messageId);
+  } else {
+    // POST a NEW persistent board. Print the message_id so the NEXT refresh can
+    // EDIT it in place (pass it back as MESSAGE_ID) rather than re-posting.
+    const res = await postToChannel(client, CHANNEL_ID, payload);
+    console.log(`post-role-board: POSTED. message_id=${res.messageId}`);
+    console.log(
+      `post-role-board: to refresh in place, re-run with MESSAGE_ID=${res.messageId}`,
+    );
+    console.log(res.messageId);
+  }
+}
+
+/**
+ * PATCH a Components-V2 message (edit-in-place) with bounded 429 retry. Mirrors
+ * the POST helper's retry shape (persona-engine cv2-post.ts) but for the message
+ * EDIT endpoint, which postToChannel does not expose. Returns the message id.
+ */
+async function editComponentsV2(
+  url: string,
+  body: { flags?: number; components: unknown[]; allowed_mentions: { parse: never[] } },
+  authorization: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", authorization },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 429) {
+      const retry = await res
+        .json()
+        .then((j: { retry_after?: number }) => j.retry_after ?? 1)
+        .catch(() => 1);
+      await new Promise((r) => setTimeout(r, Math.ceil(retry * 1000) + 250));
+      continue;
+    }
+    if (!res.ok) {
+      throw new Error(`role-board edit failed: ${res.status} ${await res.text().catch(() => "")}`);
+    }
+    const json = (await res.json().catch(() => ({}))) as { id?: string };
+    return json.id ?? "";
+  }
+  throw new Error("role-board edit failed: rate-limited after 3 attempts");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error("post-role-board: failed —", e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  });

--- a/apps/bot/src/shadow/public-role-board-cv2.test.ts
+++ b/apps/bot/src/shadow/public-role-board-cv2.test.ts
@@ -1,0 +1,228 @@
+/**
+ * public-role-board-cv2.test.ts — the PUBLIC, world-themed, VOICELESS live role
+ * board render (cycle public-role-board). Network-free: inject a
+ * `MemberRosterResult` fixture + a role-map → assert the CV2 tree: the tier
+ * ladder with per-tier counts, the honey accent, the adoption line, world
+ * theming, the injection guard, and that it is READ-ONLY (no per-member action /
+ * no Apply affordance).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  renderPublicRoleBoardCV2,
+  publicRoleBoardCV2Payload,
+  buildLadder,
+  ACCENT_HONEY,
+  type PublicRoleBoardContext,
+} from "./public-role-board-cv2.ts";
+import { IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import { summarize, type MemberTierRow, type MemberRosterResult } from "./member-roster.ts";
+import { buildPurupuruSeedRoleMap } from "./role-sync-seed-map.ts";
+import type { RoleMapConfig } from "./substrate.ts";
+
+function rosterOf(rows: MemberTierRow[]): MemberRosterResult {
+  return { rows, summary: summarize(rows) };
+}
+
+const SEED_MAP: RoleMapConfig = buildPurupuruSeedRoleMap();
+const CTX: PublicRoleBoardContext = { world: "purupuru", roleMap: SEED_MAP, generatedAt: "2026-06-04T00:00:00Z" };
+
+/** A linked member resolved to a given tier (counts toward that rung). */
+function tieredMember(id: string, name: string, tier: string): MemberTierRow {
+  return {
+    discord_id: id,
+    display_name: name,
+    linked: true,
+    wallet: `0x${id}`,
+    tier,
+    proposed_role_key: `purupuru:${tier}`,
+    current_managed_roles: [],
+    change: "ADD",
+  };
+}
+
+const UNLINKED: MemberTierRow = {
+  discord_id: "700000000000000099",
+  display_name: "nolink",
+  linked: false,
+  current_managed_roles: [],
+  change: "UNLINKED",
+};
+
+const FIXTURE = rosterOf([
+  tieredMember("700000000000000001", "soju", "sovereign"),
+  tieredMember("700000000000000002", "elderA", "elder"),
+  tieredMember("700000000000000003", "elderB", "elder"),
+  tieredMember("700000000000000004", "coreA", "core"),
+  tieredMember("700000000000000005", "memberA", "member"),
+  tieredMember("700000000000000006", "memberB", "member"),
+  tieredMember("700000000000000007", "memberC", "member"),
+  UNLINKED,
+]);
+
+function textContents(c: ReturnType<typeof renderPublicRoleBoardCV2>): string[] {
+  return c.components
+    .filter((x): x is { type: 10; content: string } => x.type === 10)
+    .map((x) => x.content);
+}
+
+describe("public-role-board — CV2 render (structural, voiceless, read-only)", () => {
+  test("CV2 grammar: container 17, honey accent, text 10 + separator 14", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    expect(c.type).toBe(17);
+    expect(c.accent_color).toBe(ACCENT_HONEY);
+    const types = c.components.map((x) => x.type);
+    expect(types).toContain(10);
+    expect(types).toContain(14);
+  });
+
+  test("payload: IS_COMPONENTS_V2 flag + inert mentions, no content/embeds", () => {
+    const p = publicRoleBoardCV2Payload(FIXTURE, CTX);
+    expect(p.flags & IS_COMPONENTS_V2).toBe(IS_COMPONENTS_V2);
+    expect(p.allowed_mentions).toEqual({ parse: [] });
+    expect((p as { content?: string }).content).toBeUndefined();
+    expect((p as { embeds?: unknown[] }).embeds).toBeUndefined();
+  });
+
+  test("world theming: the world title appears in the header", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    const txt = textContents(c).join("\n");
+    expect(txt).toContain("Purupuru");
+    expect(txt).toContain("tier landscape");
+  });
+
+  test("tier ladder: every configured tier renders with its lore name + count", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    const txt = textContents(c).join("\n");
+    // lore display names (seed = title-cased tier ids; world-customizable via map).
+    for (const name of ["Sovereign", "Elder", "Core", "Member", "Devoted", "Newcomer"]) {
+      expect(txt).toContain(name);
+    }
+    // per-tier counts: 1 sovereign, 2 elder, 1 core, 3 member, 0 devoted/newcomer.
+    expect(txt).toContain("`1` member");
+    expect(txt).toContain("`2` members");
+    expect(txt).toContain("`3` members");
+    expect(txt).toContain("`0` members");
+  });
+
+  test("ladder is a top-down progression: apex (Sovereign) precedes the crowd (Newcomer)", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    const ladder = textContents(c).find((t) => t.includes("Sovereign"))!;
+    const sovIdx = ladder.indexOf("Sovereign");
+    const newIdx = ladder.indexOf("Newcomer");
+    expect(sovIdx).toBeGreaterThanOrEqual(0);
+    expect(newIdx).toBeGreaterThan(sovIdx);
+  });
+
+  test("buildLadder: ascending strength order, exact per-tier counts", () => {
+    const rungs = buildLadder(FIXTURE, SEED_MAP, (t) =>
+      ({ newcomer: 1, member: 2, devoted: 3, core: 4, elder: 5, sovereign: 6 })[t.toLowerCase()],
+    );
+    expect(rungs.map((r) => r.tier)).toEqual([
+      "newcomer",
+      "member",
+      "devoted",
+      "core",
+      "elder",
+      "sovereign",
+    ]);
+    const counts = Object.fromEntries(rungs.map((r) => [r.tier, r.count]));
+    expect(counts).toEqual({ newcomer: 0, member: 3, devoted: 0, core: 1, elder: 2, sovereign: 1 });
+  });
+
+  test("adoption line: X of Y linked + percentage", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    const txt = textContents(c).join("\n");
+    // 7 linked of 8 members → 88%.
+    expect(txt).toContain("**7** of **8**");
+    expect(txt).toContain("88% onboarded");
+    expect(txt).toContain("linked a wallet");
+  });
+
+  test("READ-ONLY: no per-member action, no Apply affordance, no per-member rows", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    const txt = JSON.stringify(c.components);
+    // no action verbs / apply affordance from the CM dashboard surface.
+    expect(txt).not.toContain("Apply");
+    expect(txt).not.toContain("Would add");
+    expect(txt).not.toContain("would-add");
+    // no Discord button/action-row components (only text 10 + separator 14).
+    const allowed = new Set([10, 14]);
+    for (const comp of c.components) expect(allowed.has(comp.type)).toBe(true);
+    // a member's display name must NOT surface (this is aggregate-only, not a roster).
+    expect(txt).not.toContain("soju");
+    expect(txt).not.toContain("memberA");
+  });
+
+  test("VOICELESS: every string is a structural label / count / lore name", () => {
+    const c = renderPublicRoleBoardCV2(FIXTURE, CTX);
+    const txt = textContents(c).join("\n");
+    // structural framing only; no persona narration markers.
+    expect(txt).toContain("Read-only");
+    expect(txt).toContain("The ladder");
+  });
+
+  test("INJECTION GUARD: an attacker-shaped world slug / lore name is neutralized", () => {
+    const evilMap: RoleMapConfig = {
+      enabled: true,
+      namespace_prefix: "purupuru:",
+      rules: [
+        {
+          role_key: "purupuru:evil",
+          display_name: "@everyone **pwn**",
+          qualifies: { source: "tier", min_tier: "member" },
+          create_if_absent: true,
+        },
+      ],
+    } as RoleMapConfig;
+    const c = renderPublicRoleBoardCV2(
+      rosterOf([tieredMember("700000000000000010", "x", "member")]),
+      { world: "@everyone", roleMap: evilMap, generatedAt: "2026-06-04T00:00:00Z" },
+    );
+    const txt = textContents(c).join("\n");
+    // @everyone broken (zero-width inserted after @) in both header + ladder.
+    expect(txt).not.toContain("@everyone");
+    // markdown control chars escaped in the lore name.
+    expect(txt).toContain("\\*\\*pwn\\*\\*");
+  });
+
+  test("empty roster renders the ladder + a no-members adoption line, no throw", () => {
+    const c = renderPublicRoleBoardCV2(rosterOf([]), CTX);
+    const txt = textContents(c).join("\n");
+    expect(txt).toContain("Purupuru");
+    expect(txt).toContain("No members yet");
+    // ladder still renders all tiers at 0.
+    expect(txt).toContain("`0` members");
+  });
+
+  test("world-customizable: a different world reskins via its own map + accent", () => {
+    const altMap: RoleMapConfig = {
+      enabled: true,
+      namespace_prefix: "tsuheji:",
+      rules: [
+        {
+          role_key: "tsuheji:flame",
+          display_name: "Flamebearer",
+          qualifies: { source: "tier", min_tier: "sovereign" },
+          create_if_absent: true,
+        },
+        {
+          role_key: "tsuheji:spark",
+          display_name: "Spark",
+          qualifies: { source: "tier", min_tier: "member" },
+          create_if_absent: true,
+        },
+      ],
+    } as RoleMapConfig;
+    const c = renderPublicRoleBoardCV2(
+      rosterOf([tieredMember("700000000000000020", "y", "sovereign")]),
+      { world: "tsuheji", roleMap: altMap, accent: 0x123456, generatedAt: "2026-06-04T00:00:00Z" },
+    );
+    expect(c.accent_color).toBe(0x123456);
+    const txt = textContents(c).join("\n");
+    expect(txt).toContain("Tsuheji");
+    expect(txt).toContain("Flamebearer");
+    expect(txt).toContain("Spark");
+    // the Purupuru lore names must NOT leak — the board is fully reskinned.
+    expect(txt).not.toContain("Sovereign");
+  });
+});

--- a/apps/bot/src/shadow/public-role-board-cv2.ts
+++ b/apps/bot/src/shadow/public-role-board-cv2.ts
@@ -1,0 +1,277 @@
+/**
+ * shadow/public-role-board-cv2.ts — the PUBLIC, world-themed, VOICELESS live role
+ * board render: a `MemberRosterResult` → a Discord Components-V2 (CV2) message
+ * for EVERYONE in the server (cycle public-role-board, the experiment surface).
+ *
+ * ── WHY THIS, NOT member-dashboard-cv2.ts ────────────────────────────────────
+ * `member-dashboard-cv2.ts` is the EPHEMERAL CM-admin dashboard: a per-member
+ * before→after table (UNLINKED / UNTIERED / ADD / KEEP rows + a proposed-role
+ * AFTER cell), with an "apply" intent downstream. Audience: the community
+ * manager. This module is the PUBLIC counterpart from the same roster: a
+ * persistent status display of the tier LANDSCAPE — how many members sit at each
+ * rung of the tier ladder + an adoption line — framed for the whole server, with
+ * NO per-member admin actions and NO Apply affordance. Both consume the SAME
+ * `MemberRosterResult` (member-roster.ts); only the audience + framing differ.
+ * See grimoires/loa/context/2026-06-04-cm-operating-surface-medium-parity.md
+ * ("Two role surfaces over one roster").
+ *
+ * ── READ-ONLY · ZERO WRITES · ZERO ROLE MUTATIONS ────────────────────────────
+ * This is a PURE render function (`MemberRosterResult` → CV2 component JSON). It
+ * holds NO onboarding logic, mutates NO roles, fires no events, makes no Discord
+ * call. The post script (`apps/bot/scripts/post-role-board.ts`) sends the output.
+ * It surfaces ONLY aggregate counts — never a per-member action.
+ *
+ * ── VOICELESS ────────────────────────────────────────────────────────────────
+ * No persona-engine voice import. Every string is a structural label, a count,
+ * or a world-supplied DISPLAY NAME. This is the operating surface, not a
+ * character. It SHOULD feel like the world (honey-gold accent + glyph ladder +
+ * lore tier names) — but the lore names come from DATA (the role-map's
+ * `display_name` per rule), not hardcoded, so another world reskins the same
+ * board by mounting its own role-map + accent.
+ *
+ * ── WORLD-CUSTOMIZABLE (data-driven, not hardcoded) ──────────────────────────
+ * The tier ladder is built from the injected role-map rules — each rule's
+ * `display_name` (the lore name a CM authored, e.g. "Sovereign") + its
+ * `qualifies.min_tier` (the score-api tier id rows carry). The ordering comes
+ * from an injected tier-rank resolver (defaults to the Purupuru ladder). The
+ * accent is a parameter. A different world supplies its own role-map + accent +
+ * (optionally) its own rank resolver — no code change.
+ *
+ * ── INJECTION GUARD (mirrors member-dashboard-cv2 / discrepancy-cv2) ──────────
+ * The world TITLE (slug) and role DISPLAY NAMES are surfaced verbatim. Role
+ * names are CM-authored config (lower risk) but a slug or a future
+ * dashboard-authored name could carry mention/markdown syntax. We reuse
+ * `escapeRoleName` (neutralizes mention syntax + markdown) + clamp +
+ * `allowed_mentions: { parse: [] }` so no surfaced string can spoof the layout
+ * or fire a mass-ping. The board is public — the injection surface is wider, so
+ * the guard is mandatory, not optional.
+ */
+import { escapeRoleName, IS_COMPONENTS_V2 } from "./discrepancy-cv2.ts";
+import type { RoleRule, RoleMapConfig } from "@freeside-worlds/shadow-substrate";
+import type { MemberRosterResult } from "./member-roster.ts";
+import { purupuruTierRank, type TierRankResolver } from "./purupuru-tiers.ts";
+
+/** Warm honey-gold — the default world accent for the public board. */
+export const ACCENT_HONEY = 0xe0a83d;
+
+/** Max rendered display-name length before truncation (defense vs a long name). */
+const MAX_NAME_CHARS = 48;
+/** Conservative per-text-component char budget (well under Discord's ~4000). */
+const MAX_TEXT_COMPONENT_CHARS = 3500;
+
+/**
+ * The honey-comb ladder glyphs, lowest rung → highest. A short, fixed palette
+ * read bottom-up: the climb from the crowd to the world's apex. Index by the
+ * tier's POSITION on the ladder (0 = lowest shown), clamped to the last glyph for
+ * deeper ladders. Honey/element aesthetic without per-world hardcoding.
+ */
+const RUNG_GLYPHS = ["🐝", "🍯", "✨", "👑"] as const;
+
+/** A filled / empty bar cell pair for the per-tier count bar (visual weight). */
+const BAR_FILLED = "▰";
+const BAR_EMPTY = "▱";
+/** Max bar cells (the bar is a RELATIVE visual, scaled to the busiest tier). */
+const BAR_CELLS = 12;
+
+function clamp(name: string, max: number): string {
+  return name.length > max ? `${name.slice(0, max - 1)}…` : name;
+}
+
+/** Render an attacker/world-supplied display string → a safe inline string. */
+function safeText(raw: string): string {
+  return clamp(escapeRoleName(raw), MAX_NAME_CHARS);
+}
+
+/** Title-case a world slug for the header (display only; escaped). */
+function worldTitle(world: string): string {
+  const cleaned = world.replace(/[-_]+/g, " ").trim();
+  const titled = cleaned.replace(/\b\w/g, (c) => c.toUpperCase());
+  return safeText(titled.length > 0 ? titled : world);
+}
+
+type TextComponent = { type: 10; content: string };
+type SeparatorComponent = { type: 14 };
+type ContainerComponent = {
+  type: 17;
+  accent_color: number;
+  components: Array<TextComponent | SeparatorComponent>;
+};
+
+function text(content: string): TextComponent {
+  return { type: 10, content };
+}
+const sep: SeparatorComponent = { type: 14 };
+
+/** One rung of the rendered ladder (a tier + how many members hold it). */
+interface LadderRung {
+  /** the score-api tier id (the join key against roster rows). */
+  readonly tier: string;
+  /** the lore display name (CM-authored, world-customizable). */
+  readonly displayName: string;
+  /** how many CURRENT linked members resolve to exactly this tier. */
+  readonly count: number;
+}
+
+/** Context the public board carries beyond the roster result. */
+export interface PublicRoleBoardContext {
+  /** the world slug (themes the header; escaped before render). */
+  readonly world: string;
+  /**
+   * the role-map whose rules supply the ladder (lore display names + tier ids).
+   * DATA-DRIVEN: a different world reskins the board via its own map.
+   */
+  readonly roleMap: RoleMapConfig;
+  /** the world accent (defaults to honey-gold). */
+  readonly accent?: number;
+  /** the tier-strength ordering (defaults to the Purupuru ladder). */
+  readonly tierRank?: TierRankResolver;
+  /** ISO timestamp stamped in the footer (defaults to now). */
+  readonly generatedAt?: string;
+}
+
+/**
+ * Build the ordered ladder rungs from the role-map rules + the roster rows. One
+ * rung per tier rule, ordered by ascending strength rank (lowest rung first),
+ * each annotated with how many CURRENT members resolve to exactly that tier.
+ * Only the rules whose `qualifies.source === "tier"` contribute a rung.
+ */
+export function buildLadder(
+  result: MemberRosterResult,
+  roleMap: RoleMapConfig,
+  rank: TierRankResolver,
+): LadderRung[] {
+  // count linked members at each EXACT resolved tier (untiered/unlinked excluded).
+  const byTier = new Map<string, number>();
+  for (const row of result.rows) {
+    if (!row.linked || !row.tier) continue;
+    const key = row.tier.toLowerCase();
+    byTier.set(key, (byTier.get(key) ?? 0) + 1);
+  }
+
+  const tierRules = roleMap.rules.filter(
+    (r: RoleRule): boolean => r.qualifies.source === "tier",
+  );
+
+  const rungs: LadderRung[] = tierRules.map((rule) => {
+    const tier = rule.qualifies.min_tier;
+    return {
+      tier,
+      displayName: rule.display_name,
+      count: byTier.get(tier.toLowerCase()) ?? 0,
+    };
+  });
+
+  // order by ascending strength rank (lowest rung first); unknown ranks sink to
+  // the bottom deterministically by display name so the ladder is stable.
+  return rungs.sort((a, b) => {
+    const ra = rank(a.tier) ?? -Infinity;
+    const rb = rank(b.tier) ?? -Infinity;
+    if (ra !== rb) return ra - rb;
+    return a.displayName.localeCompare(b.displayName);
+  });
+}
+
+/** Render the per-tier relative count bar (scaled to the busiest rung). */
+function renderBar(count: number, max: number): string {
+  if (max <= 0) return BAR_EMPTY.repeat(BAR_CELLS);
+  const filled = Math.max(0, Math.min(BAR_CELLS, Math.round((count / max) * BAR_CELLS)));
+  // a non-zero count always shows at least one cell so a tier with members never
+  // reads as empty after rounding.
+  const cells = count > 0 ? Math.max(1, filled) : 0;
+  return BAR_FILLED.repeat(cells) + BAR_EMPTY.repeat(BAR_CELLS - cells);
+}
+
+/**
+ * Render the ladder as a visual PROGRESSION (highest rung at the TOP — the apex
+ * the climb leads to — down to the crowd). Each line:
+ *   <rung-glyph> **<lore name>**  <bar>  <count>
+ */
+function renderLadderLines(rungs: readonly LadderRung[]): string {
+  if (rungs.length === 0) return "_(no tiers configured)_";
+  const max = rungs.reduce((m, r) => Math.max(m, r.count), 0);
+  // present highest-first (apex at top): reverse the ascending-rank order.
+  const topFirst = [...rungs].reverse();
+  const lines = topFirst.map((rung, i) => {
+    // glyph by ladder POSITION (apex gets the crown); index from the top.
+    const fromTop = i;
+    const glyphIdx = Math.max(0, RUNG_GLYPHS.length - 1 - fromTop);
+    const glyph = RUNG_GLYPHS[Math.min(glyphIdx, RUNG_GLYPHS.length - 1)]!;
+    const name = safeText(rung.displayName);
+    const bar = renderBar(rung.count, max);
+    const noun = rung.count === 1 ? "member" : "members";
+    return `${glyph} **${name}**  ${bar}  \`${rung.count}\` ${noun}`;
+  });
+  return lines.join("\n");
+}
+
+/** The adoption line: "X of Y members have linked a wallet" + a share of total. */
+function renderAdoptionLine(result: MemberRosterResult): string {
+  const { members, linked } = result.summary;
+  if (members === 0) return "_No members yet._";
+  const pct = Math.round((linked / members) * 100);
+  const noun = members === 1 ? "member" : "members";
+  return `🔗 **${linked}** of **${members}** ${noun} have linked a wallet  ·  ${pct}% onboarded`;
+}
+
+/**
+ * Render a `MemberRosterResult` as the PUBLIC role-board CV2 container component
+ * (the single top-level component). The caller wraps it via
+ * {@link publicRoleBoardCV2Payload}.
+ *
+ * STRUCTURAL ONLY: a world-themed header, the tier ladder (lore names + per-tier
+ * counts as a relative bar), and a single adoption line. No persona, no voice,
+ * no per-member action, no Apply affordance. READ-ONLY.
+ */
+export function renderPublicRoleBoardCV2(
+  result: MemberRosterResult,
+  ctx: PublicRoleBoardContext,
+): ContainerComponent {
+  const accent = ctx.accent ?? ACCENT_HONEY;
+  const rank = ctx.tierRank ?? purupuruTierRank;
+  const generatedAt = ctx.generatedAt ?? new Date().toISOString();
+  const title = worldTitle(ctx.world);
+
+  const rungs = buildLadder(result, ctx.roleMap, rank);
+  const tieredCount = rungs.reduce((m, r) => m + r.count, 0);
+  const ladderBody = clampBody(renderLadderLines(rungs));
+
+  const components: Array<TextComponent | SeparatorComponent> = [
+    text(`# 🍯 ${title} — the tier landscape`),
+    text(`_A live look at where the community stands. Read-only · refreshed periodically._`),
+    sep,
+    text(`## The ladder\n${ladderBody}`),
+    sep,
+    text(
+      `${renderAdoptionLine(result)}\n` +
+        `🏅 **${tieredCount}** ${tieredCount === 1 ? "member has" : "members have"} earned a tier`,
+    ),
+    text(`_updated ${escapeRoleName(generatedAt)}_`),
+  ];
+
+  return { type: 17, accent_color: accent, components };
+}
+
+/** Hard-clamp a rendered body to the per-text-component budget (defense). */
+function clampBody(body: string): string {
+  return body.length > MAX_TEXT_COMPONENT_CHARS
+    ? `${body.slice(0, MAX_TEXT_COMPONENT_CHARS - 1)}…`
+    : body;
+}
+
+/** The full CV2 message payload (flags + components + inert mentions). */
+export function publicRoleBoardCV2Payload(
+  result: MemberRosterResult,
+  ctx: PublicRoleBoardContext,
+): {
+  flags: number;
+  components: ContainerComponent[];
+  allowed_mentions: { parse: never[] };
+} {
+  return {
+    flags: IS_COMPONENTS_V2,
+    components: [renderPublicRoleBoardCV2(result, ctx)],
+    // INJECTION GUARD: every mention is inert — a world slug / lore role name
+    // surfaced on the board cannot fire an @everyone / role / user ping.
+    allowed_mentions: { parse: [] },
+  };
+}


### PR DESCRIPTION
## What

A public, world-themed, voiceless live role board for Purupuru: a persistent Components-V2 status message showing the tier/role landscape (read-only), distinct from the ephemeral CM admin dashboard. The "see how it looks" experiment surface for #verify.

## The board (public-role-board-cv2.ts)

Apex-first tier ladder (Sovereign at the top climbing down to the crowd), glyph rungs, a relative count bar per tier plus the exact member count, honey-gold accent, and an adoption line (`X of Y members linked a wallet · N% onboarded`). Lore tier names and ordering are DATA-DRIVEN (from the role-map display names plus an injected tier-rank resolver), so another world reskins it with its own names and accent (proven by a `tsuheji` reskin test). Read-only: no Apply, no per-member admin actions. Voiceless, injection-guarded (escapeRoleName, allowed_mentions:[], aggregate-only).

## Post/refresh harness (scripts/post-role-board.ts)

Builds the roster, renders the board, posts (or edits-in-place via a stored message_id) to a target channel via the bot client. Run with `CHANNEL_ID` (and optional `MESSAGE_ID` to refresh the same message, the debounced "live" feel). Prints the message_id. Edit-in-place is a bounded-retry REST PATCH. "Live" is debounced by design (re-render and edit on demand), not per-event.

## Safety

Zero role mutations (member/identity/score reads plus one channel message post/patch). Voiceless. Injection-guarded.

## Tests

12 render tests (network-free), full apps/bot suite green, both typechecks clean, import-boundary lint and substrate conformance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
