### PR TITLE
Phase 45F feat: add Admission Wedge Dixie probe adapter

### DIFF
--- a/docs/ADMISSION-WEDGE-DIXIE-PROBE-RECONCILIATION-GATE.md
+++ b/docs/ADMISSION-WEDGE-DIXIE-PROBE-RECONCILIATION-GATE.md
@@ -536,6 +536,26 @@ Phase 45F, when opened, is a narrow alignment-proof lane — not a build of any
 live path. If it needs any item above, it must open the gate that owns it
 (decision-map §7 / §8) — Phase 45E authorizes none of them.
 
+> **Phase 45F status note (added later).** Phase 45F acted on this lane as a
+> **test-only / docs-fixture-bound no-op adapter / validator**. It adds local
+> **mirrored** copies of the Dixie Phase 33C draft v0 probes under
+> `docs/admission-wedge/dixie-probes/` (clearly marked local mirrors, not
+> canonical upstream truth) plus a pure local adapter
+> (`packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts`
+> + test) that maps the five Dixie probe scenarios
+> (`candidate_pending_not_recallable` → `before_admission_excluded`,
+> `accept_candidate_to_admitted_assertion` → `accepted_admitted_included`,
+> `reject_candidate_no_assertion` → `rejected_excluded`,
+> `supersede_with_corrected_assertion` → `supersession_corrected_only`,
+> `malformed_or_unsafe_payload_fail_closed` → `malformed_fail_closed`) onto the
+> current local proof scenarios and proves semantic equivalence against the
+> existing Phase 44A reducer / Phase 44C runner output. It **proves semantic
+> mapping only**: it renames no local fixture label, mutates no reducer reason
+> code, mutates no fixture JSON, calls no live Dixie, wires no runtime path, and
+> is not exported from the package surface. Live admission, a live Dixie
+> admission route, storage, a command, package exports, and Finn production
+> wiring all stay blocked.
+
 ---
 
 ## 12. What remains blocked now

--- a/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
+++ b/docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
@@ -1271,6 +1271,53 @@ live admission implementation.
 
 ---
 
+### 5w. Phase 45F addendum — no-op Dixie probe adapter / validator added; test-only / docs-fixture-bound, no runtime wiring
+
+> Added by Phase 45F, 2026-06-04. Targeted addendum, not a rewrite of this
+> section; §5v stays in force.
+
+Status as of Phase 45F:
+
+- **Phase 45F adds a test-only / docs-fixture-bound no-op adapter / validator
+  over mirrored Dixie probes.** It implements the narrow Option A lane Phase
+  45E selected (§5v): local **mirrored** copies of the Dixie Phase 33C draft v0
+  probes under `docs/admission-wedge/dixie-probes/` (clearly marked local
+  mirrors, not canonical upstream truth) plus a pure local adapter
+  (`packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts`
+  + `.test.ts`) that maps the five Dixie probe scenarios
+  (`candidate_pending_not_recallable` → `before_admission_excluded`,
+  `accept_candidate_to_admitted_assertion` → `accepted_admitted_included`,
+  `reject_candidate_no_assertion` → `rejected_excluded`,
+  `supersede_with_corrected_assertion` → `supersession_corrected_only`,
+  `malformed_or_unsafe_payload_fail_closed` → `malformed_fail_closed`) onto the
+  current local proof scenarios.
+- **It proves semantic mapping only.** The adapter is pure (no fs / network /
+  env / clock / storage), imports only the pure Phase 44A reducer, and the test
+  cross-checks each mapping against the existing Phase 44A reducer's output over
+  the Phase 43C fixtures (the same scenario plans the Phase 44C runner uses) —
+  not a reimplementation. It also proves no-leak over serialized results +
+  formatted summaries and fail-closed on synthetic malformed input.
+- **It does not rename local fixtures or reducer reason codes, mutates no
+  fixture JSON, and runtime-wires nothing.** The adapter is imported only by its
+  own test, is not exported from the package surface, and is reachable from no
+  Discord / dispatch / startup / registration / renderer / live-Dixie path.
+- **Live lanes remain blocked.** Live Dixie-backed admission, a live Dixie
+  admission route, a frozen final production schema, production storage /
+  admission / auth / consent, public remember-this, Discord message-history
+  ingestion, user chat becoming memory, public rollout, Telegram / private chat,
+  LLM / voice, a forget / revoke / correction UI, package exports, and Finn
+  production wiring all remain blocked. Dixie Phase 33C stays a **draft v0**,
+  not production schema, and Freeside Characters does not own the Dixie /
+  Straylight vocabulary. Phase 45F expands the prior authorization in no way,
+  and §7 (live memory admission gates) and §8 (prohibitions) stay in force.
+
+This addendum does not duplicate the Phase 45F adapter; it only records that
+the Phase 45E-selected no-op adapter / validator lane is now implemented as a
+test-only / docs-fixture-bound mapping proof, not a live admission
+implementation.
+
+---
+
 ## 6. Decision gates before live Dixie client (Option C)
 
 Before a live Dixie client is allowed, all of the following must hold:
@@ -1378,7 +1425,23 @@ corresponding gates above are satisfied.
 
 ## 9. Recommended next phase
 
-> **Current status (updated Phase 45A, 2026-06-02 · authoritative in §5s).**
+> **Latest status (updated Phase 45F, 2026-06-04 · authoritative in §5w).**
+> Phase 45F has landed: it added a test-only / docs-fixture-bound **no-op
+> Dixie probe adapter / validator over local mirrored Dixie probes** (§5w) —
+> local mirrors of the Dixie Phase 33C draft v0 probes plus a pure adapter
+> that maps the five Dixie probe scenarios onto the Phase 44A reducer's
+> scenarios and cross-checks them, proving semantic mapping and no-leak only.
+> It wires nothing at runtime, exports nothing from the package surface, and
+> calls no live Dixie route. All live / runtime lanes — live Dixie-backed
+> admission, a live Dixie admission route, a frozen production schema,
+> production storage / admission / auth / consent, a Discord command, public
+> remember-this, Discord history ingestion, user chat becoming memory,
+> package exports, and Finn production wiring — **remain blocked**, and no
+> next live lane is authorized; §7 and §8 stay in force. The Phase 45A / 45C
+> / 45D status text below is **historical / superseded** — the ladder trail
+> that led here, not the current next step.
+>
+> **Earlier status (Phase 45A, 2026-06-02 · §5s — historical / superseded).**
 > Phase 44D selected **Phase 45A — a docs / cross-repo Dixie-side Admission
 > Wedge contract request / handoff**, and that selection is now
 > **satisfied**: Phase 45A is authored as this contract request / handoff
@@ -1406,11 +1469,13 @@ corresponding gates above are satisfied.
 > reconciliation only) reconciles that response on the Freeside side. The
 > "Phase 45C reconciliation against an accepted contract" framing above is
 > refined accordingly: the accepted artifact is a contract *response* (the
-> need + a draft vocabulary), not a frozen contract. Phase 45C selects
-> **Phase 45D — a docs / decision reconciliation matrix / fixture-probe
-> alignment gate** as the conservative next lane; live admission, a live
-> Dixie route, storage, a command, package exports, and Finn production
-> wiring all remain blocked.
+> need + a draft vocabulary), not a frozen contract. Phase 45C *then*
+> selected **Phase 45D — a docs / decision reconciliation matrix /
+> fixture-probe alignment gate** as the conservative next lane (historical;
+> the ladder has since advanced docs-only through Phase 45D → 45E → **45F**,
+> whose landed no-op probe adapter / validator is the latest status — see the
+> §5w banner above and §5w); live admission, a live Dixie route, storage, a
+> command, package exports, and Finn production wiring all remain blocked.
 > The
 > intervening recommendation (**Phase 44C — a fixture-bound dev/operator
 > reducer runner**) is **completed**: the runner landed via PR #158 and is

--- a/docs/admission-wedge/dixie-probes/README.md
+++ b/docs/admission-wedge/dixie-probes/README.md
@@ -1,0 +1,81 @@
+# Admission Wedge — local mirrored Dixie probes (Phase 45F)
+
+> **Phase 45F** (Freeside Characters-side, test-only / docs-fixture-bound).
+> Date: 2026-06-04. These five JSON files are **local mirrors** of the Dixie
+> Phase 33C **draft v0** Admission Wedge contract probes, copied here only so a
+> local, pure, no-op adapter / validator
+> (`packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts`
+> + its test) can prove the Dixie probe scenarios map to the current Freeside
+> Characters local Admission Wedge proof semantics — **without** any runtime
+> wiring and **without** any live Dixie call.
+
+## What these are
+
+- **Local mirrors for Phase 45F adapter tests.** They exist so the adapter test
+  can read a probe shape and prove semantic alignment to the local proof stack.
+- **Canonical source is Dixie Phase 33C / PR #120**
+  (`../loa-dixie/docs/admission-wedge/fixtures/`). These mirrors are **not**
+  canonical upstream truth; the Dixie copy is authoritative. If the two ever
+  disagree, the Dixie copy wins and these mirrors are stale.
+- **Draft v0, non-runtime, not final schema.** Every probe carries
+  `probe_version: dixie_admission_wedge_probe_v0`, `schema_final: false`,
+  `runtime_enabled: false`, `production_admission: false`, `public_safe: true`.
+  Nothing here is frozen or final.
+- Each file additionally carries a top-level `_local_mirror` marker block that
+  records that it is a Freeside-local mirror, its canonical Dixie source, and
+  its draft / non-runtime status. The adapter ignores `_local_mirror`; it is
+  there for human readers and to make the mirror's status unambiguous on disk.
+
+## What these are NOT
+
+- **Local mirrors do not create any Freeside Characters runtime behavior.** They
+  are static JSON read only by a test. No source path imports them, no command
+  reads them, no renderer touches them, and no package surface exports them.
+- They are **not** a live Dixie call, a live Dixie admission route, storage,
+  auth / consent, a public `remember-this`, Discord history ingestion, user chat
+  becoming memory, or any production behavior. None of those is added, implied,
+  or unblocked by mirroring these probes.
+- They are **not** a rename of, or a mutation to, any local fixture under
+  `docs/admission-wedge/fixtures/` and they change no reducer reason code. The
+  local proof labels remain local proof labels; the Dixie probe labels remain
+  Dixie-owned draft v0 labels. Neither set is a frozen final schema, and Freeside
+  Characters does not own the Dixie or Straylight vocabulary.
+
+## The five mirrored probes
+
+| File | Dixie `scenario_id` | Local scenario it aligns to |
+|------|---------------------|-----------------------------|
+| `candidate-pending-not-recallable.json` | `candidate_pending_not_recallable` | `before_admission_excluded` |
+| `accept-candidate-to-admitted-assertion.json` | `accept_candidate_to_admitted_assertion` | `accepted_admitted_included` |
+| `reject-candidate-no-assertion.json` | `reject_candidate_no_assertion` | `rejected_excluded` |
+| `supersede-with-corrected-assertion.json` | `supersede_with_corrected_assertion` | `supersession_corrected_only` |
+| `malformed-or-unsafe-payload-fail-closed.json` | `malformed_or_unsafe_payload_fail_closed` | `malformed_fail_closed` |
+
+The local scenario names are the Phase 44C runner's
+(`run-admission-wedge-fixture-demo.ts`) scenario labels; the alignment is proven
+in the adapter test against the existing Phase 44A reducer / 44C runner output.
+
+## Refresh / reconciliation
+
+These mirrors are a point-in-time copy of `dixie_admission_wedge_probe_v0`. They
+should be **refreshed or reconciled only through a future gate** if the Dixie
+probes change (a later Dixie probe version, or a Dixie Phase 33D hardening). Do
+not hand-edit them to diverge from the Dixie source; if the Dixie probes move,
+open the reconciliation gate that owns the refresh rather than silently editing
+here. This directory carries **no live Dixie calls, no storage, no auth, no
+`remember-this`, no Discord ingestion, and no production behavior.**
+
+## Provenance
+
+- `../loa-dixie/docs/admission-wedge/fixtures/README.md` — Dixie Phase 33C draft
+  v0 probe set + validator (canonical source). Read only; not edited from this
+  repo.
+- `docs/ADMISSION-WEDGE-DIXIE-PROBE-RECONCILIATION-GATE.md` — Phase 45E
+  reconciliation / next-lane decision; its §10–§11 authorize this narrow,
+  test-only Phase 45F no-op adapter / validator lane.
+- `docs/admission-wedge/fixtures/README.md` — the Phase 43C local fixture /
+  operator-contract these mirrors are aligned against (unchanged; the adapter
+  renames and mutates nothing there).
+- `packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts`
+  (+ `.test.ts`) — the Phase 45F pure, local, no-op adapter / validator and its
+  test that consume these mirrors.

--- a/docs/admission-wedge/dixie-probes/accept-candidate-to-admitted-assertion.json
+++ b/docs/admission-wedge/dixie-probes/accept-candidate-to-admitted-assertion.json
@@ -1,0 +1,108 @@
+{
+  "_local_mirror": {
+    "note": "LOCAL MIRROR for Phase 45F adapter tests — NOT canonical upstream truth.",
+    "canonical_source": "loa-dixie Phase 33C / PR #120 · docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json",
+    "mirror_phase": "freeside-characters Phase 45F",
+    "mirror_status": "draft_v0 · non_runtime · not_final_schema",
+    "local_scenario": "accepted_admitted_included",
+    "creates_freeside_runtime_behavior": false,
+    "refresh_policy": "refresh/reconcile only through a future gate if the Dixie probes change"
+  },
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "accept_candidate_to_admitted_assertion",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A proposed candidate is accepted; an admission transition links it to an admitted, active assertion that becomes recall-eligible under policy, without echoing the raw candidate payload.",
+  "invariant_refs": [
+    "inv3_accepted_transition_creates_or_references_admitted_assertion",
+    "inv2_candidate_not_recallable_before_admission",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.proposed",
+    "AssertionStatus.active",
+    "Transition.admit_assertion",
+    "AuditEvent.assertion_admitted",
+    "RecallUseInstruction.usable"
+  ],
+  "draft_vocab_used": [
+    "source_candidate_id",
+    "admission_transition_id",
+    "admitted_assertion_id",
+    "recall_eligible",
+    "recall_use_instruction",
+    "rendered_candidate_payload",
+    "receipt_public_ref"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: the ACT of admission is the canonical Straylight transition 'admit_assertion' and audit event 'assertion_admitted'; the resulting STATUS is canonical 'active'. There is NO bare 'admitted' status upstream, so the probe deliberately avoids 'admitted'/'admitted_active_assertion' as a status value.",
+    "Recall eligibility is expressed as 'under policy': a boolean recall_eligible plus the canonical RecallUseInstruction signal ('usable'), not an unconditional grant. The boolean and the canonical signal are kept side by side so future reconciliation is cheap.",
+    "Receipt/audit split: the public_response carries only a public-safe receipt reference and summary; the full admission receipt (policy reasoning, candidate ref, ids) lives on the audit object.",
+    "Link field names (source_candidate_id, admission_transition_id, admitted_assertion_id) are DRAFT and subject to reconciliation against Straylight-owned assertion types."
+  ],
+  "input": {
+    "candidate_id": "cand_demo_002",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "proposed_assertion_class": "preference",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-002",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-002"
+  },
+  "admission_transition": {
+    "admission_transition_id": "trans_demo_001",
+    "transition_kind": "admit_assertion",
+    "outcome": "accepted",
+    "source_candidate_id": "cand_demo_002",
+    "admitted_assertion_id": "assn_demo_001",
+    "authority_signer_type_draft": "policy_service",
+    "policy_decision": "accepted_under_policy"
+  },
+  "admitted_assertion": {
+    "admitted_assertion_id": "assn_demo_001",
+    "assertion_status": "active",
+    "assertion_class": "preference",
+    "source_candidate_id": "cand_demo_002",
+    "admission_transition_id": "trans_demo_001",
+    "recall_eligible": true,
+    "recall_use_instruction": "usable"
+  },
+  "recall_projection": {
+    "ordinary_recall_members": [
+      "assn_demo_001"
+    ],
+    "explanation": "The admitted assertion is active and recall-eligible under policy, so it appears in ordinary recall."
+  },
+  "public_response": {
+    "outcome": "admitted",
+    "assertion_status": "active",
+    "recall_eligible": true,
+    "recall_use_instruction": "usable",
+    "rendered_candidate_payload": false,
+    "receipt_public_ref": "rcpt_demo_002",
+    "public_summary": "Candidate admitted under policy. The resulting assertion is active and recall-eligible. The candidate payload is not echoed."
+  },
+  "audit": {
+    "admission_receipt": {
+      "receipt_id": "rcpt_demo_002",
+      "decision_time_label": "demo_decision_time",
+      "service_actor": "actor_demo",
+      "policy_reason": "accepted_under_policy",
+      "source_candidate_id": "cand_demo_002",
+      "admitted_assertion_id": "assn_demo_001",
+      "recall_eligibility_result": "eligible_under_policy",
+      "audit_event": "assertion_admitted"
+    },
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-002",
+    "source_ref": "unsafe_marker:source-ref-demo-002",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/dixie-probes/candidate-pending-not-recallable.json
+++ b/docs/admission-wedge/dixie-probes/candidate-pending-not-recallable.json
@@ -1,0 +1,74 @@
+{
+  "_local_mirror": {
+    "note": "LOCAL MIRROR for Phase 45F adapter tests — NOT canonical upstream truth.",
+    "canonical_source": "loa-dixie Phase 33C / PR #120 · docs/admission-wedge/fixtures/candidate-pending-not-recallable.json",
+    "mirror_phase": "freeside-characters Phase 45F",
+    "mirror_status": "draft_v0 · non_runtime · not_final_schema",
+    "local_scenario": "before_admission_excluded",
+    "creates_freeside_runtime_behavior": false,
+    "refresh_policy": "refresh/reconcile only through a future gate if the Dixie probes change"
+  },
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "candidate_pending_not_recallable",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A candidate proposal exists but no admission transition has occurred; it is not recallable and its payload is never echoed in the public projection.",
+  "invariant_refs": [
+    "inv1_candidate_is_not_admitted",
+    "inv2_candidate_not_recallable_before_admission",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.proposed"
+  ],
+  "draft_vocab_used": [
+    "candidate_state",
+    "recall_eligible",
+    "rendered_candidate_payload",
+    "admission_transition"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: the pre-admission state uses the canonical Straylight AssertionStatus 'proposed' (Straylight-owned), NOT the Freeside-local proof label 'candidate_pending'. The scenario_id keeps the descriptive name 'candidate_pending_not_recallable' purely as a scenario label, never as a status value.",
+    "Pending-vs-denied distinction: a candidate with NO admission_transition is simply 'proposed'. This is deliberately distinct from a denied candidate (see reject-candidate-no-assertion.json, which carries a 'transition_denied' audit event). The two must not be collapsed.",
+    "Field names under draft_vocab_used are directional proposals subject to cross-repo reconciliation; only the canonical_vocab_used terms are treated as upstream-owned."
+  ],
+  "input": {
+    "candidate_id": "cand_demo_001",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "proposed_assertion_class": "observation",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-001",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-001"
+  },
+  "admission_transition": null,
+  "admitted_assertion": null,
+  "recall_projection": {
+    "ordinary_recall_members": [],
+    "explanation": "No admitted, active assertion exists; the proposed candidate is excluded from ordinary recall."
+  },
+  "public_response": {
+    "outcome": "accepted_as_proposed",
+    "candidate_state": "proposed",
+    "recall_eligible": false,
+    "rendered_candidate_payload": false,
+    "public_summary": "Candidate recorded as proposed. Not admitted and not recallable until an explicit admission transition accepts it."
+  },
+  "audit": {
+    "receipt_id": "rcpt_demo_001",
+    "candidate_id": "cand_demo_001",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-001",
+    "source_ref": "unsafe_marker:source-ref-demo-001",
+    "decision": "none_yet",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/dixie-probes/malformed-or-unsafe-payload-fail-closed.json
+++ b/docs/admission-wedge/dixie-probes/malformed-or-unsafe-payload-fail-closed.json
@@ -1,0 +1,72 @@
+{
+  "_local_mirror": {
+    "note": "LOCAL MIRROR for Phase 45F adapter tests — NOT canonical upstream truth.",
+    "canonical_source": "loa-dixie Phase 33C / PR #120 · docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json",
+    "mirror_phase": "freeside-characters Phase 45F",
+    "mirror_status": "draft_v0 · non_runtime · not_final_schema",
+    "local_scenario": "malformed_fail_closed",
+    "creates_freeside_runtime_behavior": false,
+    "refresh_policy": "refresh/reconcile only through a future gate if the Dixie probes change"
+  },
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "malformed_or_unsafe_payload_fail_closed",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A malformed or unsafe candidate input is presented; the path fails closed with a stable reason code, mints no admitted assertion, and leaks no raw payload, unsafe marker, source material, or stack trace into the public response.",
+  "invariant_refs": [
+    "inv6_fail_closed_no_leak",
+    "inv3_accepted_transition_creates_or_references_admitted_assertion",
+    "inv2_candidate_not_recallable_before_admission"
+  ],
+  "canonical_vocab_used": [],
+  "draft_vocab_used": [
+    "reason_code",
+    "recall_eligible",
+    "rendered_candidate_payload"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Reason-code alignment: the public reason_code is grounded in the existing Dixie-local refusal family, NOT a coined 'unsupported_admission_shape' or 'unsafe_*' public code. A malformed envelope maps to 'ingress.invalid_request' (HTTP-400-shaped at ingress); an unsupported assertion class would instead map to 'seam.class_validation_failed'. These exact strings exist today in app/src/services/straylight-recall-intake/refusal-mapping.ts and are Dixie-owned (not Straylight-owned).",
+    "No-leak seal: the unsafe input lives only in the 'input' and 'audit' sections and carries a generic synthetic 'unsafe_marker:' token (NOT the Freeside-local sentinel string). The public_response must contain no unsafe_marker, no raw payload, no source material, and no stack trace. The validator proves this by deep-walking public_response.",
+    "Public/audit split: admission decides its own split explicitly and does NOT inherit the recall default. raw_reasons that could carry internal/unsafe material are OMITTED from the public body and retained only on the audit object — mirroring the Phase 32K storage_unavailable posture, applied here by deliberate choice.",
+    "No admitted assertion is minted on the fail-closed path."
+  ],
+  "input": {
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "malformed": true,
+    "proposed_assertion_class": "not_a_valid_class_demo",
+    "candidate_payload": "unsafe_marker:malformed-body-demo-005",
+    "source_ref": "unsafe_marker:source-ref-demo-005"
+  },
+  "admission_transition": null,
+  "admitted_assertion": null,
+  "recall_projection": {
+    "ordinary_recall_members": [],
+    "explanation": "Input failed closed before any admission; no assertion exists and nothing enters ordinary recall."
+  },
+  "public_response": {
+    "outcome": "refused",
+    "reason_code": "ingress.invalid_request",
+    "recall_eligible": false,
+    "rendered_candidate_payload": false,
+    "public_summary": "The admission request was malformed and was refused. No candidate detail is echoed."
+  },
+  "audit": {
+    "refusal_class": "ingress.invalid_request",
+    "raw_reasons": [
+      "unsafe_marker:malformed-body-demo-005",
+      "draft_probe_validation: proposed_assertion_class not in canonical AssertionClass union"
+    ],
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "candidate_payload": "unsafe_marker:malformed-body-demo-005",
+    "source_ref": "unsafe_marker:source-ref-demo-005",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/dixie-probes/reject-candidate-no-assertion.json
+++ b/docs/admission-wedge/dixie-probes/reject-candidate-no-assertion.json
@@ -1,0 +1,90 @@
+{
+  "_local_mirror": {
+    "note": "LOCAL MIRROR for Phase 45F adapter tests — NOT canonical upstream truth.",
+    "canonical_source": "loa-dixie Phase 33C / PR #120 · docs/admission-wedge/fixtures/reject-candidate-no-assertion.json",
+    "mirror_phase": "freeside-characters Phase 45F",
+    "mirror_status": "draft_v0 · non_runtime · not_final_schema",
+    "local_scenario": "rejected_excluded",
+    "creates_freeside_runtime_behavior": false,
+    "refresh_policy": "refresh/reconcile only through a future gate if the Dixie probes change"
+  },
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "reject_candidate_no_assertion",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A proposed candidate is denied admission; no admitted assertion is minted, the candidate remains non-recallable, and a rejection receipt exists on the audit boundary.",
+  "invariant_refs": [
+    "inv4_rejected_candidate_never_recallable",
+    "inv3_accepted_transition_creates_or_references_admitted_assertion",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.proposed",
+    "Transition.admit_assertion",
+    "AuditEvent.transition_denied"
+  ],
+  "draft_vocab_used": [
+    "source_candidate_id",
+    "recall_eligible",
+    "rendered_candidate_payload",
+    "receipt_public_ref"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: rejection is anchored on the canonical Straylight audit event 'transition_denied' (a denied 'admit_assertion' transition). The probe deliberately does NOT coin a parallel 'rejected' status.",
+    "Synonym-collision flag: the Freeside-local proof labels 'rejected', 'candidate_rejected', and 'candidate_not_admitted' are a three-way synonym collision and are referenced here as proof labels only, all reconciling onto 'transition_denied'. Note 'candidate_not_admitted' (pending, never decided) is semantically distinct from an explicit denial; this probe is the explicit-denial case.",
+    "Rejection is terminal for recall eligibility; any future appeal/correction path is separately gated and not implied here.",
+    "Receipt/audit split: the public_response carries only a stable outcome and public summary; the denial receipt (policy reason, candidate ref, audit event) lives on the audit object."
+  ],
+  "input": {
+    "candidate_id": "cand_demo_003",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "proposed_assertion_class": "claim",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-003",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-003"
+  },
+  "admission_transition": {
+    "admission_transition_id": "trans_demo_002",
+    "transition_kind": "admit_assertion",
+    "outcome": "denied",
+    "source_candidate_id": "cand_demo_003",
+    "admitted_assertion_id": null,
+    "authority_signer_type_draft": "policy_service",
+    "policy_decision": "denied_by_policy"
+  },
+  "admitted_assertion": null,
+  "recall_projection": {
+    "ordinary_recall_members": [],
+    "explanation": "No admitted assertion was minted; the denied candidate is excluded from ordinary recall and remains non-recallable."
+  },
+  "public_response": {
+    "outcome": "denied",
+    "recall_eligible": false,
+    "rendered_candidate_payload": false,
+    "public_summary": "Candidate admission was denied. No assertion was created and the candidate is not recallable."
+  },
+  "audit": {
+    "admission_receipt": {
+      "receipt_id": "rcpt_demo_003",
+      "decision_time_label": "demo_decision_time",
+      "service_actor": "actor_demo",
+      "policy_reason": "denied_by_policy",
+      "source_candidate_id": "cand_demo_003",
+      "admitted_assertion_id": null,
+      "recall_eligibility_result": "not_eligible",
+      "audit_event": "transition_denied"
+    },
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-003",
+    "source_ref": "unsafe_marker:source-ref-demo-003",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/dixie-probes/supersede-with-corrected-assertion.json
+++ b/docs/admission-wedge/dixie-probes/supersede-with-corrected-assertion.json
@@ -1,0 +1,125 @@
+{
+  "_local_mirror": {
+    "note": "LOCAL MIRROR for Phase 45F adapter tests — NOT canonical upstream truth.",
+    "canonical_source": "loa-dixie Phase 33C / PR #120 · docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json",
+    "mirror_phase": "freeside-characters Phase 45F",
+    "mirror_status": "draft_v0 · non_runtime · not_final_schema",
+    "local_scenario": "supersession_corrected_only",
+    "creates_freeside_runtime_behavior": false,
+    "refresh_policy": "refresh/reconcile only through a future gate if the Dixie probes change"
+  },
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "supersede_with_corrected_assertion",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "An existing active assertion is superseded by a corrected active assertion; ordinary recall includes only the corrected active assertion while the superseded prior state remains audit/provenance only.",
+  "invariant_refs": [
+    "inv5_supersession_auditable_recall_active_only",
+    "inv2_candidate_not_recallable_before_admission",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.active",
+    "AssertionStatus.superseded",
+    "RecallUseInstruction.usable",
+    "RecallUseInstruction.do_not_use_for_action"
+  ],
+  "draft_vocab_used": [
+    "supersedes_assertion_id",
+    "superseded_by_assertion_id",
+    "supersession_transition_id",
+    "recall_eligible",
+    "recall_use_instruction",
+    "rendered_candidate_payload",
+    "receipt_public_ref"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: correction is expressed as the canonical (superseded, active) PAIR — the prior assertion moves to canonical status 'superseded' and the corrected assertion is canonical status 'active' with a supersede link. The probe deliberately does NOT coin a 'corrected'/'corrected_active' status; 'corrected active' is direction, not a new status value.",
+    "The superseded prior remains audit/provenance only: recall_eligible is false on the superseded record (signalled with RecallUseInstruction 'do_not_use_for_action'), and it is excluded from ordinary recall.",
+    "Supersession is a follow-on transition over an already-admitted assertion, not a first-pass admission outcome.",
+    "Forget/revoke/correction UI remains out of scope; this probe defines no user-facing correction surface.",
+    "Link field names (supersedes_assertion_id, superseded_by_assertion_id, supersession_transition_id) are DRAFT and subject to reconciliation against Straylight-owned assertion types."
+  ],
+  "input": {
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "correcting_actor_id": "actor_demo",
+    "prior_assertion_id": "assn_demo_002",
+    "corrected_candidate_payload": "unsafe_marker:candidate-body-demo-004",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-004"
+  },
+  "supersession_transition": {
+    "supersession_transition_id": "trans_demo_003",
+    "transition_kind": "admit_assertion",
+    "outcome": "accepted",
+    "supersedes_assertion_id": "assn_demo_002",
+    "corrected_assertion_id": "assn_demo_003",
+    "authority_signer_type_draft": "policy_service",
+    "policy_decision": "correction_accepted_under_policy"
+  },
+  "assertions": [
+    {
+      "assertion_id": "assn_demo_002",
+      "assertion_status": "superseded",
+      "assertion_class": "claim",
+      "superseded_by_assertion_id": "assn_demo_003",
+      "recall_eligible": false,
+      "recall_use_instruction": "do_not_use_for_action",
+      "audit_provenance_only": true
+    },
+    {
+      "assertion_id": "assn_demo_003",
+      "assertion_status": "active",
+      "assertion_class": "claim",
+      "supersedes_assertion_id": "assn_demo_002",
+      "recall_eligible": true,
+      "recall_use_instruction": "usable"
+    }
+  ],
+  "recall_projection": {
+    "ordinary_recall_members": [
+      "assn_demo_003"
+    ],
+    "excluded_from_ordinary_recall": [
+      "assn_demo_002"
+    ],
+    "explanation": "Ordinary recall includes the corrected active assertion only. The superseded prior assertion is retained for audit/provenance and excluded from ordinary recall."
+  },
+  "public_response": {
+    "outcome": "superseded_with_correction",
+    "active_assertion_status": "active",
+    "recall_eligible": true,
+    "recall_use_instruction": "usable",
+    "rendered_candidate_payload": false,
+    "receipt_public_ref": "rcpt_demo_004",
+    "public_summary": "A corrected active assertion now supersedes the prior assertion. Ordinary recall reflects only the corrected active assertion."
+  },
+  "audit": {
+    "supersession_receipt": {
+      "receipt_id": "rcpt_demo_004",
+      "decision_time_label": "demo_decision_time",
+      "service_actor": "actor_demo",
+      "policy_reason": "correction_accepted_under_policy",
+      "supersedes_assertion_id": "assn_demo_002",
+      "corrected_assertion_id": "assn_demo_003",
+      "recall_eligibility_result": "corrected_active_eligible",
+      "audit_event": "assertion_admitted"
+    },
+    "superseded_prior": {
+      "assertion_id": "assn_demo_002",
+      "assertion_status": "superseded",
+      "candidate_payload": "unsafe_marker:prior-body-demo-004"
+    },
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "corrected_candidate_payload": "unsafe_marker:candidate-body-demo-004",
+    "source_ref": "unsafe_marker:source-ref-demo-004",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/fixtures/README.md
+++ b/docs/admission-wedge/fixtures/README.md
@@ -327,3 +327,17 @@ it (decision-map §7) — Phase 43C authorizes none of them.
   docs / fixture-bound no-op Dixie probe adapter / validator** as the next
   lane; live admission, storage, command, Dixie route, package export, and
   Finn production wiring stay blocked.
+- `docs/admission-wedge/dixie-probes/` + `packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts`
+  (+ `.test.ts`) — **Phase 45F** test-only / docs-fixture-bound no-op Dixie
+  probe adapter / validator. It adds local **mirrored** copies of the Dixie
+  Phase 33C draft v0 probes (clearly marked local mirrors, not canonical
+  upstream truth) and a pure local adapter that maps the five Dixie probe
+  scenarios onto the current local proof scenarios (`before_admission_excluded`,
+  `accepted_admitted_included`, `rejected_excluded`,
+  `supersession_corrected_only`, `malformed_fail_closed`), proving semantic
+  equivalence against the existing Phase 44A reducer / Phase 44C runner output.
+  It **mutates no fixture JSON here** and **renames none of these fixtures'
+  labels** — it proves semantic mapping only. It mutates no reducer reason code,
+  calls no live Dixie, wires no runtime path, and is not exported from the
+  package surface; live admission, storage, command, Dixie route, package
+  export, and Finn production wiring stay blocked.

--- a/packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.test.ts
+++ b/packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.test.ts
@@ -1,0 +1,749 @@
+// Phase 45F · Admission Wedge — Dixie probe no-op adapter / validator regression
+// gate.
+//
+// Authority: docs/ADMISSION-WEDGE-DIXIE-PROBE-RECONCILIATION-GATE.md (Phase 45E
+// §6 / §10 / §11), over the locally MIRRORED Dixie Phase 33C draft v0 probes
+// (docs/admission-wedge/dixie-probes/), the Phase 44A reducer, and the Phase
+// 44C runner.
+//
+// These tests prove:
+//   1. all five Dixie probes map to the expected local proof scenarios;
+//   2. each mapping is semantically equivalent to the CURRENT local proof stack
+//      — cross-checked against the Phase 44A reducer's output over the existing
+//      Phase 43C fixtures (the same scenario plans the Phase 44C runner uses),
+//      not a reimplementation;
+//   3. the adapter results + formatted summaries leak nothing
+//      (raw payload / unsafe marker / private sentinel / raw fixture body /
+//      source material / stack trace / urls / jwt / pem / Bearer / sk- / long
+//      ids / 0x hex / audit-only keys / operational ids);
+//   4. synthetic malformed input (with unsafe strings + long ids) fails closed
+//      with a stable reason and no echo of the raw input;
+//   5. the adapter is wired into no runtime path and is not exported from the
+//      package surface;
+//   6. the adapter itself reads no file / network / env / clock and imports only
+//      the pure Phase 44A reducer.
+//
+// The adapter is a pure mapping layer: this test reads the mirrored probe JSON
+// from disk with node:fs and passes the parsed objects in. The adapter never
+// reads a file.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ADMISSION_REDUCER_REASON_CODES,
+  reduceAdmissionFixtureScenario,
+  scanForUnsafeProjection,
+  type AdmissionReducerReasonCode,
+} from "./admission-wedge-fixture-reducer.ts";
+import {
+  DIXIE_PROBE_ADAPTER_REASON_CODES,
+  DIXIE_PROBE_SCENARIO_IDS,
+  DIXIE_TO_LOCAL_SCENARIO,
+  LOCAL_ADMISSION_SCENARIOS,
+  SUPPORTED_DIXIE_PROBE_VERSION,
+  mapDixieProbe,
+  mapDixieProbes,
+  safeDixieProbeDetail,
+  type DixieProbeAlignment,
+  type DixieProbeAlignmentOk,
+} from "./admission-wedge-dixie-probe-adapter.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROBES_DIR = resolve(
+  __dirname,
+  "../../../../docs/admission-wedge/dixie-probes",
+);
+const FIXTURE_DIR = resolve(
+  __dirname,
+  "../../../../docs/admission-wedge/fixtures",
+);
+function loadFixture(relPath: string): unknown {
+  return JSON.parse(readFileSync(resolve(FIXTURE_DIR, relPath), "utf8"));
+}
+
+// scenario_id -> mirrored probe filename.
+const PROBE_FILES: Record<string, string> = {
+  candidate_pending_not_recallable: "candidate-pending-not-recallable.json",
+  accept_candidate_to_admitted_assertion:
+    "accept-candidate-to-admitted-assertion.json",
+  reject_candidate_no_assertion: "reject-candidate-no-assertion.json",
+  supersede_with_corrected_assertion: "supersede-with-corrected-assertion.json",
+  malformed_or_unsafe_payload_fail_closed:
+    "malformed-or-unsafe-payload-fail-closed.json",
+};
+
+function loadProbeRaw(scenarioId: string): string {
+  return readFileSync(resolve(PROBES_DIR, PROBE_FILES[scenarioId]), "utf8");
+}
+function loadProbe(scenarioId: string): unknown {
+  return JSON.parse(loadProbeRaw(scenarioId));
+}
+
+// Every string emitted anywhere in a value (recursively).
+function collectStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") out.push(value);
+  else if (Array.isArray(value)) for (const v of value) collectStrings(v, out);
+  else if (value && typeof value === "object")
+    for (const v of Object.values(value)) collectStrings(v, out);
+  return out;
+}
+
+// A flat "formatted summary" of an alignment result, the kind a human / future
+// runner would print. Built in the TEST (the adapter stays a pure mapping
+// layer). Scanned for leaks alongside the serialized result.
+function formatAlignment(a: DixieProbeAlignment): string {
+  const lines: string[] = [`alignmentStatus: ${a.alignmentStatus}`];
+  if (a.ok) {
+    lines.push(
+      `dixieScenario: ${a.dixieScenario}`,
+      `localScenario: ${a.localScenario}`,
+      `dixieProbeVersion: ${a.dixieProbeVersion}`,
+      `outcomeClassification: ${a.outcomeClassification}`,
+      `localReasonCode: ${a.localReasonCode}`,
+      `semanticAssertions:\n${a.semanticAssertions.map((s) => `  - ${s}`).join("\n")}`,
+      `notes:\n${a.notes.map((s) => `  - ${s}`).join("\n")}`,
+      `publicSafe: ${String(a.publicSafe)}`,
+    );
+  } else {
+    lines.push(
+      `reasonCode: ${a.reasonCode}`,
+      `detail: ${a.detail}`,
+      `publicSafe: ${String(a.publicSafe)}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+const LOCAL_REASON_CODE_SET = new Set<string>(
+  Object.values(ADMISSION_REDUCER_REASON_CODES),
+);
+
+// The CURRENT local proof stack: the existing Phase 44A reducer over the
+// existing Phase 43C fixtures, exercised with the SAME scenario plans the Phase
+// 44C runner uses. We call the reducer directly (no reimplementation, no runner
+// import) and project a small summary the same way the runner does, so the
+// adapter's mapping is cross-checked against real local proof output.
+interface LocalProofSummary {
+  readonly outcome: "excluded" | "included" | "fail_closed";
+  readonly reasonCode: AdmissionReducerReasonCode;
+  readonly includedAssertionIds: readonly string[];
+  readonly excludedIds: readonly string[];
+}
+
+// the Phase 44C runner's synthetic in-memory malformed candidate (replicated
+// here so the local malformed proof is exercised without importing the runner).
+function buildMalformedCandidate(): Record<string, unknown> {
+  return {
+    fixture_kind: "candidate_memory_packet",
+    fixture_version: "phase-43c.0",
+    candidate_id: "cand-malformed-99999999999999999999-CANDIDATE_PRIVATE_SENTINEL_DEMO",
+    actor_id: "freeside-characters:shared-substrate",
+    recall_eligibility: "eligible",
+    admission_state: "candidate_pending",
+    candidate_payload: { boundary: "public_safe", body_private: "never rendered" },
+  };
+}
+
+function localProof(name: string): LocalProofSummary {
+  let proof;
+  switch (name) {
+    case "before_admission_excluded":
+      proof = reduceAdmissionFixtureScenario({
+        kind: "before_admission",
+        candidate: loadFixture("candidates/cand-001-accepted-pending.json"),
+        recallProof: loadFixture(
+          "recall-proofs/proof-001-before-admission-excluded.json",
+        ),
+      });
+      break;
+    case "accepted_admitted_included":
+      proof = reduceAdmissionFixtureScenario({
+        kind: "accepted",
+        candidate: loadFixture("candidates/cand-001-accepted-pending.json"),
+        transition: loadFixture("transitions/trans-001-accept.json"),
+        admittedAssertion: loadFixture("admitted/assn-001-active.json"),
+        recallProof: loadFixture(
+          "recall-proofs/proof-002-after-admission-included.json",
+        ),
+      });
+      break;
+    case "rejected_excluded":
+      proof = reduceAdmissionFixtureScenario({
+        kind: "rejected",
+        candidate: loadFixture("candidates/cand-002-rejected-pending.json"),
+        transition: loadFixture("transitions/trans-002-reject.json"),
+        recallProof: loadFixture(
+          "recall-proofs/proof-003-rejected-excluded.json",
+        ),
+      });
+      break;
+    case "supersession_corrected_only":
+      proof = reduceAdmissionFixtureScenario({
+        kind: "supersession",
+        correctionCandidate: loadFixture(
+          "candidates/cand-011-correction-pending.json",
+        ),
+        supersedeTransition: loadFixture("transitions/trans-011-supersede.json"),
+        correctedAssertion: loadFixture(
+          "admitted/assn-011-active-correction.json",
+        ),
+        supersededAssertion: loadFixture("admitted/assn-010-superseded.json"),
+        recallProof: loadFixture(
+          "recall-proofs/proof-004-supersession-corrected.json",
+        ),
+      });
+      break;
+    case "malformed_fail_closed":
+      proof = reduceAdmissionFixtureScenario({
+        kind: "before_admission",
+        candidate: buildMalformedCandidate(),
+        recallProof: loadFixture(
+          "recall-proofs/proof-001-before-admission-excluded.json",
+        ),
+      });
+      break;
+    default:
+      throw new Error(`unknown local scenario: ${name}`);
+  }
+
+  if (!proof.ok) {
+    return {
+      outcome: "fail_closed",
+      reasonCode: proof.reasonCode,
+      includedAssertionIds: [],
+      excludedIds: [],
+    };
+  }
+  if (proof.recall.recallResult === "excluded") {
+    return {
+      outcome: "excluded",
+      reasonCode: proof.recall.reasonCode,
+      includedAssertionIds: [],
+      excludedIds: proof.recall.excludedCandidateIds,
+    };
+  }
+  return {
+    outcome: "included",
+    reasonCode: proof.recall.reasonCode,
+    includedAssertionIds: proof.recall.includedAssertionIds,
+    excludedIds: proof.recall.excludedAssertionIds,
+  };
+}
+
+// =========================================================================
+// 0. mirror sanity — non-vacuous: the mirrored probes carry the unsafe
+//    markers / ids we later prove never leak through the adapter.
+// =========================================================================
+
+describe("Phase 45F · 0. mirrored probe sanity (non-vacuous)", () => {
+  test("every mirrored probe exists, parses, and is a draft-v0 mirror", () => {
+    for (const id of DIXIE_PROBE_SCENARIO_IDS) {
+      const probe = loadProbe(id) as Record<string, unknown>;
+      expect(probe.probe_version).toBe(SUPPORTED_DIXIE_PROBE_VERSION);
+      expect(probe.scenario_id).toBe(id);
+      expect(probe.schema_final).toBe(false);
+      expect(probe.runtime_enabled).toBe(false);
+      expect(probe.production_admission).toBe(false);
+      expect(probe.public_safe).toBe(true);
+      // the local-mirror marker is present and self-describes as non-canonical,
+      // non-runtime, draft.
+      const marker = probe._local_mirror as Record<string, unknown>;
+      expect(marker).toBeTruthy();
+      expect(String(marker.canonical_source)).toContain("loa-dixie Phase 33C");
+      expect(marker.creates_freeside_runtime_behavior).toBe(false);
+    }
+  });
+
+  test("the private sections genuinely carry the material the no-leak tests forbid", () => {
+    // Non-vacuous: every mirror genuinely carries the Dixie 'unsafe_marker:'
+    // token, demo ids, and audit-only keys in its private input / audit
+    // sections — exactly the material the §3 no-leak tests prove never reaches
+    // the adapter's output. (The Dixie probes deliberately use 'unsafe_marker:'
+    // rather than the Freeside sentinel string, so the reducer's
+    // scanForUnsafeProjection — which keys off Freeside sentinels / long ids /
+    // urls — does NOT flag them; the no-leak proof here is substring-based.)
+    for (const id of DIXIE_PROBE_SCENARIO_IDS) {
+      const raw = loadProbeRaw(id);
+      expect(raw).toContain("unsafe_marker:");
+      expect(raw).toContain("_demo");
+      expect(raw).toContain("audit");
+      expect(raw).toContain("candidate_payload");
+    }
+  });
+});
+
+// =========================================================================
+// 1. all five Dixie probes map to the expected local scenarios
+// =========================================================================
+
+describe("Phase 45F · 1. five required probe -> local scenario mappings", () => {
+  const REQUIRED: ReadonlyArray<[string, string]> = [
+    ["candidate_pending_not_recallable", "before_admission_excluded"],
+    ["accept_candidate_to_admitted_assertion", "accepted_admitted_included"],
+    ["reject_candidate_no_assertion", "rejected_excluded"],
+    ["supersede_with_corrected_assertion", "supersession_corrected_only"],
+    ["malformed_or_unsafe_payload_fail_closed", "malformed_fail_closed"],
+  ];
+
+  for (const [dixieScenario, localScenario] of REQUIRED) {
+    test(`${dixieScenario} -> ${localScenario}`, () => {
+      const r = mapDixieProbe(loadProbe(dixieScenario));
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.dixieScenario).toBe(dixieScenario as never);
+      expect(r.localScenario).toBe(localScenario as never);
+      expect(r.alignmentStatus).toBe("aligned_semantics");
+      expect(r.dixieProbeVersion).toBe(SUPPORTED_DIXIE_PROBE_VERSION);
+      expect(r.publicSafe).toBe(true);
+    });
+  }
+
+  test("the exported flat mapping table matches the required mappings", () => {
+    expect(DIXIE_TO_LOCAL_SCENARIO).toEqual({
+      candidate_pending_not_recallable: "before_admission_excluded",
+      accept_candidate_to_admitted_assertion: "accepted_admitted_included",
+      reject_candidate_no_assertion: "rejected_excluded",
+      supersede_with_corrected_assertion: "supersession_corrected_only",
+      malformed_or_unsafe_payload_fail_closed: "malformed_fail_closed",
+    });
+  });
+
+  test("mapDixieProbes batch-maps every mirrored probe", () => {
+    const probes = DIXIE_PROBE_SCENARIO_IDS.map((id) => loadProbe(id));
+    const results = mapDixieProbes(probes);
+    expect(results.length).toBe(5);
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(
+      results.map((r) => (r.ok ? r.localScenario : "fail")),
+    ).toEqual([...LOCAL_ADMISSION_SCENARIOS]);
+  });
+});
+
+// =========================================================================
+// 2. semantic equivalence to the CURRENT local proof stack (the Phase 44A
+//    reducer over the existing Phase 43C fixtures, same scenario plans the
+//    Phase 44C runner uses) — not a reimplementation.
+// =========================================================================
+
+describe("Phase 45F · 2. semantic equivalence to the local proof stack", () => {
+  // For every Dixie probe, the adapter's mapped local scenario + outcome must
+  // match what the Phase 44A reducer actually produces for that local scenario.
+  test("adapter outcomeClassification matches the local reducer outcome per scenario", () => {
+    for (const id of DIXIE_PROBE_SCENARIO_IDS) {
+      const r = mapDixieProbe(loadProbe(id));
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const summary = localProof(r.localScenario);
+      expect(r.outcomeClassification).toBe(summary.outcome);
+    }
+  });
+
+  // For the four non-malformed scenarios the local reducer reason code is exact
+  // and stable, so the adapter's localReasonCode must equal the reducer's.
+  test("adapter localReasonCode matches the local reducer reason code (non-malformed)", () => {
+    const exact: ReadonlyArray<[string, string]> = [
+      ["candidate_pending_not_recallable", "before_admission_excluded"],
+      ["accept_candidate_to_admitted_assertion", "accepted_admitted_included"],
+      ["reject_candidate_no_assertion", "rejected_excluded"],
+      ["supersede_with_corrected_assertion", "supersession_corrected_only"],
+    ];
+    for (const [dixieScenario, localScenario] of exact) {
+      const r = mapDixieProbe(loadProbe(dixieScenario)) as DixieProbeAlignmentOk;
+      expect(r.ok).toBe(true);
+      const summary = localProof(localScenario);
+      expect(r.localReasonCode).toBe(summary.reasonCode);
+    }
+  });
+
+  // The malformed local fail-closed family has several stable codes; the local
+  // synthetic input trips candidate_recall_eligible_before_admission, while the
+  // adapter cites unsupported_fixture_shape as the representative family member.
+  // Both must be VALID local reducer codes and both must classify fail_closed.
+  test("malformed maps to a valid local fail-closed reducer code (family member)", () => {
+    const r = mapDixieProbe(
+      loadProbe("malformed_or_unsafe_payload_fail_closed"),
+    ) as DixieProbeAlignmentOk;
+    expect(r.ok).toBe(true);
+    expect(r.outcomeClassification).toBe("fail_closed");
+    expect(LOCAL_REASON_CODE_SET.has(r.localReasonCode)).toBe(true);
+    const summary = localProof("malformed_fail_closed");
+    expect(summary.outcome).toBe("fail_closed");
+    expect(LOCAL_REASON_CODE_SET.has(summary.reasonCode)).toBe(true);
+  });
+
+  // The aligned local meaning, asserted against the reducer's actual recall
+  // material per scenario (the reducer output IS the local proof stack output).
+  test("pending candidate is excluded from recall", () => {
+    const s = localProof("before_admission_excluded");
+    expect(s.outcome).toBe("excluded");
+    expect(s.includedAssertionIds).toEqual([]);
+    expect(s.excludedIds).toContain("cand-001");
+  });
+
+  test("accepted candidate yields an admitted active assertion inclusion", () => {
+    const s = localProof("accepted_admitted_included");
+    expect(s.outcome).toBe("included");
+    expect(s.includedAssertionIds).toEqual(["assn-001"]);
+    expect(s.reasonCode).toBe(
+      ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion,
+    );
+  });
+
+  test("rejected candidate yields no admitted assertion and stays excluded", () => {
+    const s = localProof("rejected_excluded");
+    expect(s.outcome).toBe("excluded");
+    expect(s.includedAssertionIds).toEqual([]);
+    expect(s.excludedIds).toContain("cand-002");
+  });
+
+  test("supersession includes corrected active only, excludes superseded prior", () => {
+    const s = localProof("supersession_corrected_only");
+    expect(s.outcome).toBe("included");
+    expect(s.includedAssertionIds).toEqual(["assn-011"]);
+    expect(s.includedAssertionIds).not.toContain("assn-010");
+    expect(s.excludedIds).toContain("assn-010");
+  });
+
+  test("malformed/unsafe fails closed with empty recall material", () => {
+    const s = localProof("malformed_fail_closed");
+    expect(s.outcome).toBe("fail_closed");
+    expect(s.includedAssertionIds).toEqual([]);
+    expect(s.excludedIds).toEqual([]);
+  });
+});
+
+// =========================================================================
+// 3. no-leak posture over adapter results + formatted summaries
+// =========================================================================
+
+describe("Phase 45F · 3. no-leak over results + formatted summaries", () => {
+  const RESULTS = DIXIE_PROBE_SCENARIO_IDS.map((id) =>
+    mapDixieProbe(loadProbe(id)),
+  );
+  const SERIALIZED = RESULTS.map((r) => JSON.stringify(r));
+  const FORMATTED = RESULTS.map((r) => formatAlignment(r));
+  const ALL_OUTPUT = [...SERIALIZED, ...FORMATTED].join("\n\n");
+
+  test("the reducer no-leak scan passes on every adapter result", () => {
+    for (const r of RESULTS) expect(scanForUnsafeProjection(r)).toBeNull();
+  });
+
+  test("no unsafe marker / raw payload / source material anywhere in output", () => {
+    expect(ALL_OUTPUT).not.toContain("unsafe_marker");
+    expect(ALL_OUTPUT).not.toContain("candidate-body-demo");
+    expect(ALL_OUTPUT).not.toContain("source-ref-demo");
+    expect(ALL_OUTPUT).not.toContain("prior-body-demo");
+    expect(ALL_OUTPUT).not.toContain("candidate_payload");
+    expect(ALL_OUTPUT).not.toContain("source_ref");
+    expect(ALL_OUTPUT).not.toContain("source_material");
+    expect(ALL_OUTPUT).not.toContain("raw_reasons");
+  });
+
+  test("no private sentinels anywhere in output", () => {
+    for (const sentinel of [
+      "CANDIDATE_PRIVATE_SENTINEL",
+      "SOURCE_SENTINEL",
+      "ADMITTED_PRIVATE_SENTINEL",
+      "SUPERSEDED_PRIVATE_SENTINEL",
+    ]) {
+      expect(ALL_OUTPUT).not.toContain(sentinel);
+    }
+  });
+
+  test("no raw probe ids / tenant / estate / actor / receipt material in output", () => {
+    for (const needle of [
+      "cand_demo",
+      "assn_demo",
+      "trans_demo",
+      "rcpt_demo",
+      "tenant_demo",
+      "estate_demo",
+      "actor_demo",
+      "audit_only",
+    ]) {
+      expect(ALL_OUTPUT).not.toContain(needle);
+    }
+  });
+
+  test("no urls / jwt / pem / Bearer / sk- / long ids / 0x hex / stack traces", () => {
+    expect(ALL_OUTPUT).not.toMatch(/https?:\/\//i);
+    expect(ALL_OUTPUT).not.toMatch(/\beyJ[A-Za-z0-9_-]{8,}/); // JWT-ish
+    expect(ALL_OUTPUT).not.toMatch(/-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+    expect(ALL_OUTPUT).not.toMatch(/\bBearer\s+\S+/);
+    expect(ALL_OUTPUT).not.toMatch(/\bsk-[A-Za-z0-9]{12,}/);
+    expect(ALL_OUTPUT).not.toMatch(/\d{17,}/); // long id / Discord snowflake run
+    expect(ALL_OUTPUT).not.toMatch(/0x[a-fA-F0-9]{40,}/);
+    expect(ALL_OUTPUT).not.toContain("at Object.");
+    expect(ALL_OUTPUT).not.toMatch(/\n\s+at\s+\S+\s+\(/); // node stack frame
+    expect(ALL_OUTPUT).not.toContain("Error:");
+  });
+
+  test("success results carry only constant strings (no raw probe value reaches output)", () => {
+    for (const r of RESULTS) {
+      expect(r.ok).toBe(true);
+      if (!r.ok) continue;
+      for (const s of collectStrings(r)) {
+        // every emitted string is short and adapter-owned; in particular it is
+        // never a probe id, payload, or marker.
+        expect(s).not.toContain("demo");
+        expect(s).not.toContain("unsafe_marker");
+      }
+    }
+  });
+});
+
+// =========================================================================
+// 4. fail-closed on synthetic malformed input (never echoes raw input)
+// =========================================================================
+
+describe("Phase 45F · 4. fail-closed on malformed input", () => {
+  const LONG_ID = "12345678901234567890"; // 20-digit run
+  const UNSAFE = "unsafe_marker:synthetic-injected-body";
+  const SENTINEL = "CANDIDATE_PRIVATE_SENTINEL_X";
+
+  function expectSealedFail(r: DixieProbeAlignment, expectedReason: string): void {
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.alignmentStatus).toBe("fail_closed");
+    expect(r.reasonCode).toBe(expectedReason as never);
+    expect(typeof r.detail).toBe("string");
+    expect(r.detail.length).toBeGreaterThan(0);
+    expect(scanForUnsafeProjection(r)).toBeNull();
+  }
+
+  test("non-object input fails closed", () => {
+    for (const bad of [null, undefined, 42, "string", []]) {
+      expectSealedFail(
+        mapDixieProbe(bad),
+        DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape,
+      );
+    }
+  });
+
+  test("wrong probe_version fails closed without echoing injected values", () => {
+    const tampered = {
+      probe_kind: "admission_wedge_contract_probe",
+      probe_version: `${LONG_ID}-${UNSAFE}`,
+      scenario_id: "candidate_pending_not_recallable",
+      schema_final: false,
+      runtime_enabled: false,
+      production_admission: false,
+      public_safe: true,
+      public_response: { rendered_candidate_payload: false, recall_eligible: false },
+    };
+    // non-vacuous: the input genuinely carries the banned material.
+    expect(JSON.stringify(tampered)).toContain(LONG_ID);
+    expect(JSON.stringify(tampered)).toContain("unsafe_marker");
+    const r = mapDixieProbe(tampered);
+    expectSealedFail(r, DIXIE_PROBE_ADAPTER_REASON_CODES.unknown_probe_version);
+    const out = JSON.stringify(r);
+    expect(out).not.toContain(LONG_ID);
+    expect(out).not.toContain("unsafe_marker");
+  });
+
+  test("unknown scenario_id fails closed without echoing injected values", () => {
+    const tampered = {
+      probe_kind: "admission_wedge_contract_probe",
+      probe_version: SUPPORTED_DIXIE_PROBE_VERSION,
+      scenario_id: `unknown_${SENTINEL}_${LONG_ID}`,
+      schema_final: false,
+      runtime_enabled: false,
+      production_admission: false,
+      public_safe: true,
+      candidate_payload: UNSAFE,
+      public_response: { rendered_candidate_payload: false, recall_eligible: false },
+    };
+    expect(JSON.stringify(tampered)).toContain(SENTINEL);
+    expect(JSON.stringify(tampered)).toContain(LONG_ID);
+    const r = mapDixieProbe(tampered);
+    expectSealedFail(
+      r,
+      DIXIE_PROBE_ADAPTER_REASON_CODES.unknown_probe_scenario,
+    );
+    const out = JSON.stringify(r);
+    expect(out).not.toContain(SENTINEL);
+    expect(out).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+    expect(out).not.toContain(LONG_ID);
+    expect(out).not.toContain("unsafe_marker");
+  });
+
+  test("a probe claiming runtime_enabled / production_admission fails closed", () => {
+    const base = loadProbe("candidate_pending_not_recallable") as Record<
+      string,
+      unknown
+    >;
+    for (const claim of [
+      { schema_final: true },
+      { runtime_enabled: true },
+      { production_admission: true },
+      { public_safe: false },
+    ]) {
+      const tampered = { ...base, ...claim };
+      const r = mapDixieProbe(tampered);
+      expectSealedFail(
+        r,
+        DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape,
+      );
+    }
+  });
+
+  test("a public-surface that contradicts the mapped scenario fails closed", () => {
+    // tamper the pending probe's public surface to claim recall_eligible=true.
+    const base = loadProbe("candidate_pending_not_recallable") as Record<
+      string,
+      unknown
+    >;
+    const pr = { ...(base.public_response as Record<string, unknown>) };
+    pr.recall_eligible = true;
+    const tampered = { ...base, public_response: pr };
+    const r = mapDixieProbe(tampered);
+    expectSealedFail(
+      r,
+      DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+    );
+  });
+
+  test("a probe that renders the candidate payload fails closed", () => {
+    const base = loadProbe("accept_candidate_to_admitted_assertion") as Record<
+      string,
+      unknown
+    >;
+    const pr = { ...(base.public_response as Record<string, unknown>) };
+    pr.rendered_candidate_payload = true;
+    const tampered = { ...base, public_response: pr };
+    const r = mapDixieProbe(tampered);
+    expectSealedFail(
+      r,
+      DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+    );
+  });
+
+  test("safeDixieProbeDetail seals every detail by reason code", () => {
+    const code = DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape;
+    const sealed = safeDixieProbeDetail(code);
+    expect(sealed).toContain(code);
+    // an unknown / unsafe reason value still seals to a safe, code-bearing string.
+    const unsafe = safeDixieProbeDetail(
+      "CANDIDATE_PRIVATE_SENTINEL_X" as typeof code,
+    );
+    expect(unsafe).not.toContain("CANDIDATE_PRIVATE_SENTINEL");
+  });
+});
+
+// =========================================================================
+// 5. no runtime import / wiring (the adapter reaches nothing live)
+// =========================================================================
+
+describe("Phase 45F · 5. not wired into any runtime path", () => {
+  const adapterSource = readFileSync(
+    resolve(__dirname, "admission-wedge-dixie-probe-adapter.ts"),
+    "utf8",
+  );
+
+  test("adapter imports only the pure Phase 44A reducer", () => {
+    const importLines = adapterSource
+      .split("\n")
+      .filter((l) => /^\s*import\s/.test(l) || /^\s*}\s+from\s+["']/.test(l));
+    // the only module specifier the adapter imports from is the reducer.
+    const specifiers = [...adapterSource.matchAll(/from\s+["']([^"']+)["']/g)].map(
+      (m) => m[1],
+    );
+    expect(specifiers).toEqual(["./admission-wedge-fixture-reducer.ts"]);
+    void importLines;
+  });
+
+  test("adapter imports no Discord / dispatch / startup / registration", () => {
+    expect(adapterSource).not.toMatch(/from\s+["']discord\.js["']/);
+    expect(adapterSource).not.toMatch(
+      /from\s+["'][^"']*discord-interactions[^"']*["']/,
+    );
+    expect(adapterSource).not.toMatch(/from\s+["'][^"']*dispatch[^"']*["']/);
+    expect(adapterSource).not.toMatch(/from\s+["'][^"']*startup[^"']*["']/);
+    expect(adapterSource).not.toMatch(/registerCommand\s*\(/);
+    expect(adapterSource).not.toMatch(/applicationCommands/);
+  });
+
+  test("adapter imports no public renderer / live Dixie client / Dixie / Straylight", () => {
+    expect(adapterSource).not.toMatch(
+      /from\s+["'][^"']*render-public-recall[^"']*["']/,
+    );
+    expect(adapterSource).not.toMatch(
+      /from\s+["'][^"']*live-dixie-client[^"']*["']/,
+    );
+    expect(adapterSource).not.toMatch(
+      /from\s+["'][^"']*dixie-envelope-adapter[^"']*["']/,
+    );
+    expect(adapterSource).not.toMatch(/from\s+["']@loa\/dixie["']/);
+    expect(adapterSource).not.toMatch(/from\s+["']@loa\/straylight["']/);
+  });
+
+  test("adapter imports no LLM SDK / storage and reaches no fs / net / env / clock", () => {
+    expect(adapterSource).not.toMatch(
+      /from\s+["']@anthropic-ai\/claude-agent-sdk["']/,
+    );
+    expect(adapterSource).not.toMatch(/from\s+["']openai["']/);
+    expect(adapterSource).not.toMatch(/from\s+["']pg["']/);
+    expect(adapterSource).not.toMatch(/from\s+["']postgres["']/);
+    expect(adapterSource).not.toMatch(/from\s+["']node:fs["']/);
+    expect(adapterSource).not.toMatch(/from\s+["']node:http["']/);
+    expect(adapterSource).not.toMatch(/readFileSync/);
+    expect(adapterSource).not.toMatch(/\bfetch\s*\(/);
+    expect(adapterSource).not.toMatch(/process\.env/);
+    expect(adapterSource).not.toMatch(/Date\.now/);
+    expect(adapterSource).not.toMatch(/Math\.random/);
+  });
+
+  test("no source file other than the adapter + its test references the adapter", () => {
+    const repoRoot = resolve(__dirname, "../../../..");
+    const { execSync } =
+      require("node:child_process") as typeof import("node:child_process");
+    const raw = execSync(
+      "grep -rl --include='*.ts' --include='*.tsx' " +
+        "'admission-wedge-dixie-probe-adapter' . " +
+        "|| true",
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    const importers = raw
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .map((l) => l.replace(/^\.\//, ""));
+    const allowed = new Set([
+      "packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts",
+      "packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.test.ts",
+    ]);
+    for (const f of importers) {
+      expect(allowed.has(f)).toBe(true);
+    }
+  });
+
+  test("the adapter is not listed in the package.json exports map", () => {
+    const repoRoot = resolve(__dirname, "../../../..");
+    const pkg = readFileSync(
+      resolve(repoRoot, "packages/persona-engine/package.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(pkg) as { exports?: Record<string, unknown> };
+    const exportTargets = Object.values(parsed.exports ?? {}).map(String);
+    for (const target of exportTargets) {
+      expect(target).not.toContain("admission-wedge-dixie-probe-adapter");
+    }
+  });
+
+  test("adapter makes no live-admission / production claim (only negated disclaimers)", () => {
+    const lc = adapterSource.toLowerCase();
+    for (const phrase of [
+      "production admission",
+      "live dixie",
+      "production storage",
+      "live admission route",
+    ]) {
+      for (const line of lc.split("\n").filter((l) => l.includes(phrase))) {
+        expect(/\b(no|not|never|nothing|reaches no)\b/.test(line)).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts
+++ b/packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts
@@ -1,0 +1,434 @@
+// Phase 45F · Admission Wedge — Dixie probe no-op adapter / validator.
+//
+// Authority: docs/ADMISSION-WEDGE-DIXIE-PROBE-RECONCILIATION-GATE.md (Phase 45E
+// §6 probe-to-local mapping, §10 selected lane, §11 boundaries), over the Dixie
+// Phase 33C draft v0 contract probes — MIRRORED locally for tests at
+// docs/admission-wedge/dixie-probes/ — and the Freeside-local Admission Wedge
+// proof stack (Phase 43C fixtures · Phase 44A reducer · Phase 44C runner).
+//
+// What this adapter does:
+//   - It is a pure, local, no-op SEMANTIC MAPPING layer. Given an
+//     already-parsed Dixie probe object, it maps the probe's draft-v0 scenario
+//     to the current local Admission Wedge proof scenario and emits a small,
+//     safe, deterministic alignment result. It proves the two sides agree at
+//     the semantic level; it wires nothing.
+//   - It maps each of the five Dixie probe scenarios onto the local proof
+//     scenario names the Phase 44C runner already uses:
+//         candidate_pending_not_recallable        -> before_admission_excluded
+//         accept_candidate_to_admitted_assertion  -> accepted_admitted_included
+//         reject_candidate_no_assertion            -> rejected_excluded
+//         supersede_with_corrected_assertion       -> supersession_corrected_only
+//         malformed_or_unsafe_payload_fail_closed  -> malformed_fail_closed
+//   - It preserves both label sets: local fixture labels remain local PROOF
+//     labels, the local reducer reason codes remain local PROOF codes, and the
+//     Dixie probe labels remain Dixie-owned DRAFT v0 labels. It renames
+//     nothing, mutates no fixture JSON, and mutates no reducer reason code.
+//     Neither label set is a frozen final schema, and Freeside Characters does
+//     not own the Dixie / Straylight vocabulary.
+//
+// What this adapter is NOT (carried from the Phase 45E gate §11 / §12):
+//   - it is NOT pure-with-side-effects: it reads no filesystem, no network, no
+//     env, no clock, no storage, and no database. It is a pure function of its
+//     already-parsed input. (Its test loads the mirrored probe JSON from disk
+//     and passes the parsed objects in; the adapter itself never reads a file.)
+//   - it imports ONLY the pure, dependency-free Phase 44A reducer
+//     (./admission-wedge-fixture-reducer.ts) for the local reason-code table
+//     and the shared no-leak scan. It imports no Discord client, no dispatch /
+//     startup / command registration, no public renderer, no live Dixie client,
+//     and no LLM SDK;
+//   - it is NOT exported from the package surface, is NOT a Discord command, and
+//     is wired into NO runtime path. It is imported only by its own test;
+//   - it does NOT mutate the Phase 44A reducer or the Phase 44C runner, does NOT
+//     call live Dixie, does NOT add a live Dixie admission route, and authorizes
+//     NO production admission, production storage, production auth / consent,
+//     public remember-this, Discord history ingestion, or user chat becoming
+//     memory. All of those remain blocked.
+//
+// No-leak posture: the adapter reads ONLY the probe's public-safe surface
+// (top-level metadata booleans + public_response). It NEVER reads the probe's
+// private `input` / `audit` sections, candidate payload, source material, or
+// `unsafe_marker:` tokens. Every successful alignment result is built entirely
+// from adapter-owned CONSTANTS (never echoing a raw probe value), and every
+// returned result — success or fail-closed — is sealed through the reducer's
+// scanForUnsafeProjection before it is returned.
+
+import {
+  ADMISSION_REDUCER_REASON_CODES,
+  scanForUnsafeProjection,
+  type AdmissionReducerReasonCode,
+} from "./admission-wedge-fixture-reducer.ts";
+
+// -- vocabulary (preserved, not renamed) -----------------------------------
+
+// The Dixie draft v0 probe scenario ids (Dixie-owned DRAFT labels — preserved
+// verbatim, never coined or renamed here).
+export const DIXIE_PROBE_SCENARIO_IDS = [
+  "candidate_pending_not_recallable",
+  "accept_candidate_to_admitted_assertion",
+  "reject_candidate_no_assertion",
+  "supersede_with_corrected_assertion",
+  "malformed_or_unsafe_payload_fail_closed",
+] as const;
+export type DixieProbeScenarioId = (typeof DIXIE_PROBE_SCENARIO_IDS)[number];
+
+// The local proof scenario names — exactly the Phase 44C runner's scenario
+// labels (local PROOF labels — preserved verbatim, never renamed here).
+export const LOCAL_ADMISSION_SCENARIOS = [
+  "before_admission_excluded",
+  "accepted_admitted_included",
+  "rejected_excluded",
+  "supersession_corrected_only",
+  "malformed_fail_closed",
+] as const;
+export type LocalAdmissionScenario = (typeof LOCAL_ADMISSION_SCENARIOS)[number];
+
+// The one Dixie draft probe version this adapter understands. A different /
+// missing version fails closed (a future probe version reconciles under its own
+// gate; this adapter does not silently accept it).
+export const SUPPORTED_DIXIE_PROBE_VERSION =
+  "dixie_admission_wedge_probe_v0" as const;
+
+const SUPPORTED_PROBE_KIND = "admission_wedge_contract_probe" as const;
+
+// Dixie-owned refusal-family direction for the malformed probe's public path
+// (Dixie-local refusal codes, cited as DRAFT direction — not a Freeside code).
+const DIXIE_REFUSAL_FAMILY = new Set<string>([
+  "ingress.invalid_request",
+  "seam.class_validation_failed",
+]);
+
+// -- adapter fail-closed reason codes (stable, adapter-local) ---------------
+
+// Stable reason codes for the adapter's own fail-closed path. These are
+// adapter-local (they classify why a probe could not be mapped); they are NOT
+// the reducer's reason codes and do NOT mutate them.
+export const DIXIE_PROBE_ADAPTER_REASON_CODES = {
+  unsupported_probe_shape: "unsupported_probe_shape",
+  unknown_probe_version: "unknown_probe_version",
+  unknown_probe_scenario: "unknown_probe_scenario",
+  probe_public_surface_mismatch: "probe_public_surface_mismatch",
+  unsafe_probe_projection: "unsafe_probe_projection",
+} as const;
+export type DixieProbeAdapterReasonCode =
+  (typeof DIXIE_PROBE_ADAPTER_REASON_CODES)[keyof typeof DIXIE_PROBE_ADAPTER_REASON_CODES];
+
+const DIXIE_PROBE_ADAPTER_REASON_CODE_SET = new Set<string>(
+  Object.values(DIXIE_PROBE_ADAPTER_REASON_CODES),
+);
+
+// -- output shapes ----------------------------------------------------------
+
+export type AdmissionOutcomeClassification =
+  | "excluded"
+  | "included"
+  | "fail_closed";
+
+export interface DixieProbeAlignmentOk {
+  readonly ok: true;
+  // the matched Dixie scenario id — emitted from the adapter's known constant,
+  // never echoed from raw input.
+  readonly dixieScenario: DixieProbeScenarioId;
+  // the local proof scenario this Dixie probe maps onto (Phase 44C runner
+  // label — a local PROOF label, preserved).
+  readonly localScenario: LocalAdmissionScenario;
+  // the Dixie draft probe version (constant); marks this as DRAFT v0, not final.
+  readonly dixieProbeVersion: typeof SUPPORTED_DIXIE_PROBE_VERSION;
+  // semantics agree on every known probe; the only deltas are naming / shape.
+  readonly alignmentStatus: "aligned_semantics";
+  // stable outcome classification matching the Phase 44C runner's outcome enum.
+  readonly outcomeClassification: AdmissionOutcomeClassification;
+  // the LOCAL reducer reason code this scenario reconciles onto — a local PROOF
+  // code (preserved, not mutated). Drawn from ADMISSION_REDUCER_REASON_CODES.
+  readonly localReasonCode: AdmissionReducerReasonCode;
+  // canned, public-safe statements of the aligned local meaning.
+  readonly semanticAssertions: readonly string[];
+  // canned disclaimers: no rename, draft v0, not final schema, no-op only.
+  readonly notes: readonly string[];
+  readonly publicSafe: true;
+}
+
+export interface DixieProbeAlignmentFailClosed {
+  readonly ok: false;
+  readonly alignmentStatus: "fail_closed";
+  readonly reasonCode: DixieProbeAdapterReasonCode;
+  // sealed human breadcrumb built ONLY from the stable reason code — it carries
+  // no raw probe value, id, payload, unsafe marker, secret, url, or json body.
+  readonly detail: string;
+  readonly publicSafe: true;
+}
+
+export type DixieProbeAlignment =
+  | DixieProbeAlignmentOk
+  | DixieProbeAlignmentFailClosed;
+
+// -- shared disclaimer notes (constant, on every success result) ------------
+
+const ALIGNMENT_NOTES: readonly string[] = [
+  "no-op alignment only: no runtime wiring, no live Dixie call, no storage, no admission, no Discord behavior",
+  "local fixture labels remain local proof labels — this adapter renames nothing",
+  "local reducer reason codes remain local proof codes — this adapter mutates none of them",
+  "Dixie probe labels remain draft v0 (dixie_admission_wedge_probe_v0) — not final schema",
+  "neither label set is a frozen final schema; Freeside Characters does not own the Dixie or Straylight vocabulary",
+];
+
+// -- the scenario mapping table (all values are adapter-owned constants) ----
+
+interface ScenarioMapping {
+  readonly dixieScenario: DixieProbeScenarioId;
+  readonly localScenario: LocalAdmissionScenario;
+  readonly outcomeClassification: AdmissionOutcomeClassification;
+  readonly localReasonCode: AdmissionReducerReasonCode;
+  readonly semanticAssertions: readonly string[];
+  // public-surface expectations, checked against the probe's public_response.
+  readonly expectRecallEligible: boolean;
+  readonly expectOutcomeIsRefused: boolean;
+  readonly expectStableRefusalReasonCode: boolean;
+}
+
+const SCENARIO_MAPPINGS: Readonly<Record<DixieProbeScenarioId, ScenarioMapping>> =
+  {
+    candidate_pending_not_recallable: {
+      dixieScenario: "candidate_pending_not_recallable",
+      localScenario: "before_admission_excluded",
+      outcomeClassification: "excluded",
+      localReasonCode: ADMISSION_REDUCER_REASON_CODES.candidate_not_admitted,
+      semanticAssertions: [
+        "pending candidate is excluded from ordinary recall before admission",
+        "candidate is not admitted memory",
+        "candidate payload is not rendered on the public surface",
+      ],
+      expectRecallEligible: false,
+      expectOutcomeIsRefused: false,
+      expectStableRefusalReasonCode: false,
+    },
+    accept_candidate_to_admitted_assertion: {
+      dixieScenario: "accept_candidate_to_admitted_assertion",
+      localScenario: "accepted_admitted_included",
+      outcomeClassification: "included",
+      localReasonCode: ADMISSION_REDUCER_REASON_CODES.admitted_active_assertion,
+      semanticAssertions: [
+        "accepted candidate yields an admitted active assertion included in ordinary recall",
+        "the admitted assertion is recall-eligible under policy",
+        "the raw candidate payload is not rendered on the public surface",
+      ],
+      expectRecallEligible: true,
+      expectOutcomeIsRefused: false,
+      expectStableRefusalReasonCode: false,
+    },
+    reject_candidate_no_assertion: {
+      dixieScenario: "reject_candidate_no_assertion",
+      localScenario: "rejected_excluded",
+      outcomeClassification: "excluded",
+      localReasonCode: ADMISSION_REDUCER_REASON_CODES.candidate_rejected,
+      semanticAssertions: [
+        "rejected candidate yields no admitted assertion",
+        "rejected candidate remains excluded from ordinary recall",
+        "the candidate payload is not rendered on the public surface",
+      ],
+      expectRecallEligible: false,
+      expectOutcomeIsRefused: false,
+      expectStableRefusalReasonCode: false,
+    },
+    supersede_with_corrected_assertion: {
+      dixieScenario: "supersede_with_corrected_assertion",
+      localScenario: "supersession_corrected_only",
+      outcomeClassification: "included",
+      localReasonCode: ADMISSION_REDUCER_REASON_CODES.corrected_active_assertion,
+      semanticAssertions: [
+        "supersession includes the corrected active assertion only",
+        "the superseded prior assertion is excluded from ordinary recall",
+        "the supersedes link is preserved for audit / provenance, not rendered",
+      ],
+      expectRecallEligible: true,
+      expectOutcomeIsRefused: false,
+      expectStableRefusalReasonCode: false,
+    },
+    malformed_or_unsafe_payload_fail_closed: {
+      dixieScenario: "malformed_or_unsafe_payload_fail_closed",
+      localScenario: "malformed_fail_closed",
+      outcomeClassification: "fail_closed",
+      // representative local fail-closed proof code; the local unsafe_* no-leak
+      // family (unsafe_candidate_payload_projection /
+      // unsafe_private_sentinel_projection) reconciles onto the same Dixie
+      // refusal direction — see the semanticAssertions below.
+      localReasonCode: ADMISSION_REDUCER_REASON_CODES.unsupported_fixture_shape,
+      semanticAssertions: [
+        "malformed / unsafe input fails closed with a stable reason code",
+        "no admitted assertion is minted on the fail-closed path",
+        "the public response leaks no candidate payload, unsafe marker, or source material",
+        "Dixie public reason_code direction is the ingress.invalid_request refusal family; the local fail-closed proof code is unsupported_fixture_shape",
+      ],
+      expectRecallEligible: false,
+      expectOutcomeIsRefused: true,
+      expectStableRefusalReasonCode: true,
+    },
+  };
+
+// The required scenario mapping, exported flat so a test / future reader can
+// assert the five mappings without reaching into the mapping table.
+export const DIXIE_TO_LOCAL_SCENARIO: Readonly<
+  Record<DixieProbeScenarioId, LocalAdmissionScenario>
+> = {
+  candidate_pending_not_recallable: "before_admission_excluded",
+  accept_candidate_to_admitted_assertion: "accepted_admitted_included",
+  reject_candidate_no_assertion: "rejected_excluded",
+  supersede_with_corrected_assertion: "supersession_corrected_only",
+  malformed_or_unsafe_payload_fail_closed: "malformed_fail_closed",
+};
+
+// -- safe readers -----------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function getString(rec: Record<string, unknown>, key: string): string | null {
+  const v = rec[key];
+  return typeof v === "string" ? v : null;
+}
+
+// Fail-closed details are sealed by reason code: the breadcrumb is built ONLY
+// from the stable reason code, so no raw probe value can leave via `detail`.
+export function safeDixieProbeDetail(
+  reasonCode: DixieProbeAdapterReasonCode,
+): string {
+  const safe = DIXIE_PROBE_ADAPTER_REASON_CODE_SET.has(reasonCode)
+    ? reasonCode
+    : DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape;
+  return `fail-closed: ${safe}`;
+}
+
+function failClosed(
+  reasonCode: DixieProbeAdapterReasonCode,
+): DixieProbeAlignmentFailClosed {
+  return {
+    ok: false,
+    alignmentStatus: "fail_closed",
+    reasonCode,
+    detail: safeDixieProbeDetail(reasonCode),
+    publicSafe: true,
+  };
+}
+
+// Final output seal. Every returned result is scanned for unsafe material; if
+// anything trips (it must not, since success results are built from constants),
+// it is replaced with a sealed fail-closed result so nothing unsafe can ever
+// leave the adapter — even if a future probe / refactor regresses.
+function sealAlignment(result: DixieProbeAlignment): DixieProbeAlignment {
+  if (scanForUnsafeProjection(result)) {
+    return failClosed(DIXIE_PROBE_ADAPTER_REASON_CODES.unsafe_probe_projection);
+  }
+  return result;
+}
+
+// =========================================================================
+// mapDixieProbe — the no-op adapter entry point.
+// =========================================================================
+//
+// Accepts an ALREADY-PARSED Dixie probe object (the test reads the mirrored
+// probe JSON and passes the parsed object in; the adapter reads no file). Maps
+// the probe's draft-v0 scenario to the local proof scenario and returns a safe,
+// deterministic alignment result. Fails closed (returns a sealed fail-closed
+// result; it does not throw) on any unknown / malformed probe shape, never
+// echoing a raw probe value.
+export function mapDixieProbe(probe: unknown): DixieProbeAlignment {
+  const rec = isPlainObject(probe) ? probe : null;
+  if (!rec) {
+    return failClosed(DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape);
+  }
+
+  // probe_kind must be the known kind.
+  if (getString(rec, "probe_kind") !== SUPPORTED_PROBE_KIND) {
+    return failClosed(DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape);
+  }
+
+  // probe_version must be the one supported draft v0.
+  if (getString(rec, "probe_version") !== SUPPORTED_DIXIE_PROBE_VERSION) {
+    return failClosed(DIXIE_PROBE_ADAPTER_REASON_CODES.unknown_probe_version);
+  }
+
+  // metadata booleans must mark the probe non-runtime / non-production / draft.
+  // A probe that claims schema_final / runtime_enabled / production_admission,
+  // or that is not public_safe, is refused (the adapter never relaxes these).
+  if (
+    rec.schema_final !== false ||
+    rec.runtime_enabled !== false ||
+    rec.production_admission !== false ||
+    rec.public_safe !== true
+  ) {
+    return failClosed(DIXIE_PROBE_ADAPTER_REASON_CODES.unsupported_probe_shape);
+  }
+
+  // scenario_id must be one of the five known Dixie probe scenarios.
+  const scenarioId = getString(rec, "scenario_id");
+  if (
+    scenarioId === null ||
+    !(scenarioId in SCENARIO_MAPPINGS) ||
+    !(DIXIE_PROBE_SCENARIO_IDS as readonly string[]).includes(scenarioId)
+  ) {
+    return failClosed(DIXIE_PROBE_ADAPTER_REASON_CODES.unknown_probe_scenario);
+  }
+  const mapping = SCENARIO_MAPPINGS[scenarioId as DixieProbeScenarioId];
+
+  // public-surface consistency check — read ONLY public_response. If the
+  // probe's public surface contradicts the mapped scenario's semantics, the
+  // adapter fails closed rather than asserting a false alignment.
+  const publicResponse = isPlainObject(rec.public_response)
+    ? rec.public_response
+    : null;
+  if (!publicResponse) {
+    return failClosed(
+      DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+    );
+  }
+  // candidate payload must never be rendered on any probe's public surface.
+  if (publicResponse.rendered_candidate_payload !== false) {
+    return failClosed(
+      DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+    );
+  }
+  if (publicResponse.recall_eligible !== mapping.expectRecallEligible) {
+    return failClosed(
+      DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+    );
+  }
+  if (mapping.expectOutcomeIsRefused) {
+    if (getString(publicResponse, "outcome") !== "refused") {
+      return failClosed(
+        DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+      );
+    }
+  }
+  if (mapping.expectStableRefusalReasonCode) {
+    const reasonCode = getString(publicResponse, "reason_code");
+    if (reasonCode === null || !DIXIE_REFUSAL_FAMILY.has(reasonCode)) {
+      return failClosed(
+        DIXIE_PROBE_ADAPTER_REASON_CODES.probe_public_surface_mismatch,
+      );
+    }
+  }
+
+  // Build the alignment result entirely from adapter-owned CONSTANTS — no raw
+  // probe value is carried through. (The scenario id is re-emitted from the
+  // matched mapping constant, not from the raw input string.)
+  const result: DixieProbeAlignmentOk = {
+    ok: true,
+    dixieScenario: mapping.dixieScenario,
+    localScenario: mapping.localScenario,
+    dixieProbeVersion: SUPPORTED_DIXIE_PROBE_VERSION,
+    alignmentStatus: "aligned_semantics",
+    outcomeClassification: mapping.outcomeClassification,
+    localReasonCode: mapping.localReasonCode,
+    semanticAssertions: mapping.semanticAssertions,
+    notes: ALIGNMENT_NOTES,
+    publicSafe: true,
+  };
+  return sealAlignment(result);
+}
+
+// Convenience batch mapper over an array of already-parsed probes. Pure; same
+// no-leak / fail-closed guarantees per element.
+export function mapDixieProbes(
+  probes: readonly unknown[],
+): readonly DixieProbeAlignment[] {
+  return probes.map((p) => mapDixieProbe(p));
+}


### PR DESCRIPTION
## Summary

Phase 45F adds a test-only / docs-fixture-bound Admission Wedge Dixie probe no-op adapter / validator.

It proves that Dixie Phase 33C draft v0 probes map semantically to the current Freeside Characters local Admission Wedge proof stack.

This is a bounded implementation slice. It adds a pure local adapter, tests, mirrored Dixie probe fixtures, and small docs status notes. It does not wire runtime behavior, call live Dixie, mutate local fixtures, rename local labels, mutate reducer reason codes, mutate runner behavior, export package surfaces, or authorize live admission.

## Files

New mirrored Dixie probe docs/fixtures:

- docs/admission-wedge/dixie-probes/README.md
- docs/admission-wedge/dixie-probes/accept-candidate-to-admitted-assertion.json
- docs/admission-wedge/dixie-probes/candidate-pending-not-recallable.json
- docs/admission-wedge/dixie-probes/malformed-or-unsafe-payload-fail-closed.json
- docs/admission-wedge/dixie-probes/reject-candidate-no-assertion.json
- docs/admission-wedge/dixie-probes/supersede-with-corrected-assertion.json

New adapter/test:

- packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.ts
- packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.test.ts

Modified docs addenda:

- docs/ADMISSION-WEDGE-DIXIE-PROBE-RECONCILIATION-GATE.md
- docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md
- docs/admission-wedge/fixtures/README.md

## Adapter behavior

The adapter is pure and local:

- accepts already-parsed probe objects
- performs no filesystem access
- performs no network access
- reads no env
- touches no database/storage
- imports no route, Discord, renderer, dispatch, startup, registration, live Dixie client, LLM, or storage modules
- is not exported from package exports
- is not imported by runtime code

It maps Dixie probe scenarios to local semantic scenarios:

- candidate_pending_not_recallable → before_admission_excluded
- accept_candidate_to_admitted_assertion → accepted_admitted_included
- reject_candidate_no_assertion → rejected_excluded
- supersede_with_corrected_assertion → supersession_corrected_only
- malformed_or_unsafe_payload_fail_closed → malformed_fail_closed

The adapter preserves both label sets:

- local proof labels remain local proof labels
- Dixie labels remain draft v0 probe labels
- no local fixture labels are renamed
- no reducer reason codes are mutated
- no final schema is frozen

## Mirrored Dixie probes

The mirrored probe files are local mirrors for adapter tests.

They identify Dixie Phase 33C / PR #120 as canonical source, remain draft v0 / non-runtime / not-final-schema, and do not create Freeside Characters runtime behavior.

The mirrors are used to prove semantic mapping only.

## Tests

The adapter test proves:

- all mirrored Dixie probes exist and parse
- all five required probe-to-local mappings work
- semantic equivalence to the current local proof stack using the existing Phase 44A reducer over Phase 43C fixtures
- pending candidate is excluded from recall
- accepted candidate yields admitted active assertion inclusion
- rejected candidate yields no admitted assertion and remains excluded
- supersession includes corrected active assertion only and excludes superseded prior assertion from ordinary recall
- malformed / unsafe probes fail closed with no public leak
- full serialized adapter results and formatted summaries do not leak unsafe markers, raw payload, source material, audit-only data, long IDs, URLs, JWT-like strings, PEM keys, Bearer/sk-style tokens, 0x long hex strings, or stack traces
- malformed synthetic inputs fail closed without echoing raw values
- adapter is not wired into Discord, dispatch, startup, registration, public renderer, live Dixie client, or package exports

The malformed-scenario local reason is treated at the fail-closed family level rather than forcing an exact reducer-code match, preserving the Phase 45E reconciliation that local unsafe/unsupported fixture families align with the Dixie ingress.invalid_request refusal direction.

## Codex audit

Codex initially returned PATCH only for stale ladder wording in docs/RECALL-WEDGE-POST-MVP-DECISION-MAP.md §9.

The stale wording was patched so §9 now points to Phase 45F / §5w as latest status, marks older Phase 45A / 45C / 45D trail as historical / superseded, and preserves that live/runtime lanes remain blocked.

Codex then returned:

- VERDICT: ACCEPT
- stale ladder blocker fully resolved
- implementation/test boundary remains acceptable
- no remaining blockers
- no required patches

Codex confirmed:

- adapter remains pure/local
- adapter test remains test-only
- mirrored Dixie probes remain docs-fixture-bound
- no runtime wiring
- no live Dixie calls
- no package export
- no fixture label renames
- no reducer reason-code mutation
- no runner behavior mutation
- no Dixie repo changes

## Validation

Validated locally:

- git diff --check: clean
- node docs/recall-wedge/fixtures/validate-fixtures.mjs: 122 checks passed / 0 failed
- node docs/admission-wedge/fixtures/validate-fixtures.mjs: 318 checks passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/admission-wedge-fixture-reducer.test.ts: 57 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/run-admission-wedge-fixture-demo.test.ts: 44 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.test.ts: 37 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/multi-surface-recall-harness.test.ts: 52 tests passed / 0 failed
- bun test packages/persona-engine/src/recall-wedge/live-dixie-client.test.ts packages/persona-engine/src/recall-wedge/run-live-dixie-recall-demo.test.ts: 110 tests passed / 0 failed

## Non-goals

This PR does not authorize or add:

- runtime Discord behavior
- Discord command
- `/remember-this`
- public remember-this
- Discord history ingestion
- user chat becoming memory
- live Dixie admission route
- live Dixie calls
- network calls
- storage writes
- production admission
- production storage
- production auth/consent
- public rollout
- package exports
- renderer changes
- dispatch/startup/command registration changes
- LLM/voice
- Finn production wiring
- forget/revoke/correction UI
- final schema freeze
- local fixture label renames
- existing local fixture JSON mutation
- reducer reason-code mutation
- runner behavior mutation
- Dixie code changes
