### PR TITLE
feat(shadow/ingestion): thj RoleSnapshot exporter → live shadow-audit seam (EXPORT-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 > Retroactive reconciliation of v0.10.0–v0.11.3 is a separate hygiene task. The
 > entry below resumes the log at the cycle-008 state.
 
+## [Unreleased] — Shadow Access Audit exporter
+
+### Added
+
+- **THJ `RoleSnapshot` exporter** — `bun run --cwd apps/bot role-snapshot:export` enumerates an
+  explicitly selected gated Discord role, resolves Discord members to wallets, emits the strict
+  cross-repo snapshot contract, and posts it to the Shadow Access Audit ingestion seam.
+- **Fail-closed live writes** — live POSTs refuse empty gated cohorts or zero resolved wallets;
+  dry-runs remain available for diagnosis. Request deadlines include response-body reads, and a
+  malformed HTTP 200 receipt is treated as possibly stored rather than safe to retry.
+- **PII floor** — human logs redact Discord and wallet identifiers. `--list-roles` and `--dry-run`
+  are explicit sensitive stdout channels; `--out` files are forced to mode `0600`.
+
+### Tests
+
+- RoleSnapshot exporter/contract/client/CLI: 46 focused tests; full bot suite 890 pass, 0 fail.
+
 ## [0.12.0] — 2026-05-23 — cycle-008 capability-wiring + FAGAN-thorough
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,3 +152,25 @@ LLM_PROVIDER=anthropic \
 ```
 
 Validate the entire pipeline before touching production cron cadences. The `digest:once` CLI fires one post per zone and exits — useful for voice-iteration without waiting for Sunday midnight.
+
+### Export a gated-role snapshot for Shadow Access Audit
+
+```bash
+# Sensitive discovery output: redirect to a restricted operator file.
+bun run --cwd apps/bot role-snapshot:export --list-roles > roles.tsv
+
+# Diagnose the exact payload without writing to the audit service.
+bun run --cwd apps/bot role-snapshot:export \
+  --role-ids <gated-role-snowflake> \
+  --owner <community-owner-wallet> \
+  --dry-run > role-snapshot.json
+
+# Live POST: also requires ROLE_SNAPSHOT_INGEST_TOKEN.
+bun run --cwd apps/bot role-snapshot:export \
+  --role-ids <gated-role-snowflake> \
+  --owner <community-owner-wallet>
+```
+
+`--role-ids` is mandatory: exporting the whole guild would make every member look like a gated-role
+holder. Human logs are redacted; stdout and snapshot files contain raw identity data. `--out` forces
+mode `0600`, but redirected stdout inherits the shell's permissions—use `umask 077` when persisting it.

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -14,7 +14,8 @@
     "test": "bun test",
     "conformance:check": "bun run scripts/check-substrate-conformance.ts",
     "lint:shadow-import-boundary": "bash ../../scripts/lint-shadow-import-boundary.sh",
-    "member-graph": "bun run src/cli/member-graph.ts"
+    "member-graph": "bun run src/cli/member-graph.ts",
+    "role-snapshot:export": "bun run src/cli/role-snapshot-export.ts"
   },
   "dependencies": {
     "@0xhoneyjar/events": "github:0xHoneyJar/loa-freeside#68f5a89cb02c6b3ddf5ab14a1d65753bc02bd9fe",

--- a/apps/bot/src/cli/role-snapshot-export.ts
+++ b/apps/bot/src/cli/role-snapshot-export.ts
@@ -85,6 +85,10 @@ Flags
   --owner <id>           REQUIRED. Provenance stamp (conventionally the community owner wallet).
                          The audit does not consume it.
   --community <name>     default: thj   (must be an OPERATED community, else the service 403s)
+  --collection <c/0x..>  default: 80094/0x886d...  the GATED COLLECTION (numeric chain / contract).
+                         thj gates 7 collections, each behind its own role — the snapshot is keyed by
+                         (community, collection), so exporting HJG1 under Honeycomb's key would make the
+                         Honeycomb audit compute drift against HoneyJar1's role-holders.
   --guild <id>           default: ${THJ_GUILD_ID} (THJ)
   --freshness <seconds>  default: ${DEFAULT_FRESHNESS_THRESHOLD_SECONDS}
   --endpoint <url>       default: ${DEFAULT_INGEST_ENDPOINT}
@@ -184,6 +188,19 @@ async function main(): Promise<void> {
   }
 
   const community = flag("community") ?? "thj";
+
+  // The GATED COLLECTION this role-set is for (S5-T1). Default: Honeycomb on berachain — the ONE
+  // operator-CONFIRMED gate edge (HC -> Honeycomb). Any deployment of a collection addresses it; the
+  // service canonicalizes across the union, so berachain and ethereum Honeycomb are the same key.
+  const collectionRaw = flag("collection") ?? "80094/0x886d2176d899796cd1affa07eff07b9b2b80f1be";
+  const [colChain, colContract] = collectionRaw.split("/");
+  if (!colChain || !/^[0-9]+$/.test(colChain) || !colContract || !/^0x[0-9a-fA-F]{40}$/.test(colContract)) {
+    log(`\u2717 --collection must be <numeric-chain-id>/<0x-contract>, e.g. 80094/0x886d...  (got '${collectionRaw}')`);
+    log("  A chain SLUG is rejected: it would be stored under a key the registry can never match, and the");
+    log("  snapshot would ingest happily and then be invisible to every audit.");
+    process.exit(2);
+  }
+  const collection = { chain: colChain, contract: colContract };
   const dryRun = has("dry-run");
   const endpoint = flag("endpoint") ?? DEFAULT_INGEST_ENDPOINT;
   const freshness = Number(flag("freshness") ?? DEFAULT_FRESHNESS_THRESHOLD_SECONDS);
@@ -208,6 +225,7 @@ async function main(): Promise<void> {
     built = await buildRoleSnapshot({
       guildId,
       community,
+      collection,
       owner,
       gatedRoleIds,
       members,

--- a/apps/bot/src/cli/role-snapshot-export.ts
+++ b/apps/bot/src/cli/role-snapshot-export.ts
@@ -1,0 +1,289 @@
+/**
+ * cli/role-snapshot-export.ts — the thj RoleSnapshot exporter (S3 / EXPORT-1). One-shot:
+ *
+ *   # 1. discover the token-gated role's snowflake (you need it for step 2)
+ *   bun run role-snapshot:export --list-roles
+ *
+ *   # 2. build the snapshot and print it — NO network write
+ *   bun run role-snapshot:export --role-ids <snowflake> --owner 0x… --dry-run
+ *
+ *   # 3. POST it to the LIVE shadow-audit ingestion seam
+ *   bun run role-snapshot:export --role-ids <snowflake> --owner 0x…
+ *
+ * Forked in spirit from `cli/member-graph.ts` (the same self-contained bot-client pattern), but a
+ * DIFFERENT job: member-graph renders a read-model; this PRODUCES the incumbent-role input the
+ * deployed shadow-audit service consumes.
+ *
+ * ── VOICELESS · READ-ONLY ────────────────────────────────────────────────────
+ * Reads Discord (members + roles) and identity-api. Mutates NO roles. The one write it performs is
+ * the HTTP POST of the snapshot to the audit service.
+ *
+ * ── PII FLOOR (S3-T3) ────────────────────────────────────────────────────────
+ * No raw wallet and no raw discord snowflake ever reaches stdout/stderr — every identifier in a log
+ * line goes through redactDiscordId / redactWallet. `--dry-run` prints the snapshot BODY (which of
+ * course contains the real identifiers — that IS the payload) to STDOUT only, so it can be piped to
+ * a file; the human-readable log stream on STDERR stays redacted. `--out` writes it to a file.
+ * The ingest token is read from the environment and NEVER logged.
+ *
+ * ── WHY --role-ids IS REQUIRED (do not add an "export everyone" default) ─────
+ * The audit reads EVERY entry in the snapshot as a holder of the token-gated role and reports the
+ * ones who no longer hold the tokens as STALE ACCESS. Exporting the whole guild would therefore
+ * report the entire server as stale access — a confidently-wrong audit. See the long-form note in
+ * `shadow/ingestion/role-snapshot-export.ts`.
+ */
+import { writeFileSync } from "node:fs";
+import { Client, GatewayIntentBits, type Client as DiscordClient } from "discord.js";
+import { MemberIdentityClient } from "../shadow/member-identity-client.ts";
+import {
+  listGuildRoles,
+  makeGuildRoleMemberSourceLive,
+} from "../shadow/ingestion/guild-role-source.live.ts";
+import {
+  buildRoleSnapshot,
+  redactDiscordId,
+  redactWallet,
+  RoleSnapshotExportError,
+  DEFAULT_FRESHNESS_THRESHOLD_SECONDS,
+  type MemberWalletResolver,
+} from "../shadow/ingestion/role-snapshot-export.ts";
+import {
+  postRoleSnapshot,
+  prepareRoleSnapshotRequest,
+  DEFAULT_INGEST_ENDPOINT,
+} from "../shadow/ingestion/role-snapshot-client.ts";
+
+/**
+ * The THJ guild snowflake. Grounded in `apps/bot/src/world-config.ts` (SEEDED_GUILD_WORLD_MAP:
+ * "THJ (0xHoneyJar main guild)"), which also maps this guild to the identity world `mibera` — hence
+ * the IDENTITY_WORLD default below. Override either with a flag/env.
+ */
+const THJ_GUILD_ID = "1135545260538339420";
+const DEFAULT_IDENTITY_WORLD = "mibera";
+
+/** stderr = the human log (REDACTED). stdout = the payload. Never cross them. */
+const log = (msg: string): void => console.error(msg);
+
+function flag(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const has = (name: string): boolean => process.argv.includes(`--${name}`);
+
+function usage(): never {
+  log(`
+thj RoleSnapshot exporter — enumerate the guild, resolve wallets, feed the shadow-audit.
+
+  bun run role-snapshot:export --list-roles
+  bun run role-snapshot:export --role-ids <id>[,<id>] --owner <id> [--dry-run]
+
+Flags
+  --list-roles           print the guild's roles (id · name · members) and exit. Use this to find
+                         the TOKEN-GATED role snowflake, then pass it to --role-ids.
+  --role-ids <a,b>       REQUIRED. The token-gated role snowflake(s). Only members holding one of
+                         these are exported — the audit reads every entry as a role-holder, so
+                         exporting the whole guild would report the server as stale access.
+  --owner <id>           REQUIRED. Provenance stamp (conventionally the community owner wallet).
+                         The audit does not consume it.
+  --community <name>     default: thj   (must be an OPERATED community, else the service 403s)
+  --guild <id>           default: ${THJ_GUILD_ID} (THJ)
+  --freshness <seconds>  default: ${DEFAULT_FRESHNESS_THRESHOLD_SECONDS}
+  --endpoint <url>       default: ${DEFAULT_INGEST_ENDPOINT}
+  --dry-run              build + print the snapshot; do NOT POST.
+  --out <path>           also write the snapshot JSON to a file.
+
+Environment
+  DISCORD_BOT_TOKEN             required — the bot must be in the guild w/ the GuildMembers intent.
+  IDENTITY_API_URL              required — identity-api base URL (discord → wallet).
+  IDENTITY_WORLD                default: ${DEFAULT_IDENTITY_WORLD} (THJ's world per world-config.ts)
+  IDENTITY_SERVICE_TOKEN        optional — sent as x-service-token.
+  ROLE_SNAPSHOT_INGEST_TOKEN    required unless --dry-run. NEVER logged.
+`);
+  process.exit(2);
+}
+
+/** Minimal, self-contained bot client (avoids the heavy bot boot) — same shape as member-graph.ts. */
+function makeGetBotClient(): () => Promise<DiscordClient | null> {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  let client: DiscordClient | null = null;
+  return async () => {
+    if (!token) return null;
+    if (client) return client;
+    const c = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers] });
+    await c.login(token);
+    await new Promise<void>((res) => c.once("clientReady", () => res()).once("ready", () => res()));
+    client = c;
+    return client;
+  };
+}
+
+/**
+ * discord id → wallet, via the member-centric identity client (the module built for exactly this
+ * direction: resolve/account/discord/{id} → /v1/profile → primary_wallet). Fail-soft by
+ * construction: an unlinked / walletless / erroring member resolves to undefined ⇒ the builder
+ * FLAGS them as unmatched rather than dropping them.
+ */
+function makeWalletResolver(): MemberWalletResolver {
+  const baseUrl = process.env.IDENTITY_API_URL;
+  if (!baseUrl) {
+    log("✗ IDENTITY_API_URL is unset — cannot resolve any wallet. Every holder would be unmatched,");
+    log("  which would make the audit's drift number meaningless. Refusing (fail-closed).");
+    process.exit(2);
+  }
+  const client = new MemberIdentityClient({
+    baseUrl,
+    world: process.env.IDENTITY_WORLD ?? DEFAULT_IDENTITY_WORLD,
+    serviceToken: process.env.IDENTITY_SERVICE_TOKEN,
+  });
+  return async (discordId: string): Promise<string | undefined> => {
+    const identity = await client.resolveMember(discordId);
+    return identity.kind === "linked" ? identity.wallet : undefined;
+  };
+}
+
+async function main(): Promise<void> {
+  if (has("help") || has("h")) usage();
+
+  const guildId = flag("guild") ?? THJ_GUILD_ID;
+  const getBotClient = makeGetBotClient();
+
+  if (!process.env.DISCORD_BOT_TOKEN) {
+    log("✗ DISCORD_BOT_TOKEN is unset — cannot read the guild.");
+    process.exit(2);
+  }
+
+  // ── --list-roles: the discovery path for --role-ids ───────────────────────
+  if (has("list-roles")) {
+    const roles = await listGuildRoles(getBotClient, guildId);
+    log(`▸ guild ${guildId} · ${roles.length} roles (most-held first)\n`);
+    console.log(["role_id", "members", "name"].join("\t"));
+    for (const r of roles) console.log([r.id, r.members, r.name].join("\t"));
+    log("\n▸ pick the TOKEN-GATED role and pass its id to --role-ids.");
+    const client = await getBotClient();
+    if (client) await client.destroy();
+    process.exit(0);
+  }
+
+  // ── inputs (fail-closed) ──────────────────────────────────────────────────
+  const roleIdsRaw = flag("role-ids") ?? process.env.ROLE_SNAPSHOT_GATED_ROLE_IDS;
+  if (!roleIdsRaw) {
+    log("✗ --role-ids is REQUIRED (the token-gated role snowflake[s]).");
+    log("  Run with --list-roles to find it. There is deliberately no 'export everyone' default:");
+    log("  the audit reads every entry as a role-holder, so exporting the whole guild would report");
+    log("  the entire server as stale access — a confidently-wrong audit.");
+    process.exit(2);
+  }
+  const gatedRoleIds = roleIdsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const owner = flag("owner") ?? process.env.ROLE_SNAPSHOT_OWNER;
+  if (!owner) {
+    log("✗ --owner is REQUIRED (provenance; conventionally the community owner wallet).");
+    process.exit(2);
+  }
+
+  const community = flag("community") ?? "thj";
+  const dryRun = has("dry-run");
+  const endpoint = flag("endpoint") ?? DEFAULT_INGEST_ENDPOINT;
+  const freshness = Number(flag("freshness") ?? DEFAULT_FRESHNESS_THRESHOLD_SECONDS);
+
+  const ingestToken = process.env.ROLE_SNAPSHOT_INGEST_TOKEN;
+  if (!dryRun && !ingestToken) {
+    log("✗ ROLE_SNAPSHOT_INGEST_TOKEN is unset — cannot POST. Use --dry-run to build without it.");
+    process.exit(2);
+  }
+
+  // ── read the guild ────────────────────────────────────────────────────────
+  log(`▸ guild ${guildId} · community '${community}' · gated roles: ${gatedRoleIds.join(", ")}`);
+  const members = await makeGuildRoleMemberSourceLive(getBotClient)(guildId);
+  log(`▸ read ${members.length} guild members`);
+
+  // ── resolve + build ───────────────────────────────────────────────────────
+  const resolveWallet = makeWalletResolver();
+  log("▸ resolving discord → wallet via identity-api …");
+
+  let built;
+  try {
+    built = await buildRoleSnapshot({
+      guildId,
+      community,
+      owner,
+      gatedRoleIds,
+      members,
+      resolveWallet,
+      capturedAt: new Date().toISOString(),
+      freshnessThresholdSeconds: freshness,
+    });
+  } catch (e) {
+    if (e instanceof RoleSnapshotExportError) {
+      log(`✗ refusing to export: ${e.message}`);
+      process.exit(1);
+    }
+    throw e;
+  }
+
+  const { snapshot, stats } = built;
+  log(
+    `▸ ${stats.gated_members} gated-role holders of ${stats.guild_members} members · ` +
+      `🔗 ${stats.resolved} resolved · ⚠️ ${stats.unmatched} UNMATCHED (flagged, not dropped)`,
+  );
+  // Sample the cohort with REDACTED identifiers so the operator can sanity-check without PII.
+  for (const e of snapshot.entries.slice(0, 5)) {
+    log(
+      `  · ${redactDiscordId(e.discord_user_id)} → ${e.wallet ? redactWallet(e.wallet) : "(unmatched)"}`,
+    );
+  }
+  if (snapshot.entries.length > 5) log(`  · … and ${snapshot.entries.length - 5} more`);
+
+  if (stats.gated_members > 0 && stats.resolved === 0) {
+    log("⚠ ZERO wallets resolved. The audit would see no role-holders and its drift number would be");
+    log("  meaningless. Check IDENTITY_API_URL / IDENTITY_WORLD before trusting this snapshot.");
+  }
+
+  const prepared = prepareRoleSnapshotRequest(snapshot, endpoint);
+  if (flag("out")) {
+    writeFileSync(flag("out")!, prepared.body, "utf8");
+    log(`▸ wrote ${prepared.bytes} bytes → ${flag("out")}`);
+  }
+
+  // ── dry-run: print exactly what WOULD be POSTed ───────────────────────────
+  if (dryRun) {
+    log(`\n▸ DRY RUN — would POST ${prepared.bytes} bytes to ${prepared.url}`);
+    log(`  X-Snapshot-Sha256: ${prepared.sha256}`);
+    log(`  X-Ingest-Token:    <ROLE_SNAPSHOT_INGEST_TOKEN> (not read in dry-run)`);
+    console.log(prepared.body); // stdout = the payload (pipe it to a file if you want it)
+    const client = await getBotClient();
+    if (client) await client.destroy();
+    process.exit(0);
+  }
+
+  // ── the live POST ─────────────────────────────────────────────────────────
+  log(`\n▸ POST ${prepared.bytes} bytes → ${prepared.url}`);
+  const result = await postRoleSnapshot(snapshot, { token: ingestToken!, endpoint });
+
+  const client = await getBotClient();
+  if (client) await client.destroy();
+
+  if (result.kind === "accepted") {
+    const r = result.receipt;
+    // stored:false is a SUCCESSFUL no-op (the store is monotonic on captured_at) — not an error.
+    log(
+      `✓ 200 · stored=${r.stored}${r.stored ? "" : " (replay / not newer — a successful NO-OP)"} · ` +
+        `community=${r.community} · captured_at=${r.captured_at} · entries=${r.entries}`,
+    );
+    process.exit(0);
+  }
+  if (result.kind === "refused") {
+    log(`✗ ${result.status} · ${result.reason}`);
+    log("  The service refuses rather than guesses — read the cause above; do not retry blindly.");
+    process.exit(1);
+  }
+  log(`✗ transport error: ${result.reason} (safe to retry — ingestion is at-least-once)`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  log(`role-snapshot-export failed: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/apps/bot/src/cli/role-snapshot-export.ts
+++ b/apps/bot/src/cli/role-snapshot-export.ts
@@ -19,11 +19,11 @@
  * the HTTP POST of the snapshot to the audit service.
  *
  * ── PII FLOOR (S3-T3) ────────────────────────────────────────────────────────
- * No raw wallet and no raw discord snowflake ever reaches stdout/stderr — every identifier in a log
- * line goes through redactDiscordId / redactWallet. `--dry-run` prints the snapshot BODY (which of
- * course contains the real identifiers — that IS the payload) to STDOUT only, so it can be piped to
- * a file; the human-readable log stream on STDERR stays redacted. `--out` writes it to a file.
- * The ingest token is read from the environment and NEVER logged.
+ * No raw wallet and no raw discord snowflake ever reaches the human log on STDERR — every identifier
+ * there goes through redactDiscordId / redactWallet. Deliberate machine-readable payload channels are
+ * the exceptions: `--list-roles` prints role ids to STDOUT for operator discovery, `--dry-run` prints
+ * the snapshot BODY to STDOUT, and `--out` writes that body to a file. The ingest token is read from
+ * the environment and NEVER logged.
  *
  * ── WHY --role-ids IS REQUIRED (do not add an "export everyone" default) ─────
  * The audit reads EVERY entry in the snapshot as a holder of the token-gated role and reports the
@@ -31,7 +31,7 @@
  * report the entire server as stale access — a confidently-wrong audit. See the long-form note in
  * `shadow/ingestion/role-snapshot-export.ts`.
  */
-import { writeFileSync } from "node:fs";
+import { closeSync, fchmodSync, openSync, writeFileSync } from "node:fs";
 import { Client, GatewayIntentBits, type Client as DiscordClient } from "discord.js";
 import { MemberIdentityClient } from "../shadow/member-identity-client.ts";
 import {
@@ -40,6 +40,7 @@ import {
 } from "../shadow/ingestion/guild-role-source.live.ts";
 import {
   buildRoleSnapshot,
+  assertLiveSnapshotHasSignal,
   redactDiscordId,
   redactWallet,
   RoleSnapshotExportError,
@@ -63,9 +64,17 @@ const DEFAULT_IDENTITY_WORLD = "mibera";
 /** stderr = the human log (REDACTED). stdout = the payload. Never cross them. */
 const log = (msg: string): void => console.error(msg);
 
+let activeClient: DiscordClient | null = null;
+
 function flag(name: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`);
-  return i >= 0 ? process.argv[i + 1] : undefined;
+  if (i < 0) return undefined;
+  const value = process.argv[i + 1];
+  if (!value || value.startsWith("--")) {
+    log(`✗ --${name} requires a value.`);
+    usage();
+  }
+  return value;
 }
 const has = (name: string): boolean => process.argv.includes(`--${name}`);
 
@@ -77,8 +86,8 @@ thj RoleSnapshot exporter — enumerate the guild, resolve wallets, feed the sha
   bun run role-snapshot:export --role-ids <id>[,<id>] --owner <id> [--dry-run]
 
 Flags
-  --list-roles           print the guild's roles (id · name · members) and exit. Use this to find
-                         the TOKEN-GATED role snowflake, then pass it to --role-ids.
+  --list-roles           print the guild's roles (id · name · members) to STDOUT and exit. This is
+                         a deliberate sensitive discovery channel; redirect it to a restricted file.
   --role-ids <a,b>       REQUIRED. The token-gated role snowflake(s). Only members holding one of
                          these are exported — the audit reads every entry as a role-holder, so
                          exporting the whole guild would report the server as stale access.
@@ -113,11 +122,33 @@ function makeGetBotClient(): () => Promise<DiscordClient | null> {
     if (!token) return null;
     if (client) return client;
     const c = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers] });
+    activeClient = c;
+    const ready = new Promise<void>((resolve) => {
+      c.once("clientReady", () => resolve()).once("ready", () => resolve());
+    });
     await c.login(token);
-    await new Promise<void>((res) => c.once("clientReady", () => res()).once("ready", () => res()));
+    if (!c.isReady()) await ready;
     client = c;
     return client;
   };
+}
+
+async function destroyBotClient(): Promise<void> {
+  if (!activeClient) return;
+  const client = activeClient;
+  activeClient = null;
+  await client.destroy();
+}
+
+/** Snapshot files contain raw identity links. Restrict an existing or new file before writing. */
+function writePrivateSnapshot(path: string, body: string): void {
+  const fd = openSync(path, "w", 0o600);
+  try {
+    fchmodSync(fd, 0o600);
+    writeFileSync(fd, body, "utf8");
+  } finally {
+    closeSync(fd);
+  }
 }
 
 /**
@@ -158,12 +189,11 @@ async function main(): Promise<void> {
   // ── --list-roles: the discovery path for --role-ids ───────────────────────
   if (has("list-roles")) {
     const roles = await listGuildRoles(getBotClient, guildId);
-    log(`▸ guild ${guildId} · ${roles.length} roles (most-held first)\n`);
+    log(`▸ guild ${redactDiscordId(guildId)} · ${roles.length} roles (most-held first)\n`);
     console.log(["role_id", "members", "name"].join("\t"));
     for (const r of roles) console.log([r.id, r.members, r.name].join("\t"));
     log("\n▸ pick the TOKEN-GATED role and pass its id to --role-ids.");
-    const client = await getBotClient();
-    if (client) await client.destroy();
+    await destroyBotClient();
     process.exit(0);
   }
 
@@ -203,7 +233,13 @@ async function main(): Promise<void> {
   const collection = { chain: colChain, contract: colContract };
   const dryRun = has("dry-run");
   const endpoint = flag("endpoint") ?? DEFAULT_INGEST_ENDPOINT;
-  const freshness = Number(flag("freshness") ?? DEFAULT_FRESHNESS_THRESHOLD_SECONDS);
+  const freshnessRaw = flag("freshness") ?? String(DEFAULT_FRESHNESS_THRESHOLD_SECONDS);
+  const freshness = Number(freshnessRaw);
+  if (!Number.isInteger(freshness) || freshness <= 0) {
+    log(`✗ --freshness must be a positive integer number of seconds (got '${freshnessRaw}').`);
+    process.exit(2);
+  }
+  const outPath = flag("out");
 
   const ingestToken = process.env.ROLE_SNAPSHOT_INGEST_TOKEN;
   if (!dryRun && !ingestToken) {
@@ -211,13 +247,17 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  const resolveWallet = makeWalletResolver();
+
   // ── read the guild ────────────────────────────────────────────────────────
-  log(`▸ guild ${guildId} · community '${community}' · gated roles: ${gatedRoleIds.join(", ")}`);
+  log(
+    `▸ guild ${redactDiscordId(guildId)} · community '${community}' · gated roles: ` +
+      gatedRoleIds.map(redactDiscordId).join(", "),
+  );
   const members = await makeGuildRoleMemberSourceLive(getBotClient)(guildId);
   log(`▸ read ${members.length} guild members`);
 
   // ── resolve + build ───────────────────────────────────────────────────────
-  const resolveWallet = makeWalletResolver();
   log("▸ resolving discord → wallet via identity-api …");
 
   let built;
@@ -236,6 +276,7 @@ async function main(): Promise<void> {
   } catch (e) {
     if (e instanceof RoleSnapshotExportError) {
       log(`✗ refusing to export: ${e.message}`);
+      await destroyBotClient();
       process.exit(1);
     }
     throw e;
@@ -260,9 +301,9 @@ async function main(): Promise<void> {
   }
 
   const prepared = prepareRoleSnapshotRequest(snapshot, endpoint);
-  if (flag("out")) {
-    writeFileSync(flag("out")!, prepared.body, "utf8");
-    log(`▸ wrote ${prepared.bytes} bytes → ${flag("out")}`);
+  if (outPath) {
+    writePrivateSnapshot(outPath, prepared.body);
+    log(`▸ wrote ${prepared.bytes} bytes → restricted output file (mode 0600)`);
   }
 
   // ── dry-run: print exactly what WOULD be POSTed ───────────────────────────
@@ -271,17 +312,25 @@ async function main(): Promise<void> {
     log(`  X-Snapshot-Sha256: ${prepared.sha256}`);
     log(`  X-Ingest-Token:    <ROLE_SNAPSHOT_INGEST_TOKEN> (not read in dry-run)`);
     console.log(prepared.body); // stdout = the payload (pipe it to a file if you want it)
-    const client = await getBotClient();
-    if (client) await client.destroy();
+    await destroyBotClient();
     process.exit(0);
   }
 
   // ── the live POST ─────────────────────────────────────────────────────────
+  try {
+    assertLiveSnapshotHasSignal(stats);
+  } catch (e) {
+    if (e instanceof RoleSnapshotExportError) {
+      log(`✗ refusing to POST: ${e.message}`);
+      await destroyBotClient();
+      process.exit(1);
+    }
+    throw e;
+  }
   log(`\n▸ POST ${prepared.bytes} bytes → ${prepared.url}`);
   const result = await postRoleSnapshot(snapshot, { token: ingestToken!, endpoint });
 
-  const client = await getBotClient();
-  if (client) await client.destroy();
+  await destroyBotClient();
 
   if (result.kind === "accepted") {
     const r = result.receipt;
@@ -292,6 +341,11 @@ async function main(): Promise<void> {
     );
     process.exit(0);
   }
+  if (result.kind === "accepted_unverified") {
+    log(`⚠ 200 · ${result.reason}`);
+    log("  Treat the write as possibly committed; inspect the held snapshot before any retry.");
+    process.exit(1);
+  }
   if (result.kind === "refused") {
     log(`✗ ${result.status} · ${result.reason}`);
     log("  The service refuses rather than guesses — read the cause above; do not retry blindly.");
@@ -301,7 +355,8 @@ async function main(): Promise<void> {
   process.exit(1);
 }
 
-main().catch((err) => {
+main().catch(async (err) => {
+  await destroyBotClient().catch(() => undefined);
   log(`role-snapshot-export failed: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 });

--- a/apps/bot/src/shadow/ingestion/fixtures/role-snapshot.golden.json
+++ b/apps/bot/src/shadow/ingestion/fixtures/role-snapshot.golden.json
@@ -1,6 +1,10 @@
 {
   "source": "discord:guild:824482353155080202",
   "community": "thj",
+  "collection": {
+    "chain": "80094",
+    "contract": "0x886d2176d899796cd1affa07eff07b9b2b80f1be"
+  },
   "captured_at": "2026-07-10T00:00:00.000Z",
   "export_method": "freeside-characters:member-graph-exporter@1",
   "owner": "0x886d2176d899796cd1affa07eff07b9b2b80f1be",
@@ -9,11 +13,15 @@
     {
       "discord_user_id": "111111111111111111",
       "wallet": "0x1111111111111111111111111111111111111111",
-      "role_ids": ["role-holder"]
+      "role_ids": [
+        "role-holder"
+      ]
     },
     {
       "discord_user_id": "222222222222222222",
-      "role_ids": ["role-holder"]
+      "role_ids": [
+        "role-holder"
+      ]
     }
   ]
 }

--- a/apps/bot/src/shadow/ingestion/fixtures/role-snapshot.golden.json
+++ b/apps/bot/src/shadow/ingestion/fixtures/role-snapshot.golden.json
@@ -1,0 +1,19 @@
+{
+  "source": "discord:guild:824482353155080202",
+  "community": "thj",
+  "captured_at": "2026-07-10T00:00:00.000Z",
+  "export_method": "freeside-characters:member-graph-exporter@1",
+  "owner": "0x886d2176d899796cd1affa07eff07b9b2b80f1be",
+  "freshness_threshold_seconds": 86400,
+  "entries": [
+    {
+      "discord_user_id": "111111111111111111",
+      "wallet": "0x1111111111111111111111111111111111111111",
+      "role_ids": ["role-holder"]
+    },
+    {
+      "discord_user_id": "222222222222222222",
+      "role_ids": ["role-holder"]
+    }
+  ]
+}

--- a/apps/bot/src/shadow/ingestion/guild-role-source.live.ts
+++ b/apps/bot/src/shadow/ingestion/guild-role-source.live.ts
@@ -1,0 +1,78 @@
+/**
+ * guild-role-source.live.ts — the LIVE Discord read for the role-snapshot exporter (S3 / EXPORT-1).
+ *
+ * Reads a guild's MEMBERS and the role SNOWFLAKES each one holds. The wire contract wants role
+ * IDS, never names — `member-source.live.ts` (the CM-dashboard reader) deliberately surfaces role
+ * NAMES filtered by the world's `namespace_prefix`, which is the wrong shape and the wrong filter
+ * for this job, so this is a sibling reader rather than a change to that one.
+ *
+ * ── READ-ONLY — NOT a role mutation ──────────────────────────────────────────
+ * `guild.members.fetch()` / `guild.roles.fetch()` are READS. Discord role/member reads sit
+ * explicitly OUTSIDE the cross-repo import-boundary lint (`scripts/lint-shadow-import-boundary.sh`),
+ * which confines only role MUTATIONS (roles.create / roles.add / roles.set / role.delete / …) to
+ * the single gated adapter `role-writer.live.ts`. Nothing here mutates. Same posture as
+ * roster-source.live.ts, which already calls `guild.roles.fetch()` under the same lint.
+ *
+ * Reuses `fetchGuildMembersCached` — gateway opcode 8 ("Request Guild Members") is rate-limited and
+ * this exporter may be run repeatedly (dry-run, then live).
+ */
+import type { Client, Guild } from "discord.js";
+import { fetchGuildMembersCached } from "../guild-members-cache.ts";
+import type { GuildRoleMemberRef, GuildRoleMemberSource } from "./role-snapshot-export.ts";
+
+/** One role as seen in the guild — what `--list-roles` prints so an operator can pick the gated id. */
+export interface GuildRoleRef {
+  readonly id: string;
+  readonly name: string;
+  readonly members: number;
+}
+
+async function requireGuild(getBotClient: () => Promise<Client | null>, guildId: string): Promise<Guild> {
+  const client = await getBotClient();
+  if (!client) {
+    throw new Error(
+      "guild-role-source: discord bot client unavailable (DISCORD_BOT_TOKEN unset) — cannot read guild members",
+    );
+  }
+  return client.guilds.fetch(guildId);
+}
+
+/**
+ * Build the LIVE `GuildRoleMemberSource`. Returns every guild member with the role snowflakes they
+ * hold, EXCLUDING @everyone (whose role id equals the guild id and which every member holds — it
+ * carries no information and is a trap for the gated-role filter).
+ *
+ * Requires the GuildMembers privileged gateway intent (the bot already requests it).
+ */
+export function makeGuildRoleMemberSourceLive(
+  getBotClient: () => Promise<Client | null>,
+): GuildRoleMemberSource {
+  return async (guildId: string): Promise<ReadonlyArray<GuildRoleMemberRef>> => {
+    const guild = await requireGuild(getBotClient, guildId);
+    const members = await fetchGuildMembersCached(guild);
+    return [...members.values()].map(
+      (m): GuildRoleMemberRef => ({
+        discord_id: m.id,
+        role_ids: [...m.roles.cache.keys()].filter((roleId) => roleId !== guild.id),
+      }),
+    );
+  };
+}
+
+/**
+ * READ the guild's roles (id + name + member count) — the discovery path for `--list-roles`, so
+ * picking the token-gated role snowflake is a lookup rather than a guess. @everyone is excluded.
+ */
+export async function listGuildRoles(
+  getBotClient: () => Promise<Client | null>,
+  guildId: string,
+): Promise<ReadonlyArray<GuildRoleRef>> {
+  const guild = await requireGuild(getBotClient, guildId);
+  const roles = await guild.roles.fetch();
+  // Hydrate the member caches so `role.members.size` is a real count, not 0.
+  await fetchGuildMembersCached(guild);
+  return [...roles.values()]
+    .filter((r) => r.id !== guild.id)
+    .map((r) => ({ id: r.id, name: r.name, members: r.members.size }))
+    .sort((a, b) => b.members - a.members);
+}

--- a/apps/bot/src/shadow/ingestion/role-snapshot-cli.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-cli.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+const cli = new URL("../../cli/role-snapshot-export.ts", import.meta.url).pathname;
+const baseArgs = [
+  "bun",
+  "run",
+  cli,
+  "--role-ids",
+  "900000000000000001",
+  "--owner",
+  "0x1111111111111111111111111111111111111111",
+  "--dry-run",
+];
+const env = {
+  ...process.env,
+  DISCORD_BOT_TOKEN: "test-token-never-used",
+  IDENTITY_API_URL: "https://identity.invalid",
+};
+
+async function run(args: string[]): Promise<{ exitCode: number; stderr: string }> {
+  const child = Bun.spawn(args, { env, stdout: "pipe", stderr: "pipe" });
+  const [exitCode, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stderr };
+}
+
+describe("role-snapshot CLI input validation", () => {
+  test("rejects a non-positive or non-numeric freshness value before opening Discord", async () => {
+    const result = await run([...baseArgs, "--freshness", "not-a-number"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("--freshness must be a positive integer");
+  });
+
+  test("does not swallow the next flag as a missing flag value", async () => {
+    const result = await run([...baseArgs, "--out", "--community", "thj"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("--out requires a value");
+  });
+});

--- a/apps/bot/src/shadow/ingestion/role-snapshot-client.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-client.test.ts
@@ -151,9 +151,39 @@ describe("postRoleSnapshot — response mapping", () => {
     if (r.kind === "transport_error") expect(r.reason).toContain("ECONNREFUSED");
   });
 
-  test("a malformed 200 receipt is refused, not silently treated as accepted", async () => {
+  test("a malformed 200 receipt is accepted-but-unverified, never a refusal", async () => {
     const { fetchImpl } = captureFetch(200, { unexpected: true });
     const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
-    expect(r.kind).toBe("refused");
+    expect(r.kind).toBe("accepted_unverified");
+    if (r.kind === "accepted_unverified") expect(r.reason).toContain("may already be stored");
+  });
+
+  test.each([
+    { ...RECEIPT(true), ok: false },
+    { ...RECEIPT(true), community: "" },
+    { ...RECEIPT(true), captured_at: null },
+    { ...RECEIPT(true), entries: -1 },
+  ])("a partial or invalid 200 receipt is accepted_unverified", async (receipt) => {
+    const { fetchImpl } = captureFetch(200, receipt);
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    expect(r.kind).toBe("accepted_unverified");
+  });
+
+  test("the request deadline covers a stalled response body", async () => {
+    const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const signal = init?.signal;
+      return {
+        status: 200,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("response body aborted")), {
+              once: true,
+            });
+          }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 10 });
+    expect(r.kind).toBe("transport_error");
+    if (r.kind === "transport_error") expect(r.reason).toContain("response body aborted");
   });
 });

--- a/apps/bot/src/shadow/ingestion/role-snapshot-client.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-client.test.ts
@@ -20,6 +20,7 @@ import { parseRoleSnapshot, type RoleSnapshot } from "./role-snapshot.contract.t
 const SNAPSHOT: RoleSnapshot = parseRoleSnapshot({
   source: "discord:guild:1135545260538339420",
   community: "thj",
+    collection: { chain: '80094', contract: '0x886d2176d899796cd1affa07eff07b9b2b80f1be' },
   captured_at: "2026-07-12T12:00:00.000Z",
   export_method: "freeside-characters:role-snapshot-exporter@1",
   owner: "0x886d2176d899796cd1affa07eff07b9b2b80f1be",
@@ -58,6 +59,7 @@ const RECEIPT = (stored: boolean) => ({
   ok: true,
   stored,
   community: "thj",
+    collection: { chain: '80094', contract: '0x886d2176d899796cd1affa07eff07b9b2b80f1be' },
   captured_at: "2026-07-12T12:00:00.000Z",
   entries: 2,
 });

--- a/apps/bot/src/shadow/ingestion/role-snapshot-client.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-client.test.ts
@@ -1,0 +1,157 @@
+/**
+ * role-snapshot-client.test.ts — the ingestion transport (S3 / EXPORT-1).
+ *
+ * Pins the integrity header (the sha256 must cover the EXACT bytes sent — a mismatch is a live 422)
+ * and the response mapping, including the one that is easy to get backwards:
+ * **`200 {stored:false}` is SUCCESS**, not an error.
+ *
+ * Network-free: fetch is injected. The live POST is NOT exercised here (no ingest token in CI) —
+ * the coordinator runs the live probe. See the report.
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  postRoleSnapshot,
+  prepareRoleSnapshotRequest,
+  DEFAULT_INGEST_ENDPOINT,
+} from "./role-snapshot-client.ts";
+import { parseRoleSnapshot, type RoleSnapshot } from "./role-snapshot.contract.ts";
+
+const SNAPSHOT: RoleSnapshot = parseRoleSnapshot({
+  source: "discord:guild:1135545260538339420",
+  community: "thj",
+  captured_at: "2026-07-12T12:00:00.000Z",
+  export_method: "freeside-characters:role-snapshot-exporter@1",
+  owner: "0x886d2176d899796cd1affa07eff07b9b2b80f1be",
+  freshness_threshold_seconds: 86400,
+  entries: [
+    {
+      discord_user_id: "111111111111111111",
+      wallet: "0x1111111111111111111111111111111111111111",
+      role_ids: ["900000000000000001"],
+    },
+    { discord_user_id: "222222222222222222", role_ids: ["900000000000000001"] },
+  ],
+});
+
+const TOKEN = "s3cr3t-ingest-token";
+
+/** Capture the outgoing request, answer with a canned response. */
+function captureFetch(status: number, body?: unknown): {
+  fetchImpl: typeof fetch;
+  seen: () => { url: string; headers: Record<string, string>; body: string };
+} {
+  let captured: { url: string; headers: Record<string, string>; body: string } | undefined;
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    captured = {
+      url: typeof input === "string" ? input : input.toString(),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: String(init?.body ?? ""),
+    };
+    if (body === undefined) return new Response(null, { status });
+    return new Response(JSON.stringify(body), { status });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, seen: () => captured! };
+}
+
+const RECEIPT = (stored: boolean) => ({
+  ok: true,
+  stored,
+  community: "thj",
+  captured_at: "2026-07-12T12:00:00.000Z",
+  entries: 2,
+});
+
+describe("prepareRoleSnapshotRequest — byte-exact integrity", () => {
+  test("the sha256 is the digest of the EXACT body string that will be sent", () => {
+    const p = prepareRoleSnapshotRequest(SNAPSHOT);
+    expect(p.sha256).toBe(createHash("sha256").update(p.body, "utf8").digest("hex"));
+    expect(p.bytes).toBe(Buffer.byteLength(p.body, "utf8"));
+    expect(p.url).toBe(`${DEFAULT_INGEST_ENDPOINT}/v1/role-snapshot`);
+  });
+
+  test("the body round-trips back through the contract (what we hash is what the service parses)", () => {
+    const p = prepareRoleSnapshotRequest(SNAPSHOT);
+    expect(() => parseRoleSnapshot(JSON.parse(p.body))).not.toThrow();
+  });
+
+  test("an unmatched entry serializes with NO wallet key (a null would be a 422)", () => {
+    const p = prepareRoleSnapshotRequest(SNAPSHOT);
+    expect(p.body).not.toContain('"wallet":null');
+    const wire = JSON.parse(p.body) as { entries: Array<Record<string, unknown>> };
+    expect(Object.keys(wire.entries[1]!).sort()).toEqual(["discord_user_id", "role_ids"]);
+  });
+});
+
+describe("postRoleSnapshot — request shape", () => {
+  test("sends the token + the sha256 of the sent bytes, as JSON", async () => {
+    const { fetchImpl, seen } = captureFetch(200, RECEIPT(true));
+    await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    const req = seen();
+    expect(req.url).toBe(`${DEFAULT_INGEST_ENDPOINT}/v1/role-snapshot`);
+    expect(req.headers["X-Ingest-Token"]).toBe(TOKEN);
+    expect(req.headers["Content-Type"]).toBe("application/json");
+    // the header must match a hash of the body ACTUALLY sent — this is what the service re-computes.
+    expect(req.headers["X-Snapshot-Sha256"]).toBe(
+      createHash("sha256").update(req.body, "utf8").digest("hex"),
+    );
+  });
+
+  test("honors a custom endpoint (and strips a trailing slash)", async () => {
+    const { fetchImpl, seen } = captureFetch(200, RECEIPT(true));
+    await postRoleSnapshot(SNAPSHOT, {
+      token: TOKEN,
+      fetchImpl,
+      timeoutMs: 0,
+      endpoint: "https://staging.example.com/",
+    });
+    expect(seen().url).toBe("https://staging.example.com/v1/role-snapshot");
+  });
+});
+
+describe("postRoleSnapshot — response mapping", () => {
+  test("200 {stored:true} ⇒ accepted", async () => {
+    const { fetchImpl } = captureFetch(200, RECEIPT(true));
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    expect(r.kind).toBe("accepted");
+    if (r.kind === "accepted") expect(r.receipt.stored).toBe(true);
+  });
+
+  test("200 {stored:false} is SUCCESS — a monotonic no-op replay, NOT an error", async () => {
+    const { fetchImpl } = captureFetch(200, RECEIPT(false));
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    expect(r.kind).toBe("accepted"); // ← the assertion that keeps at-least-once retries safe
+    if (r.kind === "accepted") expect(r.receipt.stored).toBe(false);
+  });
+
+  test.each([
+    [401, "X-Ingest-Token"],
+    [403, "not operated"],
+    [413, "10 MB"],
+    [422, "sha256"],
+    [400, "invalid JSON"],
+  ])("%i ⇒ a typed refusal naming the cause", async (status, expected) => {
+    const { fetchImpl } = captureFetch(status as number, { error: "nope" });
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    expect(r.kind).toBe("refused");
+    if (r.kind === "refused") {
+      expect(r.status).toBe(status as number);
+      expect(r.reason).toContain(expected as string);
+    }
+  });
+
+  test("a transport error is typed, never thrown", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    expect(r.kind).toBe("transport_error");
+    if (r.kind === "transport_error") expect(r.reason).toContain("ECONNREFUSED");
+  });
+
+  test("a malformed 200 receipt is refused, not silently treated as accepted", async () => {
+    const { fetchImpl } = captureFetch(200, { unexpected: true });
+    const r = await postRoleSnapshot(SNAPSHOT, { token: TOKEN, fetchImpl, timeoutMs: 0 });
+    expect(r.kind).toBe("refused");
+  });
+});

--- a/apps/bot/src/shadow/ingestion/role-snapshot-client.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-client.ts
@@ -67,6 +67,8 @@ export interface IngestReceipt {
 
 export type PostRoleSnapshotResult =
   | { readonly kind: "accepted"; readonly status: 200; readonly receipt: IngestReceipt }
+  /** HTTP 200, but the receipt could not be verified. The snapshot may already be stored. */
+  | { readonly kind: "accepted_unverified"; readonly status: 200; readonly reason: string }
   /** A typed refusal from the service (401/403/413/422/400) — READ it, do not retry blindly. */
   | { readonly kind: "refused"; readonly status: number; readonly reason: string }
   /** Transport error / deadline — the one case where a retry is sensible. */
@@ -110,6 +112,22 @@ function refusalReason(status: number, detail: string): string {
   return detail ? `${base} — ${detail}` : base;
 }
 
+function isIngestReceipt(value: unknown): value is IngestReceipt {
+  if (value === null || typeof value !== "object") return false;
+  const receipt = value as Record<string, unknown>;
+  return (
+    receipt.ok === true &&
+    typeof receipt.stored === "boolean" &&
+    typeof receipt.community === "string" &&
+    receipt.community.length > 0 &&
+    typeof receipt.captured_at === "string" &&
+    receipt.captured_at.length > 0 &&
+    typeof receipt.entries === "number" &&
+    Number.isInteger(receipt.entries) &&
+    receipt.entries >= 0
+  );
+}
+
 /** POST the snapshot. Never throws; every outcome is a typed result. */
 export async function postRoleSnapshot(
   snapshot: RoleSnapshot,
@@ -121,9 +139,8 @@ export async function postRoleSnapshot(
   const controller = new AbortController();
   const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
 
-  let res: Response;
   try {
-    res = await doFetch(prepared.url, {
+    const res = await doFetch(prepared.url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -134,25 +151,36 @@ export async function postRoleSnapshot(
       body: prepared.body,
       signal: timeoutMs > 0 ? controller.signal : undefined,
     });
+
+    if (res.status === 200) {
+      let receipt: unknown = null;
+      try {
+        receipt = await res.json();
+      } catch (e) {
+        if (controller.signal.aborted) throw e;
+      }
+      if (!isIngestReceipt(receipt)) {
+        return {
+          kind: "accepted_unverified",
+          status: 200,
+          reason: "HTTP 200 returned a malformed receipt; the snapshot may already be stored — do not retry blindly",
+        };
+      }
+      return { kind: "accepted", status: 200, receipt };
+    }
+
+    // 401 is an intentionally empty body; the others carry {error}. Read it best-effort for the
+    // operator, but never assume a shape.
+    let detail = "";
+    try {
+      detail = (await res.text()).trim().slice(0, 200);
+    } catch (e) {
+      if (controller.signal.aborted) throw e;
+    }
+    return { kind: "refused", status: res.status, reason: refusalReason(res.status, detail) };
   } catch (e) {
     return { kind: "transport_error", reason: e instanceof Error ? e.message : String(e) };
   } finally {
     if (timer) clearTimeout(timer);
   }
-
-  if (res.status === 200) {
-    const receipt = (await res.json().catch(() => null)) as IngestReceipt | null;
-    if (!receipt || typeof receipt.stored !== "boolean") {
-      return { kind: "refused", status: 200, reason: "malformed 200 receipt (expected {ok, stored, ...})" };
-    }
-    return { kind: "accepted", status: 200, receipt };
-  }
-
-  // 401 is an intentionally empty body; the others carry {error}. Read it best-effort for the
-  // operator, but never assume a shape.
-  const detail = await res
-    .text()
-    .then((t) => t.trim().slice(0, 200))
-    .catch(() => "");
-  return { kind: "refused", status: res.status, reason: refusalReason(res.status, detail) };
 }

--- a/apps/bot/src/shadow/ingestion/role-snapshot-client.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-client.ts
@@ -1,0 +1,158 @@
+/**
+ * role-snapshot-client.ts — POST a `RoleSnapshot` to the LIVE shadow-audit ingestion seam
+ * (S3 / EXPORT-1). The S1↔S3 transport.
+ *
+ *   POST <endpoint>/v1/role-snapshot
+ *     X-Ingest-Token:    <ROLE_SNAPSHOT_INGEST_TOKEN>   (operator-held; never logged)
+ *     X-Snapshot-Sha256: sha256 hex of the EXACT raw request-body bytes
+ *     Content-Type:      application/json
+ *
+ * Grounded against the consumer's route (loa-freeside
+ * `packages/services/shadow-audit/src/http/audit-router.ts`, `POST /v1/role-snapshot`):
+ *
+ *   200 { ok, stored, community, captured_at, entries }
+ *         accepted. **`stored:false` is SUCCESS**, not an error — the store is MONOTONIC on
+ *         `captured_at` (role-store.ts `isNewer`), so re-POSTing an equal-or-older snapshot is a
+ *         no-op that refuses to roll the held snapshot backwards. This makes the exporter safe to
+ *         be at-least-once: a replay cannot corrupt state.
+ *   401   missing/wrong X-Ingest-Token (constant-time compare; empty body by design)
+ *   403   `community` is not operated by this deploy (must be exactly `thj`)
+ *   413   body > 10 MB
+ *   422   sha256 mismatch, or the body fails RoleSnapshotSchema
+ *   400   invalid JSON
+ *
+ * The service REFUSES rather than guesses. A 4xx is telling you something true — read it, do not
+ * retry blindly. This client therefore does NOT retry internally; the CLI is idempotent and safe to
+ * re-run, which is the right place for a retry decision.
+ *
+ * ── INTEGRITY ────────────────────────────────────────────────────────────────
+ * The hash MUST cover the exact bytes on the wire. We serialize ONCE into `body` and both hash and
+ * send THAT string — never re-serialize (a second `JSON.stringify` could differ in key order and
+ * turn a good snapshot into a 422). The server hashes with
+ * `createHash('sha256').update(raw, 'utf8')`; we mirror it byte-for-byte.
+ *
+ * ── SECRET DISCIPLINE ────────────────────────────────────────────────────────
+ * The ingest token is read from the caller, used once as a header, and NEVER logged, echoed, or
+ * included in an error. Response bodies from this endpoint carry no member data (the receipt is
+ * counts only), so surfacing them is safe.
+ */
+import { createHash } from "node:crypto";
+import type { RoleSnapshot } from "./role-snapshot.contract.ts";
+
+/** The deployed ingestion seam (verified live 2026-07-12). */
+export const DEFAULT_INGEST_ENDPOINT = "https://shadow-audit-api-production.up.railway.app";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface PostRoleSnapshotConfig {
+  /** Base URL. Default {@link DEFAULT_INGEST_ENDPOINT}. */
+  readonly endpoint?: string;
+  /** ROLE_SNAPSHOT_INGEST_TOKEN. Operator-held. NEVER logged. */
+  readonly token: string;
+  /** Injectable fetch (tests). Production omits it (global fetch). */
+  readonly fetchImpl?: typeof fetch;
+  /** Request deadline in ms (default 30s; <=0 disables). */
+  readonly timeoutMs?: number;
+}
+
+/** The 200 receipt — counts only, no member data echoed. */
+export interface IngestReceipt {
+  readonly ok: boolean;
+  /** FALSE ⇒ an equal-or-newer snapshot is already held. A successful NO-OP, not an error. */
+  readonly stored: boolean;
+  readonly community: string;
+  readonly captured_at: string;
+  readonly entries: number;
+}
+
+export type PostRoleSnapshotResult =
+  | { readonly kind: "accepted"; readonly status: 200; readonly receipt: IngestReceipt }
+  /** A typed refusal from the service (401/403/413/422/400) — READ it, do not retry blindly. */
+  | { readonly kind: "refused"; readonly status: number; readonly reason: string }
+  /** Transport error / deadline — the one case where a retry is sensible. */
+  | { readonly kind: "transport_error"; readonly reason: string };
+
+/** What the request WOULD be (`--dry-run` prints this; the POST path sends exactly it). */
+export interface PreparedRequest {
+  readonly url: string;
+  readonly body: string;
+  readonly sha256: string;
+  readonly bytes: number;
+}
+
+/**
+ * Serialize + hash ONCE. The returned `body` is the exact string that goes on the wire, and
+ * `sha256` is the digest of exactly those utf8 bytes.
+ */
+export function prepareRoleSnapshotRequest(
+  snapshot: RoleSnapshot,
+  endpoint: string = DEFAULT_INGEST_ENDPOINT,
+): PreparedRequest {
+  const body = JSON.stringify(snapshot);
+  return {
+    url: `${endpoint.replace(/\/+$/, "")}/v1/role-snapshot`,
+    body,
+    sha256: createHash("sha256").update(body, "utf8").digest("hex"),
+    bytes: Buffer.byteLength(body, "utf8"),
+  };
+}
+
+/** Human-readable cause per refusal status — so a 4xx is actionable instead of opaque. */
+function refusalReason(status: number, detail: string): string {
+  const known: Record<number, string> = {
+    400: "invalid JSON body",
+    401: "missing/wrong X-Ingest-Token (check ROLE_SNAPSHOT_INGEST_TOKEN)",
+    403: "community is not operated by this deploy (it must be exactly 'thj')",
+    413: "snapshot exceeds the 10 MB limit",
+    422: "sha256 mismatch, or the body failed RoleSnapshotSchema validation",
+  };
+  const base = known[status] ?? `unexpected status ${status}`;
+  return detail ? `${base} — ${detail}` : base;
+}
+
+/** POST the snapshot. Never throws; every outcome is a typed result. */
+export async function postRoleSnapshot(
+  snapshot: RoleSnapshot,
+  cfg: PostRoleSnapshotConfig,
+): Promise<PostRoleSnapshotResult> {
+  const prepared = prepareRoleSnapshotRequest(snapshot, cfg.endpoint);
+  const doFetch = cfg.fetchImpl ?? fetch;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+
+  let res: Response;
+  try {
+    res = await doFetch(prepared.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        // Secret. Used here, never logged.
+        "X-Ingest-Token": cfg.token,
+        "X-Snapshot-Sha256": prepared.sha256,
+      },
+      body: prepared.body,
+      signal: timeoutMs > 0 ? controller.signal : undefined,
+    });
+  } catch (e) {
+    return { kind: "transport_error", reason: e instanceof Error ? e.message : String(e) };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+
+  if (res.status === 200) {
+    const receipt = (await res.json().catch(() => null)) as IngestReceipt | null;
+    if (!receipt || typeof receipt.stored !== "boolean") {
+      return { kind: "refused", status: 200, reason: "malformed 200 receipt (expected {ok, stored, ...})" };
+    }
+    return { kind: "accepted", status: 200, receipt };
+  }
+
+  // 401 is an intentionally empty body; the others carry {error}. Read it best-effort for the
+  // operator, but never assume a shape.
+  const detail = await res
+    .text()
+    .then((t) => t.trim().slice(0, 200))
+    .catch(() => "");
+  return { kind: "refused", status: res.status, reason: refusalReason(res.status, detail) };
+}

--- a/apps/bot/src/shadow/ingestion/role-snapshot-export.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-export.test.ts
@@ -43,6 +43,7 @@ const resolveWallet = async (id: string): Promise<string | undefined> =>
 const BASE = {
   guildId: GUILD,
   community: "thj",
+    collection: { chain: '80094', contract: '0x886d2176d899796cd1affa07eff07b9b2b80f1be' },
   owner: "0x886d2176d899796cd1affa07eff07b9b2b80f1be",
   gatedRoleIds: [GATED],
   members: MEMBERS,

--- a/apps/bot/src/shadow/ingestion/role-snapshot-export.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-export.test.ts
@@ -1,0 +1,156 @@
+/**
+ * role-snapshot-export.test.ts — the exporter's pure core (S3 / EXPORT-1).
+ *
+ * Pins the three things that, if wrong, produce a CONFIDENTLY-WRONG audit rather than a loud
+ * failure:
+ *   1. an unmatched role-holder is FLAGGED (emitted, wallet absent), never DROPPED;
+ *   2. only holders of the TOKEN-GATED role are exported (the audit reads every entry as a
+ *      role-holder — exporting the whole guild would report the server as stale access);
+ *   3. the emitted snapshot satisfies the vendored wire contract.
+ *
+ * Network-free: the guild read and the wallet resolver are injected.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  buildRoleSnapshot,
+  redactDiscordId,
+  redactWallet,
+  RoleSnapshotExportError,
+  EXPORT_METHOD,
+  type GuildRoleMemberRef,
+} from "./role-snapshot-export.ts";
+import { parseRoleSnapshot } from "./role-snapshot.contract.ts";
+
+const GUILD = "1135545260538339420"; // THJ
+const GATED = "900000000000000001"; // the token-gated role
+const OTHER = "900000000000000002"; // some unrelated role
+
+const RESOLVED_MEMBER = "111111111111111111";
+const UNMATCHED_MEMBER = "222222222222222222";
+const UNGATED_MEMBER = "333333333333333333";
+const WALLET = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const MEMBERS: GuildRoleMemberRef[] = [
+  { discord_id: RESOLVED_MEMBER, role_ids: [GATED, OTHER] },
+  { discord_id: UNMATCHED_MEMBER, role_ids: [GATED] },
+  { discord_id: UNGATED_MEMBER, role_ids: [OTHER] }, // holds NO gated role ⇒ must not be exported
+];
+
+/** Resolves exactly one member; everyone else is unmatched. */
+const resolveWallet = async (id: string): Promise<string | undefined> =>
+  id === RESOLVED_MEMBER ? WALLET : undefined;
+
+const BASE = {
+  guildId: GUILD,
+  community: "thj",
+  owner: "0x886d2176d899796cd1affa07eff07b9b2b80f1be",
+  gatedRoleIds: [GATED],
+  members: MEMBERS,
+  resolveWallet,
+  capturedAt: "2026-07-12T12:00:00.000Z",
+};
+
+describe("buildRoleSnapshot — envelope + resolved + unmatched", () => {
+  test("emits a contract-valid envelope", async () => {
+    const { snapshot } = await buildRoleSnapshot(BASE);
+    expect(() => parseRoleSnapshot(snapshot)).not.toThrow();
+    expect(snapshot.source).toBe(`discord:guild:${GUILD}`);
+    expect(snapshot.community).toBe("thj");
+    expect(snapshot.captured_at).toBe("2026-07-12T12:00:00.000Z");
+    expect(snapshot.export_method).toBe(EXPORT_METHOD);
+    expect(snapshot.freshness_threshold_seconds).toBe(86_400);
+  });
+
+  test("a RESOLVED holder carries a lowercased wallet", async () => {
+    const { snapshot } = await buildRoleSnapshot(BASE);
+    const entry = snapshot.entries.find((e) => e.discord_user_id === RESOLVED_MEMBER);
+    expect(entry?.wallet).toBe(WALLET.toLowerCase());
+    expect(entry?.role_ids).toEqual([GATED]);
+  });
+
+  test("an UNMATCHED holder is FLAGGED (emitted, wallet ABSENT), never dropped", async () => {
+    const { snapshot, stats } = await buildRoleSnapshot(BASE);
+    const entry = snapshot.entries.find((e) => e.discord_user_id === UNMATCHED_MEMBER);
+    expect(entry).toBeDefined(); // ← the load-bearing assertion: present, not dropped
+    expect(entry?.wallet).toBeUndefined();
+    expect(entry).not.toHaveProperty("wallet"); // the KEY is absent (strict schema; `null` would 422)
+    expect(entry?.role_ids).toEqual([GATED]);
+    expect(stats.unmatched).toBe(1);
+    expect(stats.resolved).toBe(1);
+  });
+
+  test("a JSON round-trip keeps the unmatched entry and omits its wallet key", async () => {
+    const { snapshot } = await buildRoleSnapshot(BASE);
+    const wire = JSON.parse(JSON.stringify(snapshot)) as { entries: Array<Record<string, unknown>> };
+    const unmatched = wire.entries.find((e) => e.discord_user_id === UNMATCHED_MEMBER)!;
+    expect(Object.keys(unmatched).sort()).toEqual(["discord_user_id", "role_ids"]);
+    expect(() => parseRoleSnapshot(wire)).not.toThrow();
+  });
+
+  test("a resolver THROW ⇒ unmatched, never a lost member (fail-soft per member)", async () => {
+    const { snapshot, stats } = await buildRoleSnapshot({
+      ...BASE,
+      resolveWallet: async (id) => {
+        if (id === UNMATCHED_MEMBER) throw new Error("identity-api 503");
+        return WALLET;
+      },
+    });
+    expect(snapshot.entries.length).toBe(2);
+    expect(snapshot.entries.find((e) => e.discord_user_id === UNMATCHED_MEMBER)?.wallet).toBeUndefined();
+    expect(stats.unmatched).toBe(1);
+  });
+
+  test("a malformed wallet from the resolver ⇒ unmatched (never a 422-poisoned snapshot)", async () => {
+    const { snapshot } = await buildRoleSnapshot({ ...BASE, resolveWallet: async () => "not-a-wallet" });
+    expect(snapshot.entries.every((e) => e.wallet === undefined)).toBe(true);
+    expect(() => parseRoleSnapshot(snapshot)).not.toThrow();
+  });
+});
+
+describe("buildRoleSnapshot — the gated-role filter (the correctness spine)", () => {
+  test("members holding NO gated role are excluded", async () => {
+    const { snapshot, stats } = await buildRoleSnapshot(BASE);
+    expect(snapshot.entries.map((e) => e.discord_user_id).sort()).toEqual(
+      [RESOLVED_MEMBER, UNMATCHED_MEMBER].sort(),
+    );
+    expect(snapshot.entries.find((e) => e.discord_user_id === UNGATED_MEMBER)).toBeUndefined();
+    expect(stats.guild_members).toBe(3);
+    expect(stats.gated_members).toBe(2);
+  });
+
+  test("an entry carries ONLY the gated roles it holds — not the member's whole role list", async () => {
+    const { snapshot } = await buildRoleSnapshot(BASE);
+    const entry = snapshot.entries.find((e) => e.discord_user_id === RESOLVED_MEMBER);
+    expect(entry?.role_ids).toEqual([GATED]);
+    expect(entry?.role_ids).not.toContain(OTHER); // minimal disclosure
+  });
+
+  test("REFUSES an empty gated-role list (no 'export everyone' default)", async () => {
+    await expect(buildRoleSnapshot({ ...BASE, gatedRoleIds: [] })).rejects.toThrow(RoleSnapshotExportError);
+  });
+
+  test("REFUSES @everyone (role id === guild id) — it would export the whole guild as role-holders", async () => {
+    await expect(buildRoleSnapshot({ ...BASE, gatedRoleIds: [GUILD] })).rejects.toThrow(
+      RoleSnapshotExportError,
+    );
+  });
+
+  test("REFUSES a role NAME in place of a snowflake", async () => {
+    await expect(buildRoleSnapshot({ ...BASE, gatedRoleIds: ["Mibera Holder"] })).rejects.toThrow(
+      RoleSnapshotExportError,
+    );
+  });
+});
+
+describe("PII floor — never log a raw wallet or a raw discord id", () => {
+  test("redactDiscordId keeps first4…last4", () => {
+    expect(redactDiscordId(RESOLVED_MEMBER)).toBe("1111…1111");
+    expect(redactDiscordId(RESOLVED_MEMBER)).not.toContain(RESOLVED_MEMBER);
+  });
+
+  test("redactWallet keeps 0x+4…last4", () => {
+    const redacted = redactWallet(WALLET.toLowerCase());
+    expect(redacted).toBe("0xaaaa…aaaa");
+    expect(redacted.length).toBeLessThan(WALLET.length);
+  });
+});

--- a/apps/bot/src/shadow/ingestion/role-snapshot-export.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-export.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildRoleSnapshot,
+  assertLiveSnapshotHasSignal,
   redactDiscordId,
   redactWallet,
   RoleSnapshotExportError,
@@ -140,6 +141,26 @@ describe("buildRoleSnapshot — the gated-role filter (the correctness spine)", 
     await expect(buildRoleSnapshot({ ...BASE, gatedRoleIds: ["Mibera Holder"] })).rejects.toThrow(
       RoleSnapshotExportError,
     );
+  });
+});
+
+describe("assertLiveSnapshotHasSignal — live-write safety gate", () => {
+  test("REFUSES a live snapshot with no gated-role holders", () => {
+    expect(() =>
+      assertLiveSnapshotHasSignal({ guild_members: 100, gated_members: 0, resolved: 0, unmatched: 0 }),
+    ).toThrow(RoleSnapshotExportError);
+  });
+
+  test("REFUSES a live snapshot when every gated holder is unmatched", () => {
+    expect(() =>
+      assertLiveSnapshotHasSignal({ guild_members: 100, gated_members: 5, resolved: 0, unmatched: 5 }),
+    ).toThrow(RoleSnapshotExportError);
+  });
+
+  test("allows a live snapshot with at least one resolved gated holder", () => {
+    expect(() =>
+      assertLiveSnapshotHasSignal({ guild_members: 100, gated_members: 5, resolved: 1, unmatched: 4 }),
+    ).not.toThrow();
   });
 });
 

--- a/apps/bot/src/shadow/ingestion/role-snapshot-export.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-export.ts
@@ -1,0 +1,230 @@
+/**
+ * role-snapshot-export.ts — build a `RoleSnapshot` from a Discord guild's members (S3 / EXPORT-1).
+ *
+ * The PURE core of the exporter: guild members (+ their role snowflakes) × a discord→wallet
+ * resolver → a contract-valid `RoleSnapshot`. Zero I/O, zero discord.js, zero network — the live
+ * adapters are INJECTED (`guild-role-source.live.ts` reads Discord; the CLI wires the identity
+ * client), so this module is fully testable without a bot token. Mirrors the repo's existing
+ * live/mock split (member-roster.ts + member-source.live.ts).
+ *
+ * ── WHY A GATED-ROLE FILTER IS MANDATORY (the correctness spine) ─────────────
+ * Read the consumer before changing this. The audit
+ * (loa-freeside `packages/services/shadow-audit/src/audit-service.ts`) does:
+ *
+ *     const { roleWallets, unmatched } = resolveRoles(snapshot);   // EVERY entry ⇒ a role-holder
+ *     const staleAccess = [...roleWallets].filter((w) => !qualifies(curBal, w));
+ *     stale_access_risk_band = staleRiskBand(staleAccess.length, roleWallets.size);
+ *
+ * i.e. it treats EVERY entry in the snapshot as "this member holds the token-gated role", and
+ * reports the ones who no longer own the tokens as STALE ACCESS — the drift the product exists to
+ * measure. So the snapshot must contain the holders of the GATED role and nobody else. Exporting
+ * every guild member would report the entire server as stale access: a confidently-wrong audit,
+ * which is the exact failure mode this cycle is built to prevent.
+ *
+ * `gatedRoleIds` is therefore REQUIRED and FAIL-CLOSED — there is no "export everyone" default,
+ * and an `@everyone` role id (which every member holds, and which would silently degenerate into
+ * exactly that) is REFUSED.
+ *
+ * ── UNMATCHED HOLDERS ARE FLAGGED, NEVER DROPPED ─────────────────────────────
+ * A gated-role holder whose wallet does not resolve is emitted with `wallet` ABSENT. Silently
+ * dropping them would understate the drift (they'd vanish from `roleWallets` rather than being
+ * counted as a role-holder we cannot verify). The consumer's `resolveRoles` collects exactly these
+ * into its `unmatched` set. The golden fixture carries an unmatched entry to pin this.
+ *
+ * ── PII FLOOR ────────────────────────────────────────────────────────────────
+ * This module NEVER logs. Callers log through `redactDiscordId` / `redactWallet` — a raw wallet or
+ * a raw discord snowflake must never reach stdout/stderr or a log sink.
+ */
+import {
+  parseRoleSnapshot,
+  WALLET_RE,
+  type RoleSnapshot,
+  type RoleSnapshotEntry,
+} from "./role-snapshot.contract.ts";
+
+/** Discord snowflakes are 17-20 digit decimal ids (same shape the identity client enforces). */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
+/** The exporter's provenance stamp (`export_method` on the wire). */
+export const EXPORT_METHOD = "freeside-characters:role-snapshot-exporter@1";
+
+/** Default freshness window — a snapshot older than this drives an `uncertain` audit downstream. */
+export const DEFAULT_FRESHNESS_THRESHOLD_SECONDS = 86_400;
+
+/** How many identity resolutions to run at once. The guild read is one call; identity is 1-2 HTTP
+ *  GETs PER MEMBER, so a serial walk over a large gated set is the whole runtime. Bounded so we
+ *  never open hundreds of sockets against identity-api. */
+const RESOLVE_CONCURRENCY = 8;
+
+/** One guild member as read from Discord: their snowflake + the role SNOWFLAKES they hold. */
+export interface GuildRoleMemberRef {
+  readonly discord_id: string;
+  /** ALL role snowflakes this member holds (ids, NEVER names — the wire contract wants ids). */
+  readonly role_ids: ReadonlyArray<string>;
+}
+
+/** Read the guild's members + their role ids. INJECTED (live adapter reads discord.js). */
+export type GuildRoleMemberSource = (guildId: string) => Promise<ReadonlyArray<GuildRoleMemberRef>>;
+
+/**
+ * Resolve a member's discord snowflake → their wallet, or `undefined` when it cannot be resolved.
+ * INJECTED. MUST be fail-soft: the CLI backs this with `MemberIdentityClient.resolveMember`, whose
+ * every read is fail-soft. A throw here is caught and treated as unmatched (never dropped).
+ */
+export type MemberWalletResolver = (discordId: string) => Promise<string | undefined>;
+
+export interface BuildRoleSnapshotInput {
+  readonly guildId: string;
+  /** MUST be an operated community (`thj`), else the live service answers 403. */
+  readonly community: string;
+  /** Provenance only — the audit does not consume it. Conventionally the community owner wallet. */
+  readonly owner: string;
+  /** The token-gated role snowflake(s). REQUIRED — see the header. */
+  readonly gatedRoleIds: ReadonlyArray<string>;
+  readonly members: ReadonlyArray<GuildRoleMemberRef>;
+  readonly resolveWallet: MemberWalletResolver;
+  /** ISO-8601 UTC. Injected so tests are deterministic; the CLI passes `new Date().toISOString()`. */
+  readonly capturedAt: string;
+  readonly freshnessThresholdSeconds?: number;
+  readonly exportMethod?: string;
+}
+
+export interface RoleSnapshotStats {
+  /** members read from the guild. */
+  readonly guild_members: number;
+  /** members holding at least one gated role (⇒ the snapshot's entries). */
+  readonly gated_members: number;
+  /** gated members whose wallet resolved. */
+  readonly resolved: number;
+  /** gated members with NO resolvable wallet — FLAGGED in the snapshot, never dropped. */
+  readonly unmatched: number;
+}
+
+export interface BuildRoleSnapshotResult {
+  readonly snapshot: RoleSnapshot;
+  readonly stats: RoleSnapshotStats;
+}
+
+/** Thrown when the exporter's inputs are unsafe — fail-closed, never a silently-degraded export. */
+export class RoleSnapshotExportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RoleSnapshotExportError";
+  }
+}
+
+/** first4…last4 — the PII floor for a discord snowflake. NEVER log the raw id. */
+export function redactDiscordId(id: string): string {
+  return id.length <= 8 ? "…" : `${id.slice(0, 4)}…${id.slice(-4)}`;
+}
+
+/** 0x1234…abcd — the PII floor for a wallet. NEVER log the raw address. */
+export function redactWallet(wallet: string): string {
+  return wallet.length <= 10 ? "0x…" : `${wallet.slice(0, 6)}…${wallet.slice(-4)}`;
+}
+
+/**
+ * Validate the gated-role ids. FAIL-CLOSED on the two mistakes that would silently produce a
+ * confidently-wrong audit:
+ *   • an EMPTY list — there is no "export everyone" default (see the header).
+ *   • the @everyone role — in Discord its id EQUALS the guild id, and every member holds it, so it
+ *     would degenerate into exporting the whole guild as token-gated role-holders.
+ */
+function assertGatedRoleIds(gatedRoleIds: ReadonlyArray<string>, guildId: string): void {
+  if (gatedRoleIds.length === 0) {
+    throw new RoleSnapshotExportError(
+      "gatedRoleIds is empty — refusing to export. The audit treats EVERY entry as a holder of the " +
+        "token-gated role, so exporting the whole guild would report the entire server as stale access. " +
+        "Pass the token-gated role snowflake(s) explicitly.",
+    );
+  }
+  for (const id of gatedRoleIds) {
+    if (!SNOWFLAKE_RE.test(id)) {
+      throw new RoleSnapshotExportError(
+        `gated role id '${id}' is not a Discord snowflake (17-20 digits). Role NAMES are not accepted — ` +
+          "the wire contract requires ids.",
+      );
+    }
+    if (id === guildId) {
+      throw new RoleSnapshotExportError(
+        "gated role id equals the guild id — that is @everyone, which every member holds. Exporting it " +
+          "would mark the entire guild as token-gated role-holders. Refusing.",
+      );
+    }
+  }
+}
+
+/** Run `fn` over `items` with bounded concurrency, preserving order. */
+async function mapBounded<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let i = next++; i < items.length; i = next++) {
+      out[i] = await fn(items[i]!);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+/**
+ * Build the snapshot. The returned snapshot is VALIDATED against the vendored contract before it is
+ * handed back — this module cannot emit a shape the live service would 422.
+ */
+export async function buildRoleSnapshot(input: BuildRoleSnapshotInput): Promise<BuildRoleSnapshotResult> {
+  assertGatedRoleIds(input.gatedRoleIds, input.guildId);
+
+  const gated = new Set(input.gatedRoleIds);
+
+  // The gated cohort: members holding >= 1 gated role. Their entry carries ONLY the gated roles they
+  // hold — not their whole role list. Minimal disclosure (the audit only ever reports role_ids back
+  // for unmatched holders), and it keeps the wire payload about the audited grant, nothing else.
+  const cohort: Array<{ discord_id: string; role_ids: string[] }> = [];
+  for (const m of input.members) {
+    const held = m.role_ids.filter((r) => gated.has(r));
+    if (held.length > 0) cohort.push({ discord_id: m.discord_id, role_ids: held });
+  }
+
+  const entries = await mapBounded(cohort, RESOLVE_CONCURRENCY, async (m): Promise<RoleSnapshotEntry> => {
+    let wallet: string | undefined;
+    try {
+      wallet = await input.resolveWallet(m.discord_id);
+    } catch {
+      // FAIL-SOFT ⇒ UNMATCHED, never dropped. A transient identity blip on one member must not
+      // remove them from the snapshot — that would understate the drift.
+      wallet = undefined;
+    }
+    // A resolver that hands back a malformed address is treated as unmatched rather than poisoning
+    // the whole snapshot with a 422 (the contract would reject a non-0x40hex wallet).
+    const usable = wallet && WALLET_RE.test(wallet) ? wallet.toLowerCase() : undefined;
+    return usable
+      ? { discord_user_id: m.discord_id, wallet: usable, role_ids: m.role_ids }
+      : { discord_user_id: m.discord_id, role_ids: m.role_ids };
+  });
+
+  const snapshot = parseRoleSnapshot({
+    source: `discord:guild:${input.guildId}`,
+    community: input.community,
+    captured_at: input.capturedAt,
+    export_method: input.exportMethod ?? EXPORT_METHOD,
+    owner: input.owner,
+    freshness_threshold_seconds:
+      input.freshnessThresholdSeconds ?? DEFAULT_FRESHNESS_THRESHOLD_SECONDS,
+    entries,
+  });
+
+  const resolved = entries.filter((e) => e.wallet).length;
+  return {
+    snapshot,
+    stats: {
+      guild_members: input.members.length,
+      gated_members: cohort.length,
+      resolved,
+      unmatched: entries.length - resolved,
+    },
+  };
+}

--- a/apps/bot/src/shadow/ingestion/role-snapshot-export.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-export.ts
@@ -122,6 +122,25 @@ export class RoleSnapshotExportError extends Error {
   }
 }
 
+/**
+ * Refuse a live write that would replace useful held state with an empty signal.
+ * Dry-runs deliberately skip this gate so operators can diagnose identity coverage.
+ */
+export function assertLiveSnapshotHasSignal(stats: RoleSnapshotStats): void {
+  if (stats.gated_members === 0) {
+    throw new RoleSnapshotExportError(
+      "no gated-role holders were found — refusing the live POST. Check the guild and gated role ids; " +
+        "use --dry-run for diagnostics.",
+    );
+  }
+  if (stats.resolved === 0) {
+    throw new RoleSnapshotExportError(
+      "zero gated-role holders resolved to wallets — refusing the live POST. Check IDENTITY_API_URL / " +
+        "IDENTITY_WORLD; use --dry-run for diagnostics.",
+    );
+  }
+}
+
 /** first4…last4 — the PII floor for a discord snowflake. NEVER log the raw id. */
 export function redactDiscordId(id: string): string {
   return id.length <= 8 ? "…" : `${id.slice(0, 4)}…${id.slice(-4)}`;

--- a/apps/bot/src/shadow/ingestion/role-snapshot-export.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot-export.ts
@@ -77,6 +77,15 @@ export interface BuildRoleSnapshotInput {
   readonly guildId: string;
   /** MUST be an operated community (`thj`), else the live service answers 403. */
   readonly community: string;
+  /**
+   * The GATED COLLECTION this export is for — `{chain, contract}`, chain = NUMERIC EVM chain id.
+   *
+   * REQUIRED upstream (S5-T1). thj gates SEVEN collections, each behind its own Discord role; the store
+   * keys snapshots by (community, collection). Without it the HJG1 export would OVERWRITE the Honeycomb
+   * one and the Honeycomb audit would compute drift against HoneyJar1's role-holders — silently.
+   * ANY deployment of the collection addresses it (the service canonicalizes across the union).
+   */
+  readonly collection: { readonly chain: string; readonly contract: string };
   /** Provenance only — the audit does not consume it. Conventionally the community owner wallet. */
   readonly owner: string;
   /** The token-gated role snowflake(s). REQUIRED — see the header. */
@@ -209,6 +218,7 @@ export async function buildRoleSnapshot(input: BuildRoleSnapshotInput): Promise<
   const snapshot = parseRoleSnapshot({
     source: `discord:guild:${input.guildId}`,
     community: input.community,
+    collection: input.collection,
     captured_at: input.capturedAt,
     export_method: input.exportMethod ?? EXPORT_METHOD,
     owner: input.owner,

--- a/apps/bot/src/shadow/ingestion/role-snapshot.contract.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot.contract.test.ts
@@ -1,0 +1,99 @@
+/**
+ * role-snapshot.contract.test.ts — the EXPORTER side of the cross-repo `/v1/role-snapshot`
+ * contract pin (S3 / EXPORT-1).
+ *
+ * This is the MIRROR of the consumer's test (loa-freeside
+ * `packages/services/shadow-audit/src/__tests__/role-snapshot-contract.test.ts`), run against
+ * the SAME golden fixture, copied verbatim into `./fixtures/role-snapshot.golden.json`.
+ *
+ * ── WHAT THIS TEST IS FOR ────────────────────────────────────────────────────
+ * It is the DRIFT ALARM. The contract is vendored (see role-snapshot.contract.ts's provenance
+ * header) because the canonical zod schema is not importable across the repo boundary. A
+ * vendored contract can silently rot. This test makes the rot LOUD: re-copy the fixture from
+ * the source repo and, if the wire shape moved, these assertions fail HERE — instead of the
+ * live POST failing with an opaque 422 at 3am.
+ *
+ * Each case pins one rule of the source schema.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  parseRoleSnapshot,
+  parseRoleSnapshotEntry,
+  RoleSnapshotContractError,
+} from "./role-snapshot.contract.ts";
+
+const golden: unknown = JSON.parse(
+  readFileSync(new URL("./fixtures/role-snapshot.golden.json", import.meta.url), "utf8"),
+);
+
+describe("/v1/role-snapshot cross-repo contract (S3 exporter side)", () => {
+  test("the canonical fixture parses against the vendored contract", () => {
+    const parsed = parseRoleSnapshot(golden);
+    expect(parsed.community).toBe("thj");
+    expect(parsed.entries.length).toBe(2);
+  });
+
+  test("pins the EXACT top-level wire keys — an add/remove breaks the exporter contract", () => {
+    expect(Object.keys(golden as object).sort()).toEqual(
+      [
+        "captured_at",
+        "community",
+        "entries",
+        "export_method",
+        "freshness_threshold_seconds",
+        "owner",
+        "source",
+      ].sort(),
+    );
+  });
+
+  test("pins entry shape: wallet is OPTIONAL (an unmatched role-holder is FLAGGED, never dropped)", () => {
+    const entries = (golden as { entries: unknown[] }).entries.map((e) => parseRoleSnapshotEntry(e));
+    const matched = entries.find((e) => e.wallet);
+    const unmatched = entries.find((e) => !e.wallet);
+    expect(matched?.wallet).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    // The fixture MUST carry an unmatched entry — that is the contract the exporter must honor.
+    expect(unmatched).toBeDefined();
+    expect(unmatched?.role_ids.length).toBeGreaterThan(0);
+  });
+
+  test("the schema is CLOSED — an extra top-level field is rejected (strict wire shape ⇒ live 422)", () => {
+    expect(() => parseRoleSnapshot({ ...(golden as object), unexpected: "nope" })).toThrow(
+      RoleSnapshotContractError,
+    );
+  });
+
+  test("the schema is CLOSED at the ENTRY level too — an extra entry field is rejected", () => {
+    expect(() =>
+      parseRoleSnapshotEntry({ discord_user_id: "1", role_ids: ["r"], display_name: "leaky" }),
+    ).toThrow(RoleSnapshotContractError);
+  });
+
+  test("a bad wallet in an entry is rejected (identity fields are shape-checked)", () => {
+    expect(() => parseRoleSnapshotEntry({ discord_user_id: "x", wallet: "0xnothex", role_ids: ["h"] })).toThrow(
+      RoleSnapshotContractError,
+    );
+  });
+
+  test("role_ids must carry at least one id", () => {
+    expect(() => parseRoleSnapshotEntry({ discord_user_id: "x", role_ids: [] })).toThrow(
+      RoleSnapshotContractError,
+    );
+  });
+
+  test("captured_at must be an ISO-8601 UTC instant (an offset form is rejected)", () => {
+    const withOffset = { ...(golden as object), captured_at: "2026-07-10T00:00:00+02:00" };
+    expect(() => parseRoleSnapshot(withOffset)).toThrow(RoleSnapshotContractError);
+    const notADate = { ...(golden as object), captured_at: "yesterday" };
+    expect(() => parseRoleSnapshot(notADate)).toThrow(RoleSnapshotContractError);
+  });
+
+  test("freshness_threshold_seconds must be a POSITIVE INTEGER", () => {
+    for (const bad of [0, -1, 1.5, "86400"]) {
+      expect(() => parseRoleSnapshot({ ...(golden as object), freshness_threshold_seconds: bad })).toThrow(
+        RoleSnapshotContractError,
+      );
+    }
+  });
+});

--- a/apps/bot/src/shadow/ingestion/role-snapshot.contract.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot.contract.test.ts
@@ -92,6 +92,8 @@ describe("/v1/role-snapshot cross-repo contract (S3 exporter side)", () => {
     expect(() => parseRoleSnapshot(withOffset)).toThrow(RoleSnapshotContractError);
     const notADate = { ...(golden as object), captured_at: "yesterday" };
     expect(() => parseRoleSnapshot(notADate)).toThrow(RoleSnapshotContractError);
+    const impossibleDate = { ...(golden as object), captured_at: "2026-02-30T00:00:00.000Z" };
+    expect(() => parseRoleSnapshot(impossibleDate)).toThrow(RoleSnapshotContractError);
   });
 
   test("freshness_threshold_seconds must be a POSITIVE INTEGER", () => {

--- a/apps/bot/src/shadow/ingestion/role-snapshot.contract.test.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot.contract.test.ts
@@ -38,6 +38,11 @@ describe("/v1/role-snapshot cross-repo contract (S3 exporter side)", () => {
     expect(Object.keys(golden as object).sort()).toEqual(
       [
         "captured_at",
+        // The gated collection (S5-T1 upstream): thj gates SEVEN collections, each behind its own Discord
+        // role, and the store keys snapshots by (community, collection). Without it, exporting HJG1 would
+        // OVERWRITE Honeycomb's snapshot and the Honeycomb audit would compute drift against HoneyJar1's
+        // role-holders — silently. This pin is the DRIFT ALARM; it fired when upstream added the field.
+        "collection",
         "community",
         "entries",
         "export_method",

--- a/apps/bot/src/shadow/ingestion/role-snapshot.contract.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot.contract.ts
@@ -1,0 +1,200 @@
+/**
+ * role-snapshot.contract.ts — the VENDORED `RoleSnapshot` wire contract (S3 / EXPORT-1).
+ *
+ * ── PROVENANCE (this is a COPY — keep it in sync) ─────────────────────────────
+ *   source repo:   0xHoneyJar/loa-freeside
+ *   source path:   packages/services/shadow-audit/src/role-snapshot.ts
+ *   source commit: 025cbe6d37f08346b1519c119d6982966836e894  (HEAD @ copy, 2026-07-12)
+ *   schema commit: c674bd39  (the commit that last changed the schema itself)
+ *   consumed by:   POST https://shadow-audit-api-production.up.railway.app/v1/role-snapshot
+ *
+ * ── WHY A COPY AND NOT AN IMPORT ──────────────────────────────────────────────
+ * The canonical schema is a zod schema living at a SUBPATH inside the loa-freeside
+ * monorepo (`packages/services/shadow-audit`). A git-URL dependency cannot install a
+ * monorepo subdirectory, and this repo has zero `@freeside/*` deps. So the contract is
+ * vendored. `role-snapshot.contract.test.ts` parses the vendored GOLDEN FIXTURE (also
+ * copied verbatim from the source repo) with this validator — that test is the DRIFT
+ * ALARM. If the upstream schema changes and the fixture is re-copied, the test fails
+ * here instead of the ingest failing live with a 422.
+ *
+ * ── WHY HAND-WRITTEN AND NOT ZOD ──────────────────────────────────────────────
+ * `zod` is NOT a dependency of apps/bot (it resolves only under packages/persona-engine's
+ * own node_modules — `import { z } from "zod"` from here fails at runtime), and adding a
+ * runtime dependency is out of scope for this task. So the validator below is a zero-dep
+ * transcription of the source's zod rules. Every rule is annotated with the zod line it
+ * mirrors. The rules, verbatim from the source:
+ *
+ *   RoleSnapshotEntrySchema = z.object({
+ *     discord_user_id: z.string().min(1),
+ *     wallet:          z.string().regex(/^0x[0-9a-fA-F]{40}$/).optional(),
+ *     role_ids:        z.array(z.string().min(1)).min(1),
+ *   }).strict();
+ *
+ *   RoleSnapshotSchema = z.object({
+ *     source:                      z.string().min(1),
+ *     community:                   z.string().min(1),
+ *     captured_at:                 z.string().datetime(),      // ISO-8601, UTC "Z"
+ *     export_method:               z.string().min(1),
+ *     owner:                       z.string().min(1),
+ *     freshness_threshold_seconds: z.number().int().positive(),
+ *     entries:                     z.array(RoleSnapshotEntrySchema),
+ *   }).strict();
+ *
+ * `.strict()` is load-bearing: an EXTRA field is a 422 from the live service, not a
+ * warning. The validator below rejects unknown keys for exactly that reason.
+ *
+ * KNOWN NUANCE: zod's `.datetime()` uses a calendar-aware regex (it rejects 2026-02-30).
+ * This transcription checks the ISO-UTC *shape* by regex and delegates calendar validity
+ * to `Date.parse` returning a real instant — equivalent for every value this exporter
+ * emits (always `new Date().toISOString()`), and never LOOSER than the source in a way
+ * that would let us emit a snapshot the service rejects.
+ */
+
+/** A rejected snapshot, with the offending path (mirrors a zod issue closely enough to debug a 422). */
+export class RoleSnapshotContractError extends Error {
+  constructor(readonly path: string, message: string) {
+    super(`role-snapshot contract violation at '${path}': ${message}`);
+    this.name = "RoleSnapshotContractError";
+  }
+}
+
+/** Resolved on-chain wallet: 0x + 40 hex. Mirrors the source regex EXACTLY. */
+export const WALLET_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/** ISO-8601 UTC instant (zod `.datetime()`: the "Z" form; an offset like +02:00 is REJECTED). */
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?Z$/;
+
+/** One role-holder. `wallet` ABSENT ⇒ the holder is FLAGGED as unmatched, never dropped. */
+export interface RoleSnapshotEntry {
+  readonly discord_user_id: string;
+  readonly wallet?: string;
+  readonly role_ids: ReadonlyArray<string>;
+}
+
+export interface RoleSnapshot {
+  readonly source: string;
+  readonly community: string;
+  readonly captured_at: string;
+  readonly export_method: string;
+  readonly owner: string;
+  readonly freshness_threshold_seconds: number;
+  readonly entries: ReadonlyArray<RoleSnapshotEntry>;
+}
+
+const ENTRY_KEYS = ["discord_user_id", "wallet", "role_ids"] as const;
+const SNAPSHOT_KEYS = [
+  "source",
+  "community",
+  "captured_at",
+  "export_method",
+  "owner",
+  "freshness_threshold_seconds",
+  "entries",
+] as const;
+
+function asObject(v: unknown, path: string): Record<string, unknown> {
+  if (v === null || typeof v !== "object" || Array.isArray(v)) {
+    throw new RoleSnapshotContractError(path, "expected an object");
+  }
+  return v as Record<string, unknown>;
+}
+
+/** `.strict()` — an unknown key is a 422 from the live service, so it is a rejection here. */
+function rejectUnknownKeys(o: Record<string, unknown>, allowed: ReadonlyArray<string>, path: string): void {
+  for (const k of Object.keys(o)) {
+    if (!allowed.includes(k)) {
+      throw new RoleSnapshotContractError(path, `unrecognized key '${k}' (the schema is strict)`);
+    }
+  }
+}
+
+/** z.string().min(1) */
+function nonEmptyString(v: unknown, path: string): string {
+  if (typeof v !== "string") throw new RoleSnapshotContractError(path, "expected a string");
+  if (v.length < 1) throw new RoleSnapshotContractError(path, "expected a non-empty string");
+  return v;
+}
+
+/** z.string().datetime() */
+function isoUtcDatetime(v: unknown, path: string): string {
+  const s = nonEmptyString(v, path);
+  if (!ISO_UTC_RE.test(s) || Number.isNaN(Date.parse(s))) {
+    throw new RoleSnapshotContractError(path, `expected an ISO-8601 UTC datetime (e.g. 2026-07-12T00:00:00.000Z), got '${s}'`);
+  }
+  return s;
+}
+
+/** z.number().int().positive() */
+function positiveInt(v: unknown, path: string): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) {
+    throw new RoleSnapshotContractError(path, "expected a finite number");
+  }
+  if (!Number.isInteger(v)) throw new RoleSnapshotContractError(path, "expected an integer");
+  if (v <= 0) throw new RoleSnapshotContractError(path, "expected a positive integer");
+  return v;
+}
+
+/** RoleSnapshotEntrySchema */
+export function parseRoleSnapshotEntry(input: unknown, path = "entry"): RoleSnapshotEntry {
+  const o = asObject(input, path);
+  rejectUnknownKeys(o, ENTRY_KEYS, path);
+
+  const discord_user_id = nonEmptyString(o.discord_user_id, `${path}.discord_user_id`);
+
+  const role_ids_raw = o.role_ids;
+  if (!Array.isArray(role_ids_raw)) {
+    throw new RoleSnapshotContractError(`${path}.role_ids`, "expected an array");
+  }
+  if (role_ids_raw.length < 1) {
+    throw new RoleSnapshotContractError(`${path}.role_ids`, "expected at least one role id");
+  }
+  const role_ids = role_ids_raw.map((r, i) => nonEmptyString(r, `${path}.role_ids[${i}]`));
+
+  // `wallet` is OPTIONAL by design: an unmatched role-holder is FLAGGED (emitted with the
+  // key ABSENT), never dropped. Dropping them would understate the drift the audit exists
+  // to measure. An explicit `undefined` is tolerated (it JSON-serializes to absent).
+  if (o.wallet === undefined) {
+    return { discord_user_id, role_ids };
+  }
+  const wallet = nonEmptyString(o.wallet, `${path}.wallet`);
+  if (!WALLET_RE.test(wallet)) {
+    throw new RoleSnapshotContractError(`${path}.wallet`, "expected 0x + 40 hex characters");
+  }
+  return { discord_user_id, wallet, role_ids };
+}
+
+/** RoleSnapshotSchema — the full wire shape. Throws {@link RoleSnapshotContractError} on any violation. */
+export function parseRoleSnapshot(input: unknown, path = "snapshot"): RoleSnapshot {
+  const o = asObject(input, path);
+  rejectUnknownKeys(o, SNAPSHOT_KEYS, path);
+
+  const entries_raw = o.entries;
+  if (!Array.isArray(entries_raw)) {
+    throw new RoleSnapshotContractError(`${path}.entries`, "expected an array");
+  }
+
+  return {
+    source: nonEmptyString(o.source, `${path}.source`),
+    community: nonEmptyString(o.community, `${path}.community`),
+    captured_at: isoUtcDatetime(o.captured_at, `${path}.captured_at`),
+    export_method: nonEmptyString(o.export_method, `${path}.export_method`),
+    owner: nonEmptyString(o.owner, `${path}.owner`),
+    freshness_threshold_seconds: positiveInt(
+      o.freshness_threshold_seconds,
+      `${path}.freshness_threshold_seconds`,
+    ),
+    entries: entries_raw.map((e, i) => parseRoleSnapshotEntry(e, `${path}.entries[${i}]`)),
+  };
+}
+
+/** Non-throwing variant. */
+export function safeParseRoleSnapshot(
+  input: unknown,
+): { ok: true; snapshot: RoleSnapshot } | { ok: false; error: RoleSnapshotContractError } {
+  try {
+    return { ok: true, snapshot: parseRoleSnapshot(input) };
+  } catch (e) {
+    if (e instanceof RoleSnapshotContractError) return { ok: false, error: e };
+    throw e;
+  }
+}

--- a/apps/bot/src/shadow/ingestion/role-snapshot.contract.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot.contract.ts
@@ -71,9 +71,16 @@ export interface RoleSnapshotEntry {
   readonly role_ids: ReadonlyArray<string>;
 }
 
+/** The gated collection this export is FOR. `chain` is the NUMERIC EVM chain id. */
+export interface SnapshotCollection {
+  readonly chain: string;
+  readonly contract: string;
+}
+
 export interface RoleSnapshot {
   readonly source: string;
   readonly community: string;
+  readonly collection: SnapshotCollection;
   readonly captured_at: string;
   readonly export_method: string;
   readonly owner: string;
@@ -85,12 +92,28 @@ const ENTRY_KEYS = ["discord_user_id", "wallet", "role_ids"] as const;
 const SNAPSHOT_KEYS = [
   "source",
   "community",
+  /**
+   * The GATED COLLECTION this export is for (added upstream by S5-T1, loa-freeside).
+   *
+   * REQUIRED. A community gates SEVERAL collections (thj gates Honeycomb + HoneyJar1-6, each behind its
+   * own Discord role) and this exporter exports ONE gated role-set at a time. Without it the service can
+   * only key role data by community — so ingesting the HJG1 export would OVERWRITE the Honeycomb one, and
+   * the Honeycomb audit would then compute stale-access against HoneyJar1's role-holders. A
+   * confidently-wrong audit, and a silent one.
+   */
+  "collection",
   "captured_at",
   "export_method",
   "owner",
   "freshness_threshold_seconds",
   "entries",
 ] as const;
+
+/** Numeric EVM chain id — the service's ChainSchema is `^[0-9]+$`. A slug ("ethereum") is REJECTED: it
+ *  would be stored under a key the collection registry can never match, and the snapshot would ingest
+ *  happily and then be invisible to every audit. */
+const CHAIN_RE = /^[0-9]+$/;
+const COLLECTION_KEYS = ["chain", "contract"] as const;
 
 function asObject(v: unknown, path: string): Record<string, unknown> {
   if (v === null || typeof v !== "object" || Array.isArray(v)) {
@@ -163,6 +186,26 @@ export function parseRoleSnapshotEntry(input: unknown, path = "entry"): RoleSnap
   return { discord_user_id, wallet, role_ids };
 }
 
+/** The gated collection — `{chain, contract}`. `chain` is the NUMERIC EVM chain id. */
+function parseCollection(v: unknown, path: string): SnapshotCollection {
+  const o = asObject(v, path);
+  rejectUnknownKeys(o, COLLECTION_KEYS, path);
+  const chain = nonEmptyString(o.chain, `${path}.chain`);
+  if (!CHAIN_RE.test(chain)) {
+    throw new RoleSnapshotContractError(
+      `${path}.chain`,
+      `expected a NUMERIC EVM chain id (e.g. "1" or "80094"), got '${chain}'. A slug is rejected: it would ` +
+        "be stored under a key the collection registry can never match, and the snapshot would be invisible " +
+        "to every audit.",
+    );
+  }
+  const contract = nonEmptyString(o.contract, `${path}.contract`);
+  if (!WALLET_RE.test(contract)) {
+    throw new RoleSnapshotContractError(`${path}.contract`, "expected 0x + 40 hex characters");
+  }
+  return { chain, contract };
+}
+
 /** RoleSnapshotSchema — the full wire shape. Throws {@link RoleSnapshotContractError} on any violation. */
 export function parseRoleSnapshot(input: unknown, path = "snapshot"): RoleSnapshot {
   const o = asObject(input, path);
@@ -176,6 +219,7 @@ export function parseRoleSnapshot(input: unknown, path = "snapshot"): RoleSnapsh
   return {
     source: nonEmptyString(o.source, `${path}.source`),
     community: nonEmptyString(o.community, `${path}.community`),
+    collection: parseCollection(o.collection, `${path}.collection`),
     captured_at: isoUtcDatetime(o.captured_at, `${path}.captured_at`),
     export_method: nonEmptyString(o.export_method, `${path}.export_method`),
     owner: nonEmptyString(o.owner, `${path}.owner`),

--- a/apps/bot/src/shadow/ingestion/role-snapshot.contract.ts
+++ b/apps/bot/src/shadow/ingestion/role-snapshot.contract.ts
@@ -4,8 +4,8 @@
  * ── PROVENANCE (this is a COPY — keep it in sync) ─────────────────────────────
  *   source repo:   0xHoneyJar/loa-freeside
  *   source path:   packages/services/shadow-audit/src/role-snapshot.ts
- *   source commit: 025cbe6d37f08346b1519c119d6982966836e894  (HEAD @ copy, 2026-07-12)
- *   schema commit: c674bd39  (the commit that last changed the schema itself)
+ *   source commit: 4c770ebfb444ece59de29249af5e9a182a1e2711  (HEAD @ copy, 2026-07-13)
+ *   schema commit: 4c770ebf  (the commit that last changed the schema itself)
  *   consumed by:   POST https://shadow-audit-api-production.up.railway.app/v1/role-snapshot
  *
  * ── WHY A COPY AND NOT AN IMPORT ──────────────────────────────────────────────
@@ -33,6 +33,7 @@
  *   RoleSnapshotSchema = z.object({
  *     source:                      z.string().min(1),
  *     community:                   z.string().min(1),
+ *     collection:                  SnapshotCollectionSchema,
  *     captured_at:                 z.string().datetime(),      // ISO-8601, UTC "Z"
  *     export_method:               z.string().min(1),
  *     owner:                       z.string().min(1),
@@ -43,11 +44,8 @@
  * `.strict()` is load-bearing: an EXTRA field is a 422 from the live service, not a
  * warning. The validator below rejects unknown keys for exactly that reason.
  *
- * KNOWN NUANCE: zod's `.datetime()` uses a calendar-aware regex (it rejects 2026-02-30).
- * This transcription checks the ISO-UTC *shape* by regex and delegates calendar validity
- * to `Date.parse` returning a real instant — equivalent for every value this exporter
- * emits (always `new Date().toISOString()`), and never LOOSER than the source in a way
- * that would let us emit a snapshot the service rejects.
+ * zod's `.datetime()` is calendar-aware (it rejects 2026-02-30). The transcription below
+ * validates both the ISO-UTC shape and exact UTC calendar components.
  */
 
 /** A rejected snapshot, with the offending path (mirrors a zod issue closely enough to debug a 422). */
@@ -62,7 +60,7 @@ export class RoleSnapshotContractError extends Error {
 export const WALLET_RE = /^0x[0-9a-fA-F]{40}$/;
 
 /** ISO-8601 UTC instant (zod `.datetime()`: the "Z" form; an offset like +02:00 is REJECTED). */
-const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?Z$/;
+const ISO_UTC_RE = /^(\d{4})-(\d{2})-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.(\d+))?Z$/;
 
 /** One role-holder. `wallet` ABSENT ⇒ the holder is FLAGGED as unmatched, never dropped. */
 export interface RoleSnapshotEntry {
@@ -141,8 +139,28 @@ function nonEmptyString(v: unknown, path: string): string {
 /** z.string().datetime() */
 function isoUtcDatetime(v: unknown, path: string): string {
   const s = nonEmptyString(v, path);
-  if (!ISO_UTC_RE.test(s) || Number.isNaN(Date.parse(s))) {
+  const match = ISO_UTC_RE.exec(s);
+  if (!match) {
     throw new RoleSnapshotContractError(path, `expected an ISO-8601 UTC datetime (e.g. 2026-07-12T00:00:00.000Z), got '${s}'`);
+  }
+  const [, year, month, day, hour, minute, second, fraction = ""] = match;
+  const date = new Date(0);
+  date.setUTCFullYear(Number(year), Number(month) - 1, Number(day));
+  date.setUTCHours(
+    Number(hour),
+    Number(minute),
+    Number(second),
+    Number(fraction.slice(0, 3).padEnd(3, "0")),
+  );
+  if (
+    date.getUTCFullYear() !== Number(year) ||
+    date.getUTCMonth() !== Number(month) - 1 ||
+    date.getUTCDate() !== Number(day) ||
+    date.getUTCHours() !== Number(hour) ||
+    date.getUTCMinutes() !== Number(minute) ||
+    date.getUTCSeconds() !== Number(second)
+  ) {
+    throw new RoleSnapshotContractError(path, `expected a real UTC calendar instant, got '${s}'`);
   }
   return s;
 }


### PR DESCRIPTION
## EXPORT-1 — thj RoleSnapshot exporter

Builds the **incumbent-role side** of the Shadow Access Audit: enumerate the thj Discord guild, resolve discord → wallet, emit a contract-valid `RoleSnapshot`, and POST it to the deployed shadow-audit ingestion seam (`POST /v1/role-snapshot`).

Coordination tracker: 0xHoneyJar/freeside-characters#190 (master task EXPORT-1). Does **not** `Closes` it — that issue carries sibling tasks.

### The load-bearing decision: `--role-ids` is required and fail-closed

The consumer (`loa-freeside packages/services/shadow-audit/src/audit-service.ts`) reads **every** snapshot entry as a holder of the token-gated role:

```ts
const { roleWallets } = resolveRoles(snapshot);              // EVERY entry ⇒ a role-holder
const staleAccess = [...roleWallets].filter((w) => !qualifies(curBal, w));
```

`resolveRoles` never looks at `role_ids`. So exporting the whole guild would report **the entire server** as stale access. `--role-ids` is therefore mandatory, `@everyone` (role id == guild id) is refused, and there is deliberately no "export everyone" default.

### Other invariants

- **Unmatched holders are FLAGGED, never dropped** — a gated-role holder whose wallet doesn't resolve is emitted with `wallet` absent. Dropping them would understate the drift the audit exists to measure.
- **Contract is vendored, not imported** — `apps/bot` has zero `@freeside/*` deps and the schema lives at a subpath inside the loa-freeside monorepo (a git-URL dep can't install a monorepo subdir). `role-snapshot.contract.ts` is a zero-dep transcription of `RoleSnapshotSchema` @ `025cbe6d`; the vendored golden fixture + contract test are the **drift alarm**.
- **Integrity** — the body is serialized **once**; `X-Snapshot-Sha256` hashes exactly the bytes sent (a second `JSON.stringify` could reorder keys → 422).
- **PII floor** — no raw wallet or discord snowflake reaches a log line (redacted `first4…last4`); the ingest token is read from env and never logged.
- **At-least-once safe** — ingestion is monotonic on `captured_at`; `stored:false` is a successful no-op, not an error.

### Verification

- 75 tests pass / 0 fail in `src/shadow/ingestion`; `tsc --noEmit` clean.
- **Live Discord read proven**: `--list-roles` and a full `--dry-run` run against the real THJ guild (34,732 members read, 515 HC-role holders, 39,522-byte contract-valid payload).

### ⚠️ The live POST is deliberately NOT yet done

The dry-run against the real guild surfaced a blocker the unit tests could not:

**Only 1 of 515 HC-role holders resolves to a wallet.** A 25-member sample shows `GET /v1/resolve/account/discord/{id}` returning **404 for 25/25** — thj's members have no identity-api accounts at all. Their discord↔wallet links live in their incumbent system (CollabLand), not ours.

POSTing that snapshot would make the audit read **fresh** (clearing its `uncertain` flag) over a role-wallet denominator of **1**, with `newly_eligible` ≈ every Honeycomb holder. A confidently-wrong audit — the exact failure this cycle exists to prevent.

The exporter is correct; the missing piece is upstream. Two follow-ups are filed:
1. **Consumer gap** (loa-freeside): `unmatchedRoleHolders` is returned but does not drive `uncertain` and is absent from the aggregate. A mostly-unmatched snapshot must not present as confident. **This lands before the POST.**
2. **Identity coverage** (product): mounting onto an existing community needs its incumbent gate config + identity links imported (CollabLand) or an operator-assisted mapping flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
