### PR TITLE
chore(governance): declare system component intent

### DIFF
--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   continuity-contract:
-    uses: 0xHoneyJar/loa-freeside/.github/workflows/reusable-flow-moment-governance.yml@177a57a4fdb18c071b4f82f7560ca705b5807a1c
+    uses: 0xHoneyJar/loa-freeside/.github/workflows/reusable-flow-moment-governance.yml@ba3c1347f93e388e488f109ed5c9c5cf39642d5d
     with:
-      governance-ref: 177a57a4fdb18c071b4f82f7560ca705b5807a1c
+      governance-ref: ba3c1347f93e388e488f109ed5c9c5cf39642d5d

--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -1,0 +1,15 @@
+name: Flow Moment Governance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  continuity-contract:
+    uses: 0xHoneyJar/loa-freeside/.github/workflows/reusable-flow-moment-governance.yml@177a57a4fdb18c071b4f82f7560ca705b5807a1c
+    with:
+      governance-ref: 177a57a4fdb18c071b4f82f7560ca705b5807a1c

--- a/product/system-components/freeside-characters.system.json
+++ b/product/system-components/freeside-characters.system.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://raw.githubusercontent.com/0xHoneyJar/loa-freeside/177a57a4fdb18c071b4f82f7560ca705b5807a1c/spec/product/system-component.schema.json",
+  "schema_version": "1.0",
+  "component_id": "freeside-characters",
+  "repository": "github:0xHoneyJar/freeside-characters",
+  "layer": "agent-surface",
+  "operator": {
+    "role": "Community operator and character author",
+    "job": "Configure a character that can express approved substrate truth in voice without mixing persona, tools, and delivery responsibilities."
+  },
+  "object": {
+    "kind": "agent-product",
+    "description": "The multi-character Discord agent substrate with separate character voice, MCP orchestration, and delivery boundaries."
+  },
+  "question": "Can this character communicate the right community capability in its own voice while the substrate preserves tool and delivery contracts?",
+  "responsibility": "Own character configuration, prompt composition, MCP orchestration, scheduling, and Discord delivery while keeping voice in character-owned artifacts.",
+  "consumers": [
+    {
+      "name": "community operators",
+      "need": "Reliable character operations and inspectable tool scope."
+    },
+    {
+      "name": "character authors",
+      "need": "A narrow voice and exemplar surface without Discord or orchestration code."
+    },
+    {
+      "name": "community members",
+      "need": "Consistent in-character interactions grounded in approved capabilities."
+    }
+  ],
+  "trust": {
+    "contract_status": "declared",
+    "contract_refs": [
+      "file:packages/persona-engine/src/config.ts",
+      "file:packages/persona-engine/src/orchestrator/_schema/contract.ts"
+    ],
+    "evidence_refs": [
+      "file:README.md"
+    ],
+    "note": "CharacterConfig and orchestrator contracts separate voice from substrate behavior; configured MCP access does not itself authorize a new product flow or private feedback use."
+  },
+  "actions": [
+    "configure",
+    "compose",
+    "invoke-tools",
+    "deliver",
+    "inspect"
+  ],
+  "boundaries": {
+    "owns": [
+      "Character configuration, prompt composition, MCP orchestration, cron, and Discord delivery.",
+      "The separation between character voice and shared agent substrate."
+    ],
+    "does_not_own": [
+      "The truth or policy inside identity, score, inventory, or activity tools.",
+      "A community-manager Audit UI or an implied campaign action.",
+      "Use of private member feedback without an explicit consent and evidence contract."
+    ],
+    "missing_capability_handoff": "Add or request a typed MCP capability at its producer boundary; do not embed producer logic or new authority in character voice."
+  },
+  "flow_moments": [],
+  "unmapped_reason": "Characters are included in the system map, but the current Audit MVP has no activated Discord character surface or feedback role."
+}

--- a/product/system-components/freeside-characters.system.json
+++ b/product/system-components/freeside-characters.system.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/0xHoneyJar/loa-freeside/177a57a4fdb18c071b4f82f7560ca705b5807a1c/spec/product/system-component.schema.json",
+  "$schema": "https://raw.githubusercontent.com/0xHoneyJar/loa-freeside/ba3c1347f93e388e488f109ed5c9c5cf39642d5d/spec/product/system-component.schema.json",
   "schema_version": "1.0",
   "component_id": "freeside-characters",
   "repository": "github:0xHoneyJar/freeside-characters",


### PR DESCRIPTION
## Summary

- declare this repository's operator, object, question, responsibility, consumers, trust surface, actions, and domain boundaries
- record why this component is not yet joined to `FM-AUDIT-COMPOSITION`, preventing a false-positive architecture map
- add a CI gate pinned to canonical governance commit `ba3c1347f93e388e488f109ed5c9c5cf39642d5d`

## Dependency

Draft until [0xHoneyJar/loa-freeside#468](https://github.com/0xHoneyJar/loa-freeside/pull/468) establishes the canonical schemas, validators, Audit flow record, and reusable workflow.

## Validation

- canonical system-component schema validation passed
- local contract and evidence references resolved
- continuity receipt rendered
- workflow YAML parsed
- staged diff passed `git diff --check`

## Reviewer focus

- Check that character voice, MCP orchestration, and delivery stay separated; no Discord Audit or private-feedback role is implied.
